### PR TITLE
feat(callbacks): add childSessionTitle template variable

### DIFF
--- a/apps/agor-daemon/src/services/tasks.callbacks.test.ts
+++ b/apps/agor-daemon/src/services/tasks.callbacks.test.ts
@@ -1,4 +1,4 @@
-import { runWithTenantDatabaseScope } from '@agor/core/db';
+import { runWithTenantDatabaseScope, shortId } from '@agor/core/db';
 import { type Session, type Task, TaskStatus } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
 import { completionCallbackTaskId } from '../utils/durable-task-id.js';
@@ -345,6 +345,28 @@ describe('TasksService completion callbacks', () => {
     expect(callbackPrompt).toContain(originalPrompt);
     expect(callbackPrompt).toContain('**Result:**');
     expect(callbackPrompt).toContain('Final child result');
+  });
+
+  it('exposes childSessionTitle to custom callback templates', async () => {
+    const { service, createPending } = makeService({
+      childSession: { title: 'Investigate flaky test' },
+      parentSession: {
+        callback_config: {
+          template: 'Child "{{childSessionTitle}}" ({{childSessionId}}) is done.',
+        },
+      },
+    });
+
+    await service.patch(taskId, {
+      status: TaskStatus.COMPLETED,
+      completed_at: '2026-01-01T00:00:05.000Z',
+    });
+
+    await vi.waitFor(() => expect(createPending).toHaveBeenCalledTimes(1));
+    const callbackPrompt = createPending.mock.calls[0][0].full_prompt as string;
+    expect(callbackPrompt).toBe(
+      `Child "Investigate flaky test" (${shortId(childSessionId as Session['session_id'])}) is done.`
+    );
   });
 
   it('uses the same single templated patch completion path for sessions.create callbacks without spawn genealogy', async () => {

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -1230,6 +1230,7 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
       const context: ChildCompletionContext = {
         childSessionId: shortId(childSession.session_id),
         childSessionFullId: childSession.session_id,
+        childSessionTitle: childSession.title || '',
         childTaskId: shortId(task.task_id),
         childTaskFullId: task.task_id,
         parentSessionId: shortId(targetSessionId), // backward compat

--- a/apps/agor-ui/src/components/CallbackConfigForm/CallbackConfigForm.tsx
+++ b/apps/agor-ui/src/components/CallbackConfigForm/CallbackConfigForm.tsx
@@ -73,9 +73,9 @@ export const CallbackConfigForm: React.FC<CallbackConfigFormProps> = ({ showHelp
       {showHelpText && (
         <Paragraph type="secondary" style={{ fontSize: 12, marginTop: -16 }}>
           Advanced: Customize the callback message template using Handlebars syntax. Available
-          variables: <Text code>childSessionId</Text>, <Text code>spawnPrompt</Text>,{' '}
-          <Text code>status</Text>, <Text code>messageCount</Text>, <Text code>toolUseCount</Text>,{' '}
-          <Text code>lastAssistantMessage</Text>
+          variables: <Text code>childSessionId</Text>, <Text code>childSessionTitle</Text>,{' '}
+          <Text code>spawnPrompt</Text>, <Text code>status</Text>, <Text code>messageCount</Text>,{' '}
+          <Text code>toolUseCount</Text>, <Text code>lastAssistantMessage</Text>
         </Paragraph>
       )}
     </>

--- a/context/explorations/parent-session-callbacks.md
+++ b/context/explorations/parent-session-callbacks.md
@@ -127,9 +127,9 @@ Parent receives notification, can fetch details via MCP
    - Also provide MCP tool instructions for deeper inspection
 
 4. **Task Description for Spawn Prompt**
-   - ✅ Confirmed: `task.description` contains the spawn prompt (truncated to 120 chars)
-   - Consistent with TaskHeader display in UI
-   - Use `task.description` in callback template
+   - ✅ Confirmed: `task.full_prompt` contains the spawn prompt (not truncated)
+   - Only included in the callback context when `callback_config.include_original_prompt` is set
+   - Use `task.full_prompt` in callback template
 
 5. **Database Schema**
    - `callback_config` stored as JSON TEXT column
@@ -311,6 +311,7 @@ All open questions have been resolved and moved to "Design Decisions" section:
                      │ Render Callback     │
                      │ Template with:      │
                      │ - childSessionId    │
+                     │ - childSessionTitle │
                      │ - spawnPrompt       │
                      │ - completedAt       │
                      │ - messageCount      │
@@ -462,7 +463,7 @@ Parent Agent    MCP Server    Sessions Svc    Child Session    TasksService    M
 ```json
 {
   "task_id": "task-uuid",
-  "status": "COMPLETED",
+  "status": "completed",
   "completed_at": "2025-01-14T15:32:18Z",
   "message_range": {
     "start_index": 0,
@@ -482,11 +483,12 @@ Parent Agent    MCP Server    Sessions Svc    Child Session    TasksService    M
 {
   "childSessionId": "4a7b3c2d",
   "childSessionFullId": "4a7b3c2d-e5f6-7890-abcd-ef1234567890",
+  "childSessionTitle": "Analyze git history",
   "childTaskId": "8f3e9a1c",
   "childTaskFullId": "8f3e9a1c-1234-5678-90ab-cdef12345678",
   "parentSessionId": "03b62447",
   "spawnPrompt": "Analyze the git history for the past week",
-  "status": "COMPLETED",
+  "status": "completed",
   "completedAt": "2025-01-14T15:32:18Z",
   "messageCount": 12,
   "toolUseCount": 8
@@ -499,7 +501,7 @@ Parent Agent    MCP Server    Sessions Svc    Child Session    TasksService    M
 [Agor] Child session 4a7b3c2d has completed.
 
 **Task:** Analyze the git history for the past week
-**Status:** COMPLETED
+**Status:** completed
 **Stats:** 12 messages, 8 tool uses
 
 **Result:**
@@ -520,7 +522,7 @@ Use `agor_tasks_get` (taskId: "8f3e9a1c-1234-5678-90ab-cdef12345678") or `agor_s
 [Agor] Child session 4a7b3c2d has failed.
 
 **Task:** Analyze the git history for the past week
-**Status:** FAILED
+**Status:** failed
 **Stats:** 8 messages, 5 tool uses
 
 **Result:**
@@ -588,16 +590,17 @@ import Handlebars from 'handlebars';
  * Variables available:
  * - childSessionId: Short ID of completed child session
  * - childSessionFullId: Full UUIDv7 of child session
+ * - childSessionTitle: Title of the completed child session
  * - childTaskId: Short ID of completed task
  * - childTaskFullId: Full UUIDv7 of task
  * - parentSessionId: Short ID of parent session
  * - spawnPrompt: Original prompt given to child
- * - status: Task status (COMPLETED, FAILED, etc.)
+ * - status: Task status (completed, failed, etc.)
  * - completedAt: ISO timestamp of completion
  * - messageCount: Number of messages in completed task
  * - toolUseCount: Number of tools used
  */
-const DEFAULT_TEMPLATE = `[Agor] Child session {{childSessionId}} has {{#if (eq status "COMPLETED")}}completed{{else}}failed{{/if}}.
+const DEFAULT_TEMPLATE = `[Agor] Child session {{childSessionId}} has {{#if (eq status "completed")}}completed{{else}}failed{{/if}}.
 
 **Task:** {{spawnPrompt}}
 **Status:** {{status}}
@@ -606,18 +609,19 @@ const DEFAULT_TEMPLATE = `[Agor] Child session {{childSessionId}} has {{#if (eq 
 {{#if lastAssistantMessage}}**Result:**
 {{lastAssistantMessage}}
 
-{{/if}}{{#if (eq status "COMPLETED")}}Use \`agor_tasks_get\` (taskId: "{{childTaskFullId}}") or \`agor_sessions_get\` (sessionId: "{{childSessionFullId}}") for more details.{{else}}Investigate the failure using \`agor_tasks_get\` (taskId: "{{childTaskFullId}}") or \`agor_sessions_get\` (sessionId: "{{childSessionFullId}}").
+{{/if}}{{#if (eq status "completed")}}Use \`agor_tasks_get\` (taskId: "{{childTaskFullId}}") or \`agor_sessions_get\` (sessionId: "{{childSessionFullId}}") for more details.{{else}}Investigate the failure using \`agor_tasks_get\` (taskId: "{{childTaskFullId}}") or \`agor_sessions_get\` (sessionId: "{{childSessionFullId}}").
 
 Review what went wrong and decide whether to retry or take a different approach.{{/if}}`;
 
 export interface ChildCompletionContext {
-  childSessionId: string; // Short ID (first 8 chars)
+  childSessionId: string; // Canonical short ID (24 chars, via shortId())
   childSessionFullId: string; // Full UUIDv7
+  childSessionTitle: string; // Title of the completed child session (empty string if unset)
   childTaskId: string; // Short ID of completed task
   childTaskFullId: string; // Full UUIDv7 of task
   parentSessionId: string; // Short ID of parent
-  spawnPrompt: string; // Original prompt from spawn (truncated to 120 chars)
-  status: string; // Task status (COMPLETED, FAILED, etc.)
+  spawnPrompt?: string; // Original prompt from spawn (only when include_original_prompt is set; not truncated)
+  status: string; // Task status (completed, failed, etc.)
   completedAt: string; // ISO timestamp
   messageCount: number;
   toolUseCount: number;

--- a/packages/core/src/callbacks/child-completion-template.ts
+++ b/packages/core/src/callbacks/child-completion-template.ts
@@ -6,6 +6,8 @@
  *   `SHORT_ID_LENGTH` chars via `shortId(id)`; collision-safe even when
  *   parents fan out children in the same millisecond)
  * - childSessionFullId: Full UUIDv7 of child session
+ * - childSessionTitle: Title of the completed child session (falls back to
+ *   the empty string when the child session has no title set)
  * - childTaskId: Short ID of completed task (same shape)
  * - childTaskFullId: Full UUIDv7 of task
  * - parentSessionId: Short ID of callback target session (alias: callbackSessionId)
@@ -43,6 +45,7 @@ Review what went wrong and decide whether to retry or take a different approach.
 export interface ChildCompletionContext {
   childSessionId: string; // Canonical short ID (shortId(childSession.session_id))
   childSessionFullId: string; // Full UUIDv7
+  childSessionTitle: string; // Title of the completed child session (empty string if unset)
   childTaskId: string; // Canonical short ID
   childTaskFullId: string; // Full UUIDv7 of task
   parentSessionId: string; // Canonical short ID of callback target (kept for backward compat)


### PR DESCRIPTION
## Summary
- Adds `childSessionTitle` to the child-completion callback template context, so custom Handlebars templates can reference the completed child session's human-readable title alongside `childSessionId`.
- Populates it at the single call site that builds `ChildCompletionContext` (`TasksService.queueCallbackToSession` in `apps/agor-daemon/src/services/tasks.ts`), which handles both spawn-based (subsession) and `sessions.create`-based (remote/cross-branch orchestrator) callbacks — there is only one construction site, so both paths get the new variable for free.
- Updates the `CallbackConfigForm` help text listing available template variables.
- Adds a test exercising a custom template that uses `{{childSessionTitle}}`.

## Naming rationale
Went with **`childSessionTitle`** rather than `sessionTitle`/`sessionName`/etc:
- The field is called `title` on the `Session` type (`packages/core/src/types/session.ts`) and in the API response (`agor_sessions_get`/`agor_sessions_list` return `title`), backed by `data.title` in the DB and flattened by the repository layer — there's no separate "name" or "summary" concept for this field internally.
- The existing context already namespaces child-session fields with a `child` prefix (`childSessionId`, `childSessionFullId`), so `childSessionTitle` is consistent with that convention and unambiguous next to `parentSessionId`/`callbackSessionId` (the target/orchestrator session).

Falls back to an empty string when the child session has no title set, so existing templates that don't reference it are unaffected and templates that do reference it never render `undefined`.

## Test plan
- [x] `pnpm --filter @agor/daemon exec vitest run src/services/tasks.callbacks.test.ts` — 16 passed, including new `exposes childSessionTitle to custom callback templates` test
- [x] `pnpm exec biome check` on all touched files — clean
- [x] Pre-commit hooks (biome) passed on commit