### PR TITLE
fix(mcp): merge partial auth updates instead of full-replace (#2500)

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/mcp-servers.ts
+++ b/apps/agor-daemon/src/mcp/tools/mcp-servers.ts
@@ -472,7 +472,7 @@ const mcpServerUpdateSchema = z
     auth: mcpAuthInputSchema
       .optional()
       .describe(
-        "Replace auth config. Existing redacted secrets are preserved if their redacted placeholders are passed back; prefer omitting auth unless changing it. Use { type: 'none' } to clear auth."
+        "Patch auth config: fields you send are merged onto the stored config, so sending only { type:'oauth', oauth_scope:'…' } widens the scope while preserving oauth_client_id, oauth_client_secret, oauth_compatibility_mode, etc. `type` must match the stored mode to merge — changing it (e.g. to a different auth mode, or { type:'none' } to clear auth) replaces the config wholesale. Redacted secrets are preserved when their placeholders are passed back. Send a field as an empty string to clear it."
       ),
     scope: z.enum(['global', 'session']).optional().describe('Scope to set.'),
     enabled: z.boolean().optional().describe('Enabled flag.'),
@@ -842,7 +842,7 @@ export function registerMcpServerTools(server: McpServer, ctx: McpContext): void
     'agor_mcp_servers_update',
     {
       description:
-        'Update an existing MCP server definition. Permissions are service-enforced: admins always may, members only under the workspace `mcp_member_policy`, and nobody but an admin or the owner may touch a private server. Updating config does not create a session-specific link: enabled `global` servers are already effective for all sessions, while `session` scoped servers need `agor_sessions_add_mcp_server`. Provide only fields to change. Validation rejects incompatible combinations (e.g. stdio+url/auth/headers, remote+command/args, wrong auth fields). OAuth tip: keep only `auth:{type:"oauth"}` unless discovery fails or a provider requires endpoint/client overrides. Use `auth:{type:"none"}` to clear auth.',
+        'Update an existing MCP server definition. Permissions are service-enforced: admins always may, members only under the workspace `mcp_member_policy`, and nobody but an admin or the owner may touch a private server. Updating config does not create a session-specific link: enabled `global` servers are already effective for all sessions, while `session` scoped servers need `agor_sessions_add_mcp_server`. Provide only fields to change; the `auth` object is merged onto the stored config field-by-field (same `auth.type`), so you can widen one OAuth field without resending the rest. Validation rejects incompatible combinations (e.g. stdio+url/auth/headers, remote+command/args, wrong auth fields). OAuth tip: keep only `auth:{type:"oauth"}` unless discovery fails or a provider requires endpoint/client overrides. Use `auth:{type:"none"}` to clear auth.',
       annotations: { destructiveHint: false, idempotentHint: false },
       inputSchema: mcpServerUpdateSchema,
     },

--- a/packages/core/src/db/repositories/mcp-servers.test.ts
+++ b/packages/core/src/db/repositories/mcp-servers.test.ts
@@ -460,6 +460,126 @@ describe('MCPServerRepository custom headers', () => {
     }
   );
 
+  dbTest('should merge a partial auth update onto stored config (issue #2500)', async ({ db }) => {
+    const repo = new MCPServerRepository(db);
+    const created = await repo.create(
+      createMCPServerData({
+        name: 'calendar',
+        transport: 'http',
+        url: 'https://mcp.example.com/mcp',
+        auth: {
+          type: 'oauth',
+          oauth_client_id: 'pre-registered-client',
+          oauth_client_secret: 'stored-secret',
+          oauth_compatibility_mode: 'legacy',
+          oauth_scope: 'read',
+        },
+      })
+    );
+
+    // Widen just the scope, exactly as the bug report's agent did.
+    const updated = await repo.update(created.mcp_server_id, {
+      auth: { type: 'oauth', oauth_scope: 'read write' },
+    });
+
+    // Untouched fields survive instead of being clobbered.
+    expect(updated.auth).toEqual({
+      type: 'oauth',
+      oauth_client_id: 'pre-registered-client',
+      oauth_client_secret: 'stored-secret',
+      oauth_compatibility_mode: 'legacy',
+      oauth_scope: 'read write',
+    });
+
+    const found = await repo.findById(created.mcp_server_id);
+    expect(found?.auth).toEqual(updated.auth);
+  });
+
+  dbTest('should apply a full auth update as sent', async ({ db }) => {
+    const repo = new MCPServerRepository(db);
+    const created = await repo.create(
+      createMCPServerData({
+        name: 'calendar',
+        transport: 'http',
+        url: 'https://mcp.example.com/mcp',
+        auth: {
+          type: 'oauth',
+          oauth_client_id: 'pre-registered-client',
+          oauth_client_secret: 'stored-secret',
+          oauth_compatibility_mode: 'legacy',
+        },
+      })
+    );
+
+    // A caller that resends every field still overwrites them all.
+    const updated = await repo.update(created.mcp_server_id, {
+      auth: {
+        type: 'oauth',
+        oauth_client_id: 'new-client',
+        oauth_client_secret: 'new-secret',
+        oauth_compatibility_mode: 'strict',
+        oauth_scope: 'read write',
+      },
+    });
+
+    expect(updated.auth).toEqual({
+      type: 'oauth',
+      oauth_client_id: 'new-client',
+      oauth_client_secret: 'new-secret',
+      oauth_compatibility_mode: 'strict',
+      oauth_scope: 'read write',
+    });
+  });
+
+  dbTest('should clear a single auth field sent as explicit null', async ({ db }) => {
+    const repo = new MCPServerRepository(db);
+    const created = await repo.create(
+      createMCPServerData({
+        name: 'calendar',
+        transport: 'http',
+        url: 'https://mcp.example.com/mcp',
+        auth: {
+          type: 'oauth',
+          oauth_client_id: 'pre-registered-client',
+          oauth_compatibility_mode: 'legacy',
+        },
+      })
+    );
+
+    const updated = await repo.update(created.mcp_server_id, {
+      // null unsets exactly this field; the rest is preserved.
+      auth: { type: 'oauth', oauth_compatibility_mode: null } as unknown as MCPServer['auth'],
+    });
+
+    expect(updated.auth).toEqual({
+      type: 'oauth',
+      oauth_client_id: 'pre-registered-client',
+    });
+  });
+
+  dbTest('should replace auth wholesale on a mode switch', async ({ db }) => {
+    const repo = new MCPServerRepository(db);
+    const created = await repo.create(
+      createMCPServerData({
+        name: 'calendar',
+        transport: 'http',
+        url: 'https://mcp.example.com/mcp',
+        auth: {
+          type: 'oauth',
+          oauth_client_id: 'pre-registered-client',
+          oauth_client_secret: 'stored-secret',
+        },
+      })
+    );
+
+    // Switching auth mode must not leave stale oauth_* fields behind.
+    const updated = await repo.update(created.mcp_server_id, {
+      auth: { type: 'bearer', token: 'new-token' },
+    });
+
+    expect(updated.auth).toEqual({ type: 'bearer', token: 'new-token' });
+  });
+
   dbTest('should clear custom headers when updating to stdio transport', async ({ db }) => {
     const repo = new MCPServerRepository(db);
     const created = await repo.create(

--- a/packages/core/src/db/repositories/mcp-servers.ts
+++ b/packages/core/src/db/repositories/mcp-servers.ts
@@ -15,7 +15,7 @@ import type {
 } from '@agor/core/types';
 import { and, eq, isNull, like, or } from 'drizzle-orm';
 import { generateId } from '../../lib/ids';
-import { restoreRedactedMCPAuthSecrets } from '../../tools/mcp/auth-secrets';
+import { mergeMCPAuth } from '../../tools/mcp/auth-secrets';
 import { restoreRedactedMCPEnvSecrets } from '../../tools/mcp/env-secrets';
 import {
   normalizeMCPCustomHeaders,
@@ -280,7 +280,10 @@ export class MCPServerRepository
         });
       }
       if ('auth' in updates) {
-        merged.auth = restoreRedactedMCPAuthSecrets({
+        // Partial auth updates PATCH onto the stored config: omitted fields are
+        // preserved, an explicit null clears a single field, and a mode switch
+        // (changed `auth.type`) replaces wholesale. See issue #2500.
+        merged.auth = mergeMCPAuth({
           current: current.auth,
           next: updates.auth,
         });

--- a/packages/core/src/tools/mcp/auth-secrets.test.ts
+++ b/packages/core/src/tools/mcp/auth-secrets.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { redactMCPAuthSecrets, restoreRedactedMCPAuthSecrets } from './auth-secrets';
+import type { MCPAuth } from '../../types/mcp';
+import { mergeMCPAuth, redactMCPAuthSecrets, restoreRedactedMCPAuthSecrets } from './auth-secrets';
 import { MCP_HEADER_REDACTED_SENTINEL } from './http-headers';
 
 describe('MCP auth secret helpers', () => {
@@ -180,5 +181,107 @@ describe('MCP auth secret helpers', () => {
 
     expect(restored).toEqual({ type: 'oauth', oauth_client_id: 'public-client-id' });
     expect(restored).not.toHaveProperty('oauth_access_token');
+  });
+});
+
+describe('mergeMCPAuth', () => {
+  const stored: MCPAuth = {
+    type: 'oauth',
+    oauth_client_id: 'pre-registered-client',
+    oauth_client_secret: 'stored-secret',
+    oauth_compatibility_mode: 'legacy',
+    oauth_scope: 'read',
+  };
+
+  it('preserves untouched fields when only one sub-field changes (issue #2500)', () => {
+    // The bug: widening scope on a Google Calendar connector wiped the
+    // pre-registered client id/secret and the legacy compatibility mode.
+    const merged = mergeMCPAuth({
+      current: stored,
+      next: { type: 'oauth', oauth_scope: 'read write' },
+    });
+
+    expect(merged).toEqual({
+      type: 'oauth',
+      oauth_client_id: 'pre-registered-client',
+      oauth_client_secret: 'stored-secret',
+      oauth_compatibility_mode: 'legacy',
+      oauth_scope: 'read write',
+    });
+  });
+
+  it('keeps stored secrets when a redaction sentinel is passed back', () => {
+    const merged = mergeMCPAuth({
+      current: stored,
+      next: {
+        type: 'oauth',
+        oauth_client_secret: MCP_HEADER_REDACTED_SENTINEL,
+        oauth_scope: 'read write',
+      },
+    });
+
+    expect(merged?.oauth_client_secret).toBe('stored-secret');
+    expect(merged?.oauth_scope).toBe('read write');
+    // Untouched metadata still survives the merge.
+    expect(merged?.oauth_compatibility_mode).toBe('legacy');
+  });
+
+  it('clears exactly one field when it is sent as an explicit null', () => {
+    const merged = mergeMCPAuth({
+      current: stored,
+      // Callers reach this path through the service/REST layer; null is the
+      // documented "unset this one field" escape hatch.
+      next: { type: 'oauth', oauth_compatibility_mode: null } as unknown as MCPAuth,
+    });
+
+    expect(merged).not.toHaveProperty('oauth_compatibility_mode');
+    // Everything the caller did not mention is still there.
+    expect(merged?.oauth_client_id).toBe('pre-registered-client');
+    expect(merged?.oauth_client_secret).toBe('stored-secret');
+    expect(merged?.oauth_scope).toBe('read');
+  });
+
+  it('distinguishes an explicit null from an omitted field', () => {
+    const merged = mergeMCPAuth({
+      current: stored,
+      // oauth_scope omitted → kept; oauth_client_id null → cleared.
+      next: { type: 'oauth', oauth_client_id: null } as unknown as MCPAuth,
+    });
+
+    expect(merged).not.toHaveProperty('oauth_client_id');
+    expect(merged?.oauth_scope).toBe('read');
+  });
+
+  it('replaces wholesale on a mode switch so stale fields never survive', () => {
+    const merged = mergeMCPAuth({
+      current: stored,
+      next: { type: 'bearer', token: 'new-token' },
+    });
+
+    expect(merged).toEqual({ type: 'bearer', token: 'new-token' });
+  });
+
+  it('drops a sentinel with nothing to restore on a mode switch', () => {
+    const merged = mergeMCPAuth({
+      current: stored,
+      next: { type: 'bearer', token: MCP_HEADER_REDACTED_SENTINEL },
+    });
+
+    expect(merged).toEqual({ type: 'bearer' });
+    expect(merged).not.toHaveProperty('token');
+  });
+
+  it('replaces wholesale when there is no stored auth', () => {
+    const merged = mergeMCPAuth({
+      current: undefined,
+      next: { type: 'oauth', oauth_scope: 'read' },
+    });
+
+    expect(merged).toEqual({ type: 'oauth', oauth_scope: 'read' });
+  });
+
+  it('clears auth entirely when next is null or undefined', () => {
+    expect(mergeMCPAuth({ current: stored, next: null })).toBeUndefined();
+    expect(mergeMCPAuth({ current: stored, next: undefined })).toBeUndefined();
   });
 });

--- a/packages/core/src/tools/mcp/auth-secrets.ts
+++ b/packages/core/src/tools/mcp/auth-secrets.ts
@@ -84,3 +84,62 @@ export function restoreRedactedMCPAuthSecrets(options: {
 
   return restored;
 }
+
+/**
+ * Merge a partial `auth` update onto the stored config for a persisted update.
+ *
+ * The stored update path is PATCH, not PUT: a caller widening one sub-field
+ * (say `oauth_scope`) must not silently clear the others. Widening scope on a
+ * Google Calendar connector used to wipe `oauth_compatibility_mode`, the
+ * pre-registered `oauth_client_id`, and the client secret, because the whole
+ * `auth` object was replaced by whatever the caller sent (see issue #2500). So:
+ *
+ * - An **omitted** field keeps its stored value.
+ * - An **explicit `null`** clears that one field — the escape hatch for unsetting
+ *   a previously-set value without resending the rest.
+ * - A **redaction sentinel** in a secret field is a claim of "unchanged": the
+ *   stored secret is preserved and the sentinel is never persisted (see the
+ *   INVARIANT on {@link restoreRedactedMCPAuthSecrets}).
+ * - A **new value** overwrites.
+ *
+ * Merging is scoped to a single auth *mode*. Changing `type` (e.g. `oauth` →
+ * `none`, or `oauth` → `bearer`) makes the previous mode's fields meaningless,
+ * so a mode switch is a full replace — stale fields from the old mode never
+ * survive. An omitted or `null` `next` clears auth entirely.
+ */
+export function mergeMCPAuth(options: {
+  current?: MCPAuth;
+  next?: MCPAuth | null;
+}): MCPAuth | undefined {
+  if (options.next === null || options.next === undefined) return undefined;
+
+  const next = options.next as unknown as Record<string, unknown>;
+
+  // Only merge within one mode. On a mode switch (or when there is no stored
+  // auth) start from an empty base so the incoming object fully replaces it.
+  const sameType = options.current !== undefined && next.type === options.current.type;
+  const merged: Record<string, unknown> = sameType
+    ? { ...(options.current as unknown as Record<string, unknown>) }
+    : {};
+
+  const secretFields = new Set<string>(MCP_AUTH_SECRET_FIELDS);
+
+  for (const key of Object.keys(next)) {
+    const value = next[key];
+    // Present-but-undefined is treated as omission: keep the stored value.
+    if (value === undefined) continue;
+    // Explicit null clears exactly this field; omission would have kept it.
+    if (value === null) {
+      delete merged[key];
+      continue;
+    }
+    // A sentinel means "unchanged": keep the stored secret already carried in
+    // `merged` (same-mode merge), or drop it when there is nothing stored to
+    // restore (mode switch, or a stale form after a concurrent edit). The
+    // sentinel itself must never be persisted.
+    if (secretFields.has(key) && value === MCP_HEADER_REDACTED_SENTINEL) continue;
+    merged[key] = value;
+  }
+
+  return merged as unknown as MCPAuth;
+}

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.test.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.test.ts
@@ -1377,14 +1377,20 @@ describe('strict current MCP OAuth profile', () => {
 
   it('guesses issuer-relative /register only for explicit legacy fallback', async () => {
     globalThis.fetch = strictFetch();
-    await expect(
+    const missingEndpointError = await rejectedError<Error & { diagnostic: MCPOAuthDCRDiagnostic }>(
       startMCPOAuthFlow(
         `Bearer resource_metadata="${metadataUri}"`,
         undefined,
         'https://agor.example.com/mcp-servers/oauth-callback',
         { resourceUri, compatibilityMode: 'legacy', dcrMode: 'advertised' }
       )
-    ).rejects.toThrow('does not advertise');
+    );
+    expect(missingEndpointError.message).toContain('does not advertise');
+    // The internal stage identifier stays on the structured diagnostic for
+    // logging but must not leak into the user-facing message (issue #2500).
+    expect(missingEndpointError.diagnostic.stage).toBe('dcr_endpoint_discovery');
+    expect(missingEndpointError.message).not.toContain('stage:');
+    expect(missingEndpointError.message).not.toContain('dcr_endpoint_discovery');
     expect(vi.mocked(globalThis.fetch)).not.toHaveBeenCalledWith(
       `${issuer}/register`,
       expect.objectContaining({ method: 'POST' })

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.ts
@@ -471,8 +471,11 @@ function registrationFailure(
     ? lead
     : `Dynamic Client Registration failed: ${lead}`;
   const status = diagnostic.http_status === undefined ? '' : ` (HTTP ${diagnostic.http_status})`;
+  // The internal `diagnostic.stage` identifier is carried on the structured
+  // diagnostic (and logged), but must not leak into the user-facing message —
+  // see issue #2500. The message stays actionable via the recovery guidance.
   return new OAuthDCRFailure(
-    `${failureLead}${status} at stage ${diagnostic.stage}. ${dcrRecoveryGuidance(diagnostic)}`,
+    `${failureLead}${status}. ${dcrRecoveryGuidance(diagnostic)}`,
     diagnostic
   );
 }
@@ -480,7 +483,7 @@ function registrationFailure(
 function missingRegistrationEndpointFailure(): OAuthDCRFailure {
   const diagnostic: MCPOAuthDCRDiagnostic = { stage: 'dcr_endpoint_discovery' };
   return new OAuthDCRFailure(
-    'OAuth client_id is required because the authorization server does not advertise a Dynamic Client Registration endpoint (stage: dcr_endpoint_discovery). The provider may require a pre-registered OAuth app. Enter the Client ID and Client Secret in Advanced — OAuth settings, then retry.',
+    'OAuth client_id is required because the authorization server does not advertise a Dynamic Client Registration endpoint. The provider may require a pre-registered OAuth app. Enter the Client ID and Client Secret in Advanced — OAuth settings, then retry.',
     diagnostic
   );
 }


### PR DESCRIPTION
## Summary

Fixes the root cause of #2500: `agor_mcp_servers_update` (and every REST/UI path through `MCPServerRepository.update`) did a **full replace** of the `auth` object rather than a merge. An agent widening one OAuth sub-field — e.g. sending `{ type: "oauth", oauth_scope: "..." }` to broaden Google Calendar write scope — silently cleared `oauth_compatibility_mode` (was `legacy`), the pre-registered `oauth_client_id`, and the client secret. That then cascaded into two more confusing, unrelated-looking errors (`Protected resource metadata does not match the MCP resource URI`, then `OAuth client_id is required ... (stage: dcr_endpoint_discovery)`), each of which looked like a new bug. Since there's no read/GET of current auth, callers had no safe way to merge client-side first.

## What changed

**Merge semantics (the core fix).** Stored `auth` updates are now PATCH, not PUT, via a new `mergeMCPAuth` helper used in the single repository update choke point (so it fixes the MCP tool, the REST API, and the web UI at once):

- **Omitted** fields keep their stored value.
- An **explicit `null`** clears exactly that one field — so a previously-set field can still be intentionally unset without resending the rest.
- A **redaction sentinel** in a secret field still means "unchanged" and is never persisted (existing invariant, preserved).
- Changing **`auth.type`** (a mode switch, e.g. `oauth` → `none`/`bearer`) still replaces wholesale, so stale fields from the old mode never survive as dead config.

Tool descriptions for `agor_mcp_servers_update` were updated to document the merge behavior.

**Leaky OAuth error strings (small, in-scope cleanup from the issue).** The internal DCR stage identifier (e.g. `stage: dcr_endpoint_discovery`) no longer leaks into user-facing OAuth error messages. The stage stays on the structured `diagnostic` object for logging/telemetry, and the message keeps its actionable recovery guidance ("configure a pre-registered Client ID/Secret in Advanced — OAuth settings").

## Tests

- Unit tests for `mergeMCPAuth`: partial merge preserves untouched fields, sentinel preservation, explicit-null vs omitted, mode-switch full replace, no-stored-auth replace, whole-object clear.
- Repository integration tests: partial auth update preserves untouched fields (the exact #2500 repro), full update overwrites, single-field `null` clear, mode switch drops stale fields.
- Regression test that the internal DCR stage identifier does not appear in the user-facing message while the structured `diagnostic.stage` still carries it.
- The read-path secret-redaction invariant (secrets never returned in read responses) remains covered by the existing service/hook tests, which this change does not touch.

Ran `packages/core` MCP suites (194 passed) and the relevant daemon MCP service/hook suites (38 passed); Biome clean on all touched files.

## Follow-up (intentionally out of scope)

The issue also flags **session hot-reload**: an MCP server auth change does not propagate to already-attached/in-progress sessions without a manual reconnect. That's a separately-scoped executor/session config-propagation change and is deliberately **not** included here so it doesn't block the merge-semantics fix. Flagging explicitly rather than dropping it.

## Related

- Fixes #2500
- Cross-references #2271 (strict/legacy DCR migration gap). That issue tracks a different scope; this PR addresses the general update-safety bug its comment thread flags as a caveat. Not a duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)