### PR TITLE
fix(oauth): auto-close successful callback tabs

### DIFF
--- a/apps/agor-daemon/src/register-services.oauth-callback.test.ts
+++ b/apps/agor-daemon/src/register-services.oauth-callback.test.ts
@@ -115,6 +115,46 @@ describe('register-services OAuth callback URL regression', () => {
     expect(loggedExpressions).not.toMatch(/\b(?:code|state|tokenResponse|pendingFlow\.context)\b/);
   });
 
+  it('persists the grant and notifies the initiating UI before serving the closing page', () => {
+    const callbackBody = rawSource.slice(
+      rawSource.indexOf('const oauthCallbackHandler'),
+      rawSource.indexOf("app.use('/mcp-servers',")
+    );
+    const successBody = callbackBody.slice(
+      callbackBody.indexOf(
+        "persistOAuthTokenForPendingFlow(tokenResponse, pendingFlow, 'OAuth Callback')"
+      ),
+      callbackBody.indexOf('} catch (innerErr)')
+    );
+
+    const persistIndex = successBody.indexOf('persistOAuthTokenForPendingFlow');
+    const notifyIndex = successBody.indexOf('emitOAuthCompletion(pendingFlow, true)');
+    const resolveIndex = successBody.indexOf('pendingFlow.tokenResolve?.(tokenResponse)');
+    const renderIndex = successBody.indexOf('sendOAuthResultPage(res, true');
+
+    expect(persistIndex).toBeGreaterThanOrEqual(0);
+    expect(notifyIndex).toBeGreaterThan(persistIndex);
+    expect(resolveIndex).toBeGreaterThan(notifyIndex);
+    expect(renderIndex).toBeGreaterThan(resolveIndex);
+  });
+
+  it('marks callback responses no-store and renders denied/error states without success mode', () => {
+    const callbackBody = codeOnly.slice(
+      codeOnly.indexOf('const oauthCallbackHandler'),
+      codeOnly.indexOf("app.use('/mcp-servers',")
+    );
+
+    expect(callbackBody).toMatch(
+      /setHeader\s*\(\s*['"]Cache-Control['"]\s*,\s*['"]no-store['"]\s*\)/
+    );
+    expect(callbackBody).toMatch(
+      /if\s*\(\s*error\s*\)[\s\S]*sendOAuthResultPage\s*\(\s*res\s*,\s*false/
+    );
+    expect(callbackBody).toMatch(
+      /if\s*\(\s*!code\s*\|\|\s*!state\s*\)[\s\S]*sendOAuthResultPage\s*\(\s*res\s*,\s*false/
+    );
+  });
+
   it('uses one phase-aware failure classifier for callback and manual completion', () => {
     const classifications = codeOnly.match(/classifyMCPOAuthCompletionFailure\s*\(/g) ?? [];
     expect(classifications).toHaveLength(2);

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -192,7 +192,7 @@ import { requestExecutorTermination } from './termination-coordinator.js';
 import { appendSystemMessage } from './utils/append-system-message.js';
 import { requireMinimumRole } from './utils/authorization.js';
 import { emitServiceEvent } from './utils/emit-service-event.js';
-import { escapeHtml } from './utils/html.js';
+import { renderOAuthResultPage } from './utils/html.js';
 import { persistDiscoveredMCPCapabilities } from './utils/mcp-discovered-capabilities.js';
 import {
   shouldExposeMCPServerSecrets,
@@ -1438,19 +1438,6 @@ async function registerMCPServices(
     });
   };
 
-  // Helper to generate a simple HTML page for OAuth callback results
-  function oauthResultPage(success: boolean, message: string): string {
-    const color = success ? '#52c41a' : '#ff4d4f';
-    const icon = success ? '&#10003;' : '&#10007;';
-    const safeMessage = escapeHtml(message);
-    return `<!DOCTYPE html>
-<html><head><meta charset="utf-8"><title>Agor OAuth</title>
-<style>body{font-family:system-ui,sans-serif;display:flex;justify-content:center;align-items:center;min-height:100vh;margin:0;background:#1a1a1a;color:#fff}
-.card{text-align:center;padding:2rem;border-radius:8px;background:#2a2a2a;max-width:400px}
-.icon{font-size:3rem;color:${color}}</style></head>
-<body><div class="card"><div class="icon">${icon}</div><p>${safeMessage}</p></div></body></html>`;
-  }
-
   type PendingOAuthFlow = {
     attemptId: MCPOAuthAttemptID;
     context: OAuthFlowContext;
@@ -2136,7 +2123,7 @@ async function registerMCPServices(
 
   const terminalMessageForStatus = (status: MCPOAuthPendingFlowStatus): string => {
     if (status === 'succeeded') {
-      return 'OAuth authentication already completed. You can close this tab.';
+      return 'OAuth authentication has already completed successfully.';
     }
     if (status === 'ambiguous' || status === 'exchanging') {
       return 'OAuth exchange outcome is uncertain. Start a new OAuth flow; the previous authorization code will not be replayed.';
@@ -2144,12 +2131,23 @@ async function registerMCPServices(
     return 'OAuth flow did not complete. Please start a new flow.';
   };
 
+  const sendOAuthResultPage = (
+    res: express.Response,
+    success: boolean,
+    message: string,
+    status = 200
+  ): void => {
+    const page = renderOAuthResultPage(success, message);
+    res.setHeader('Content-Security-Policy', page.contentSecurityPolicy);
+    res.status(status).send(page.html);
+  };
+
   // Set the OAuth callback handler
   const oauthCallbackHandler = async (req: express.Request, res: express.Response) => {
-    res.setHeader('Content-Security-Policy', "default-src 'none'; style-src 'unsafe-inline'");
     res.setHeader('X-Content-Type-Options', 'nosniff');
     res.setHeader('X-Frame-Options', 'DENY');
     res.setHeader('Referrer-Policy', 'no-referrer');
+    res.setHeader('Cache-Control', 'no-store');
     try {
       const code = req.query.code as string | undefined;
       const state = req.query.state as string | undefined;
@@ -2170,14 +2168,17 @@ async function registerMCPServices(
             pendingOAuthFlows.delete(state);
           }
         }
-        res
-          .status(400)
-          .send(oauthResultPage(false, 'Authorization was not completed. Please restart OAuth.'));
+        sendOAuthResultPage(
+          res,
+          false,
+          'Authorization was not completed. Please restart OAuth.',
+          400
+        );
         return;
       }
 
       if (!code || !state) {
-        res.status(400).send(oauthResultPage(false, 'Missing code or state parameter'));
+        sendOAuthResultPage(res, false, 'Missing code or state parameter', 400);
         return;
       }
 
@@ -2186,28 +2187,24 @@ async function registerMCPServices(
         const claimed = await durableOAuthFlows.claimForCallback(state);
         if (claimed.outcome === 'not_claimed') {
           if (claimed.flow?.status === 'succeeded') {
-            res.send(oauthResultPage(true, terminalMessageForStatus('succeeded')));
+            sendOAuthResultPage(res, true, terminalMessageForStatus('succeeded'));
             return;
           }
-          res
-            .status(409)
-            .send(
-              oauthResultPage(
-                false,
-                claimed.flow
-                  ? terminalMessageForStatus(claimed.flow.status)
-                  : 'OAuth flow expired or not found. Please start the flow again.'
-              )
-            );
+          sendOAuthResultPage(
+            res,
+            false,
+            claimed.flow
+              ? terminalMessageForStatus(claimed.flow.status)
+              : 'OAuth flow expired or not found. Please start the flow again.',
+            409
+          );
           return;
         }
         try {
           pendingFlow = pendingFromDurableClaim(durableOAuthFlows.openClaim(claimed.flow, state));
         } catch {
           await durableOAuthFlows.finish(claimed.flow, 'failed', 'sealed_material_unavailable');
-          res
-            .status(409)
-            .send(oauthResultPage(false, 'OAuth flow cannot be resumed. Please start again.'));
+          sendOAuthResultPage(res, false, 'OAuth flow cannot be resumed. Please start again.', 409);
           return;
         }
       } else {
@@ -2230,11 +2227,12 @@ async function registerMCPServices(
         }
       }
       if (!pendingFlow) {
-        res
-          .status(400)
-          .send(
-            oauthResultPage(false, 'OAuth flow expired or not found. Please start the flow again.')
-          );
+        sendOAuthResultPage(
+          res,
+          false,
+          'OAuth flow expired or not found. Please start the flow again.',
+          400
+        );
         return;
       }
 
@@ -2256,7 +2254,7 @@ async function registerMCPServices(
         pendingFlow.tokenResolve?.(tokenResponse);
 
         console.log('[OAuth Callback] Flow completed successfully');
-        res.send(oauthResultPage(true, 'OAuth authentication successful! You can close this tab.'));
+        sendOAuthResultPage(res, true, 'OAuth authentication was successful.');
       } catch (innerErr) {
         const classification = classifyMCPOAuthCompletionFailure(innerErr);
         const { ambiguous } = classification;
@@ -2282,25 +2280,24 @@ async function registerMCPServices(
               : 'OAuth provider rejected the authorization. Start a new OAuth flow.'
           )
         );
-        res
-          .status(ambiguous ? 409 : 400)
-          .send(
-            oauthResultPage(false, terminalMessageForStatus(ambiguous ? 'ambiguous' : 'failed'))
-          );
+        sendOAuthResultPage(
+          res,
+          false,
+          terminalMessageForStatus(ambiguous ? 'ambiguous' : 'failed'),
+          ambiguous ? 409 : 400
+        );
         return;
       }
     } catch (err) {
       console.error(
         `[OAuth Callback] Failed category=${err instanceof Error ? err.name : 'unknown'}`
       );
-      res
-        .status(500)
-        .send(
-          oauthResultPage(
-            false,
-            'Authentication could not be completed. Please start a new OAuth flow.'
-          )
-        );
+      sendOAuthResultPage(
+        res,
+        false,
+        'Authentication could not be completed. Please start a new OAuth flow.',
+        500
+      );
     }
   };
 

--- a/apps/agor-daemon/src/utils/html.test.ts
+++ b/apps/agor-daemon/src/utils/html.test.ts
@@ -1,0 +1,148 @@
+import vm from 'node:vm';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { OAUTH_SUCCESS_AUTO_CLOSE_DELAY_MS, renderOAuthResultPage } from './html.js';
+
+function inlineScript(html: string): string {
+  const match = html.match(/<script nonce="[^"]+">([\s\S]*?)<\/script>/);
+  if (!match?.[1]) throw new Error('Expected an inline OAuth confirmation script');
+  return match[1];
+}
+
+function confirmationRuntime(opts: { closeAllowed?: boolean } = {}) {
+  const elements = {
+    'close-countdown': { textContent: '3 seconds' },
+    'close-status': {
+      textContent: 'This tab will close automatically in 3 seconds.',
+    },
+  };
+  const root = { dataset: {} as Record<string, string> };
+  let pagehide: (() => void) | undefined;
+  const windowObject = {
+    closed: false,
+    close: vi.fn(),
+    setInterval,
+    clearInterval,
+    setTimeout,
+    clearTimeout,
+    addEventListener: vi.fn((type: string, listener: () => void) => {
+      if (type === 'pagehide') pagehide = listener;
+    }),
+  };
+  if (opts.closeAllowed) {
+    windowObject.close.mockImplementation(() => {
+      windowObject.closed = true;
+    });
+  }
+  const documentObject = {
+    documentElement: root,
+    getElementById: (id: keyof typeof elements) => elements[id] ?? null,
+  };
+
+  return {
+    elements,
+    pagehide: () => pagehide?.(),
+    root,
+    run: (script: string) =>
+      vm.runInNewContext(script, { document: documentObject, window: windowObject }),
+    window: windowObject,
+  };
+}
+
+describe('renderOAuthResultPage', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('shows a clear success and accessible three-second close notice immediately', () => {
+    const page = renderOAuthResultPage(true, 'OAuth authentication was successful.');
+
+    expect(page.html).toContain('<h1 id="result-heading">Authentication complete</h1>');
+    expect(page.html).toContain('OAuth authentication was successful.');
+    expect(page.html).toContain('This tab will close automatically in');
+    expect(page.html).toContain('role="timer" aria-live="off"');
+    expect(page.html).toContain('3 seconds');
+    expect(page.html).toContain('If this page stays open, you can close this tab');
+
+    const nonce = page.html.match(/<script nonce="([^"]+)">/)?.[1];
+    expect(nonce).toBeTruthy();
+    expect(page.contentSecurityPolicy).toContain(`script-src 'nonce-${nonce}'`);
+  });
+
+  it('attempts to close only after the full delay and updates the quiet countdown', () => {
+    const page = renderOAuthResultPage(true, 'Connected.');
+    const runtime = confirmationRuntime({ closeAllowed: true });
+    runtime.run(inlineScript(page.html));
+
+    expect(runtime.window.close).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1_000);
+    expect(runtime.elements['close-countdown'].textContent).toBe('2 seconds');
+    vi.advanceTimersByTime(1_000);
+    expect(runtime.elements['close-countdown'].textContent).toBe('1 second');
+    vi.advanceTimersByTime(OAUTH_SUCCESS_AUTO_CLOSE_DELAY_MS - 2_000 - 1);
+    expect(runtime.window.close).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(runtime.window.close).toHaveBeenCalledOnce();
+  });
+
+  it('keeps a useful manual-tab fallback when the browser blocks close', () => {
+    const page = renderOAuthResultPage(true, 'Connected.');
+    const runtime = confirmationRuntime();
+    runtime.run(inlineScript(page.html));
+
+    vi.advanceTimersByTime(OAUTH_SUCCESS_AUTO_CLOSE_DELAY_MS);
+
+    expect(runtime.window.close).toHaveBeenCalledOnce();
+    expect(runtime.window.closed).toBe(false);
+    expect(runtime.elements['close-status'].textContent).toBe(
+      'This tab did not close automatically. You can close this tab and return to Agor.'
+    );
+  });
+
+  it('does not depend on an opener for direct navigation', () => {
+    const page = renderOAuthResultPage(true, 'Connected.');
+    const runtime = confirmationRuntime();
+
+    expect(() => runtime.run(inlineScript(page.html))).not.toThrow();
+    expect('opener' in runtime.window).toBe(false);
+    vi.advanceTimersByTime(OAUTH_SUCCESS_AUTO_CLOSE_DELAY_MS);
+    expect(runtime.elements['close-status'].textContent).toMatch(
+      /close this tab and return to Agor/
+    );
+  });
+
+  it('starts only one timer set if the success script is evaluated more than once', () => {
+    const page = renderOAuthResultPage(true, 'Connected.');
+    const runtime = confirmationRuntime();
+    const script = inlineScript(page.html);
+
+    runtime.run(script);
+    runtime.run(script);
+    vi.advanceTimersByTime(OAUTH_SUCCESS_AUTO_CLOSE_DELAY_MS);
+
+    expect(runtime.window.close).toHaveBeenCalledOnce();
+    expect(runtime.window.addEventListener).toHaveBeenCalledOnce();
+  });
+
+  it('cleans up both timers when the page is discarded', () => {
+    const page = renderOAuthResultPage(true, 'Connected.');
+    const runtime = confirmationRuntime();
+    runtime.run(inlineScript(page.html));
+
+    vi.advanceTimersByTime(1_000);
+    runtime.pagehide();
+    vi.advanceTimersByTime(OAUTH_SUCCESS_AUTO_CLOSE_DELAY_MS);
+
+    expect(runtime.window.close).not.toHaveBeenCalled();
+    expect(runtime.elements['close-countdown'].textContent).toBe('2 seconds');
+  });
+
+  it('never adds timers or close script to error, denied, or recovery pages', () => {
+    const page = renderOAuthResultPage(false, '<provider error>');
+
+    expect(page.html).toContain('Authentication not completed');
+    expect(page.html).toContain('&lt;provider error&gt;');
+    expect(page.html).not.toContain('<script');
+    expect(page.html).not.toContain('window.close');
+    expect(page.html).not.toContain('close-countdown');
+    expect(page.contentSecurityPolicy).not.toContain('script-src');
+  });
+});

--- a/apps/agor-daemon/src/utils/html.ts
+++ b/apps/agor-daemon/src/utils/html.ts
@@ -6,6 +6,21 @@
  * a handful of times — this is a targeted helper, not a rendering engine.
  */
 
+import { randomBytes } from 'node:crypto';
+
+/**
+ * Keep successful OAuth confirmation visible long enough to be understood,
+ * without making the user clean up a transient authorization tab themselves.
+ * Three seconds is a conventional short confirmation interval and gives the
+ * user time to read both the result and the close notice.
+ */
+export const OAUTH_SUCCESS_AUTO_CLOSE_DELAY_MS = 3_000;
+
+export interface RenderedHtmlPage {
+  html: string;
+  contentSecurityPolicy: string;
+}
+
 /**
  * Escape a value for safe insertion into HTML text or quoted-attribute
  * contexts. Covers the five characters required by both contexts:
@@ -22,4 +37,91 @@ export function escapeHtml(value: unknown): string {
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#39;');
+}
+
+/**
+ * Render the terminal MCP OAuth callback page.
+ *
+ * Only confirmed successes receive script and a close timer. Error, denied,
+ * expired, malformed, and recovery pages remain static so the user can read
+ * and act on them. The script never reads the callback URL, provider response,
+ * or opener, and a per-response nonce keeps the callback's CSP narrow.
+ */
+export function renderOAuthResultPage(success: boolean, message: string): RenderedHtmlPage {
+  const color = success ? '#3fb950' : '#f85149';
+  const icon = success ? '&#10003;' : '&#10007;';
+  const heading = success ? 'Authentication complete' : 'Authentication not completed';
+  const safeMessage = escapeHtml(message);
+  const nonce = success ? randomBytes(18).toString('base64url') : undefined;
+  const autoCloseSeconds = Math.ceil(OAUTH_SUCCESS_AUTO_CLOSE_DELAY_MS / 1_000);
+  const autoCloseMarkup = success
+    ? `<p id="close-status" class="close-status">This tab will close automatically in <span id="close-countdown" role="timer" aria-live="off" aria-atomic="true">${autoCloseSeconds} seconds</span>.</p>
+    <p class="fallback">If this page stays open, you can close this tab and return to Agor.</p>
+    <noscript><p class="fallback">JavaScript is unavailable, so you can close this tab and return to Agor.</p></noscript>`
+    : '';
+  const autoCloseScript = success
+    ? `<script nonce="${nonce}">
+(() => {
+  const root = document.documentElement;
+  if (root.dataset.agorOauthAutoCloseStarted === 'true') return;
+  root.dataset.agorOauthAutoCloseStarted = 'true';
+
+  const status = document.getElementById('close-status');
+  const countdown = document.getElementById('close-countdown');
+  let secondsRemaining = ${autoCloseSeconds};
+  const intervalId = window.setInterval(() => {
+    if (secondsRemaining <= 1) return;
+    secondsRemaining -= 1;
+    if (countdown) {
+      countdown.textContent = secondsRemaining + (secondsRemaining === 1 ? ' second' : ' seconds');
+    }
+  }, 1000);
+  const closeTimerId = window.setTimeout(() => {
+    window.clearInterval(intervalId);
+    window.close();
+    if (!window.closed && status) {
+      status.textContent = 'This tab did not close automatically. You can close this tab and return to Agor.';
+    }
+  }, ${OAUTH_SUCCESS_AUTO_CLOSE_DELAY_MS});
+
+  window.addEventListener('pagehide', () => {
+    window.clearInterval(intervalId);
+    window.clearTimeout(closeTimerId);
+  }, { once: true });
+})();
+</script>`
+    : '';
+
+  return {
+    contentSecurityPolicy: nonce
+      ? `default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}'`
+      : "default-src 'none'; style-src 'unsafe-inline'",
+    html: `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Agor OAuth</title>
+  <style>
+    * { box-sizing: border-box; }
+    body { font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; display: flex; justify-content: center; align-items: center; min-height: 100vh; margin: 0; padding: 24px; background: #0d1117; color: #e6edf3; }
+    .card { width: 100%; max-width: 440px; padding: 32px; border: 1px solid #30363d; border-radius: 12px; background: #161b22; text-align: center; }
+    .icon { color: ${color}; font-size: 3rem; line-height: 1; }
+    h1 { margin: 16px 0 12px; color: ${color}; font-size: 1.5rem; }
+    p { margin: 0; color: #b1bac4; line-height: 1.6; }
+    .close-status { margin-top: 16px; color: #e6edf3; }
+    .fallback { margin-top: 10px; font-size: 0.875rem; }
+  </style>
+</head>
+<body>
+  <main class="card" aria-labelledby="result-heading">
+    <div class="icon" aria-hidden="true">${icon}</div>
+    <h1 id="result-heading">${heading}</h1>
+    <p>${safeMessage}</p>
+    ${autoCloseMarkup}
+  </main>
+  ${autoCloseScript}
+</body>
+</html>`,
+  };
 }


### PR DESCRIPTION
## Summary

- keep the confirmed MCP OAuth success page visible for **3 seconds**, with an accessible, non-announcing countdown, before attempting `window.close()`
- keep a useful manual-tab fallback when browsers reject script-driven close, and make the timer idempotent/cleanup-safe
- preserve static, readable pages for denied, malformed, expired, ambiguous, and recovery outcomes
- serve the success script through a per-response CSP nonce and mark callback responses `no-store`

## Delay rationale

Three seconds is at the upper end of the requested short confirmation interval: it is long enough to recognize the success heading and read the close notice, while still feeling like transient OAuth completion feedback. `window.close()` is only expected to work for script-opened browsing contexts, so the page always retains manual-close guidance ([MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/close)). The countdown uses `role="timer"` with its implicit `aria-live="off"`, so updates remain inspectable without producing repeated screen-reader announcements ([MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/timer_role)). There is no animation to reconcile with reduced-motion preferences.

## OAuth surface review

- **MCP Settings OAuth start:** opened in a new tab with `window.open(..., '_blank', 'noopener,noreferrer')`; completion remains authoritative through durable attempt polling/refetch plus the scoped realtime hint. Changed its daemon callback success page.
- **MCP discover/test compatibility flows:** the daemon sends `oauth:open_browser` only to the initiating socket and the UI opens the same kind of isolated tab. Changed the shared daemon callback success page.
- **Direct/reloaded MCP callback URL:** confirmed durable `succeeded` outcomes use the same success page and safely fall back to manual close when the tab is not script-closable.
- **GitHub App gateway setup callback:** opened in a new tab, but its callback only returns an unverified installation ID that the admin must carry into the remaining setup flow. It is intentionally unchanged and does not auto-close.
- **OpenCode native provider OAuth:** the UI opens a provider/runtime-owned authorization URL and the managed OpenCode runtime owns callback completion; Agor does not render a callback confirmation page there. It is intentionally unchanged.

Server-side token exchange, tenant-scoped persistence, durable completion, realtime notification, and blocking-flow resolution all still happen before the browser receives the closing page. No opener/postMessage relationship is introduced or required.

## Tests

- `pnpm exec vitest run src/utils/html.test.ts src/register-services.oauth-callback.test.ts` — 17 passed
- focused daemon OAuth/callback/security suite — 70 passed, 12 PostgreSQL-environment tests skipped
- focused UI OAuth start/recovery/polling suite — 13 passed
- full daemon suite — 2,971 passed, 78 skipped
- focused Biome check — passed
- direct TypeScript check for the new helper and tests — passed

The package-level daemon typecheck could not resolve unbuilt workspace declaration packages such as `@agor/core/*` in this fresh worktree; no build was run per repository instructions.

## Security / tenancy

This changes only terminal callback rendering. Existing tenant-bound pending-flow authority and token persistence are unchanged. Success script generation uses a random CSP nonce, never reads the callback URL/opener, never logs browser state, and renders no authorization code or raw provider error.
