### PR TITLE
fix: enforce superadmin role authority hierarchy

### DIFF
--- a/apps/agor-daemon/src/auth/terminal-executor-guard.test.ts
+++ b/apps/agor-daemon/src/auth/terminal-executor-guard.test.ts
@@ -1,9 +1,8 @@
 /**
  * Proves the terminal-executor identity is REJECTED from REST/Feathers — not
  * merely under-privileged. These exercise the real production authz predicates
- * (`requireMinimumRole` / `hasMinimumRole`), not token shape, which is exactly
- * the gap a shape-only test missed: `role: 'terminal-executor'` falls through
- * the RBAC rank table to viewer rank and would otherwise pass viewer gating.
+ * (`requireMinimumRole` / `hasMinimumRole`) as well as the explicit guard. The
+ * rank helper and the transport guard are intentionally defense in depth.
  */
 
 import { Forbidden } from '@agor/core/feathers';
@@ -29,21 +28,17 @@ function ctx(user: unknown): HookContext {
 }
 
 describe('terminal-executor identity is rejected from REST/Feathers', () => {
-  it('THE GAP: the RBAC rank system alone does not reject the terminal role', () => {
-    // Real production predicate: 'terminal-executor' isn't a rank key, so it
-    // falls through to 0 (== viewer). This is why an explicit reject is needed.
-    expect(hasMinimumRole('terminal-executor', ROLES.VIEWER)).toBe(true);
+  it('fails closed when the RBAC rank system sees the terminal role', () => {
+    expect(hasMinimumRole('terminal-executor', ROLES.VIEWER)).toBe(false);
   });
 
-  it('THE GAP: a real viewer-gated hook lets the terminal identity through', () => {
+  it('does not let the terminal identity through a viewer-gated hook', () => {
     const viewerGate = requireMinimumRole(ROLES.VIEWER, 'read data');
-    // Without the guard, this does NOT throw — the terminal token would reach
-    // the service handler with viewer-level access.
-    expect(() => viewerGate(ctx(terminalUser))).not.toThrow();
-    expect(viewerGate(ctx(terminalUser))).toBeDefined();
+    expect(() => viewerGate(ctx(terminalUser))).toThrow(Forbidden);
+    expect(() => viewerGate(ctx(terminalUser))).toThrow(/viewer access/);
   });
 
-  it('THE FIX: the guard rejects the terminal identity outright', async () => {
+  it('the transport guard still rejects the terminal identity outright', async () => {
     await expect(rejectTerminalExecutorIdentity(ctx(terminalUser))).rejects.toBeInstanceOf(
       Forbidden
     );

--- a/apps/agor-daemon/src/auth/terminal-executor-guard.ts
+++ b/apps/agor-daemon/src/auth/terminal-executor-guard.ts
@@ -5,11 +5,10 @@
  * authenticates ONLY the Socket.IO terminal channel — those events are handled
  * in socketio.ts, outside Feathers, and are gated on `terminal_user_id`.
  *
- * As a REST/Feathers identity it must be REJECTED, not merely under-privileged:
- * its `role: 'terminal-executor'` is not a key in the RBAC rank table, so
- * `hasMinimumRole()` falls through to rank 0 (== viewer) and it would otherwise
- * pass `requireAuth` and any viewer-gated check. "Low" is not "none"; we make it
- * "none" here by rejecting the request outright at the shared auth chokepoint.
+ * As a REST/Feathers identity it must be REJECTED, not merely under-privileged.
+ * The canonical RBAC helpers fail closed for this non-user role, and this guard
+ * independently rejects it at the shared auth chokepoint so a future change to
+ * role comparison cannot accidentally turn a terminal token into an API user.
  */
 
 import { Forbidden } from '@agor/core/feathers';

--- a/apps/agor-daemon/src/auth/token-invalidation.test.ts
+++ b/apps/agor-daemon/src/auth/token-invalidation.test.ts
@@ -130,18 +130,27 @@ async function createUser(service: UsersService, email: string): Promise<User> {
 
 dbTest('redacts token invalidation marker from external user service responses', async ({ db }) => {
   const usersService = createUsersService(db);
+  const admin = await usersService.create({
+    email: 'redaction-admin@example.test',
+    password: 'password-1234',
+    role: ROLES.ADMIN,
+  });
+  const adminParams = {
+    provider: 'rest',
+    user: { user_id: admin.user_id, email: admin.email, role: admin.role },
+  };
   const user = await createUser(usersService, 'redacted-users@example.test');
 
   const createResult = await usersService.create(
     { email: 'redacted-create@example.test', password: 'password-1234', role: ROLES.MEMBER },
-    { provider: 'rest' }
+    adminParams
   );
   expectNoTokenMarker(createResult);
 
   const patchResult = await usersService.patch(
     user.user_id,
     { password: 'new-password-1234' },
-    { provider: 'rest' }
+    adminParams
   );
   expectNoTokenMarker(patchResult);
 
@@ -152,7 +161,7 @@ dbTest('redacts token invalidation marker from external user service responses',
   expectNoTokenMarker(getResult);
 
   const findResult = await usersService.find({ provider: 'rest' });
-  expect(findResult.data).toHaveLength(2);
+  expect(findResult.data).toHaveLength(3);
   for (const publicUser of findResult.data) {
     expectNoTokenMarker(publicUser);
   }
@@ -257,6 +266,11 @@ dbTest(
       usersService,
     });
     const target = await createUser(usersService, 'admin-reset-target@example.test');
+    const admin = await usersService.create({
+      email: 'admin@example.test',
+      password: 'admin-password-1234',
+      role: ROLES.ADMIN,
+    });
     const issuedBefore = Date.now() - 10_000;
     const oldTokens = issueRuntimeTokenPair(
       target,
@@ -272,7 +286,7 @@ dbTest(
       {
         provider: 'rest',
         authenticated: true,
-        user: { user_id: 'admin-user' as UserID, email: 'admin@example.test', role: ROLES.ADMIN },
+        user: { user_id: admin.user_id, email: admin.email, role: admin.role },
       }
     );
 

--- a/apps/agor-daemon/src/register-hooks.test.ts
+++ b/apps/agor-daemon/src/register-hooks.test.ts
@@ -396,6 +396,73 @@ describe('tenant-owned service registration', () => {
   });
 });
 
+describe('registered board admin authority', () => {
+  type RegisteredHook = (context: HookContext) => HookContext | Promise<HookContext>;
+  type RegisteredHooks = {
+    before?: Partial<Record<'patch', RegisteredHook[]>>;
+  };
+
+  const captureBoardHooks = (allowSuperadmin: boolean): RegisteredHooks[] => {
+    const registrations: RegisteredHooks[] = [];
+    const app = {
+      service(path: string) {
+        return {
+          hooks(hooks: RegisteredHooks) {
+            if (path.replace(/^\//, '') === 'boards') registrations.push(hooks);
+          },
+        };
+      },
+      use() {},
+      publish() {},
+    };
+
+    registerHooks({
+      db: {} as RegisterHooksContext['db'],
+      app: app as RegisterHooksContext['app'],
+      config: {
+        database: { dialect: 'sqlite' },
+        multi_tenancy: { mode: 'static', static_tenant_id: 'registration-test' },
+        execution: { branch_rbac: true },
+      } as RegisterHooksContext['config'],
+      jwtSecret: 'registration-test-secret',
+      requireAuth: async (context) => context,
+      superadminOpts: { allowSuperadmin },
+      sessionsService: {} as RegisterHooksContext['sessionsService'],
+      messagesService: {} as RegisterHooksContext['messagesService'],
+      boardsService: undefined,
+      branchRepository: {} as RegisterHooksContext['branchRepository'],
+      usersRepository: {} as RegisterHooksContext['usersRepository'],
+      sessionsRepository: {} as RegisterHooksContext['sessionsRepository'],
+      deployment: { mode: 'standalone' },
+    });
+
+    return registrations;
+  };
+
+  it('preserves ordinary board-admin authority for superadmins when bypass is disabled', async () => {
+    const context = {
+      path: 'boards',
+      method: 'patch',
+      id: 'board-1',
+      data: { name: 'Renamed' },
+      params: {
+        provider: 'rest',
+        user: { user_id: 'super-1', role: 'superadmin' },
+      },
+    } as HookContext;
+
+    const registrations = captureBoardHooks(false);
+    expect(registrations).not.toHaveLength(0);
+    for (const registration of registrations) {
+      for (const hook of registration.before?.patch ?? []) {
+        await hook(context);
+      }
+    }
+
+    expect(context).toBeDefined();
+  });
+});
+
 describe('shouldValidateRepoEnvironmentPayload', () => {
   it('skips absent repo environment payloads', () => {
     expect(shouldValidateRepoEnvironmentPayload(undefined)).toBe(false);

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -968,9 +968,6 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     return context;
   };
 
-  // Helper to get usersService from app
-  const usersService = app.service('users');
-
   /**
    * Authorization chain shared by the two externally-initiated prompt writes,
    * `messages.create` and `tasks.create`.
@@ -2263,115 +2260,13 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         },
       ],
       get: [authorizeUsersGet],
-      create: [
-        (context) => protectFilesystemHomeWrite(context, config),
-        async (context: HookContext<Board>) => {
-          const params = context.params as AuthenticatedParams;
-
-          if (!params.provider) {
-            return context;
-          }
-
-          const existing = (await usersService.find({ query: { $limit: 1 } })) as Paginated<User>;
-          if (existing.total > 0) {
-            ensureMinimumRole(params, ROLES.ADMIN, 'create users');
-          }
-
-          // Only superadmins can create superadmin users
-          // Guard both 'superadmin' and legacy 'owner' to prevent bypass
-          // Cast to include 'owner' for legacy client compatibility (UserRole excludes 'owner')
-          const data = context.data as Partial<Omit<User, 'role'> & { role?: string }>;
-          if (hasMinimumRole(data?.role, ROLES.SUPERADMIN)) {
-            const callerRole = params.user?.role;
-            if (!hasMinimumRole(callerRole, ROLES.SUPERADMIN)) {
-              throw new Forbidden('Only superadmins can create superadmin users');
-            }
-          }
-
-          return context;
-        },
-      ],
-      patch: [
-        (context) => protectFilesystemHomeWrite(context, config),
-        async (context) => {
-          const params = context.params as AuthenticatedParams;
-          const userId = context.id as string;
-          const callerRole = params.user?.role;
-          const callerIsAdmin = hasMinimumRole(callerRole, ROLES.ADMIN);
-
-          // Field-level restrictions: only admins can modify unix_username, role, and must_change_password.
-          // filesystem_home is protected and validated by the preceding hook.
-          if (!Array.isArray(context.data)) {
-            if (context.data?.unix_username !== undefined) {
-              if (!callerIsAdmin) {
-                throw new Forbidden('Only admins can modify unix_username');
-              }
-            }
-            if (context.data?.role !== undefined) {
-              if (!callerIsAdmin) {
-                throw new Forbidden('Only admins can modify user roles');
-              }
-              // Only superadmins can assign the superadmin role
-              // Guard both 'superadmin' and legacy 'owner' to prevent bypass
-              if (
-                hasMinimumRole(context.data.role, ROLES.SUPERADMIN) &&
-                !hasMinimumRole(callerRole, ROLES.SUPERADMIN)
-              ) {
-                // Bootstrap: allow first superadmin promotion if none exist yet
-                // Note: usersService.find() doesn't filter by role, so filter in JS
-                const allUsers = (await usersService.find({})) as Paginated<User>;
-                const hasSuperadmin = allUsers.data.some((u) => u.role === ROLES.SUPERADMIN);
-                if (hasSuperadmin) {
-                  throw new Forbidden('Only superadmins can assign the superadmin role');
-                }
-              }
-            }
-            if (context.data?.must_change_password !== undefined) {
-              if (!callerIsAdmin) {
-                throw new Forbidden('Only admins can force password changes');
-              }
-            }
-          }
-
-          // General authorization: admins can patch any user
-          if (callerIsAdmin) {
-            return context;
-          }
-
-          // Any authenticated user can update their own profile (except unix_username and role, checked above)
-          if (params.user && params.user.user_id === userId) {
-            return context;
-          }
-
-          // Env-var-specific trusted write escape hatch. Set ONLY by the widget
-          // submit path, which has already authorized the caller via
-          // `canResolveWidget` (session-creator OR prompt-tier branch RBAC)
-          // before calling users.patch on the session creator's behalf.
-          //
-          // Deliberately narrow: only allows `env_vars` + `env_var_scopes`
-          // fields — any attempt to slip in other fields (e.g. role, unix_username)
-          // throws immediately. Field-level admin gates above run first and are
-          // NOT bypassed regardless.
-          //
-          // Grep for: trustedEnvVarWrite — to audit every site that sets it.
-          if (
-            !context.params.provider &&
-            (params as { trustedEnvVarWrite?: boolean }).trustedEnvVarWrite === true
-          ) {
-            const keys = Object.keys(context.data ?? {});
-            if (!keys.every((k) => k === 'env_vars' || k === 'env_var_scopes')) {
-              throw new Forbidden(
-                'trustedEnvVarWrite only permits env_vars and env_var_scopes updates'
-              );
-            }
-            return context;
-          }
-
-          // Otherwise forbidden
-          throw new Forbidden('You can only update your own profile');
-        },
-      ],
-      remove: [requireMinimumRole(ROLES.ADMIN, 'delete users')],
+      // UsersService owns target-aware role authorization. Keeping it in the
+      // mutation methods means REST, Socket.IO, MCP, and direct Feathers calls
+      // all compare the fresh actor role with both the target's current role
+      // and any requested role. Hooks remain responsible for transport
+      // validation only and cannot accidentally become an alternate bypass.
+      create: [(context) => protectFilesystemHomeWrite(context, config)],
+      patch: [(context) => protectFilesystemHomeWrite(context, config)],
     },
     after: {
       // Refresh derived profile presentation after user creation or update.
@@ -2851,8 +2746,9 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       const user = context.params.user;
       if (!user) throw new NotAuthenticated('Authentication required');
       if (user._isServiceAccount) return context;
-      const allowSuperadmin = superadminOpts?.allowSuperadmin ?? true;
-      if (user.role === ROLES.ADMIN || (allowSuperadmin && user.role === ROLES.SUPERADMIN)) {
+      // `allow_superadmin` controls the exceptional branch/board RBAC bypass;
+      // it must never strip ordinary admin authority from a superadmin.
+      if (hasMinimumRole(user.role, ROLES.ADMIN)) {
         return context;
       }
 

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -4238,6 +4238,9 @@ async function bootstrapSuperadminUsers(
       // biome-ignore lint/suspicious/noExplicitAny: userId is a branded UserID at runtime
       const user = await usersService.get(userId as any);
       if (user.role === ROLES.SUPERADMIN) continue;
+      // Deliberately use the provider-less, actor-less UsersService seam. This
+      // is daemon startup provisioning from operator-owned config, not a user
+      // request; request-derived callers must always carry actor params.
       // biome-ignore lint/suspicious/noExplicitAny: userId is a branded UserID at runtime
       await usersService.patch(userId as any, { role: ROLES.SUPERADMIN });
       promotedCount++;

--- a/apps/agor-daemon/src/services/groups.test.ts
+++ b/apps/agor-daemon/src/services/groups.test.ts
@@ -1,14 +1,17 @@
-import type { BranchRepository } from '@agor/core/db';
-import type { HookContext } from '@agor/core/types';
+import { type BranchRepository, GroupRepository } from '@agor/core/db';
+import type { AuthenticatedParams, HookContext, User } from '@agor/core/types';
 import { ROLES } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
+import { dbTest } from '../../../../packages/core/src/db/test-helpers';
 import {
   assertBranchGroupGrantPermissionLevel,
   branchGroupGrantPermissionLevelOrDefault,
+  createGroupMembershipsService,
   groupMembershipsHooks,
   groupsHooks,
   requireBranchGrantManager,
 } from './groups';
+import { UsersService } from './users';
 
 function contextFor(role?: string, extraUser: Record<string, unknown> = {}): HookContext {
   return {
@@ -70,6 +73,52 @@ describe('groups service authorization hooks', () => {
     expect(() => groupsHooks.before.all[0](context)).not.toThrow();
     expect(() => groupsHooks.before.create[0](context)).not.toThrow();
     expect(() => groupMembershipsHooks.before.all[0](context)).not.toThrow();
+  });
+});
+
+describe('group membership target authority', () => {
+  dbTest('enforces actor authority over the membership target', async ({ db }) => {
+    const users = new UsersService(db);
+    const memberships = createGroupMembershipsService(db);
+    const group = await new GroupRepository(db).create({ name: 'Authority group' });
+    const superadmin = await users.create({
+      email: 'group-superadmin@example.test',
+      password: 'password-1234',
+      role: 'superadmin',
+    });
+    const admin = await users.create({
+      email: 'group-admin@example.test',
+      password: 'password-1234',
+      role: 'admin',
+    });
+    const member = await users.create({
+      email: 'group-member@example.test',
+      password: 'password-1234',
+      role: 'member',
+    });
+    const params = (actor: User): AuthenticatedParams => ({
+      provider: 'rest',
+      user: { user_id: actor.user_id, email: actor.email, role: actor.role },
+    });
+
+    await expect(
+      memberships.create({ group_id: group.group_id, user_id: superadmin.user_id }, params(admin))
+    ).rejects.toMatchObject({ code: 403 });
+
+    await memberships.create({ group_id: group.group_id, user_id: superadmin.user_id });
+    await expect(
+      memberships.remove(superadmin.user_id, {
+        ...params(admin),
+        query: { group_id: group.group_id },
+      })
+    ).rejects.toMatchObject({ code: 403 });
+
+    await expect(
+      memberships.create({ group_id: group.group_id, user_id: admin.user_id }, params(superadmin))
+    ).resolves.toMatchObject({ user_id: admin.user_id });
+    await expect(
+      memberships.create({ group_id: group.group_id, user_id: member.user_id }, params(admin))
+    ).resolves.toMatchObject({ user_id: member.user_id });
   });
 });
 

--- a/apps/agor-daemon/src/services/groups.test.ts
+++ b/apps/agor-daemon/src/services/groups.test.ts
@@ -1,4 +1,8 @@
-import { type BranchRepository, GroupRepository } from '@agor/core/db';
+import {
+  type BranchRepository,
+  GroupRepository,
+  getCurrentTenantDatabaseScope,
+} from '@agor/core/db';
 import type { AuthenticatedParams, HookContext, User } from '@agor/core/types';
 import { ROLES } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
@@ -100,15 +104,31 @@ describe('group membership target authority', () => {
       provider: 'rest',
       user: { user_id: actor.user_id, email: actor.email, role: actor.role },
     });
+    const directParams = (actor: User): AuthenticatedParams =>
+      ({
+        user: { user_id: actor.user_id, email: actor.email, role: actor.role },
+      }) as AuthenticatedParams;
 
     await expect(
       memberships.create({ group_id: group.group_id, user_id: superadmin.user_id }, params(admin))
+    ).rejects.toMatchObject({ code: 403 });
+    await expect(
+      memberships.create(
+        { group_id: group.group_id, user_id: superadmin.user_id },
+        directParams(admin)
+      )
     ).rejects.toMatchObject({ code: 403 });
 
     await memberships.create({ group_id: group.group_id, user_id: superadmin.user_id });
     await expect(
       memberships.remove(superadmin.user_id, {
         ...params(admin),
+        query: { group_id: group.group_id },
+      })
+    ).rejects.toMatchObject({ code: 403 });
+    await expect(
+      memberships.remove(superadmin.user_id, {
+        ...directParams(admin),
         query: { group_id: group.group_id },
       })
     ).rejects.toMatchObject({ code: 403 });
@@ -120,6 +140,43 @@ describe('group membership target authority', () => {
       memberships.create({ group_id: group.group_id, user_id: member.user_id }, params(admin))
     ).resolves.toMatchObject({ user_id: member.user_id });
   });
+
+  dbTest(
+    'keeps the authority decision and membership write in one SQLite transaction',
+    async ({ db }) => {
+      const users = new UsersService(db);
+      const memberships = createGroupMembershipsService(db);
+      const group = await new GroupRepository(db).create({ name: 'Atomic authority group' });
+      const admin = await users.create({
+        email: 'atomic-group-admin@example.test',
+        password: 'password-1234',
+        role: 'admin',
+      });
+      const member = await users.create({
+        email: 'atomic-group-member@example.test',
+        password: 'password-1234',
+        role: 'member',
+      });
+      const addMember = GroupRepository.prototype.addMember;
+      const transactionStates: Array<boolean | undefined> = [];
+      const addMemberSpy = vi
+        .spyOn(GroupRepository.prototype, 'addMember')
+        .mockImplementation(function (...args) {
+          transactionStates.push(getCurrentTenantDatabaseScope()?.transactionActive);
+          return addMember.apply(this, args);
+        });
+
+      try {
+        await memberships.create({ group_id: group.group_id, user_id: member.user_id }, {
+          user: { user_id: admin.user_id, email: admin.email, role: admin.role },
+        } as AuthenticatedParams);
+      } finally {
+        addMemberSpy.mockRestore();
+      }
+
+      expect(transactionStates).toEqual([true]);
+    }
+  );
 });
 
 describe('branch group grant permission validation', () => {

--- a/apps/agor-daemon/src/services/groups.ts
+++ b/apps/agor-daemon/src/services/groups.ts
@@ -9,8 +9,10 @@ import {
   BoardRepository,
   eq,
   GroupRepository,
+  runWithTenantDatabaseTransaction,
   select,
   type TenantScopeAwareDatabase,
+  type TenantScopedDatabase,
   users,
 } from '@agor/core/db';
 import { BadRequest, Forbidden, NotAuthenticated } from '@agor/core/feathers';
@@ -140,21 +142,28 @@ export function createGroupsService(db: TenantScopeAwareDatabase) {
 export function createGroupMembershipsService(db: TenantScopeAwareDatabase) {
   const repo = new GroupRepository(db);
 
-  const assertCanManageMembershipTarget = async (userId: string, params?: Params) => {
-    if (!params?.provider) return;
-    const authenticated = params as AuthenticatedParams;
-    if (authenticated.user?._isServiceAccount) return;
-    const actorId = authenticated.user?.user_id;
+  const assertCanManageMembershipTarget = async (
+    operationDb: TenantScopedDatabase,
+    userId: string,
+    params?: Params
+  ) => {
+    const authenticated = params as AuthenticatedParams | undefined;
+    // Actor-less provider-less calls are the explicit trusted provisioning
+    // seam. A provider-less call that carries a human actor is still a user
+    // action and must not acquire internal-call authority by changing transport.
+    if (!params?.provider && !authenticated?.user) return;
+    if (authenticated?.user?._isServiceAccount) return;
+    const actorId = authenticated?.user?.user_id;
     if (!actorId) throw new NotAuthenticated('Authentication required');
 
-    await lockUserAuthorityMutation(db, params);
+    await lockUserAuthorityMutation(operationDb, params);
 
     // Load both sides under the active tenant/RLS scope. Missing and
     // cross-tenant targets intentionally produce the same response as an
     // authority failure so this write path cannot enumerate identities.
     const [actor, target] = await Promise.all([
-      select(db).from(users).where(eq(users.user_id, actorId)).one(),
-      select(db).from(users).where(eq(users.user_id, userId)).one(),
+      select(operationDb).from(users).where(eq(users.user_id, actorId)).one(),
+      select(operationDb).from(users).where(eq(users.user_id, userId)).one(),
     ]);
     if (
       !actor ||
@@ -177,13 +186,20 @@ export function createGroupMembershipsService(db: TenantScopeAwareDatabase) {
       data: { group_id?: string; user_id?: string },
       params?: Params
     ): Promise<GroupMembership> {
-      if (!data.group_id || !data.user_id)
-        throw new BadRequest('group_id and user_id are required');
-      await assertCanManageMembershipTarget(data.user_id, params);
-      return repo.addMember(
-        data.group_id,
-        data.user_id,
-        paramsUser(params)?.user_id as UserID | undefined
+      const groupId = data.group_id;
+      const userId = data.user_id;
+      if (!groupId || !userId) throw new BadRequest('group_id and user_id are required');
+      return runWithTenantDatabaseTransaction(
+        db,
+        (params as AuthenticatedParams | undefined)?.tenant?.tenant_id,
+        async (operationDb) => {
+          await assertCanManageMembershipTarget(operationDb, userId, params);
+          return new GroupRepository(operationDb).addMember(
+            groupId,
+            userId,
+            paramsUser(params)?.user_id as UserID | undefined
+          );
+        }
       );
     },
     async remove(id: string, params?: Params): Promise<GroupMembership> {
@@ -192,10 +208,16 @@ export function createGroupMembershipsService(db: TenantScopeAwareDatabase) {
         (paramsRoute(params)?.groupId as string | undefined);
       const userId = (params?.query?.user_id as string | undefined) || id;
       if (!groupId || !userId) throw new BadRequest('group_id and user_id are required');
-      await assertCanManageMembershipTarget(userId, params);
-      const removed = await repo.removeMember(groupId, userId);
-      if (!removed) throw new BadRequest(`Membership not found: ${groupId}/${userId}`);
-      return removed;
+      return runWithTenantDatabaseTransaction(
+        db,
+        (params as AuthenticatedParams | undefined)?.tenant?.tenant_id,
+        async (operationDb) => {
+          await assertCanManageMembershipTarget(operationDb, userId, params);
+          const removed = await new GroupRepository(operationDb).removeMember(groupId, userId);
+          if (!removed) throw new BadRequest(`Membership not found: ${groupId}/${userId}`);
+          return removed;
+        }
+      );
     },
   };
 }

--- a/apps/agor-daemon/src/services/groups.ts
+++ b/apps/agor-daemon/src/services/groups.ts
@@ -5,9 +5,17 @@
  */
 
 import type { BranchRepository } from '@agor/core/db';
-import { BoardRepository, GroupRepository, type TenantScopeAwareDatabase } from '@agor/core/db';
+import {
+  BoardRepository,
+  eq,
+  GroupRepository,
+  select,
+  type TenantScopeAwareDatabase,
+  users,
+} from '@agor/core/db';
 import { BadRequest, Forbidden, NotAuthenticated } from '@agor/core/feathers';
 import type {
+  AuthenticatedParams,
   BoardGroupGrantWithGroup,
   BoardID,
   Branch,
@@ -22,8 +30,14 @@ import type {
   User,
   UserID,
 } from '@agor/core/types';
-import { BRANCH_PERMISSION_LEVELS, hasMinimumRole, ROLES } from '@agor/core/types';
+import {
+  BRANCH_PERMISSION_LEVELS,
+  hasMinimumRole,
+  hasRoleAuthorityOver,
+  ROLES,
+} from '@agor/core/types';
 import { PERMISSION_RANK } from '../utils/branch-authorization.js';
+import { lockUserAuthorityMutation } from './user-authority-lock.js';
 
 function requireMember(context: HookContext): HookContext {
   if (!context.params.provider) return context;
@@ -125,6 +139,33 @@ export function createGroupsService(db: TenantScopeAwareDatabase) {
 
 export function createGroupMembershipsService(db: TenantScopeAwareDatabase) {
   const repo = new GroupRepository(db);
+
+  const assertCanManageMembershipTarget = async (userId: string, params?: Params) => {
+    if (!params?.provider) return;
+    const authenticated = params as AuthenticatedParams;
+    if (authenticated.user?._isServiceAccount) return;
+    const actorId = authenticated.user?.user_id;
+    if (!actorId) throw new NotAuthenticated('Authentication required');
+
+    await lockUserAuthorityMutation(db, params);
+
+    // Load both sides under the active tenant/RLS scope. Missing and
+    // cross-tenant targets intentionally produce the same response as an
+    // authority failure so this write path cannot enumerate identities.
+    const [actor, target] = await Promise.all([
+      select(db).from(users).where(eq(users.user_id, actorId)).one(),
+      select(db).from(users).where(eq(users.user_id, userId)).one(),
+    ]);
+    if (
+      !actor ||
+      !target ||
+      !hasMinimumRole(actor.role, ROLES.ADMIN) ||
+      !hasRoleAuthorityOver(actor.role, target.role)
+    ) {
+      throw new Forbidden('You do not have authority to manage this user');
+    }
+  };
+
   return {
     async find(params?: Params): Promise<GroupMembership[]> {
       return repo.listMemberships({
@@ -138,6 +179,7 @@ export function createGroupMembershipsService(db: TenantScopeAwareDatabase) {
     ): Promise<GroupMembership> {
       if (!data.group_id || !data.user_id)
         throw new BadRequest('group_id and user_id are required');
+      await assertCanManageMembershipTarget(data.user_id, params);
       return repo.addMember(
         data.group_id,
         data.user_id,
@@ -150,6 +192,7 @@ export function createGroupMembershipsService(db: TenantScopeAwareDatabase) {
         (paramsRoute(params)?.groupId as string | undefined);
       const userId = (params?.query?.user_id as string | undefined) || id;
       if (!groupId || !userId) throw new BadRequest('group_id and user_id are required');
+      await assertCanManageMembershipTarget(userId, params);
       const removed = await repo.removeMember(groupId, userId);
       if (!removed) throw new BadRequest(`Membership not found: ${groupId}/${userId}`);
       return removed;

--- a/apps/agor-daemon/src/services/user-authority-lock.ts
+++ b/apps/agor-daemon/src/services/user-authority-lock.ts
@@ -1,0 +1,40 @@
+import {
+  executeRaw,
+  getCurrentTenantDatabaseScope,
+  isPostgresDatabaseHandle,
+  sql,
+  type TenantScopeAwareDatabase,
+} from '@agor/core/db';
+import type { AuthenticatedParams, Params } from '@agor/core/types';
+
+const USER_AUTHORITY_LOCK_NAMESPACE = 'agor:user-role-authority:v1';
+
+/**
+ * Serialize human user-authority decisions within one PostgreSQL tenant.
+ *
+ * Callers must already be inside the request's tenant transaction. Sharing
+ * this lock between user CRUD and related access mutations prevents a role
+ * demotion from racing an operation authorized by the actor's previous role.
+ * SQLite's write transaction supplies the equivalent serialization.
+ */
+export async function lockUserAuthorityMutation(
+  db: TenantScopeAwareDatabase,
+  params?: Params
+): Promise<void> {
+  const user = (params as AuthenticatedParams | undefined)?.user;
+  if (!user || user._isServiceAccount || !isPostgresDatabaseHandle(db)) return;
+
+  const scope = getCurrentTenantDatabaseScope();
+  if (scope?.kind !== 'tenant' || !scope.transactionActive) {
+    throw new Error('User authority mutations require an active tenant transaction');
+  }
+  const tenantId = (params as AuthenticatedParams | undefined)?.tenant?.tenant_id;
+  if (!scope.tenantId || (tenantId && tenantId !== scope.tenantId)) {
+    throw new Error('User authority mutation tenant does not match the active transaction');
+  }
+  const lockKey = `${USER_AUTHORITY_LOCK_NAMESPACE}:${scope.tenantId}`;
+  await executeRaw(
+    db,
+    sql`SELECT pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtextextended(${lockKey}, 0))`
+  );
+}

--- a/apps/agor-daemon/src/services/user-authority-lock.ts
+++ b/apps/agor-daemon/src/services/user-authority-lock.ts
@@ -4,6 +4,7 @@ import {
   isPostgresDatabaseHandle,
   sql,
   type TenantScopeAwareDatabase,
+  type TenantScopedDatabase,
 } from '@agor/core/db';
 import type { AuthenticatedParams, Params } from '@agor/core/types';
 
@@ -15,10 +16,11 @@ const USER_AUTHORITY_LOCK_NAMESPACE = 'agor:user-role-authority:v1';
  * Callers must already be inside the request's tenant transaction. Sharing
  * this lock between user CRUD and related access mutations prevents a role
  * demotion from racing an operation authorized by the actor's previous role.
- * SQLite's write transaction supplies the equivalent serialization.
+ * SQLite callers obtain equivalent serialization by running the complete
+ * authority decision and write in an immediate tenant database transaction.
  */
 export async function lockUserAuthorityMutation(
-  db: TenantScopeAwareDatabase,
+  db: TenantScopeAwareDatabase | TenantScopedDatabase,
   params?: Params
 ): Promise<void> {
   const user = (params as AuthenticatedParams | undefined)?.user;

--- a/apps/agor-daemon/src/services/user-avatar-sync.ts
+++ b/apps/agor-daemon/src/services/user-avatar-sync.ts
@@ -17,6 +17,7 @@ import type {
   UserID,
 } from '@agor/core/types';
 import { hasMinimumRole, ROLES } from '@agor/core/types';
+import { markTrustedUserMutation } from './user-mutation-trust.js';
 
 const NAMESPACE = 'user_avatars';
 const SETTINGS_KEY = 'settings';
@@ -151,8 +152,18 @@ export class UserAvatarSyncManager {
     const allUsers = await this.users.findAll();
     const slackUsers = allUsers.filter((user) => user.avatar_source === 'slack');
     await Promise.all(
-      slackUsers.map((user) =>
-        this.app.service('users').patch(
+      slackUsers.map((user) => {
+        const mutationParams = {
+          skipAvatarRefresh: true,
+          user: {
+            user_id: 'user-avatars-service',
+            email: 'user-avatars@agor.internal',
+            role: ROLES.ADMIN,
+            _isServiceAccount: true,
+          },
+        } as Params;
+        markTrustedUserMutation(mutationParams, 'avatar-sync');
+        return this.app.service('users').patch(
           user.user_id,
           {
             avatar_url: null,
@@ -161,17 +172,9 @@ export class UserAvatarSyncManager {
             avatar_source_id: null,
             avatar_synced_at: null,
           } as unknown as Partial<User>,
-          {
-            skipAvatarRefresh: true,
-            user: {
-              user_id: 'user-avatars-service',
-              email: 'user-avatars@agor.internal',
-              role: ROLES.ADMIN,
-              _isServiceAccount: true,
-            },
-          } as Params
-        )
-      )
+          mutationParams
+        );
+      })
     );
   }
 
@@ -274,6 +277,16 @@ export class UserAvatarSyncManager {
         return { matched: 1, updated: 0, skipped: 1, failed: 0, failures: [] };
       }
 
+      const mutationParams = {
+        skipAvatarRefresh: true,
+        user: {
+          user_id: 'user-avatars-service',
+          email: 'user-avatars@agor.internal',
+          role: ROLES.ADMIN,
+          _isServiceAccount: true,
+        },
+      } as Params;
+      markTrustedUserMutation(mutationParams, 'avatar-sync');
       await this.app.service('users').patch(
         user.user_id,
         {
@@ -282,19 +295,7 @@ export class UserAvatarSyncManager {
           avatar_source_id: profile.slackUserId,
           avatar_synced_at: new Date().toISOString(),
         } as Partial<User>,
-        {
-          skipAvatarRefresh: true,
-          // users.patch has field-level/profile ownership hooks even for
-          // internal calls. Avatar sync is an admin-only service action, so
-          // carry an internal service user through the hook chain rather than
-          // bypassing the users service and losing Feathers events.
-          user: {
-            user_id: 'user-avatars-service',
-            email: 'user-avatars@agor.internal',
-            role: ROLES.ADMIN,
-            _isServiceAccount: true,
-          },
-        } as Params
+        mutationParams
       );
 
       return { matched: 1, updated: 1, skipped: 0, failed: 0, failures: [] };

--- a/apps/agor-daemon/src/services/user-mutation-trust.ts
+++ b/apps/agor-daemon/src/services/user-mutation-trust.ts
@@ -1,0 +1,26 @@
+import type { Params } from '@agor/core/types';
+
+export type TrustedUserMutationPurpose = 'avatar-sync' | 'env-vars-widget';
+
+const TRUSTED_USER_MUTATION_PARAM = Symbol('agor.users.trusted-mutation');
+
+interface TrustedUserMutationParams extends Params {
+  [TRUSTED_USER_MUTATION_PARAM]?: TrustedUserMutationPurpose;
+}
+
+/**
+ * Mark a narrowly-scoped in-process users.patch call.
+ *
+ * A symbol is intentionally used instead of a serializable parameter so REST,
+ * Socket.IO, and MCP callers cannot forge a trusted mutation purpose.
+ */
+export function markTrustedUserMutation(params: Params, purpose: TrustedUserMutationPurpose): void {
+  (params as TrustedUserMutationParams)[TRUSTED_USER_MUTATION_PARAM] = purpose;
+}
+
+export function getTrustedUserMutationPurpose(
+  params: Params | undefined
+): TrustedUserMutationPurpose | undefined {
+  if (!params || params.provider) return undefined;
+  return (params as TrustedUserMutationParams)[TRUSTED_USER_MUTATION_PARAM];
+}

--- a/apps/agor-daemon/src/services/users.authority.postgres.test.ts
+++ b/apps/agor-daemon/src/services/users.authority.postgres.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Production-shaped role-authority coverage. The shared PostgreSQL runner
+ * supplies a disposable non-superuser, NOBYPASSRLS role.
+ */
+
+import {
+  createDatabase,
+  createTenantScopedDatabaseProxy,
+  type Database,
+  executeRaw,
+  generateId,
+  initializeDatabase,
+  isPostgresDatabase,
+  runWithTenantDatabaseScope,
+  sql,
+  type TenantScopeAwareDatabase,
+  UsersRepository,
+} from '@agor/core/db';
+import type { AuthenticatedParams, User, UserID, UserRole } from '@agor/core/types';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { UsersService } from './users.js';
+
+const postgresUrl = process.env.AGOR_TEST_POSTGRES_URL;
+const usesPostgresSchema = process.env.AGOR_DB_DIALECT === 'postgresql';
+
+function rowsOf(result: unknown): Array<Record<string, unknown>> {
+  if (Array.isArray(result)) return result as Array<Record<string, unknown>>;
+  const rows = (result as { rows?: unknown[] } | undefined)?.rows;
+  return Array.isArray(rows) ? (rows as Array<Record<string, unknown>>) : [];
+}
+
+describe.skipIf(!postgresUrl || !usesPostgresSchema)(
+  'UsersService role authority (PostgreSQL/RLS)',
+  () => {
+    let rawDb: Database;
+    let db: TenantScopeAwareDatabase;
+
+    beforeAll(async () => {
+      rawDb = createDatabase({ dialect: 'postgresql', url: postgresUrl! });
+      await initializeDatabase(rawDb);
+      if (!isPostgresDatabase(rawDb)) throw new Error('PostgreSQL test requires PostgreSQL');
+      const [role] = rowsOf(
+        await executeRaw(
+          rawDb,
+          sql`SELECT rolsuper, rolbypassrls FROM pg_roles WHERE rolname = current_user`
+        )
+      );
+      expect(role).toMatchObject({ rolsuper: false, rolbypassrls: false });
+      db = createTenantScopedDatabaseProxy(rawDb, {
+        requireScope: true,
+        label: 'users-authority-test',
+      });
+    }, 60_000);
+
+    afterAll(async () => {
+      await (rawDb as Database & { $client: { end: () => Promise<void> } }).$client.end();
+    });
+
+    async function seed(tenantId: string, role: UserRole, label: string): Promise<User> {
+      return runWithTenantDatabaseScope(db, tenantId, (scoped) =>
+        new UsersRepository(scoped).create({
+          email: `${label}-${generateId()}@example.test`,
+          name: label,
+          role,
+        })
+      ) as Promise<User>;
+    }
+
+    function params(actor: User, tenantId: string): AuthenticatedParams {
+      return {
+        provider: 'rest',
+        user: { user_id: actor.user_id, email: actor.email, role: actor.role },
+        tenant: { tenant_id: tenantId, source: 'auth_claim' },
+      };
+    }
+
+    it('enforces hierarchy inside a tenant and hides cross-tenant targets', async () => {
+      const tenantA = `users-authority-a-${generateId()}`;
+      const tenantB = `users-authority-b-${generateId()}`;
+      const superadminA = await seed(tenantA, 'superadmin', 'superadmin-a');
+      const adminA = await seed(tenantA, 'admin', 'admin-a');
+      const memberA = await seed(tenantA, 'member', 'member-a');
+      const superadminB = await seed(tenantB, 'superadmin', 'superadmin-b');
+      const service = new UsersService(db);
+
+      await runWithTenantDatabaseScope(db, tenantA, async () => {
+        await expect(
+          service.patch(
+            superadminA.user_id as UserID,
+            { password: 'forbidden-reset' },
+            params(adminA, tenantA)
+          )
+        ).rejects.toMatchObject({ code: 403 });
+        await expect(
+          service.patch(
+            memberA.user_id as UserID,
+            { name: 'Managed member' },
+            params(adminA, tenantA)
+          )
+        ).resolves.toMatchObject({ name: 'Managed member' });
+        await expect(
+          service.patch(
+            adminA.user_id as UserID,
+            { name: 'Managed admin' },
+            params(superadminA, tenantA)
+          )
+        ).resolves.toMatchObject({ name: 'Managed admin' });
+
+        const absentMessage = await service
+          .patch(generateId() as UserID, { name: 'missing' }, params(adminA, tenantA))
+          .catch((error: Error & { code?: number }) => ({
+            code: error.code,
+            message: error.message,
+          }));
+        const crossTenantMessage = await service
+          .patch(superadminB.user_id as UserID, { name: 'cross-tenant' }, params(adminA, tenantA))
+          .catch((error: Error & { code?: number }) => ({
+            code: error.code,
+            message: error.message,
+          }));
+        expect(crossTenantMessage).toEqual(absentMessage);
+        expect(crossTenantMessage).toMatchObject({ code: 403 });
+      });
+
+      await runWithTenantDatabaseScope(db, tenantB, async (scoped) => {
+        const visible = rowsOf(
+          await executeRaw(
+            scoped,
+            sql`SELECT user_id, name FROM users WHERE user_id = ${superadminB.user_id}`
+          )
+        );
+        expect(visible).toHaveLength(1);
+        expect(visible[0]?.name).toBe('superadmin-b');
+      });
+    });
+
+    it('serializes concurrent peer demotions and preserves a superadmin', async () => {
+      const tenantId = `users-authority-race-${generateId()}`;
+      const first = await seed(tenantId, 'superadmin', 'first-superadmin');
+      const second = await seed(tenantId, 'superadmin', 'second-superadmin');
+      const service = new UsersService(db);
+
+      const results = await Promise.allSettled([
+        runWithTenantDatabaseScope(db, tenantId, () =>
+          service.patch(second.user_id as UserID, { role: 'admin' }, params(first, tenantId))
+        ),
+        runWithTenantDatabaseScope(db, tenantId, () =>
+          service.patch(first.user_id as UserID, { role: 'admin' }, params(second, tenantId))
+        ),
+      ]);
+
+      expect(results.filter((result) => result.status === 'fulfilled')).toHaveLength(1);
+      expect(results.filter((result) => result.status === 'rejected')).toHaveLength(1);
+      await runWithTenantDatabaseScope(db, tenantId, async (scoped) => {
+        const remaining = await new UsersRepository(scoped).findAll();
+        expect(remaining.filter((user) => user.role === 'superadmin')).toHaveLength(1);
+      });
+    });
+  }
+);

--- a/apps/agor-daemon/src/services/users.authority.postgres.test.ts
+++ b/apps/agor-daemon/src/services/users.authority.postgres.test.ts
@@ -8,6 +8,7 @@ import {
   createTenantScopedDatabaseProxy,
   type Database,
   executeRaw,
+  GroupRepository,
   generateId,
   initializeDatabase,
   isPostgresDatabase,
@@ -18,6 +19,7 @@ import {
 } from '@agor/core/db';
 import type { AuthenticatedParams, User, UserID, UserRole } from '@agor/core/types';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createGroupMembershipsService } from './groups.js';
 import { UsersService } from './users.js';
 
 const postgresUrl = process.env.AGOR_TEST_POSTGRES_URL;
@@ -154,6 +156,63 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
       await runWithTenantDatabaseScope(db, tenantId, async (scoped) => {
         const remaining = await new UsersRepository(scoped).findAll();
         expect(remaining.filter((user) => user.role === 'superadmin')).toHaveLength(1);
+      });
+    });
+
+    it('enforces membership target authority for transport and direct calls under RLS', async () => {
+      const tenantId = `membership-authority-${generateId()}`;
+      const otherTenantId = `membership-authority-other-${generateId()}`;
+      const superadmin = await seed(tenantId, 'superadmin', 'membership-superadmin');
+      const admin = await seed(tenantId, 'admin', 'membership-admin');
+      const member = await seed(tenantId, 'member', 'membership-member');
+      const otherSuperadmin = await seed(
+        otherTenantId,
+        'superadmin',
+        'membership-other-superadmin'
+      );
+      const memberships = createGroupMembershipsService(db);
+
+      await runWithTenantDatabaseScope(db, tenantId, async (scoped) => {
+        const group = await new GroupRepository(scoped).create({ name: 'Membership authority' });
+        const adminParams = params(admin, tenantId);
+        const directAdminParams = {
+          ...adminParams,
+          provider: undefined,
+        } as AuthenticatedParams;
+
+        await expect(
+          memberships.create({ group_id: group.group_id, user_id: superadmin.user_id }, adminParams)
+        ).rejects.toMatchObject({ code: 403 });
+        await expect(
+          memberships.create(
+            { group_id: group.group_id, user_id: superadmin.user_id },
+            directAdminParams
+          )
+        ).rejects.toMatchObject({ code: 403 });
+        await expect(
+          memberships.create(
+            { group_id: group.group_id, user_id: otherSuperadmin.user_id },
+            adminParams
+          )
+        ).rejects.toMatchObject({ code: 403 });
+
+        await memberships.create({ group_id: group.group_id, user_id: superadmin.user_id });
+        await expect(
+          memberships.remove(superadmin.user_id, {
+            ...directAdminParams,
+            query: { group_id: group.group_id },
+          })
+        ).rejects.toMatchObject({ code: 403 });
+
+        await expect(
+          memberships.create(
+            { group_id: group.group_id, user_id: admin.user_id },
+            params(superadmin, tenantId)
+          )
+        ).resolves.toMatchObject({ user_id: admin.user_id });
+        await expect(
+          memberships.create({ group_id: group.group_id, user_id: member.user_id }, adminParams)
+        ).resolves.toMatchObject({ user_id: member.user_id });
       });
     });
   }

--- a/apps/agor-daemon/src/services/users.authority.test.ts
+++ b/apps/agor-daemon/src/services/users.authority.test.ts
@@ -1,0 +1,327 @@
+import { feathers } from '@agor/core/feathers';
+import type { AuthenticatedParams, Params, User, UserID, UserRole } from '@agor/core/types';
+import { describe, expect } from 'vitest';
+import { dbTest } from '../../../../packages/core/src/db/test-helpers';
+import { markTrustedUserMutation } from './user-mutation-trust';
+import { createUsersService, UsersService } from './users';
+
+async function createUser(service: UsersService, role: UserRole, label: string): Promise<User> {
+  return service.create({
+    email: `${label}-${Math.random().toString(36).slice(2)}@example.test`,
+    password: 'password-1234',
+    name: label,
+    role,
+  });
+}
+
+function externalParams(actor: User, provider = 'rest'): AuthenticatedParams {
+  return {
+    provider,
+    user: {
+      user_id: actor.user_id,
+      email: actor.email,
+      role: actor.role,
+    },
+  };
+}
+
+describe('UsersService role authority', () => {
+  for (const provider of ['rest', 'socketio', 'mcp']) {
+    dbTest(`denies ${provider} admins every mutation against a superadmin`, async ({ db }) => {
+      const service = new UsersService(db);
+      const superadmin = await createUser(service, 'superadmin', `superadmin-${provider}`);
+      const admin = await createUser(service, 'admin', `admin-${provider}`);
+      const params = externalParams(admin, provider);
+      await expect(
+        service.create(
+          {
+            email: `created-superadmin-${provider}@example.test`,
+            password: 'password-1234',
+            role: 'superadmin',
+          },
+          params
+        )
+      ).rejects.toMatchObject({ code: 403 });
+      const forbiddenPatches = [
+        { name: 'renamed' },
+        { email: `changed-${provider}@example.test` },
+        { role: 'member' as const },
+        { password: 'replaced-password' },
+        { unix_username: 'changed-home' },
+        { filesystem_home: '/tmp/changed-home' },
+        { must_change_password: true },
+        { preferences: { changed: true } },
+        { agentic_tools: { codex: { OPENAI_API_KEY: 'secret-key' } } },
+        { env_vars: { SECRET: 'secret-value' } },
+      ];
+
+      for (const patch of forbiddenPatches) {
+        await expect(
+          service.patch(superadmin.user_id as UserID, patch, params)
+        ).rejects.toMatchObject({ code: 403 });
+      }
+      await expect(service.remove(superadmin.user_id as UserID, params)).rejects.toMatchObject({
+        code: 403,
+      });
+    });
+  }
+
+  dbTest('enforces the actor role ceiling on create and patch', async ({ db }) => {
+    const service = new UsersService(db);
+    const admin = await createUser(service, 'admin', 'admin');
+    const member = await createUser(service, 'member', 'member');
+
+    await expect(
+      service.create(
+        {
+          email: 'created-superadmin@example.test',
+          password: 'password-1234',
+          role: 'superadmin',
+        },
+        externalParams(admin)
+      )
+    ).rejects.toMatchObject({ code: 403 });
+    await expect(
+      service.create(
+        {
+          email: 'created-owner-alias@example.test',
+          password: 'password-1234',
+          role: 'owner',
+        } as never,
+        externalParams(admin)
+      )
+    ).rejects.toMatchObject({ code: 403 });
+    await expect(
+      service.patch(member.user_id as UserID, { role: 'superadmin' }, externalParams(admin))
+    ).rejects.toMatchObject({ code: 403 });
+
+    await expect(
+      service.patch(member.user_id as UserID, { role: 'admin' }, externalParams(admin))
+    ).resolves.toMatchObject({ role: 'admin' });
+  });
+
+  dbTest('allows a superadmin to manage an admin', async ({ db }) => {
+    const service = new UsersService(db);
+    const superadmin = await createUser(service, 'superadmin', 'superadmin');
+    const admin = await createUser(service, 'admin', 'admin');
+
+    await expect(
+      service.create(
+        {
+          email: 'created-admin@example.test',
+          password: 'password-1234',
+          role: 'admin',
+        },
+        externalParams(superadmin)
+      )
+    ).resolves.toMatchObject({ role: 'admin' });
+
+    await expect(
+      service.patch(
+        admin.user_id as UserID,
+        { name: 'Managed admin', password: 'reset-password', role: 'member' },
+        externalParams(superadmin)
+      )
+    ).resolves.toMatchObject({ name: 'Managed admin', role: 'member' });
+    await expect(
+      service.remove(admin.user_id as UserID, externalParams(superadmin))
+    ).resolves.toMatchObject({ user_id: admin.user_id });
+  });
+
+  dbTest('allows an admin to manage a member', async ({ db }) => {
+    const service = new UsersService(db);
+    const admin = await createUser(service, 'admin', 'admin');
+    const member = await createUser(service, 'member', 'member');
+
+    await expect(
+      service.create(
+        {
+          email: 'created-member@example.test',
+          password: 'password-1234',
+          role: 'member',
+        },
+        externalParams(admin)
+      )
+    ).resolves.toMatchObject({ role: 'member' });
+
+    await expect(
+      service.patch(
+        member.user_id as UserID,
+        { name: 'Managed member', password: 'reset-password', must_change_password: true },
+        externalParams(admin)
+      )
+    ).resolves.toMatchObject({ name: 'Managed member', must_change_password: true });
+    await expect(
+      service.remove(member.user_id as UserID, externalParams(admin))
+    ).resolves.toMatchObject({ user_id: member.user_id });
+  });
+
+  dbTest('blocks self role changes, self deletion, and last-superadmin removal', async ({ db }) => {
+    const service = new UsersService(db);
+    const superadmin = await createUser(service, 'superadmin', 'only-superadmin');
+
+    await expect(
+      service.patch(superadmin.user_id as UserID, { role: 'admin' }, externalParams(superadmin))
+    ).rejects.toMatchObject({ code: 403 });
+    await expect(
+      service.remove(superadmin.user_id as UserID, externalParams(superadmin))
+    ).rejects.toMatchObject({ code: 403 });
+    await expect(service.patch(superadmin.user_id as UserID, { role: 'admin' })).rejects.toThrow(
+      /last superadmin/i
+    );
+    await expect(service.remove(superadmin.user_id as UserID)).rejects.toThrow(/last superadmin/i);
+  });
+
+  dbTest(
+    'allows one superadmin to demote a peer without allowing self-demotion',
+    async ({ db }) => {
+      const service = new UsersService(db);
+      const actor = await createUser(service, 'superadmin', 'actor-superadmin');
+      const peer = await createUser(service, 'superadmin', 'peer-superadmin');
+
+      await expect(
+        service.patch(peer.user_id as UserID, { role: 'admin' }, externalParams(actor))
+      ).resolves.toMatchObject({ role: 'admin' });
+      await expect(
+        service.patch(actor.user_id as UserID, { role: 'admin' }, externalParams(actor))
+      ).rejects.toMatchObject({ code: 403 });
+    }
+  );
+
+  dbTest('uses fresh database roles instead of stale or forged actor claims', async ({ db }) => {
+    const service = new UsersService(db);
+    const storedMember = await createUser(service, 'member', 'stale-member');
+    const target = await createUser(service, 'member', 'target');
+    const forgedParams = externalParams({ ...storedMember, role: 'superadmin' });
+
+    await expect(
+      service.patch(target.user_id as UserID, { name: 'forged' }, forgedParams)
+    ).rejects.toMatchObject({ code: 403 });
+  });
+
+  dbTest('rejects bulk and invalid-role field smuggling', async ({ db }) => {
+    const service = new UsersService(db);
+    const superadmin = await createUser(service, 'superadmin', 'superadmin');
+    const member = await createUser(service, 'member', 'member');
+
+    await expect(
+      service.create(
+        [
+          {
+            email: 'bulk@example.test',
+            password: 'password-1234',
+            role: 'superadmin',
+          },
+        ] as never,
+        externalParams(superadmin)
+      )
+    ).rejects.toMatchObject({ code: 400 });
+    await expect(
+      service.patch(null as never, { role: 'superadmin' }, externalParams(superadmin))
+    ).rejects.toMatchObject({ code: 400 });
+    await expect(service.remove(null as never, externalParams(superadmin))).rejects.toMatchObject({
+      code: 400,
+    });
+    await expect(
+      service.patch(
+        member.user_id as UserID,
+        [{ role: 'superadmin' }] as never,
+        externalParams(superadmin)
+      )
+    ).rejects.toMatchObject({ code: 400 });
+    await expect(
+      service.patch(member.user_id as UserID, { role: 'root' } as never, externalParams(superadmin))
+    ).rejects.toMatchObject({ code: 400 });
+    await expect(
+      service.patch(member.user_id as UserID, { role: 'root' } as never)
+    ).rejects.toMatchObject({ code: 400 });
+  });
+
+  dbTest('keeps trusted internal mutation purposes narrow', async ({ db }) => {
+    const service = new UsersService(db);
+    const superadmin = await createUser(service, 'superadmin', 'superadmin');
+    const admin = await createUser(service, 'admin', 'admin');
+
+    const avatarParams = {
+      user: {
+        user_id: 'avatar-service',
+        email: 'avatar-service@agor.internal',
+        role: 'admin',
+        _isServiceAccount: true,
+      },
+    } as Params;
+    markTrustedUserMutation(avatarParams, 'avatar-sync');
+    await expect(
+      service.patch(
+        superadmin.user_id as UserID,
+        { avatar_url: 'https://example.test/avatar.png' },
+        avatarParams
+      )
+    ).resolves.toMatchObject({ avatar_url: 'https://example.test/avatar.png' });
+    await expect(
+      service.patch(superadmin.user_id as UserID, { role: 'member' }, avatarParams)
+    ).rejects.toMatchObject({ code: 403 });
+
+    const forgedSelfServiceAccount = {
+      user: {
+        user_id: superadmin.user_id,
+        email: superadmin.email,
+        role: 'superadmin',
+        _isServiceAccount: true,
+      },
+    } as Params;
+    await expect(
+      service.patch(
+        superadmin.user_id as UserID,
+        { name: 'service-account-smuggling' },
+        forgedSelfServiceAccount
+      )
+    ).rejects.toMatchObject({ code: 403 });
+    await expect(
+      service.remove(superadmin.user_id as UserID, forgedSelfServiceAccount)
+    ).rejects.toMatchObject({ code: 403 });
+
+    const envParams = externalParams(admin) as Params;
+    delete envParams.provider;
+    markTrustedUserMutation(envParams, 'env-vars-widget');
+    await expect(
+      service.patch(
+        superadmin.user_id as UserID,
+        { env_vars: { SECRET: 'replacement' } },
+        envParams
+      )
+    ).rejects.toMatchObject({ code: 403 });
+  });
+
+  dbTest('enforces authority after permissive before hooks run', async ({ db }) => {
+    const app = feathers();
+    app.use('users', createUsersService(db));
+    const service = app.service('users');
+    const superadmin = await service.create({
+      email: 'hook-superadmin@example.test',
+      password: 'password-1234',
+      role: 'superadmin',
+    });
+    const admin = await service.create({
+      email: 'hook-admin@example.test',
+      password: 'password-1234',
+      role: 'admin',
+    });
+    service.hooks({
+      before: {
+        patch: [
+          (context) => {
+            // A stale hook/claim that says superadmin must not outrank the
+            // fresh actor row loaded by the service method.
+            if (context.params.user) context.params.user.role = 'superadmin';
+            return context;
+          },
+        ],
+      },
+    });
+
+    await expect(
+      service.patch(superadmin.user_id, { name: 'hook bypass' }, externalParams(admin))
+    ).rejects.toMatchObject({ code: 403 });
+  });
+});

--- a/apps/agor-daemon/src/services/users.ts
+++ b/apps/agor-daemon/src/services/users.ts
@@ -30,6 +30,7 @@ import {
   hash,
   insert,
   select,
+  sql,
   type TenantScopeAwareDatabase,
   update,
   users,
@@ -57,15 +58,23 @@ import type {
 } from '@agor/core/types';
 import {
   AGENTIC_TOOL_NAMES,
+  canAssignUserRole,
   extractAgenticToolsPublicValues,
   hasMinimumRole,
+  hasRoleAuthorityOver,
+  isUserRole,
   isValidExecutionHomeKey,
   normalizeRole,
   ROLES,
   toAgenticToolsStatus,
   WORKSPACE_DEFAULT_AGENTIC_CONFIGURATION,
 } from '@agor/core/types';
+import { lockUserAuthorityMutation } from './user-authority-lock.js';
 import { UserAvatarSyncManager } from './user-avatar-sync.js';
+import {
+  getTrustedUserMutationPurpose,
+  type TrustedUserMutationPurpose,
+} from './user-mutation-trust.js';
 
 function optionalNonNegativeInteger(value: unknown): number | undefined {
   if (value === undefined || value === null || value === '') return undefined;
@@ -281,6 +290,57 @@ interface UpdateUserData {
   default_mcp_server_ids?: string[];
 }
 
+type UserRow = typeof users.$inferSelect;
+
+interface AuthorizedUserMutation {
+  target: UserRow;
+  actor?: UserRow;
+}
+
+const USER_AUTHORITY_DENIED = 'You do not have authority to manage this user';
+const ADMIN_OWNED_USER_FIELDS = new Set<keyof UpdateUserData>([
+  'role',
+  'unix_username',
+  'filesystem_home',
+  'must_change_password',
+]);
+const TRUSTED_USER_MUTATION_FIELDS: Readonly<
+  Record<TrustedUserMutationPurpose, ReadonlySet<keyof UpdateUserData>>
+> = {
+  'avatar-sync': new Set([
+    'avatar_url',
+    'avatar',
+    'avatar_source',
+    'avatar_source_id',
+    'avatar_synced_at',
+  ]),
+  'env-vars-widget': new Set(['env_vars', 'env_var_scopes']),
+};
+
+function canonicalizeRoleWrite(value: unknown): UserRole {
+  const normalized = value === 'owner' ? ROLES.SUPERADMIN : value;
+  if (!isUserRole(normalized)) {
+    throw new BadRequest('Invalid user role');
+  }
+  return normalized;
+}
+
+function assertSingleUserMutation(data: unknown): void {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    throw new BadRequest('Bulk user mutations are not supported');
+  }
+}
+
+function assertTrustedMutationFields(
+  purpose: TrustedUserMutationPurpose,
+  data: UpdateUserData
+): void {
+  const allowed = TRUSTED_USER_MUTATION_FIELDS[purpose];
+  if (!Object.keys(data).every((field) => allowed.has(field as keyof UpdateUserData))) {
+    throw new Forbidden(`${purpose} cannot modify the requested user fields`);
+  }
+}
+
 function assertValidExecutionHomeKeyWrite(value: string | undefined): void {
   if (value === undefined || isValidExecutionHomeKey(value)) return;
   throw new BadRequest(
@@ -308,6 +368,166 @@ export class UsersService {
       throw new Error('User avatar sync is not available in this service context');
     }
     return this.avatarSync;
+  }
+
+  private async loadUserRow(id: string, params?: Params): Promise<UserRow | null> {
+    return select(this.db)
+      .from(users)
+      .where(withTenantPredicate(params, eq(users.user_id, id)))
+      .one();
+  }
+
+  private mutationNeedsActor(params?: Params): boolean {
+    // Feathers' provider-less, actor-less form is the explicit trusted
+    // in-process persistence seam used during bootstrap/provisioning. Any call
+    // carrying a human actor is authorized even when it is in-process, so
+    // internal wrappers cannot accidentally turn a user action into a bypass.
+    return !!params?.provider || !!(params as AuthenticatedParams | undefined)?.user;
+  }
+
+  /** Resolve the actor from the database so stale token role claims grant no authority. */
+  private async loadMutationActor(params?: Params): Promise<UserRow> {
+    const claimed = (params as AuthenticatedParams | undefined)?.user;
+    if (!claimed || claimed._isServiceAccount) {
+      throw new Forbidden(USER_AUTHORITY_DENIED);
+    }
+    const actor = await this.loadUserRow(claimed.user_id, params);
+    if (!actor) {
+      // Keep deleted/cross-tenant principals indistinguishable from an
+      // insufficiently privileged in-tenant actor.
+      throw new Forbidden(USER_AUTHORITY_DENIED);
+    }
+    return actor;
+  }
+
+  private async authorizeCreate(data: CreateUserData, params?: Params): Promise<UserRow | null> {
+    if (!this.mutationNeedsActor(params)) return null;
+
+    const actor = await this.loadMutationActor(params);
+    if (!hasMinimumRole(actor.role, ROLES.ADMIN)) {
+      throw new Forbidden(USER_AUTHORITY_DENIED);
+    }
+    const requestedRole = canonicalizeRoleWrite(data.role ?? ROLES.MEMBER);
+    if (!canAssignUserRole(actor.role, requestedRole)) {
+      throw new Forbidden('You cannot assign a role above your own');
+    }
+    return actor;
+  }
+
+  private async authorizePatch(
+    id: UserID,
+    data: UpdateUserData,
+    params?: Params
+  ): Promise<AuthorizedUserMutation> {
+    const target = await this.loadUserRow(id, params);
+    if (!target) throw new Forbidden(USER_AUTHORITY_DENIED);
+
+    // Validation and canonicalization apply even to trusted provisioning.
+    // Trust may bypass actor authorization, never the stored role domain.
+    const requestedRole = Object.hasOwn(data, 'role')
+      ? canonicalizeRoleWrite(data.role)
+      : undefined;
+    if (requestedRole) data.role = requestedRole;
+
+    const purpose = getTrustedUserMutationPurpose(params);
+    if (purpose) {
+      assertTrustedMutationFields(purpose, data);
+      if (purpose === 'avatar-sync') return { target };
+    }
+
+    if (!this.mutationNeedsActor(params)) return { target };
+
+    const claimedActor = (params as AuthenticatedParams).user;
+    if (claimedActor?._isServiceAccount) {
+      throw new Forbidden(USER_AUTHORITY_DENIED);
+    }
+    const actor =
+      target.user_id === claimedActor?.user_id ? target : await this.loadMutationActor(params);
+
+    // The env-vars widget is separately authorized by session/branch scope, but
+    // it must still respect role authority when it writes another user's
+    // credential-bearing environment. It does not gain general admin powers.
+    if (purpose === 'env-vars-widget') {
+      if (!hasRoleAuthorityOver(actor.role, target.role)) {
+        throw new Forbidden(USER_AUTHORITY_DENIED);
+      }
+      return { target, actor };
+    }
+
+    if (actor.user_id === target.user_id) {
+      if (requestedRole && requestedRole !== normalizeRole(target.role)) {
+        throw new Forbidden('You cannot change your own role');
+      }
+      const writesAdminField = Object.keys(data).some((field) =>
+        ADMIN_OWNED_USER_FIELDS.has(field as keyof UpdateUserData)
+      );
+      if (writesAdminField && !hasMinimumRole(actor.role, ROLES.ADMIN)) {
+        throw new Forbidden(USER_AUTHORITY_DENIED);
+      }
+      return { target, actor };
+    }
+
+    if (
+      !hasMinimumRole(actor.role, ROLES.ADMIN) ||
+      !hasRoleAuthorityOver(actor.role, target.role)
+    ) {
+      throw new Forbidden(USER_AUTHORITY_DENIED);
+    }
+    if (requestedRole && !canAssignUserRole(actor.role, requestedRole)) {
+      throw new Forbidden('You cannot assign a role above your own');
+    }
+    return { target, actor };
+  }
+
+  private async authorizeRemove(id: UserID, params?: Params): Promise<AuthorizedUserMutation> {
+    const target = await this.loadUserRow(id, params);
+    if (!target) throw new Forbidden(USER_AUTHORITY_DENIED);
+    if (!this.mutationNeedsActor(params)) return { target };
+
+    const claimedActor = (params as AuthenticatedParams).user;
+    if (claimedActor?._isServiceAccount) {
+      throw new Forbidden(USER_AUTHORITY_DENIED);
+    }
+    const actor =
+      target.user_id === claimedActor?.user_id ? target : await this.loadMutationActor(params);
+    if (actor.user_id === target.user_id) {
+      throw new Forbidden('You cannot delete your own account');
+    }
+    if (
+      !hasMinimumRole(actor.role, ROLES.ADMIN) ||
+      !hasRoleAuthorityOver(actor.role, target.role)
+    ) {
+      throw new Forbidden(USER_AUTHORITY_DENIED);
+    }
+    return { target, actor };
+  }
+
+  private actorStillCurrentPredicate(actor: UserRow | undefined, params?: Params) {
+    if (!actor) return undefined;
+    const tenantId = (params as AuthenticatedParams | undefined)?.tenant?.tenant_id;
+    const tenantCheck =
+      tenantId && usersTableHasTenantColumn()
+        ? sql` AND authority_actor.tenant_id = ${tenantId}`
+        : sql``;
+    return sql`EXISTS (
+      SELECT 1 FROM ${users} authority_actor
+      WHERE authority_actor.user_id = ${actor.user_id}
+        AND authority_actor.role = ${actor.role}${tenantCheck}
+    )`;
+  }
+
+  private async assertNotLastSuperadmin(target: UserRow, params?: Params): Promise<void> {
+    if (normalizeRole(target.role) !== ROLES.SUPERADMIN) return;
+    const tenant = tenantPredicate(params);
+    const superadmins = tenant
+      ? await select(this.db).from(users).where(tenant).all()
+      : await select(this.db).from(users).all();
+    if (
+      superadmins.filter((user: UserRow) => normalizeRole(user.role) === ROLES.SUPERADMIN).length <=
+      1
+    ) {
+      throw new Forbidden('The last superadmin cannot be demoted or deleted');
+    }
   }
 
   /**
@@ -410,7 +630,12 @@ export class UsersService {
    * Create new user
    */
   async create(data: CreateUserData, params?: Params): Promise<User> {
+    assertSingleUserMutation(data);
     assertValidExecutionHomeKeyWrite(data.unix_username);
+    if (Object.hasOwn(data, 'role')) data.role = canonicalizeRoleWrite(data.role);
+    await lockUserAuthorityMutation(this.db, params);
+    await this.authorizeCreate(data, params);
+
     // Check if email already exists
     const existing = await select(this.db)
       .from(users)
@@ -428,7 +653,7 @@ export class UsersService {
     const now = new Date();
     const user_id = generateId() as UserID;
 
-    const role = data.role || ROLES.MEMBER;
+    const role = data.role ?? ROLES.MEMBER;
     const defaultEmoji = role === ROLES.ADMIN ? '⭐' : '👤';
 
     const row = await insert(this.db, users)
@@ -464,7 +689,22 @@ export class UsersService {
    * Update user
    */
   async patch(id: UserID, data: UpdateUserData, params?: Params): Promise<User> {
+    if (typeof id !== 'string' || !id) {
+      throw new BadRequest('Bulk user mutations are not supported');
+    }
+    assertSingleUserMutation(data);
     assertValidExecutionHomeKeyWrite(data.unix_username);
+    await lockUserAuthorityMutation(this.db, params);
+    const authority = await this.authorizePatch(id, data, params);
+    if (
+      Object.hasOwn(data, 'role') &&
+      data.role !== undefined &&
+      normalizeRole(authority.target.role) === ROLES.SUPERADMIN &&
+      data.role !== ROLES.SUPERADMIN
+    ) {
+      await this.assertNotLastSuperadmin(authority.target, params);
+    }
+
     const now = new Date();
     const updates: Record<string, unknown> = { updated_at: now };
 
@@ -509,11 +749,13 @@ export class UsersService {
       data.default_agentic_selection ||
       data.default_mcp_server_ids !== undefined
     ) {
-      const current = await this.get(id, params);
-      const currentRow = await select(this.db)
-        .from(users)
-        .where(withTenantPredicate(params, eq(users.user_id, id)))
-        .one();
+      const current = this.rowToUser(
+        authority.target,
+        false,
+        (params as AuthenticatedParams | undefined)?.user?.user_id as UserID | undefined,
+        shouldIncludeAuthMetadata(params)
+      );
+      const currentRow = authority.target;
       const currentData = currentRow?.data as {
         avatar_url?: string;
         avatar?: string;
@@ -719,14 +961,20 @@ export class UsersService {
       };
     }
 
+    const authorityActorPredicate = this.actorStillCurrentPredicate(authority.actor, params);
     const row = await update(this.db, users)
       .set(updates)
-      .where(eq(users.user_id, id))
+      .where(
+        withTenantPredicate(
+          params,
+          and(eq(users.user_id, id), eq(users.role, authority.target.role), authorityActorPredicate)
+        )
+      )
       .returning()
       .one();
 
     if (!row) {
-      throw new Error(`User not found: ${id}`);
+      throw new Forbidden(USER_AUTHORITY_DENIED);
     }
 
     const requesterId = (params as AuthenticatedParams | undefined)?.user?.user_id as
@@ -739,9 +987,34 @@ export class UsersService {
    * Delete user
    */
   async remove(id: UserID, params?: Params): Promise<User> {
-    const user = await this.get(id, params);
+    if (typeof id !== 'string' || !id) {
+      throw new BadRequest('Bulk user mutations are not supported');
+    }
+    await lockUserAuthorityMutation(this.db, params);
+    const authority = await this.authorizeRemove(id, params);
+    await this.assertNotLastSuperadmin(authority.target, params);
+    const requesterId = (params as AuthenticatedParams | undefined)?.user?.user_id as
+      | UserID
+      | undefined;
+    const user = this.rowToUser(
+      authority.target,
+      false,
+      requesterId,
+      shouldIncludeAuthMetadata(params)
+    );
 
-    await deleteFrom(this.db, users).where(eq(users.user_id, id)).run();
+    const authorityActorPredicate = this.actorStillCurrentPredicate(authority.actor, params);
+    const removed = await deleteFrom(this.db, users)
+      .where(
+        withTenantPredicate(
+          params,
+          and(eq(users.user_id, id), eq(users.role, authority.target.role), authorityActorPredicate)
+        )
+      )
+      .run();
+    if (removed.rowsAffected !== 1) {
+      throw new Forbidden(USER_AUTHORITY_DENIED);
+    }
 
     return user;
   }

--- a/apps/agor-daemon/src/utils/branch-authorization.ts
+++ b/apps/agor-daemon/src/utils/branch-authorization.ts
@@ -1773,7 +1773,8 @@ export function scopeFindToAccessibleBoardsSql(options?: { allowSuperadmin?: boo
  *
  * Behavior:
  * - Service accounts (executor) pass through.
- * - Admin / superadmin pass through (respecting `allowSuperadmin`).
+ * - Admin / superadmin pass through. `allowSuperadmin` only controls the
+ *   exceptional branch-RBAC bypass; it cannot remove ordinary admin authority.
  * - Session creator passes through.
  * - Everyone else → Forbidden. Branch `all` does NOT grant access: session
  *   env selections expose the creator's private credentials to the executor.
@@ -1789,10 +1790,9 @@ export function checkSessionOwnerOrAdmin(
   // Service accounts (executor) bypass RBAC
   if (user._isServiceAccount) return;
 
-  const allowSuperadmin = options?.allowSuperadmin ?? true;
   const userRole = user.role;
 
-  if (userRole === ROLES.ADMIN || isSuperAdmin(userRole, allowSuperadmin)) {
+  if (hasMinimumRole(userRole, ROLES.ADMIN)) {
     return;
   }
 
@@ -1879,7 +1879,6 @@ export function determineSpawnIdentity(
   branch: { branch_id: string; dangerously_allow_session_sharing?: boolean } | undefined,
   options?: { allowSuperadmin?: boolean }
 ): { created_by: string; usedLegacySharing: boolean } {
-  const allowSuperadmin = options?.allowSuperadmin ?? true;
   const callerId = caller.user_id;
   const role = caller.role;
 
@@ -1892,7 +1891,9 @@ export function determineSpawnIdentity(
 
   // Admin / superadmin → always attributed to themselves so the audit trail
   // points at the human who pressed the button. Never inherit parent identity.
-  if (role === ROLES.ADMIN || isSuperAdmin(role, allowSuperadmin)) {
+  // `allow_superadmin` only gates exceptional branch-RBAC bypasses. A
+  // superadmin always retains the ordinary admin authority represented here.
+  if (hasMinimumRole(role, ROLES.ADMIN)) {
     if (!callerId) {
       // Should not happen — admins always have an id — but fall back safely.
       return { created_by: parent.created_by, usedLegacySharing: false };

--- a/apps/agor-daemon/src/utils/determine-spawn-identity.test.ts
+++ b/apps/agor-daemon/src/utils/determine-spawn-identity.test.ts
@@ -124,16 +124,20 @@ describe('determineSpawnIdentity', () => {
     expect(result.created_by).toBe(SUPER);
   });
 
-  it('allowSuperadmin=false demotes superadmin to regular user (caller-as-owner)', () => {
-    const result = determineSpawnIdentity(
-      { created_by: BOB },
-      { user_id: SUPER, role: ROLES.SUPERADMIN },
-      WT_FLAG_OFF,
-      { allowSuperadmin: false }
-    );
-    // Without superadmin powers, falls into the "non-admin caller" branch
-    // and the safe default still attributes to caller.
-    expect(result.created_by).toBe(SUPER);
+  it('allowSuperadmin=false preserves ordinary admin authority for superadmins', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const result = determineSpawnIdentity(
+        { created_by: BOB },
+        { user_id: SUPER, role: ROLES.SUPERADMIN },
+        WT_FLAG_ON,
+        { allowSuperadmin: false }
+      );
+      expect(result).toEqual({ created_by: SUPER, usedLegacySharing: false });
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it('service accounts preserve parent attribution (no human caller)', () => {

--- a/apps/agor-daemon/src/utils/ensure-session-owner-or-admin.test.ts
+++ b/apps/agor-daemon/src/utils/ensure-session-owner-or-admin.test.ts
@@ -105,13 +105,13 @@ describe('ensureSessionOwnerOrAdmin', () => {
     expect(() => hook(ctx)).toThrow(/loadSession/);
   });
 
-  it('allowSuperadmin: false blocks superadmins', () => {
+  it('allowSuperadmin: false preserves ordinary admin authority for superadmins', () => {
     const strict = ensureSessionOwnerOrAdmin({ allowSuperadmin: false });
     const ctx = makeContext({
       provider: 'rest',
       user: { user_id: 'super-1', role: ROLES.SUPERADMIN },
       session: { created_by: 'alice' },
     });
-    expect(() => strict(ctx)).toThrow(Forbidden);
+    expect(() => strict(ctx)).not.toThrow();
   });
 });

--- a/apps/agor-daemon/src/widgets/env-vars/index.test.ts
+++ b/apps/agor-daemon/src/widgets/env-vars/index.test.ts
@@ -18,6 +18,7 @@
 
 import type { UserID } from '@agor/core/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getTrustedUserMutationPurpose } from '../../services/user-mutation-trust';
 import { _resetWidgetRegistryForTests, getWidget } from '../registry';
 
 const sessionSelectionRepoMock = vi.hoisted(() => ({
@@ -293,14 +294,13 @@ describe('env_vars widget — applySubmit', () => {
       env_vars: { HUBSPOT_API_KEY: 'shh' },
       env_var_scopes: { HUBSPOT_API_KEY: 'global' },
     });
-    // Regression: must pass auth params so the users.patch hook accepts a
-    // write to a user other than the caller via the `trustedEnvVarWrite`
-    // escape hatch (the widget endpoint already authorized via canResolveWidget).
-    expect(params).toEqual({
+    // Regression: the non-serializable purpose marker cannot be forged by a
+    // transport caller, and the users service keeps its field allow-list.
+    expect(params).toMatchObject({
       user: { user_id: 'user-creator', role: 'member' },
       authenticated: true,
-      trustedEnvVarWrite: true,
     });
+    expect(getTrustedUserMutationPurpose(params)).toBe('env-vars-widget');
   });
 
   it('passes submitter identity through for audit when an admin submits', async () => {
@@ -317,11 +317,11 @@ describe('env_vars widget — applySubmit', () => {
     );
     const [, , params] = patchSpy.mock.calls[0];
     // Auth params carry the SUBMITTER identity so the patch is attributable.
-    expect(params).toEqual({
+    expect(params).toMatchObject({
       user: { user_id: 'user-admin', role: 'admin' },
       authenticated: true,
-      trustedEnvVarWrite: true,
     });
+    expect(getTrustedUserMutationPurpose(params)).toBe('env-vars-widget');
   });
 
   it('writes ALL submitted names in one patch call', async () => {

--- a/apps/agor-daemon/src/widgets/env-vars/index.ts
+++ b/apps/agor-daemon/src/widgets/env-vars/index.ts
@@ -18,8 +18,9 @@ import {
 } from '@agor/core/config';
 import { type Database, SessionEnvSelectionRepository } from '@agor/core/db';
 import { BadRequest } from '@agor/core/feathers';
-import type { User, UserID } from '@agor/core/types';
+import type { Params, User, UserID } from '@agor/core/types';
 import { z } from 'zod';
+import { markTrustedUserMutation } from '../../services/user-mutation-trust.js';
 import { registerWidget, type WidgetRegistryEntry, type WidgetSubmitCtx } from '../registry.js';
 
 /** Mirror of the regex used by the users service. */
@@ -233,11 +234,7 @@ async function applyEnvVarsSubmit(
         env_vars?: Record<string, string>;
         env_var_scopes?: Record<string, 'global' | 'session'>;
       },
-      params?: {
-        user: { user_id: UserID; role: string | undefined };
-        authenticated: true;
-        trustedEnvVarWrite?: boolean;
-      }
+      params?: Params
     ): Promise<unknown>;
   };
 
@@ -268,26 +265,29 @@ async function applyEnvVarsSubmit(
   }
 
   // The widget submit endpoint already authorized the caller via
-  // `canResolveWidget` (session-creator OR prompt-tier branch RBAC), so
-  // we set `trustedEnvVarWrite` on the users.patch hook to bypass its
-  // self-only check (`register-hooks.ts`). Field-level admin gates for
-  // unix_username/role/must_change_password run first and are NOT bypassed.
-  // The hook also enforces that only env_vars/env_var_scopes fields are
-  // written — this escape hatch cannot be used to patch other user fields.
+  // `canResolveWidget` (session-creator OR prompt-tier branch RBAC). The
+  // in-process purpose marker permits only env_vars/env_var_scopes and the
+  // users service still compares the submitter's fresh role with the session
+  // creator's current role. A lower-authority collaborator therefore cannot
+  // use a widget to mutate a higher-authority user's credential environment.
   //
   // submitter identity is still threaded through for audit; the widget
   // submit handler records it separately as `metadata.widget.submitted_by`.
   //
-  // Grep for: trustedEnvVarWrite — to audit every site that sets it.
+  // Grep for: markTrustedUserMutation — to audit every trusted mutation site.
   if (submittedNames.length > 0) {
+    const mutationParams = {
+      user: {
+        user_id: ctx.submitterUserId,
+        role: ctx.submitterRole,
+      },
+      authenticated: true,
+    } as unknown as Params;
+    markTrustedUserMutation(mutationParams, 'env-vars-widget');
     await usersService.patch(
       ctx.sessionCreatorUserId,
       { env_vars: orderedValues, env_var_scopes },
-      {
-        user: { user_id: ctx.submitterUserId, role: ctx.submitterRole },
-        authenticated: true,
-        trustedEnvVarWrite: true,
-      }
+      mutationParams
     );
   }
 

--- a/apps/agor-ui/src/components/SettingsModal/GroupsTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GroupsTable.test.tsx
@@ -1,0 +1,58 @@
+import type { AgorClient, Group, User } from '@agor-live/client';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { App as AntApp, ConfigProvider } from 'antd';
+import { describe, expect, it, vi } from 'vitest';
+import { GroupsTable } from './GroupsTable';
+
+function user(user_id: string, role: User['role']): User {
+  return {
+    user_id,
+    email: `${user_id}@example.test`,
+    name: user_id,
+    role,
+    created_at: new Date(),
+  } as User;
+}
+
+describe('GroupsTable membership authority', () => {
+  it('disables higher-authority users in membership selectors', async () => {
+    const group = {
+      group_id: 'group-1',
+      name: 'Engineering',
+      slug: 'engineering',
+    } as Group;
+    const client = {
+      service: vi.fn((path: string) => ({
+        findAll: vi.fn(async () => (path === 'groups' ? [group] : [])),
+      })),
+    } as unknown as AgorClient;
+    const admin = user('admin', 'admin');
+    const superadmin = user('superadmin', 'superadmin');
+    const member = user('member', 'member');
+
+    render(
+      <ConfigProvider theme={{ hashed: false }}>
+        <AntApp>
+          <GroupsTable
+            client={client}
+            currentUser={admin}
+            userById={
+              new Map([
+                [admin.user_id, admin],
+                [superadmin.user_id, superadmin],
+                [member.user_id, member],
+              ])
+            }
+          />
+        </AntApp>
+      </ConfigProvider>
+    );
+
+    expect(await screen.findByText('Engineering')).toBeInTheDocument();
+    fireEvent.mouseDown(screen.getByRole('combobox'));
+    const superadminOption = await screen.findByText('superadmin (superadmin@example.test)');
+    const memberOption = await screen.findByText('member (member@example.test)');
+    expect(superadminOption.closest('[aria-disabled]')).toHaveAttribute('aria-disabled', 'true');
+    expect(memberOption.closest('[aria-disabled]')).toHaveAttribute('aria-disabled', 'false');
+  });
+});

--- a/apps/agor-ui/src/components/SettingsModal/GroupsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GroupsTable.tsx
@@ -1,5 +1,5 @@
 import type { AgorClient, Group, GroupMembership, User } from '@agor-live/client';
-import { hasMinimumRole, ROLES } from '@agor-live/client';
+import { hasMinimumRole, hasRoleAuthorityOver, ROLES } from '@agor-live/client';
 import { DeleteOutlined, EditOutlined, PlusOutlined, TeamOutlined } from '@ant-design/icons';
 import {
   Button,
@@ -158,7 +158,10 @@ export const GroupsTable: React.FC<GroupsTableProps> = ({ client, currentUser, u
   }
 
   const userOptions = mapToSortedArray(userById, (a, b) => a.email.localeCompare(b.email)).map(
-    toUserSelectOption
+    (user) => ({
+      ...toUserSelectOption(user),
+      disabled: !hasRoleAuthorityOver(currentUser?.role, user.role),
+    })
   );
   const filteredGroups = filterBySettingsSearch(
     [...groups].sort((a, b) => a.name.localeCompare(b.name)),

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
@@ -170,6 +170,78 @@ function makeUser(overrides: Partial<User> = {}): User {
 const ASYNC = { timeout: 10_000 };
 
 describe('UserSettingsModal', { timeout: 60_000 }, () => {
+  it('fails closed when an admin opens a superadmin settings modal', () => {
+    const currentAdmin = makeUser({
+      user_id: 'admin-1',
+      email: 'admin@example.test',
+      role: 'admin',
+    });
+    const targetSuperadmin = makeUser({
+      user_id: 'superadmin-1',
+      email: 'superadmin@example.test',
+      role: 'superadmin',
+    });
+
+    renderWithApp(
+      <UserSettingsModal
+        open
+        onClose={vi.fn()}
+        user={targetSuperadmin}
+        currentUser={currentAdmin}
+        client={null}
+        onUpdate={vi.fn()}
+        initialTab="security"
+      />
+    );
+
+    expect(screen.getByRole('menuitem', { name: /profile/i })).toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: /security/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: /codex/i })).not.toBeInTheDocument();
+    expect(screen.getByPlaceholderText('John Doe')).toBeDisabled();
+    expect(screen.getByPlaceholderText('user@example.com')).toBeDisabled();
+    expect(screen.getByRole('button', { name: /^save$/i })).toBeDisabled();
+  });
+
+  it('lets a superadmin manage an admin while locking self role changes', () => {
+    const currentSuperadmin = makeUser({
+      user_id: 'superadmin-1',
+      email: 'superadmin@example.test',
+      role: 'superadmin',
+    });
+    const targetAdmin = makeUser({
+      user_id: 'admin-1',
+      email: 'admin@example.test',
+      role: 'admin',
+    });
+    const { unmount } = renderWithApp(
+      <UserSettingsModal
+        open
+        onClose={vi.fn()}
+        user={targetAdmin}
+        currentUser={currentSuperadmin}
+        client={null}
+        onUpdate={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('menuitem', { name: /security/i })).toBeInTheDocument();
+    expect(screen.getByLabelText('Role')).toBeEnabled();
+    expect(screen.getByRole('button', { name: /^save$/i })).toBeEnabled();
+
+    unmount();
+    renderWithApp(
+      <UserSettingsModal
+        open
+        onClose={vi.fn()}
+        user={currentSuperadmin}
+        currentUser={currentSuperadmin}
+        client={null}
+        onUpdate={vi.fn()}
+      />
+    );
+    expect(screen.getByLabelText('Role')).toBeDisabled();
+  });
+
   it('saves dirty agentic defaults across tabs and closes from the footer', async () => {
     const user = makeUser({
       default_agentic_config: {

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -14,7 +14,13 @@ import type {
   UpdateUserInput,
   User,
 } from '@agor-live/client';
-import { hasMinimumRole, ROLE_OPTIONS, ROLES } from '@agor-live/client';
+import {
+  canAssignUserRole,
+  hasMinimumRole,
+  hasRoleAuthorityOver,
+  ROLE_OPTIONS,
+  ROLES,
+} from '@agor-live/client';
 import {
   BellOutlined,
   CheckCircleFilled,
@@ -288,6 +294,12 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
   const isAdmin = hasMinimumRole(currentUser?.role, ROLES.ADMIN);
   const isEditingOther = !!user && !!currentUser && user.user_id !== currentUser.user_id;
   const isSelf = !!user && !!currentUser && user.user_id === currentUser.user_id;
+  const canEditTarget =
+    !isEditingOther || (isAdmin && hasRoleAuthorityOver(currentUser?.role, user?.role));
+  const canAdministerTarget = isAdmin && canEditTarget;
+  const assignableRoleOptions = ROLE_OPTIONS.filter((option) =>
+    canAssignUserRole(currentUser?.role, option.value)
+  );
 
   // Authorize the active panel SYNCHRONOUSLY during render (never correct it in
   // an effect): a stale/unauthorized key must resolve to Profile before any
@@ -296,6 +308,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
   // tenant-disabled provider deep link can't render its credential controls.
   // Mirrors the permission gating that builds `navGroups`.
   const activeKey = ((): string => {
+    if (isEditingOther && !canEditTarget) return 'profile';
     if (rawActiveKey.startsWith(PROVIDER_KEY_PREFIX)) {
       // FAIL CLOSED until availability is known: an unhydrated store reports
       // every tool as enabled, so a disabled-provider deep link would briefly
@@ -308,7 +321,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
     }
     if ((rawActiveKey === 'tokens' || rawActiveKey === 'uploads') && isEditingOther)
       return 'profile';
-    if (rawActiveKey === 'access' && !isAdmin) return 'profile';
+    if (rawActiveKey === 'access' && !canAdministerTarget) return 'profile';
     return rawActiveKey;
   })();
 
@@ -424,7 +437,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
 
   const loadUserGroups = useCallback(async () => {
     const userId = user?.user_id;
-    if (!client || !userId || !isAdmin) {
+    if (!client || !userId || !canAdministerTarget) {
       setAvailableGroups([]);
       setUserGroupIds([]);
       setGroupsLoaded(false);
@@ -451,7 +464,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
     } finally {
       setLoadingGroups(false);
     }
-  }, [client, form, isAdmin, user?.user_id]);
+  }, [canAdministerTarget, client, form, user?.user_id]);
 
   // Initialize when modal opens with user data
   useEffect(() => {
@@ -587,7 +600,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
   };
 
   const syncUserGroups = async (nextGroupIds: string[]) => {
-    if (!client || !user || !isAdmin || !groupsLoaded) return;
+    if (!client || !user || !canAdministerTarget || !groupsLoaded) return;
     await syncGroupsForUser(client, user.user_id, userGroupIds, nextGroupIds);
     setUserGroupIds(nextGroupIds);
   };
@@ -667,7 +680,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
   // Profile edit and a Preferences edit from clobbering each other's keys when
   // both are flushed against the same not-yet-refreshed `user` prop.
   const commitMainPanels = async (panels: Set<string>): Promise<boolean> => {
-    if (!user) return false;
+    if (!user || !canEditTarget) return false;
 
     try {
       const toValidate: string[] = [];
@@ -710,7 +723,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
         preferencesTouched = true;
       }
 
-      if (panels.has('access') && isAdmin && isEditingOther) {
+      if (panels.has('access') && canAdministerTarget && isEditingOther) {
         updates.must_change_password = form.getFieldValue('must_change_password');
       }
 
@@ -985,6 +998,15 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
   // Sidebar navigation model. Kept as plain data so the same structure feeds
   // both the AntD menu and the search filter.
   const navGroups = useMemo(() => {
+    if (isEditingOther && !canEditTarget) {
+      return [
+        {
+          key: 'grp-account',
+          label: 'Account',
+          children: [{ key: 'profile', ...PANEL_META.profile }],
+        },
+      ];
+    }
     const groups: Array<{
       key: string;
       label: string;
@@ -1032,7 +1054,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
       },
     ];
 
-    if (isAdmin) {
+    if (canAdministerTarget) {
       groups.push({
         key: 'grp-admin',
         label: 'Admin',
@@ -1040,7 +1062,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
       });
     }
     return groups;
-  }, [visibleAgenticToolTabs, isAdmin, isEditingOther, resolveProvider]);
+  }, [canAdministerTarget, canEditTarget, visibleAgenticToolTabs, isEditingOther, resolveProvider]);
 
   const menuItems: MenuProps['items'] = useMemo(
     () =>
@@ -1411,7 +1433,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
   // per field, so "Done" only flushes any dirty session-defaults left over
   // from another provider before closing.
   const handleModalSave = async () => {
-    if (!user || savingModal) return;
+    if (!user || savingModal || !canEditTarget) return;
     setSavingModal(true);
     try {
       // Flush EVERY edited main panel (plus the active one if it owns the shared
@@ -1442,7 +1464,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
       <PanelHeader title={PANEL_META.profile.title} />
       <Form form={form} layout="vertical" onValuesChange={() => markMainPanelDirty('profile')}>
         <FieldRow label="Name" name="name">
-          <Input placeholder="John Doe" />
+          <Input placeholder="John Doe" disabled={!canEditTarget} />
         </FieldRow>
 
         <FieldRow
@@ -1454,7 +1476,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
             { type: 'email', message: 'Please enter a valid email' },
           ]}
         >
-          <Input placeholder="user@example.com" />
+          <Input placeholder="user@example.com" disabled={!canEditTarget} />
         </FieldRow>
 
         <FieldRow
@@ -1463,7 +1485,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
           valuePropName="checked"
           tooltip="Shows your Slack-synced profile image instead of your initials tile. Turns off automatically if Slack sync is removed."
         >
-          <Switch />
+          <Switch disabled={!canEditTarget} />
         </FieldRow>
 
         <FieldRow
@@ -1471,12 +1493,12 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
           required
           name="role"
           rules={[{ required: true, message: 'Please select a role' }]}
-          help={isAdmin ? undefined : 'Maintained by administrators'}
+          help={canAdministerTarget ? undefined : 'Maintained by administrators'}
         >
           <Select
-            disabled={!isAdmin}
+            disabled={!canAdministerTarget || isSelf}
             style={{ maxWidth: 320 }}
-            options={ROLE_OPTIONS.map((opt) => ({
+            options={assignableRoleOptions.map((opt) => ({
               value: opt.value,
               label: opt.label,
               description: opt.description,
@@ -1519,14 +1541,14 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
       <PanelHeader title={PANEL_META.security.title} />
       <Form form={form} layout="vertical" onValuesChange={() => markMainPanelDirty('security')}>
         <FieldRow label="Password" name="password" help="Leave blank to keep current password">
-          <Input.Password placeholder="••••••••" />
+          <Input.Password placeholder="••••••••" disabled={!canEditTarget} />
         </FieldRow>
 
         <FieldRow
           label="Execution home key"
           name="unix_username"
           help={
-            isAdmin
+            canAdministerTarget
               ? 'Transitional home key used only by delegated execution'
               : 'Maintained by administrators'
           }
@@ -1539,7 +1561,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
             { max: 32, message: 'Execution home key must be 32 characters or less' },
           ]}
         >
-          <Input placeholder="johnsmith" maxLength={32} disabled={!isAdmin} />
+          <Input placeholder="johnsmith" maxLength={32} disabled={!canAdministerTarget} />
         </FieldRow>
       </Form>
     </>
@@ -1618,7 +1640,7 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
           />
         </FieldRow>
 
-        {isAdmin && isEditingOther && (
+        {canAdministerTarget && isEditingOther && (
           <>
             <SectionDivider label="Danger zone" />
             <Form.Item
@@ -1966,7 +1988,13 @@ export const UserSettingsModal: React.FC<UserSettingsModalProps> = ({
         <Button key="close" onClick={handleClose} disabled={savingModal}>
           Close
         </Button>,
-        <Button key="save" type="primary" onClick={handleModalSave} loading={savingModal}>
+        <Button
+          key="save"
+          type="primary"
+          onClick={handleModalSave}
+          loading={savingModal}
+          disabled={!canEditTarget}
+        >
           Save
         </Button>,
       ];

--- a/apps/agor-ui/src/components/SettingsModal/UsersTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UsersTable.test.tsx
@@ -1,0 +1,62 @@
+import type { User } from '@agor-live/client';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { App as AntApp, ConfigProvider } from 'antd';
+import { describe, expect, it, vi } from 'vitest';
+import { UsersTable } from './UsersTable';
+
+function user(user_id: string, role: User['role']): User {
+  return {
+    user_id,
+    email: `${user_id}@example.test`,
+    name: user_id,
+    role,
+    created_at: new Date(),
+    default_agentic_config: {},
+  } as User;
+}
+
+function renderTable(currentUser: User, users: User[]) {
+  return render(
+    <ConfigProvider theme={{ hashed: false }}>
+      <AntApp>
+        <UsersTable
+          userById={new Map(users.map((item) => [item.user_id, item]))}
+          client={null}
+          currentUser={currentUser}
+          onCreate={vi.fn()}
+          onUpdate={vi.fn()}
+          onDelete={vi.fn()}
+        />
+      </AntApp>
+    </ConfigProvider>
+  );
+}
+
+describe('UsersTable role authority', () => {
+  it('hides superadmin mutation actions from admins but keeps member actions', () => {
+    const admin = user('admin', 'admin');
+    const superadmin = user('superadmin', 'superadmin');
+    const member = user('member', 'member');
+    renderTable(admin, [admin, superadmin, member]);
+
+    expect(screen.queryByLabelText('Edit superadmin@example.test')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Delete superadmin@example.test')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Edit member@example.test')).toBeInTheDocument();
+    expect(screen.getByLabelText('Delete member@example.test')).toBeInTheDocument();
+    expect(screen.getByLabelText('Edit admin@example.test')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Delete admin@example.test')).not.toBeInTheDocument();
+  });
+
+  it('does not offer superadmin in an admin create-role selector', async () => {
+    const admin = user('admin', 'admin');
+    renderTable(admin, [admin]);
+
+    fireEvent.click(screen.getByRole('button', { name: /new user/i }));
+    const roleSelect = screen.getAllByRole('combobox').at(-1);
+    expect(roleSelect).toBeDefined();
+    fireEvent.mouseDown(roleSelect!);
+
+    expect(await screen.findByText('Admin')).toBeInTheDocument();
+    expect(screen.queryByText('Superadmin')).not.toBeInTheDocument();
+  });
+});

--- a/apps/agor-ui/src/components/SettingsModal/UsersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UsersTable.tsx
@@ -8,7 +8,13 @@ import type {
   UpdateUserInput,
   User,
 } from '@agor-live/client';
-import { hasMinimumRole, ROLE_OPTIONS, ROLES } from '@agor-live/client';
+import {
+  canAssignUserRole,
+  hasMinimumRole,
+  hasRoleAuthorityOver,
+  ROLE_OPTIONS,
+  ROLES,
+} from '@agor-live/client';
 import { DeleteOutlined, EditOutlined, PlusOutlined } from '@ant-design/icons';
 import {
   Button,
@@ -61,6 +67,19 @@ export const UsersTable: React.FC<UsersTableProps> = ({
   const [searchTerm, setSearchTerm] = useState('');
   const [form] = Form.useForm();
   const isAdmin = hasMinimumRole(currentUser?.role, ROLES.ADMIN);
+  const assignableRoleOptions = ROLE_OPTIONS.filter((option) =>
+    canAssignUserRole(currentUser?.role, option.value)
+  );
+
+  const canEditUser = (target: User): boolean =>
+    currentUser?.user_id === target.user_id ||
+    (isAdmin && hasRoleAuthorityOver(currentUser?.role, target.role));
+
+  const canDeleteUser = (target: User): boolean =>
+    !!currentUser &&
+    currentUser.user_id !== target.user_id &&
+    isAdmin &&
+    hasRoleAuthorityOver(currentUser.role, target.role);
 
   const loadGroups = useCallback(async () => {
     if (!client || !isAdmin) {
@@ -215,26 +234,42 @@ export const UsersTable: React.FC<UsersTableProps> = ({
       title: 'Actions',
       key: 'actions',
       width: 88,
-      render: (_: unknown, user: User) => (
-        <SettingsActionGroup>
-          <Button
-            type="text"
-            size="small"
-            icon={<EditOutlined />}
-            onClick={() => setEditingUser(user)}
-          />
-          <Popconfirm
-            title="Delete user?"
-            description={`Are you sure you want to delete user "${user.email}"?`}
-            onConfirm={() => handleDelete(user.user_id)}
-            okText="Delete"
-            cancelText="Cancel"
-            okButtonProps={{ danger: true }}
-          >
-            <Button type="text" size="small" icon={<DeleteOutlined />} danger />
-          </Popconfirm>
-        </SettingsActionGroup>
-      ),
+      render: (_: unknown, user: User) => {
+        const showEdit = canEditUser(user);
+        const showDelete = canDeleteUser(user);
+        if (!showEdit && !showDelete) return null;
+        return (
+          <SettingsActionGroup>
+            {showEdit && (
+              <Button
+                type="text"
+                size="small"
+                icon={<EditOutlined />}
+                aria-label={`Edit ${user.email}`}
+                onClick={() => setEditingUser(user)}
+              />
+            )}
+            {showDelete && (
+              <Popconfirm
+                title="Delete user?"
+                description={`Are you sure you want to delete user "${user.email}"?`}
+                onConfirm={() => handleDelete(user.user_id)}
+                okText="Delete"
+                cancelText="Cancel"
+                okButtonProps={{ danger: true }}
+              >
+                <Button
+                  type="text"
+                  size="small"
+                  icon={<DeleteOutlined />}
+                  aria-label={`Delete ${user.email}`}
+                  danger
+                />
+              </Popconfirm>
+            )}
+          </SettingsActionGroup>
+        );
+      },
     },
   ];
 
@@ -257,9 +292,11 @@ export const UsersTable: React.FC<UsersTableProps> = ({
             onChange={(event) => setSearchTerm(event.target.value)}
             style={{ width: 320 }}
           />
-          <Button type="primary" icon={<PlusOutlined />} onClick={() => setCreateModalOpen(true)}>
-            New User
-          </Button>
+          {isAdmin && (
+            <Button type="primary" icon={<PlusOutlined />} onClick={() => setCreateModalOpen(true)}>
+              New User
+            </Button>
+          )}
         </Space>
       </div>
 
@@ -333,7 +370,7 @@ export const UsersTable: React.FC<UsersTableProps> = ({
             rules={[{ required: true, message: 'Please select a role' }]}
           >
             <Select
-              options={ROLE_OPTIONS.map((opt) => ({
+              options={assignableRoleOptions.map((opt) => ({
                 value: opt.value,
                 label: opt.label,
                 title: opt.description,

--- a/packages/core/src/db/repositories/users.ts
+++ b/packages/core/src/db/repositories/users.ts
@@ -34,6 +34,12 @@ import {
 
 /**
  * Users repository implementation
+ *
+ * Security boundary: this is a persistence primitive for trusted bootstrap,
+ * external-identity provisioning, and background jobs. It intentionally has
+ * no actor context. Request-driven REST, Socket.IO, MCP, and CLI mutations must
+ * go through the daemon UsersService, which enforces actor/target role
+ * authority before calling the database.
  */
 export class UsersRepository implements BaseRepository<InternalUser, Partial<InternalUser>> {
   constructor(private db: Database) {}

--- a/packages/core/src/types/user.test.ts
+++ b/packages/core/src/types/user.test.ts
@@ -5,7 +5,14 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { normalizeRole } from './user';
+import {
+  canAssignUserRole,
+  compareRoleAuthority,
+  hasMinimumRole,
+  hasRoleAuthorityOver,
+  normalizeRole,
+  ROLES,
+} from './user';
 
 describe('normalizeRole', () => {
   it('converts owner to superadmin', () => {
@@ -30,5 +37,35 @@ describe('normalizeRole', () => {
 
   it('defaults undefined to member', () => {
     expect(normalizeRole(undefined)).toBe('member');
+  });
+});
+
+describe('role authority ordering', () => {
+  const ordered = [ROLES.VIEWER, ROLES.MEMBER, ROLES.ADMIN, ROLES.SUPERADMIN] as const;
+
+  it('orders every role from viewer through superadmin', () => {
+    for (const [actorIndex, actor] of ordered.entries()) {
+      for (const [targetIndex, target] of ordered.entries()) {
+        expect(hasRoleAuthorityOver(actor, target)).toBe(actorIndex >= targetIndex);
+        expect(canAssignUserRole(actor, target)).toBe(actorIndex >= targetIndex);
+        expect(Math.sign(compareRoleAuthority(actor, target))).toBe(
+          Math.sign(actorIndex - targetIndex)
+        );
+      }
+    }
+  });
+
+  it('keeps owner as a read-compatible superadmin alias', () => {
+    expect(compareRoleAuthority('owner', ROLES.SUPERADMIN)).toBe(0);
+    expect(hasRoleAuthorityOver('owner', ROLES.ADMIN)).toBe(true);
+  });
+
+  it('does not grant authority to a missing or unknown role', () => {
+    expect(hasMinimumRole(undefined, ROLES.VIEWER)).toBe(false);
+    expect(hasMinimumRole('not-a-role', ROLES.VIEWER)).toBe(false);
+    expect(hasRoleAuthorityOver(undefined, ROLES.VIEWER)).toBe(false);
+    expect(hasRoleAuthorityOver('not-a-role', ROLES.VIEWER)).toBe(false);
+    expect(hasRoleAuthorityOver('not-a-role', 'not-a-role')).toBe(false);
+    expect(canAssignUserRole('not-a-role', 'not-a-role')).toBe(false);
   });
 });

--- a/packages/core/src/types/user.ts
+++ b/packages/core/src/types/user.ts
@@ -68,13 +68,18 @@ export const ROLE_OPTIONS: readonly RoleOption[] = [
  * Role rank used for minimum-role comparisons.
  * Higher rank = more privileges. 'owner' is a deprecated alias for superadmin.
  */
-const ROLE_RANK: Record<string, number> = {
+const ROLE_AUTHORITY_RANK: Readonly<Record<UserRole | 'owner', number>> = {
   [ROLES.VIEWER]: 0,
   [ROLES.MEMBER]: 1,
   [ROLES.ADMIN]: 2,
   [ROLES.SUPERADMIN]: 3,
   owner: 3,
 };
+
+/** Return true only for canonical roles accepted on new writes. */
+export function isUserRole(role: unknown): role is UserRole {
+  return typeof role === 'string' && Object.values(ROLES).includes(role as UserRole);
+}
 
 /**
  * Normalize legacy role values.
@@ -90,8 +95,55 @@ export function normalizeRole(role: string | undefined): UserRole {
  * Shared by backend hooks and frontend permission checks.
  */
 export function hasMinimumRole(userRole: string | undefined, minimumRole: UserRole): boolean {
+  if (!userRole) return false;
   const normalized = normalizeRole(userRole);
-  return (ROLE_RANK[normalized] ?? 0) >= ROLE_RANK[minimumRole];
+  return (ROLE_AUTHORITY_RANK[normalized] ?? -1) >= (ROLE_AUTHORITY_RANK[minimumRole] ?? -1);
+}
+
+/**
+ * Compare two roles by authority.
+ *
+ * Positive means `left` has more authority, zero means equal authority, and
+ * negative means less authority. Unknown/missing roles are always below every
+ * canonical role. The deprecated `owner` value retains superadmin authority
+ * for reads of historical data, but is canonicalized before new writes.
+ */
+export function compareRoleAuthority(left: string | undefined, right: string | undefined): number {
+  return roleAuthorityRank(left) - roleAuthorityRank(right);
+}
+
+function roleAuthorityRank(role: string | undefined): number {
+  if (!role) return -1;
+  const normalized = normalizeRole(role);
+  return ROLE_AUTHORITY_RANK[normalized] ?? -1;
+}
+
+function isKnownRoleAuthority(role: string | undefined): boolean {
+  return !!role && (isUserRole(role) || role === 'owner');
+}
+
+/** Whether an actor's role is authoritative over a target's current role. */
+export function hasRoleAuthorityOver(
+  actorRole: string | undefined,
+  targetRole: string | undefined
+): boolean {
+  return (
+    isKnownRoleAuthority(actorRole) &&
+    isKnownRoleAuthority(targetRole) &&
+    compareRoleAuthority(actorRole, targetRole) >= 0
+  );
+}
+
+/** Whether an actor may assign the requested role without exceeding their ceiling. */
+export function canAssignUserRole(
+  actorRole: string | undefined,
+  requestedRole: string | undefined
+): boolean {
+  return (
+    isKnownRoleAuthority(actorRole) &&
+    isKnownRoleAuthority(requestedRole) &&
+    compareRoleAuthority(actorRole, requestedRole) >= 0
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

- establish one shared, exhaustive role-authority ordering: `superadmin > admin > member > viewer` (including the legacy `owner` alias)
- enforce actor-vs-target-current-role and actor-vs-requested-role checks inside `UsersService` so REST, Socket.IO, MCP, CLI/REST, and direct Feathers calls share the same authoritative boundary
- reject bulk user mutations, invalid role smuggling, self role changes/deletion, and last-superadmin demotion/deletion; use fresh database actors, target/actor CAS predicates, tenant predicates, and a PostgreSQL tenant advisory lock for authority-changing races
- preserve explicit bootstrap/external-identity persistence seams while replacing serializable trusted flags with narrow in-process markers for avatar sync and env-var widgets
- apply target-role authority to group membership mutations and align Users/Groups settings affordances with server capabilities
- preserve ordinary admin authority for superadmins when `allow_superadmin=false`; that option only disables exceptional branch-RBAC bypass and no longer locks superadmins out of board/session admin operations

## Root cause

User mutations were authorized only by broad before-hooks that checked whether the caller was an admin. They did not load or compare the target user's current role, so a normal admin could patch credentials/profile/role fields on, or delete, a superadmin. The first-superadmin hook also allowed an unsafe promotion path. Separately, the board gate admitted `admin` unconditionally but admitted `superadmin` only when `allow_superadmin` was enabled, inverting the global hierarchy and causing the lockout reported in #2352.

## Enforcement points

- `packages/core/src/types/user.ts`: canonical role comparison and assignment-ceiling helpers
- `apps/agor-daemon/src/services/users.ts`: fresh actor/target authorization, role validation, self/last-superadmin safeguards, tenant/CAS write predicates
- `apps/agor-daemon/src/services/user-authority-lock.ts`: PostgreSQL transaction-scoped serialization for user and membership authority decisions
- `apps/agor-daemon/src/services/user-mutation-trust.ts`: non-transportable, purpose-scoped internal mutation markers
- `apps/agor-daemon/src/services/groups.ts`: target-aware group-membership authorization
- board/session authorization helpers: superadmins always retain the ordinary authority held by admins
- Settings Users/Groups tables and user modal: action visibility, disabled state, and role-option ceilings mirror server policy

## Tests

- focused daemon suites: **395 passed**, **2 PostgreSQL/RLS tests skipped locally** when `AGOR_TEST_POSTGRES_URL` is unavailable
- focused core repository/type suites: **33 passed**
- focused UI settings suites: **33 passed**
- source-aware TypeScript checks for core, daemon, and UI
- Biome staged-file checks
- short-ID, multitenancy, daemon-filesystem, realtime, and `agor-live` dependency boundary checks

PostgreSQL/RLS coverage is included for cross-tenant indistinguishability, positive/negative hierarchy cases, NOBYPASSRLS execution, and concurrent peer-demotion serialization.

Fixes #2352
