### PR TITLE
fix(zone-trigger): Fork/Spawn from zone trigger picker do nothing

### DIFF
--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -75,6 +75,7 @@ import {
   selectUserById,
 } from '../../store/selectors';
 import type { AgenticToolOption } from '../../types';
+import { useThemedMessage } from '../../utils/message';
 import { REACT_FLOW_DRAG_HANDLE_SELECTOR } from '../../utils/reactFlowDragClasses';
 import { buildScopedBoardCss } from '../../utils/sanitizeCss';
 import { isDarkTheme } from '../../utils/theme';
@@ -453,6 +454,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
   ) => {
     const { token } = theme.useToken();
     const mutationGate = useMutationGate();
+    const { showError } = useThemedMessage();
 
     // Entity state via narrow store subscriptions. Each whole-map selector is a
     // stable module-level reference, so a slice only re-renders the canvas when
@@ -618,7 +620,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
             case 'fork': {
               const forkedSession = (await client
                 .service(`sessions/${targetSessionId}/fork`)
-                .create({})) as Session;
+                .create({ prompt: renderedTemplate })) as Session;
               await client.sessions.prompt(forkedSession.session_id, renderedTemplate, {
                 permissionMode,
               });
@@ -628,7 +630,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
             case 'spawn': {
               const spawnedSession = (await client
                 .service(`sessions/${targetSessionId}/spawn`)
-                .create({})) as Session;
+                .create({ prompt: renderedTemplate })) as Session;
               await client.sessions.prompt(spawnedSession.session_id, renderedTemplate, {
                 permissionMode,
               });
@@ -641,6 +643,9 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
           if (resultSessionId) onSessionClick?.(resultSessionId);
         } catch (error) {
           console.error('❌ Failed to execute zone trigger:', error);
+          showError(
+            `Failed to ${action} session: ${error instanceof Error ? error.message : String(error)}`
+          );
         } finally {
           setBranchTriggerModal(null);
         }


### PR DESCRIPTION
## Repro steps

1. Configure a board zone with trigger type `show_picker`.
2. Drop a worktree/branch card into the zone.
3. In the resulting picker, choose **Fork** or **Spawn** (not Prompt).

**Expected:** a new forked/spawned session is created and starts working on the rendered prompt.
**Actual:** the modal just closes. No session is created, no error is shown to the user.

## Root cause

In `apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx`, the zone trigger modal's `onExecute` handler builds a `switch (action)` over `prompt` / `fork` / `spawn`:

- `case 'prompt'` correctly calls `client.sessions.prompt(targetSessionId, renderedTemplate, ...)`.
- `case 'fork'` and `case 'spawn'` called `.../fork` and `.../spawn` with an **empty** `{}` body, then tried to send the prompt via a separate follow-up `client.sessions.prompt(...)` call afterward.

On the backend (`apps/agor-daemon/src/services/sessions.ts`):
- `fork(id, data, params)` does `title: data.prompt.substring(0, 100)` with no guard — `data.prompt` is `undefined` when called with `{}`, so this throws a `TypeError` synchronously before any session is created.
- `spawn(id, data, params)` explicitly does `if (!data.prompt) throw new Error('Spawn requires a prompt')`.

Both exceptions propagate to the frontend's outer `try/catch`, which only did `console.error(...)` and closed the modal in `finally`. From the user's perspective: pick Fork or Spawn, modal closes, nothing visible happens.

## What changed

- `fork` and `spawn` `.create()` calls now pass `{ prompt: renderedTemplate }`, matching what the `prompt` case already does, so the backend no longer throws.
- Kept the existing follow-up `client.sessions.prompt(...)` call after fork/spawn — verified it is *not* redundant: `fork()`/`spawn()` only persist `title`/`description` on the new session row (status `idle`); no task is created and the executor is never invoked. Only the `/sessions/:id/prompt` route actually creates/dispatches a task via `executeTask`, so it's still required to make the new session start working.
- Wired the `onExecute` catch block into the existing `useThemedMessage()` error toast (already used elsewhere in the app, e.g. `SessionCard.tsx`, `SessionPanel.tsx`) instead of `console.error`-only, so failures on this path are now visible to the user.

## Test plan

- [x] `pnpm --filter agor-ui lint` (biome) — clean on the touched file
- [x] `pnpm --filter @agor/daemon exec vitest run src/services/zone-trigger.test.ts src/services/sessions.child-identity.test.ts` — 7 passed
- [x] `pnpm --filter agor-ui exec vitest run src/components/SessionCanvas/canvas/ZoneTriggerModal.test.tsx src/components/SessionCanvas/SessionCanvas.rerender.test.tsx` — 19 passed
- [x] Manual verification in a running dev environment: drop a branch into a `show_picker` zone and confirm Fork/Spawn now create a working session (not done in this task — static verification only, per task scope)

Note: `pnpm --filter agor-ui typecheck` currently fails repo-wide with `Cannot find module '@agor-live/client'` across dozens of unrelated files — this is a pre-existing unbuilt-workspace-package issue in this environment, not something introduced by this change (confirmed no new errors reference `utils/message` or the edited lines beyond pre-existing unrelated `TS18046`/`TS2307` noise in the same file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)