### PR TITLE
fix(ui): surface gateway session genealogy

### DIFF
--- a/apps/agor-docs/content/guide/message-gateway.mdx
+++ b/apps/agor-docs/content/guide/message-gateway.mdx
@@ -220,7 +220,11 @@ Gateway conversations appear under **Gateway Sessions** on the target branch. Se
 
 ### Optional session cleanup
 
-Gateway Sessions are retained until someone archives them. If a teammate branch accumulates too many old conversations, use a [scheduled prompt](/guide/scheduler) for an explicit, workspace-specific policy rather than relying on a product-wide default. Have the scheduled teammate call `agor_sessions_bulk_archive` with `sessionType: "gateway"`, its `branchId`, and the desired `olderThanDays`; test the filter with `dryRun: true` before changing the schedule to `dryRun: false`.
+Gateway Sessions are retained until someone archives them. Agor does not currently run an automatic gateway-retention worker or expose a per-channel retention setting.
+
+For branch-wide cleanup today, use a [scheduled prompt](/guide/scheduler) for an explicit, workspace-specific policy. Have the scheduled teammate call `agor_sessions_bulk_archive` with `sessionType: "gateway"`, its `branchId`, and the desired `olderThanDays`; test the filter with `dryRun: true` before changing the schedule to `dryRun: false`.
+
+This workaround is not the same as per-channel inactivity retention. It uses the Session's last-updated time, accepts whole days, scopes to a branch rather than a gateway channel, and archives only the matching gateway Session rows—not their spawned or remote-created children. Review those children separately before setting `dryRun: false`.
 
 Archiving is reversible and preserves the Session transcript for search and audit. The tool applies the schedule owner's normal RBAC permissions and reports Sessions it cannot modify.
 

--- a/apps/agor-docs/content/guide/message-gateway.mdx
+++ b/apps/agor-docs/content/guide/message-gateway.mdx
@@ -216,6 +216,14 @@ The one step neither path can cover is the **app-level token**: `connections:wri
 
 DM the bot from the **Apps** section of Slack, or `@mention` it in any channel or group the bot has been added to. You'll see session creation confirmed, followed by the agent's response in the same thread. In channels and group DMs the bot responds **only** to explicit `@`-mentions; direct messages don't need one.
 
+Gateway conversations appear under **Gateway Sessions** on the target branch. Sessions they spawn are nested beneath the gateway parent, including remote-created sessions that live on another branch; selecting a remote child opens its canonical session. Gateway roots are ordered by most recent activity. Section and parent collapse choices persist on board cards.
+
+### Optional session cleanup
+
+Gateway Sessions are retained until someone archives them. If a teammate branch accumulates too many old conversations, use a [scheduled prompt](/guide/scheduler) for an explicit, workspace-specific policy rather than relying on a product-wide default. Have the scheduled teammate call `agor_sessions_bulk_archive` with `sessionType: "gateway"`, its `branchId`, and the desired `olderThanDays`; test the filter with `dryRun: true` before changing the schedule to `dryRun: false`.
+
+Archiving is reversible and preserves the Session transcript for search and audit. The tool applies the schedule owner's normal RBAC permissions and reports Sessions it cannot modify.
+
 ### Scope reference
 
 The wizard and manifest bake these in automatically. This table is for understanding what each capability grants, not a checklist to apply by hand. Scopes are bot scopes (requested in the manifest); `connections:write` is the one app-level scope, generated separately on the app-level (`xapp-`) token.

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.test.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.test.tsx
@@ -90,6 +90,22 @@ function makeManualSession(
   } as unknown as Session;
 }
 
+function makeGatewaySession(
+  overrides: { session_id: string; title: string } & Record<string, unknown>
+): Session {
+  return makeManualSession({
+    custom_context: {
+      gateway_source: {
+        channel_id: 'gateway-channel-1',
+        channel_type: 'slack',
+        channel_name: 'Team Slack',
+        thread_id: 'thread-1',
+      },
+    },
+    ...overrides,
+  });
+}
+
 function getSessionTreeToggle(sessionTitle: string): HTMLElement {
   const mockedToggle = screen.queryByLabelText(
     new RegExp(`(collapse|expand) ${sessionTitle}`, 'i')
@@ -200,6 +216,85 @@ describe('BranchSessionSections', () => {
     expect(screen.queryByText('Archived parent')).not.toBeInTheDocument();
     expect(screen.getByText('Visible child')).toBeInTheDocument();
     expect(screen.getByText('1')).toBeInTheDocument();
+  });
+
+  it('nests local and remote children under MRU-sorted gateway parents', async () => {
+    const olderGateway = makeGatewaySession({
+      session_id: 'gateway-older',
+      title: 'Older gateway',
+      last_updated: '2026-06-01T00:00:00.000Z',
+      genealogy: { children: ['gateway-child', 'gateway-remote-child'] },
+    });
+    const child = makeManualSession({
+      session_id: 'gateway-child',
+      title: 'Spawned child',
+      genealogy: { parent_session_id: olderGateway.session_id, children: [] },
+    });
+    const remoteChild = makeManualSession({
+      session_id: 'gateway-remote-child',
+      title: 'Remote child',
+      genealogy: { parent_session_id: olderGateway.session_id, children: [] },
+      remote_surrogate: {
+        source_session_id: olderGateway.session_id,
+        source_branch_id: 'branch-1',
+        target_branch_id: 'branch-2',
+        relationship: { relationship_type: 'remote_create' },
+      },
+    });
+    const newerGateway = makeGatewaySession({
+      session_id: 'gateway-newer',
+      title: 'Newer gateway',
+      last_updated: '2026-06-04T00:00:00.000Z',
+    });
+    const onSessionClick = vi.fn();
+
+    const { container, unmount } = renderSections({
+      sessions: [olderGateway, child, remoteChild, newerGateway],
+      onSessionClick,
+    });
+
+    expect(screen.getByText('Spawned child')).toBeInTheDocument();
+    expect(screen.getByText('Remote child')).toBeInTheDocument();
+    expect(screen.getAllByText('Team Slack')).toHaveLength(2);
+    expect(
+      Array.from(container.querySelectorAll('[data-session-id]')).map((row) =>
+        row.getAttribute('data-session-id')
+      )
+    ).toEqual(['gateway-newer', 'gateway-older', 'gateway-child', 'gateway-remote-child']);
+
+    fireEvent.click(getSessionTreeToggle('Older gateway'));
+    await waitFor(() => expect(screen.queryByText('Spawned child')).not.toBeInTheDocument());
+    expect(screen.queryByText('Remote child')).not.toBeInTheDocument();
+
+    unmount();
+    renderSections({
+      sessions: [olderGateway, child, remoteChild, newerGateway],
+      onSessionClick,
+    });
+    expect(screen.queryByText('Spawned child')).not.toBeInTheDocument();
+    expect(screen.queryByText('Remote child')).not.toBeInTheDocument();
+
+    fireEvent.click(getSessionTreeToggle('Older gateway'));
+    fireEvent.click(await screen.findByText('Remote child'));
+    expect(onSessionClick).toHaveBeenCalledWith('gateway-remote-child');
+  });
+
+  it('persists a collapsed Gateway Sessions section across card remounts', async () => {
+    const gateway = makeGatewaySession({
+      session_id: 'gateway-session',
+      title: 'Gateway conversation',
+    });
+    const { unmount } = renderSections({ sessions: [gateway] });
+
+    fireEvent.click(screen.getByText('Gateway Sessions'));
+    await waitFor(() => {
+      expect(readStoredCollapsedNodes()?.['branch-1']?.sections).toContain('gateway-sessions');
+    });
+
+    unmount();
+    renderSections({ sessions: [gateway] });
+    expect(screen.queryByText('Gateway conversation')).not.toBeInTheDocument();
+    expect(screen.getByText('Gateway Sessions')).toBeInTheDocument();
   });
 
   it('keeps a manually collapsed parent collapsed after selecting another session', async () => {

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -515,9 +515,45 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
   }, []);
 
   const activeSessions = useMemo(() => sessions.filter((s) => !s.archived), [sessions]);
-  const manualSessions = useMemo(
-    () => activeSessions.filter((s) => !s.scheduled_from_branch && !isGatewaySession(s)),
+  const gatewayRootSessions = useMemo(
+    () => activeSessions.filter((s) => !s.scheduled_from_branch && isGatewaySession(s)),
     [activeSessions, isGatewaySession]
+  );
+  const gatewayTreeSessionIds = useMemo(() => {
+    const included = new Set<string>(gatewayRootSessions.map((session) => session.session_id));
+    const candidates = activeSessions.filter((session) => !session.scheduled_from_branch);
+    const childrenByParent = new Map<string, string[]>();
+
+    // A gateway child does not carry gateway_source itself. Follow the same
+    // genealogy edges used by buildSessionTree (including remote surrogates)
+    // so descendants stay with the gateway conversation instead of being
+    // promoted to unrelated roots in the manual Sessions section.
+    for (const session of candidates) {
+      const parentId =
+        session.genealogy?.parent_session_id ?? session.genealogy?.forked_from_session_id;
+      if (!parentId) continue;
+      const children = childrenByParent.get(parentId) ?? [];
+      children.push(session.session_id);
+      childrenByParent.set(parentId, children);
+    }
+    const pending = [...included];
+    for (let index = 0; index < pending.length; index += 1) {
+      for (const childId of childrenByParent.get(pending[index]) ?? []) {
+        if (included.has(childId)) continue;
+        included.add(childId);
+        pending.push(childId);
+      }
+    }
+
+    return included;
+  }, [activeSessions, gatewayRootSessions]);
+  const manualSessions = useMemo(
+    () =>
+      activeSessions.filter(
+        (session) =>
+          !session.scheduled_from_branch && !gatewayTreeSessionIds.has(session.session_id)
+      ),
+    [activeSessions, gatewayTreeSessionIds]
   );
   const scheduledSessions = useMemo(
     () =>
@@ -526,13 +562,16 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
         .sort((a, b) => (b.scheduled_run_at || 0) - (a.scheduled_run_at || 0)),
     [activeSessions]
   );
-  const gatewaySessions = useMemo(
-    () => activeSessions.filter((s) => isGatewaySession(s)),
-    [activeSessions, isGatewaySession]
+  const gatewayTreeSessions = useMemo(
+    () =>
+      activeSessions.filter(
+        (session) => !session.scheduled_from_branch && gatewayTreeSessionIds.has(session.session_id)
+      ),
+    [activeSessions, gatewayTreeSessionIds]
   );
   const searchablePanelSessions = useMemo(
-    () => [...manualSessions, ...scheduledSessions, ...gatewaySessions],
-    [gatewaySessions, manualSessions, scheduledSessions]
+    () => [...manualSessions, ...scheduledSessions, ...gatewayTreeSessions],
+    [gatewayTreeSessions, manualSessions, scheduledSessions]
   );
   const sortedManualSessions = useMemo(
     () => (isManualSessionsOpen ? sortSessions(manualSessions, sort) : []),
@@ -542,20 +581,29 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
     () => (isManualSessionsOpen ? buildSessionTree(sortedManualSessions) : []),
     [isManualSessionsOpen, sortedManualSessions]
   );
-  const expandableKeys = useMemo(() => {
-    const collectKeysWithChildren = (nodes: SessionTreeNode[]): React.Key[] => {
-      const keys: React.Key[] = [];
-      for (const node of nodes) {
-        if (node.children && node.children.length > 0) {
-          keys.push(node.key);
-          keys.push(...collectKeysWithChildren(node.children));
-        }
+  const gatewaySessionTreeData = useMemo(
+    () =>
+      isGatewaySessionsOpen ? buildSessionTree(sortSessions(gatewayTreeSessions, 'recent')) : [],
+    [gatewayTreeSessions, isGatewaySessionsOpen]
+  );
+  const collectExpandableKeys = useCallback((nodes: SessionTreeNode[]): React.Key[] => {
+    const keys: React.Key[] = [];
+    for (const node of nodes) {
+      if (node.children && node.children.length > 0) {
+        keys.push(node.key);
+        keys.push(...collectExpandableKeys(node.children));
       }
-      return keys;
-    };
-
-    return collectKeysWithChildren(sessionTreeData);
-  }, [sessionTreeData]);
+    }
+    return keys;
+  }, []);
+  const manualExpandableKeys = useMemo(
+    () => collectExpandableKeys(sessionTreeData),
+    [collectExpandableKeys, sessionTreeData]
+  );
+  const gatewayExpandableKeys = useMemo(
+    () => collectExpandableKeys(gatewaySessionTreeData),
+    [collectExpandableKeys, gatewaySessionTreeData]
+  );
   const searchResults = useMemo(
     () =>
       isPanel && searchActive
@@ -569,8 +617,8 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
     [scheduledSessions]
   );
   const hasRunningGatewaySession = useMemo(
-    () => gatewaySessions.some(isSessionExecuting),
-    [gatewaySessions]
+    () => gatewayTreeSessions.some(isSessionExecuting),
+    [gatewayTreeSessions]
   );
 
   const isCreating = branch.filesystem_status === 'creating';
@@ -583,9 +631,13 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
   // that newly gain children start expanded, while stored exceptions survive
   // sessions temporarily leaving the tree (archive, lost children).
   const collapsedSessionIds = collapsedNode.sessionIds;
-  const expandedKeys = useMemo(
-    () => expandableKeys.filter((key) => !collapsedSessionIds?.includes(String(key))),
-    [collapsedSessionIds, expandableKeys]
+  const expandedManualKeys = useMemo(
+    () => manualExpandableKeys.filter((key) => !collapsedSessionIds?.includes(String(key))),
+    [collapsedSessionIds, manualExpandableKeys]
+  );
+  const expandedGatewayKeys = useMemo(
+    () => gatewayExpandableKeys.filter((key) => !collapsedSessionIds?.includes(String(key))),
+    [collapsedSessionIds, gatewayExpandableKeys]
   );
 
   const toggleSessionCollapsed = useCallback(
@@ -601,7 +653,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
   );
 
   const handleSessionTreeExpand = useCallback(
-    (keys: React.Key[]) => {
+    (keys: React.Key[], expandableKeys: React.Key[]) => {
       // Only reconcile keys currently in the tree so exceptions stored for
       // sessions outside this render set (archived, filtered) are preserved.
       const expandedKeySet = new Set(keys.map(String));
@@ -615,7 +667,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
         return { ...node, sessionIds: [...sessionIds] };
       });
     },
-    [expandableKeys, updateCollapsedNode]
+    [updateCollapsedNode]
   );
 
   const sessionRowStyle = (session: Session): React.CSSProperties => {
@@ -827,6 +879,8 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
     const isRemoteSurrogate = node.relationshipType === 'remote';
     const callbackToggle = getCallbackToggle(session);
     const remoteParentId = getRemoteParentId(session);
+    const gatewaySource = getGatewaySource(session);
+    const isGateway = isGatewaySession(session);
 
     return (
       <SessionItemWithActions
@@ -862,7 +916,15 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
             }
           }}
         >
-          <div style={{ display: 'flex', alignItems: 'center', gap: 4, flex: 1, minWidth: 0 }}>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: isGateway ? 'flex-start' : 'center',
+              gap: 4,
+              flex: 1,
+              minWidth: 0,
+            }}
+          >
             {isActive ? <Spin size="small" /> : <ToolIcon tool={session.agentic_tool} size={20} />}
             {isRemoteSurrogate ? (
               <Tooltip title="Remote session created from this session. Click to open it in its own branch.">
@@ -871,7 +933,25 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
             ) : (
               <SessionRelationshipIcon session={session} size={10} />
             )}
-            {renderSessionTitleWithFailure(session)}
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 4, minWidth: 0 }}>
+                {renderSessionTitleWithFailure(session)}
+              </div>
+              {isGateway && (
+                <div style={{ marginTop: 4 }}>
+                  {gatewaySource ? (
+                    <ChannelPill
+                      channelType={gatewaySource.channel_type}
+                      channelName={gatewaySource.channel_name}
+                    />
+                  ) : (
+                    <Typography.Text type="secondary" style={{ fontSize: 11, fontStyle: 'italic' }}>
+                      (Gateway - metadata unavailable)
+                    </Typography.Text>
+                  )}
+                </div>
+              )}
+            </div>
           </div>
         </div>
       </SessionItemWithActions>
@@ -883,8 +963,8 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
       <Tree
         className="agor-flat-tree"
         treeData={sessionTreeData}
-        expandedKeys={expandedKeys}
-        onExpand={(keys) => handleSessionTreeExpand(keys as React.Key[])}
+        expandedKeys={expandedManualKeys}
+        onExpand={(keys) => handleSessionTreeExpand(keys as React.Key[], manualExpandableKeys)}
         showLine
         switcherIcon={renderTreeSwitcherIcon}
         showIcon={false}
@@ -1021,7 +1101,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
         <MessageOutlined style={{ color: token.colorSuccess }} />
         <Typography.Text strong>Gateway Sessions</Typography.Text>
         <Badge
-          count={gatewaySessions.length}
+          count={gatewayRootSessions.length}
           showZero
           style={{ backgroundColor: token.colorSuccessBgHover }}
         />
@@ -1031,76 +1111,21 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
   );
 
   const gatewaySessionsContent = isGatewaySessionsOpen ? (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-      {gatewaySessions.map((session) => {
-        const gatewaySource = getGatewaySource(session);
-        const isActive = isSessionExecuting(session);
-        const callbackToggle = getCallbackToggle(session);
-        const remoteParentId = getRemoteParentId(session);
-
-        return (
-          <SessionItemWithActions
-            key={session.session_id}
-            sessionId={session.session_id}
-            isArchiving={archivingSessionIds.has(session.session_id)}
-            isPeeked={peekedIds.has(session.session_id)}
-            onArchive={handleArchiveSession}
-            onTogglePeek={onTogglePeekSession ? handleTogglePeekSession : undefined}
-            callbackToggle={callbackToggle ?? undefined}
-            onToggleCallback={callbackToggle ? handleToggleCallback : undefined}
-            remoteParentLink={
-              remoteParentId
-                ? { tooltip: 'Open remote parent session that created this session' }
-                : undefined
-            }
-            onOpenRemoteParent={remoteParentId ? handleOpenRemoteParent : undefined}
-            onSettings={
-              onOpenSessionSettings
-                ? (id, e) => {
-                    e.stopPropagation();
-                    onOpenSessionSettings(id);
-                  }
-                : undefined
-            }
-          >
-            <div
-              style={sessionRowStyle(session)}
-              onClick={() => onSessionClick?.(session.session_id)}
-            >
-              <Space size={4} align="center" style={{ flex: 1, minWidth: 0 }}>
-                {isActive ? (
-                  <Spin size="small" />
-                ) : (
-                  <ToolIcon tool={session.agentic_tool} size={20} />
-                )}
-                <div
-                  style={{ flex: 1, minWidth: 0, display: 'flex', flexDirection: 'column', gap: 4 }}
-                >
-                  <div style={{ display: 'flex', alignItems: 'center', gap: 4, minWidth: 0 }}>
-                    {renderSessionTitleWithFailure(session)}
-                  </div>
-                  <div style={{ alignSelf: 'flex-start' }}>
-                    {gatewaySource ? (
-                      <ChannelPill
-                        channelType={gatewaySource.channel_type}
-                        channelName={gatewaySource.channel_name}
-                      />
-                    ) : (
-                      <Typography.Text
-                        type="secondary"
-                        style={{ fontSize: 11, fontStyle: 'italic' }}
-                      >
-                        (Gateway - metadata unavailable)
-                      </Typography.Text>
-                    )}
-                  </div>
-                </div>
-              </Space>
-            </div>
-          </SessionItemWithActions>
-        );
-      })}
-    </div>
+    <ConfigProvider theme={{ components: { Tree: { colorBgContainer: 'transparent' } } }}>
+      <Tree
+        className="agor-flat-tree"
+        treeData={gatewaySessionTreeData}
+        expandedKeys={expandedGatewayKeys}
+        onExpand={(keys) => handleSessionTreeExpand(keys as React.Key[], gatewayExpandableKeys)}
+        showLine
+        switcherIcon={renderTreeSwitcherIcon}
+        showIcon={false}
+        blockNode
+        selectable={false}
+        style={{ background: 'transparent', borderRadius: 0, padding: 0 }}
+        titleRender={renderSessionNode}
+      />
+    </ConfigProvider>
   ) : null;
 
   const sessionSearchBar =
@@ -1269,7 +1294,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
             />
           )}
 
-          {gatewaySessions.length > 0 && (
+          {gatewayRootSessions.length > 0 && (
             <Collapse
               activeKey={openSectionKeys}
               onChange={handleGatewaySessionsChange}

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -25,6 +25,7 @@ import {
   Button,
   Collapse,
   ConfigProvider,
+  Flex,
   Space,
   Spin,
   Tooltip,
@@ -916,14 +917,11 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
             }
           }}
         >
-          <div
-            style={{
-              display: 'flex',
-              alignItems: isGateway ? 'flex-start' : 'center',
-              gap: 4,
-              flex: 1,
-              minWidth: 0,
-            }}
+          <Flex
+            align={isGateway ? 'flex-start' : 'center'}
+            gap={token.marginXXS}
+            flex={1}
+            style={{ minWidth: 0 }}
           >
             {isActive ? <Spin size="small" /> : <ToolIcon tool={session.agentic_tool} size={20} />}
             {isRemoteSurrogate ? (
@@ -933,58 +931,53 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
             ) : (
               <SessionRelationshipIcon session={session} size={10} />
             )}
-            <div style={{ flex: 1, minWidth: 0 }}>
-              <div style={{ display: 'flex', alignItems: 'center', gap: 4, minWidth: 0 }}>
+            <Flex vertical gap={isGateway ? token.marginXXS : 0} flex={1} style={{ minWidth: 0 }}>
+              <Flex align="center" gap={token.marginXXS} style={{ minWidth: 0 }}>
                 {renderSessionTitleWithFailure(session)}
-              </div>
-              {isGateway && (
-                <div style={{ marginTop: 4 }}>
-                  {gatewaySource ? (
-                    <ChannelPill
-                      channelType={gatewaySource.channel_type}
-                      channelName={gatewaySource.channel_name}
-                    />
-                  ) : (
-                    <Typography.Text type="secondary" style={{ fontSize: 11, fontStyle: 'italic' }}>
-                      (Gateway - metadata unavailable)
-                    </Typography.Text>
-                  )}
-                </div>
-              )}
-            </div>
-          </div>
+              </Flex>
+              {isGateway &&
+                (gatewaySource ? (
+                  <ChannelPill
+                    channelType={gatewaySource.channel_type}
+                    channelName={gatewaySource.channel_name}
+                  />
+                ) : (
+                  <Typography.Text type="secondary" style={{ fontSize: 11, fontStyle: 'italic' }}>
+                    (Gateway - metadata unavailable)
+                  </Typography.Text>
+                ))}
+            </Flex>
+          </Flex>
         </div>
       </SessionItemWithActions>
     );
   };
 
-  const sessionListContent = isManualSessionsOpen ? (
-    <ConfigProvider theme={{ components: { Tree: { colorBgContainer: 'transparent' } } }}>
-      <Tree
-        className="agor-flat-tree"
-        treeData={sessionTreeData}
-        expandedKeys={expandedManualKeys}
-        onExpand={(keys) => handleSessionTreeExpand(keys as React.Key[], manualExpandableKeys)}
-        showLine
-        switcherIcon={renderTreeSwitcherIcon}
-        showIcon={false}
-        blockNode
-        selectable={false}
-        style={{ background: 'transparent', borderRadius: 0, padding: 0 }}
-        titleRender={renderSessionNode}
-      />
-    </ConfigProvider>
-  ) : null;
+  const renderSessionTree = (
+    treeData: SessionTreeNode[],
+    expandedKeys: React.Key[],
+    expandableKeys: React.Key[]
+  ) => (
+    <Tree
+      className="agor-flat-tree"
+      treeData={treeData}
+      expandedKeys={expandedKeys}
+      onExpand={(keys) => handleSessionTreeExpand(keys as React.Key[], expandableKeys)}
+      showLine
+      switcherIcon={renderTreeSwitcherIcon}
+      showIcon={false}
+      blockNode
+      selectable={false}
+      titleRender={renderSessionNode}
+    />
+  );
+
+  const sessionListContent = isManualSessionsOpen
+    ? renderSessionTree(sessionTreeData, expandedManualKeys, manualExpandableKeys)
+    : null;
 
   const sessionListHeader = (
-    <div
-      style={{
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        width: '100%',
-      }}
-    >
+    <Flex justify="space-between" align="center" style={{ width: '100%' }}>
       <Space size={4} align="center">
         <Typography.Text strong>Sessions</Typography.Text>
         <Badge
@@ -1013,18 +1006,11 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
           </Button>
         </div>
       )}
-    </div>
+    </Flex>
   );
 
   const scheduledRunsHeader = (
-    <div
-      style={{
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        width: '100%',
-      }}
-    >
+    <Flex justify="space-between" align="center" style={{ width: '100%' }}>
       <Space size={4} align="center">
         <ClockCircleOutlined style={{ color: token.colorInfo }} />
         <Typography.Text strong>Scheduled Runs</Typography.Text>
@@ -1035,7 +1021,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
         />
         {hasRunningScheduledSession && <Spin size="small" />}
       </Space>
-    </div>
+    </Flex>
   );
 
   const scheduledRunsContent = isScheduledRunsOpen ? (
@@ -1089,14 +1075,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
   ) : null;
 
   const gatewaySessionsHeader = (
-    <div
-      style={{
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        width: '100%',
-      }}
-    >
+    <Flex justify="space-between" align="center" style={{ width: '100%' }}>
       <Space size={4} align="center">
         <MessageOutlined style={{ color: token.colorSuccess }} />
         <Typography.Text strong>Gateway Sessions</Typography.Text>
@@ -1107,26 +1086,12 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
         />
         {hasRunningGatewaySession && <Spin size="small" />}
       </Space>
-    </div>
+    </Flex>
   );
 
-  const gatewaySessionsContent = isGatewaySessionsOpen ? (
-    <ConfigProvider theme={{ components: { Tree: { colorBgContainer: 'transparent' } } }}>
-      <Tree
-        className="agor-flat-tree"
-        treeData={gatewaySessionTreeData}
-        expandedKeys={expandedGatewayKeys}
-        onExpand={(keys) => handleSessionTreeExpand(keys as React.Key[], gatewayExpandableKeys)}
-        showLine
-        switcherIcon={renderTreeSwitcherIcon}
-        showIcon={false}
-        blockNode
-        selectable={false}
-        style={{ background: 'transparent', borderRadius: 0, padding: 0 }}
-        titleRender={renderSessionNode}
-      />
-    </ConfigProvider>
-  ) : null;
+  const gatewaySessionsContent = isGatewaySessionsOpen
+    ? renderSessionTree(gatewaySessionTreeData, expandedGatewayKeys, gatewayExpandableKeys)
+    : null;
 
   const sessionSearchBar =
     isPanel && activeSessions.length > 0 ? (


### PR DESCRIPTION
## Summary

- render gateway sessions through the existing genealogy tree so local, spawned, and cross-branch children remain under their gateway parent
- keep gateway roots in most-recently-used order and persist both parent-row and section collapse state through the existing branch-local UI store
- reuse one Ant Design `Tree` presentation for manual and gateway genealogy, use `Flex` for the added row layout, and rely on the existing root theme/`agor-flat-tree` styling instead of nested tree `ConfigProvider`s
- document the exact capabilities and limitations of today's opt-in scheduled cleanup workflow

## Root cause

The session store already materializes cross-branch children as remote surrogates with the correct genealogy and canonical target ID. `BranchSessionSections` then split gateway sessions out **before** building the genealogy tree and rendered those roots as a flat list. Their descendants were consequently promoted into the manual-session tree as unrelated roots.

This fixes the authoritative presentation layer: it collects descendants from the complete branch projection, removes them from the manual section, and sends the gateway subtree through the same tree renderer and persisted-collapse path used elsewhere.

## Retention scope

The latest issue refinement identifies first-class retention as a product/compliance design question: gateway-vs-teammate scope, default policy, and audit expectations are not yet settled. This PR therefore does not add an implicit archiver, schema, or config surface; automatic gateway retention is intentionally deferred to a separate follow-up.

The guide documents today's opt-in teammate schedule using `agor_sessions_bulk_archive`, including dry-run-first operation, RBAC, and reversible archival. It also calls out that this is branch/day-based cleanup using the Session's update timestamp, not per-channel inactivity retention, and that the bulk tool archives matching gateway roots without cascading into spawned or remote-created children. The existing `thread_session_map.last_message_at` is a better authority for a future channel-scoped policy, but an HA-safe worker and the intended child/remote semantics require a separate design.

## Testing

- `pnpm i` — workspace already up to date
- `pnpm check` — workspace typecheck, lint, short-ID/multitenancy/filesystem/realtime boundary checks, and production builds passed
- `pnpm --filter agor-ui exec vitest run src/components/BranchCard/BranchSessionSections.test.tsx` — 14 passed
- `pnpm --filter @agor/docs exec prettier --check content/guide/message-gateway.mdx`
- `git diff --check` through `simple-git`
- managed disposable SQLite environment: daemon health HTTP 200; browser login and default board load with no page errors
- GitHub CI: lint, workspace typecheck/build, full test matrix, docs, image build, and packaged-install smoke passed on the current head

No PostgreSQL check is applicable because this PR remains a UI/docs-only change with no persistence, API, RLS, or backend runtime changes.

Closes #2511
