### PR TITLE
docs(mcp): make cross-branch session-targeting discoverable in tool descriptions

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/branches.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.ts
@@ -1139,7 +1139,7 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
     'agor_branches_set_zone',
     {
       description:
-        "Pin a branch to a zone on a board, clear its current zone pin with zoneId:null, and optionally trigger the zone's prompt template. Calculates zone center position automatically and creates board association. If the zone has an 'always_new' trigger, a new session is automatically created and the prompt template is executed (matching UI drag-drop behavior). For 'show_picker' zones, use triggerTemplate + targetSessionId to send to an existing session.",
+        "Pin a branch to a zone on a board, clear its current zone pin with zoneId:null, and optionally trigger the zone's prompt template. Calculates zone center position automatically and creates board association. If the zone has an 'always_new' trigger, a new session is automatically created and the prompt template is executed (matching UI drag-drop behavior). For 'show_picker' zones, use triggerTemplate + targetSessionId to send to an existing session on the branch being moved (targetSessionId must live on that branch — cross-branch targets are rejected, since the trigger prompt acts on the moved branch's files). A remote orchestrator on a different branch does NOT target itself here; to be notified when the work finishes, register a completion callback instead (agor_sessions_create enableCallback/callbackSessionId, or agor_sessions_prompt callback).",
       inputSchema: z.object({
         branchId: mcpRequiredId(
           'branchId',
@@ -1158,7 +1158,9 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
         targetSessionId: mcpOptionalId(
           'targetSessionId',
           'Session',
-          'Session ID to send the zone trigger prompt to (required if triggerTemplate is true)'
+          'Session ID to send the zone trigger prompt to (required if triggerTemplate is true). ' +
+            'Must be a session on the branch being moved — cross-branch targets are rejected. ' +
+            'For cross-branch completion notifications (e.g. a remote orchestrator), use a callback instead; see agor_sessions_create.'
         ),
         triggerTemplate: z
           .boolean()

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -359,7 +359,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
     'agor_sessions_get_current',
     {
       description:
-        'Get information about the current session (the one making this MCP call). Returns session details, denormalized branch/repo/board context, and the MCP servers attached to this session (each with `oauth_authenticated` so callers can spot servers needing auth). To browse the broader catalog of servers eligible to attach, use `agor_mcp_servers_list`.',
+        'Get information about the current session (the one making this MCP call). Returns session details, denormalized branch/repo/board context, and the MCP servers attached to this session (each with `oauth_authenticated` so callers can spot servers needing auth). To browse the broader catalog of servers eligible to attach, use `agor_mcp_servers_list`. The returned session_id is the value a remote orchestrator passes as callbackSessionId (agor_sessions_create) to self-target cross-branch completion callbacks; agor_sessions_get_current_context is the leaner way to fetch it.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({}),
     },
@@ -443,7 +443,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
     'agor_sessions_get_current_context',
     {
       description:
-        'Get a lean orientation snapshot for the current session in ONE call. Returns deduplicated context: session identity, user, latest task Git boundaries, branch (zone, issue/PR, notes, environment), board (with zones), repo (slug, default branch), genealogy, and sibling sessions. Every field appears exactly once. Use get_current or entity-specific tools for full details.',
+        'Get a lean orientation snapshot for the current session in ONE call. Returns deduplicated context: session identity, user, latest task Git boundaries, branch (zone, issue/PR, notes, environment), board (with zones), repo (slug, default branch), genealogy, and sibling sessions. Every field appears exactly once. Use get_current or entity-specific tools for full details. The returned session_id is what a remote orchestrator passes as callbackSessionId (agor_sessions_create) to self-target cross-branch completion callbacks.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
         includeSiblings: z
@@ -951,7 +951,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
     'agor_session_relationships_set_callback',
     {
       description:
-        'Enable or disable callback/report-back delivery for a durable session relationship without deleting the relationship itself.',
+        'Enable or disable callback/report-back delivery for a durable session relationship without deleting the relationship itself. Works for cross-branch relationships too (e.g. a remote-created child reporting back to an orchestrator living on another branch).',
       inputSchema: z.object({
         relationshipId: mcpRequiredString(
           'relationshipId',
@@ -1038,7 +1038,8 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         callbackSessionId: mcpOptionalId(
           'callbackSessionId',
           'Session',
-          'Session ID to notify on completion (defaults to the current/creating session when enableCallback is true)'
+          'Session ID to notify on completion (defaults to the current/creating session when enableCallback is true). ' +
+            'Not restricted to the target branch: this may be a session in a DIFFERENT branch — e.g. a remote orchestrator registering its own session (fetch that ID via agor_sessions_get_current_context) to be notified when cross-branch work finishes.'
         ),
         includeLastMessage: z
           .boolean()


### PR DESCRIPTION
## What & why

An orchestrator agent lives on one branch; the actual work happens on a *different* work branch (e.g. a Slack gateway session lands on a teammate's branch, a work branch gets created, and later moves to a "ready for review" zone). The question raised in #agor Slack (2026-08-20): **how does the orchestrator end up notified when that cross-branch work finishes?**

The capability already exists — `agor_sessions_create` has `enableCallback`/`callbackSessionId` built exactly for cross-branch completion routing, and it defaults the callback target to the calling session. But it took real back-and-forth in Slack to establish that, because the tool descriptions alone give an agent no strong signal that:

1. `callbackSessionId` accepts a session in a **different** branch (including the orchestrator's own), and
2. calling `agor_sessions_get_current_context` first to fetch your own `session_id` is the intended way to self-target that callback.

This PR is an **MCP-interface-usability / documentation fix**. It only edits description strings — **no runtime logic changes.**

## Changes (one clarifying clause per spot)

- **`agor_sessions_create`** — `callbackSessionId` now states it is *not* restricted to the target branch and may be the orchestrator's own session on another branch (fetched via `agor_sessions_get_current_context`).
- **`agor_sessions_get_current_context`** / **`agor_sessions_get_current`** — note the returned `session_id` is the value you pass as `callbackSessionId` to self-target cross-branch completion callbacks.
- **`agor_session_relationships_set_callback`** — note it governs cross-branch report-back too.
- **`agor_branches_set_zone`** — corrects a discoverability trap that runs the *opposite* way from the original premise (see below).

## ⚠️ Correction to the original premise: `set_zone` `targetSessionId` is same-branch by design

The task assumed `agor_branches_set_zone`'s `targetSessionId` accepts any session (including a cross-branch orchestrator's own) for self-targeting. **It does not.** The handler explicitly rejects a `targetSessionId` whose branch differs from the branch being moved (`branches.ts:1202-1210`), and this is asserted by a test (`branches.test.ts:1022`). That restriction is intentional: a zone trigger prompt acts on the *moved branch's* files, so its target must live on that branch.

So rather than documenting a cross-branch capability that doesn't exist (and would error), this PR does the honest thing: it makes the same-branch constraint explicit and points cross-branch orchestrators to the **callback** mechanism instead. The correct pattern for "notify me when this branch's work finishes" is a callback, not zone-trigger self-targeting — matching the live "Codex review" zone template precedent ("enable Agor's system callback option … Agor will deliver the callback automatically").

## Scope note

Adjacent tool `agor_sessions_prompt` has a `callback` param that already routes back to the current calling session (works cross-branch); its description was already clear that the target is "the current calling Agor session," so it was left untouched. No broader tool audit was performed — edits stayed within the zone-trigger/session/callback cluster.

## Verification

- `turbo run typecheck --filter=@agor/daemon` ✅
- `vitest run` on `branches.test.ts` + `sessions.test.ts` → **88 passed** ✅
- `biome` lint on both edited files ✅ (also enforced by pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)