### PR TITLE
fix(ui): improve session tree accessibility

### DIFF
--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.test.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.test.tsx
@@ -256,6 +256,10 @@ describe('BranchSessionSections', () => {
     expect(screen.getByText('Spawned child')).toBeInTheDocument();
     expect(screen.getByText('Remote child')).toBeInTheDocument();
     expect(screen.getAllByText('Team Slack')).toHaveLength(2);
+    for (const channelPill of screen.getAllByTitle('Team Slack')) {
+      expect(channelPill.getAttribute('style')).toContain('align-self: flex-start');
+      expect(channelPill.getAttribute('style')).toContain('max-width: 100%');
+    }
     expect(
       Array.from(container.querySelectorAll('[data-session-id]')).map((row) =>
         row.getAttribute('data-session-id')
@@ -275,7 +279,14 @@ describe('BranchSessionSections', () => {
     expect(screen.queryByText('Remote child')).not.toBeInTheDocument();
 
     fireEvent.click(getSessionTreeToggle('Older gateway'));
-    fireEvent.click(await screen.findByText('Remote child'));
+    const remoteChildButton = await screen.findByLabelText('Open session Remote child');
+    expect(remoteChildButton.tagName).toBe('BUTTON');
+    remoteChildButton.focus();
+    expect(remoteChildButton).toHaveFocus();
+    // Keyboard activation of a native button is delivered as a click with no
+    // pointer detail; exercise that navigation path without reimplementing the
+    // browser's Enter/Space semantics in the component.
+    fireEvent.click(remoteChildButton, { detail: 0 });
     expect(onSessionClick).toHaveBeenCalledWith('gateway-remote-child');
   });
 

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.test.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.test.tsx
@@ -184,6 +184,9 @@ describe('BranchSessionSections', () => {
 
     expect(screen.getByText('Investigate crash')).toBeInTheDocument();
     expect(screen.getByLabelText('Latest task failed')).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('Open session Investigate crash; latest task failed')
+    ).toBeInTheDocument();
   });
 
   it('does not mark idle sessions as failures', () => {
@@ -279,7 +282,9 @@ describe('BranchSessionSections', () => {
     expect(screen.queryByText('Remote child')).not.toBeInTheDocument();
 
     fireEvent.click(getSessionTreeToggle('Older gateway'));
-    const remoteChildButton = await screen.findByLabelText('Open session Remote child');
+    const remoteChildButton = await screen.findByLabelText(
+      'Open session Remote child; remote session; opens in its own branch'
+    );
     expect(remoteChildButton.tagName).toBe('BUTTON');
     remoteChildButton.focus();
     expect(remoteChildButton).toHaveFocus();

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -69,7 +69,11 @@ import {
   SessionSortButton,
 } from '../SessionSearchControls';
 import { ToolIcon } from '../ToolIcon';
-import { buildSessionTree, type SessionTreeNode } from './buildSessionTree';
+import {
+  buildSessionTree,
+  collectSessionSubtreeIds,
+  type SessionTreeNode,
+} from './buildSessionTree';
 
 // Stable theme object so the ConfigProvider context value doesn't churn.
 const NO_MOTION_THEME = { token: { motion: false } };
@@ -134,7 +138,9 @@ const SessionItemWithActions: React.FC<{
   children,
 }) => {
   const [hovered, setHovered] = useState(false);
+  const [focusWithin, setFocusWithin] = useState(false);
   const { token } = theme.useToken();
+  const showActions = hovered || focusWithin;
 
   const buttonStyle: React.CSSProperties = {
     background: `${token.colorBgContainer}cc`,
@@ -159,6 +165,12 @@ const SessionItemWithActions: React.FC<{
       style={{ position: 'relative', minWidth: 0, width: '100%' }}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
+      onFocus={() => setFocusWithin(true)}
+      onBlur={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+          setFocusWithin(false);
+        }
+      }}
     >
       {children}
       <div
@@ -167,9 +179,9 @@ const SessionItemWithActions: React.FC<{
           right: 4,
           top: '50%',
           transform: 'translateY(-50%)',
-          opacity: hovered ? 1 : 0,
+          opacity: showActions ? 1 : 0,
           transition: 'opacity 0.15s ease-in-out',
-          pointerEvents: hovered ? 'auto' : 'none',
+          pointerEvents: showActions ? 'auto' : 'none',
           display: 'flex',
           gap: 2,
           width: 'fit-content',
@@ -521,32 +533,16 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
     [activeSessions, isGatewaySession]
   );
   const gatewayTreeSessionIds = useMemo(() => {
-    const included = new Set<string>(gatewayRootSessions.map((session) => session.session_id));
     const candidates = activeSessions.filter((session) => !session.scheduled_from_branch);
-    const childrenByParent = new Map<string, string[]>();
 
-    // A gateway child does not carry gateway_source itself. Follow the same
+    // A gateway child does not carry gateway_source itself. Follow the exact
     // genealogy edges used by buildSessionTree (including remote surrogates)
     // so descendants stay with the gateway conversation instead of being
     // promoted to unrelated roots in the manual Sessions section.
-    for (const session of candidates) {
-      const parentId =
-        session.genealogy?.parent_session_id ?? session.genealogy?.forked_from_session_id;
-      if (!parentId) continue;
-      const children = childrenByParent.get(parentId) ?? [];
-      children.push(session.session_id);
-      childrenByParent.set(parentId, children);
-    }
-    const pending = [...included];
-    for (let index = 0; index < pending.length; index += 1) {
-      for (const childId of childrenByParent.get(pending[index]) ?? []) {
-        if (included.has(childId)) continue;
-        included.add(childId);
-        pending.push(childId);
-      }
-    }
-
-    return included;
+    return collectSessionSubtreeIds(
+      candidates,
+      gatewayRootSessions.map((session) => session.session_id)
+    );
   }, [activeSessions, gatewayRootSessions]);
   const manualSessions = useMemo(
     () =>
@@ -675,11 +671,9 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
     const isSessionSelected = session.session_id === selectedSessionId;
     const isRemoteSurrogate = Boolean(session.remote_surrogate);
     return {
-      border: session.ready_for_prompt
-        ? `1px solid ${token.colorPrimary}`
-        : isRemoteSurrogate
-          ? `1px dashed ${token.colorBorderSecondary}`
-          : `1px solid ${token.colorBorderSecondary}`,
+      borderWidth: 1,
+      borderStyle: isRemoteSurrogate ? 'dashed' : 'solid',
+      borderColor: session.ready_for_prompt ? token.colorPrimary : token.colorBorderSecondary,
       borderRadius: isPanel ? 6 : 4,
       padding: isPanel ? 10 : 8,
       background: isRemoteSurrogate
@@ -689,9 +683,15 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
           : 'transparent',
       display: 'flex',
       alignItems: 'center',
+      justifyContent: 'flex-start',
       width: '100%',
+      height: 'auto',
       boxSizing: 'border-box',
       cursor: 'pointer',
+      color: 'inherit',
+      font: 'inherit',
+      textAlign: 'left',
+      whiteSpace: 'normal',
       marginBottom: 4,
       opacity: isRemoteSurrogate ? 0.78 : undefined,
       boxShadow: session.ready_for_prompt ? `0 0 12px ${token.colorPrimary}30` : undefined,
@@ -786,9 +786,11 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
             : undefined
         }
       >
-        <div
+        <button
+          type="button"
           style={sessionRowStyle(session)}
           data-session-id={session.session_id}
+          aria-label={`Open session ${titleText}`}
           onClick={() => onSessionClick?.(session.session_id)}
         >
           <div style={{ display: 'flex', alignItems: 'flex-start', gap: 4, flex: 1, minWidth: 0 }}>
@@ -828,7 +830,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
               )}
             </div>
           </div>
-        </div>
+        </button>
       </SessionItemWithActions>
     );
   };
@@ -882,6 +884,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
     const remoteParentId = getRemoteParentId(session);
     const gatewaySource = getGatewaySource(session);
     const isGateway = isGatewaySession(session);
+    const sessionTitle = getSessionDisplayTitle(session, { includeAgentFallback: true });
 
     return (
       <SessionItemWithActions
@@ -907,9 +910,11 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
             : undefined
         }
       >
-        <div
+        <button
+          type="button"
           style={sessionRowStyle(session)}
           data-session-id={session.session_id}
+          aria-label={`Open session ${sessionTitle}`}
           onClick={() => onSessionClick?.(session.session_id)}
           onContextMenu={(e) => {
             if (onForkSession || onSpawnSession) {
@@ -940,6 +945,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
                   <ChannelPill
                     channelType={gatewaySource.channel_type}
                     channelName={gatewaySource.channel_name}
+                    style={{ alignSelf: 'flex-start' }}
                   />
                 ) : (
                   <Typography.Text type="secondary" style={{ fontSize: 11, fontStyle: 'italic' }}>
@@ -948,7 +954,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
                 ))}
             </Flex>
           </Flex>
-        </div>
+        </button>
       </SessionItemWithActions>
     );
   };
@@ -1055,8 +1061,12 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
                 : undefined
             }
           >
-            <div
+            <button
+              type="button"
               style={sessionRowStyle(session)}
+              aria-label={`Open session ${getSessionDisplayTitle(session, {
+                includeAgentFallback: true,
+              })}`}
               onClick={() => onSessionClick?.(session.session_id)}
             >
               <Space size={4} align="center" style={{ flex: 1, minWidth: 0 }}>
@@ -1067,7 +1077,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
                 )}
                 {renderSessionTitleWithFailure(session, { secondary: true })}
               </Space>
-            </div>
+            </button>
           </SessionItemWithActions>
         );
       })}

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -80,6 +80,23 @@ const NO_MOTION_THEME = { token: { motion: false } };
 
 const SECTION_KEYS: BranchSectionKey[] = ['sessions', 'scheduled-runs', 'gateway-sessions'];
 
+const isSessionFailed = (session: Session): boolean => session.status === SessionStatus.FAILED;
+
+function getSessionRowAccessibleLabel(session: Session): string {
+  const details = [
+    `Open session ${getSessionDisplayTitle(session, { includeAgentFallback: true })}`,
+  ];
+
+  if (session.remote_surrogate) {
+    details.push('remote session', 'opens in its own branch');
+  }
+  if (isSessionFailed(session)) {
+    details.push('latest task failed');
+  }
+
+  return details.join('; ');
+}
+
 export type BranchSessionSectionsMode = 'card' | 'panel';
 type CollapseKey = string | number;
 type RemoteRelationshipRef = {
@@ -621,8 +638,6 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
   const isCreating = branch.filesystem_status === 'creating';
   const isFailed = branch.filesystem_status === 'failed';
 
-  const isSessionFailed = (session: Session): boolean => session.status === SessionStatus.FAILED;
-
   // Parent sessions default to expanded; only collapsed exceptions are kept in
   // the collapsedBranchNodes store. Deriving the expanded set means sessions
   // that newly gain children start expanded, while stored exceptions survive
@@ -790,7 +805,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
           type="button"
           style={sessionRowStyle(session)}
           data-session-id={session.session_id}
-          aria-label={`Open session ${titleText}`}
+          aria-label={getSessionRowAccessibleLabel(session)}
           onClick={() => onSessionClick?.(session.session_id)}
         >
           <div style={{ display: 'flex', alignItems: 'flex-start', gap: 4, flex: 1, minWidth: 0 }}>
@@ -884,7 +899,6 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
     const remoteParentId = getRemoteParentId(session);
     const gatewaySource = getGatewaySource(session);
     const isGateway = isGatewaySession(session);
-    const sessionTitle = getSessionDisplayTitle(session, { includeAgentFallback: true });
 
     return (
       <SessionItemWithActions
@@ -914,7 +928,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
           type="button"
           style={sessionRowStyle(session)}
           data-session-id={session.session_id}
-          aria-label={`Open session ${sessionTitle}`}
+          aria-label={getSessionRowAccessibleLabel(session)}
           onClick={() => onSessionClick?.(session.session_id)}
           onContextMenu={(e) => {
             if (onForkSession || onSpawnSession) {
@@ -1064,9 +1078,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
             <button
               type="button"
               style={sessionRowStyle(session)}
-              aria-label={`Open session ${getSessionDisplayTitle(session, {
-                includeAgentFallback: true,
-              })}`}
+              aria-label={getSessionRowAccessibleLabel(session)}
               onClick={() => onSessionClick?.(session.session_id)}
             >
               <Space size={4} align="center" style={{ flex: 1, minWidth: 0 }}>

--- a/apps/agor-ui/src/components/BranchCard/buildSessionTree.test.ts
+++ b/apps/agor-ui/src/components/BranchCard/buildSessionTree.test.ts
@@ -1,0 +1,55 @@
+import type { Session } from '@agor-live/client';
+import { describe, expect, it } from 'vitest';
+import {
+  buildSessionTree,
+  collectSessionSubtreeIds,
+  getSessionTreeParentId,
+} from './buildSessionTree';
+
+function makeSession(
+  sessionId: string,
+  genealogy: Session['genealogy'] = { children: [] }
+): Session {
+  return {
+    session_id: sessionId,
+    genealogy,
+  } as Session;
+}
+
+describe('session tree genealogy', () => {
+  it('uses one parent rule for tree construction and descendant collection', () => {
+    const root = makeSession('root');
+    const spawned = makeSession('spawned', {
+      parent_session_id: root.session_id,
+      children: [],
+    });
+    const forked = makeSession('forked', {
+      forked_from_session_id: spawned.session_id,
+      children: [],
+    });
+    const unrelated = makeSession('unrelated');
+    const sessions = [root, spawned, forked, unrelated];
+
+    expect(collectSessionSubtreeIds(sessions, [root.session_id])).toEqual(
+      new Set(['root', 'spawned', 'forked'])
+    );
+    expect(buildSessionTree(sessions)).toMatchObject([
+      {
+        key: 'root',
+        children: [{ key: 'spawned', children: [{ key: 'forked' }] }],
+      },
+      { key: 'unrelated' },
+    ]);
+  });
+
+  it('falls back to a fork parent when a patched parent ID is empty', () => {
+    const forked = makeSession('forked', {
+      parent_session_id: '' as Session['session_id'],
+      forked_from_session_id: 'root' as Session['session_id'],
+      children: [],
+    });
+
+    expect(getSessionTreeParentId(forked)).toBe('root');
+    expect(collectSessionSubtreeIds([forked], ['root'])).toEqual(new Set(['root', 'forked']));
+  });
+});

--- a/apps/agor-ui/src/components/BranchCard/buildSessionTree.ts
+++ b/apps/agor-ui/src/components/BranchCard/buildSessionTree.ts
@@ -17,6 +17,45 @@ export interface SessionTreeNode extends DataNode {
   children?: SessionTreeNode[];
 }
 
+/** Return the single genealogy edge used to place a Session in the UI tree. */
+export function getSessionTreeParentId(session: Session): string | undefined {
+  return (
+    session.genealogy?.parent_session_id || session.genealogy?.forked_from_session_id || undefined
+  );
+}
+
+/**
+ * Collect roots and every descendant reachable through the same genealogy
+ * edges as buildSessionTree. Keeping this alongside tree construction avoids
+ * section partitioning drifting from the rendered hierarchy.
+ */
+export function collectSessionSubtreeIds(
+  sessions: Session[],
+  rootSessionIds: Iterable<string>
+): Set<string> {
+  const included = new Set(rootSessionIds);
+  const childrenByParent = new Map<string, string[]>();
+
+  for (const session of sessions) {
+    const parentId = getSessionTreeParentId(session);
+    if (!parentId) continue;
+    const children = childrenByParent.get(parentId) ?? [];
+    children.push(session.session_id);
+    childrenByParent.set(parentId, children);
+  }
+
+  const pending = [...included];
+  for (let index = 0; index < pending.length; index += 1) {
+    for (const childId of childrenByParent.get(pending[index]!) ?? []) {
+      if (included.has(childId)) continue;
+      included.add(childId);
+      pending.push(childId);
+    }
+  }
+
+  return included;
+}
+
 /**
  * Build genealogy tree from sessions for Ant Design Tree
  *
@@ -38,8 +77,7 @@ export function buildSessionTree(sessions: Session[]): SessionTreeNode[] {
   // this render set. Otherwise promote the session to a root so the tree does
   // not silently hide visible sessions behind a filtered-out ancestor.
   for (const session of sessions) {
-    const parentId =
-      session.genealogy?.parent_session_id || session.genealogy?.forked_from_session_id;
+    const parentId = getSessionTreeParentId(session);
 
     if (parentId && sessionMap.has(parentId)) {
       // Has a parent - add to children map

--- a/apps/agor-ui/src/components/Pill/Pill.tsx
+++ b/apps/agor-ui/src/components/Pill/Pill.tsx
@@ -1235,7 +1235,7 @@ export const ChannelPill: React.FC<ChannelPillProps> = ({ channelType, channelNa
   };
 
   return (
-    <Tag icon={getIcon()} color={PILL_COLORS.success} style={style}>
+    <Tag icon={getIcon()} color={PILL_COLORS.success} truncate title={channelName} style={style}>
       {channelName}
     </Tag>
   );


### PR DESCRIPTION
## Summary

- render every navigable session row as a native button so gateway descendants and other session links work with keyboard navigation
- reveal session actions on keyboard focus as well as pointer hover
- announce remote-branch navigation and latest-task failures in each row's accessible name
- centralize session parent resolution and subtree collection alongside the existing tree builder to avoid genealogy-rule drift
- keep gateway channel pills compact and truncate long names while preserving the full name in a native tooltip
- add focused regression coverage for remote-child keyboard navigation, accessible row state, and shared spawn/fork ancestry rules

## Context

Follow-up to #2512 (which fixed #2511). The original PR was merged while its Codex review follow-ups were still in progress, so this PR contains only those review-driven improvements on top of current `main`.

Session-retention automation remains intentionally out of scope, as agreed in #2512.

## Validation

- `pnpm --filter agor-ui exec vitest run src/components/BranchCard/BranchSessionSections.test.tsx src/components/BranchCard/buildSessionTree.test.ts` — 16/16 passed
- `pnpm --filter agor-ui typecheck` — passed
- `pnpm check` — passed (typecheck, lint/design-system, boundary checks, and production builds)
- `git diff --check` via `simple-git` — passed

PostgreSQL/database checks are not applicable because this is a presentation-only UI follow-up with no API, persistence, authorization, realtime, or lifecycle changes.
