### PR TITLE
fix(env): fence health checks to active lifecycle

### DIFF
--- a/apps/agor-daemon/src/declarations.ts
+++ b/apps/agor-daemon/src/declarations.ts
@@ -333,7 +333,11 @@ export interface BranchesServiceImpl extends Service<Branch, Partial<Branch>, Fe
     data: { variant?: string } | undefined,
     params?: FeathersParams
   ): Promise<Branch>;
-  checkHealth(id: BranchID, params?: FeathersParams): Promise<Branch>;
+  checkHealth(
+    id: BranchID,
+    params?: FeathersParams,
+    internalOptions?: { signal?: AbortSignal; automatic?: boolean }
+  ): Promise<Branch>;
   getLogs(
     id: BranchID,
     params?: FeathersParams

--- a/apps/agor-daemon/src/declarations.ts
+++ b/apps/agor-daemon/src/declarations.ts
@@ -42,6 +42,7 @@ import type {
   TaskPendingDispatchStatus,
 } from '@agor/core/types';
 import type { DaemonMetrics } from './metrics/index.js';
+import type { EnvironmentHealthCheckOptions } from './services/branches.js';
 import type {
   ExecuteTaskData,
   SessionArchiveOptions,
@@ -336,7 +337,7 @@ export interface BranchesServiceImpl extends Service<Branch, Partial<Branch>, Fe
   checkHealth(
     id: BranchID,
     params?: FeathersParams,
-    internalOptions?: { signal?: AbortSignal; automatic?: boolean }
+    internalOptions?: EnvironmentHealthCheckOptions
   ): Promise<Branch>;
   getLogs(
     id: BranchID,

--- a/apps/agor-daemon/src/mcp/tools/environment.ts
+++ b/apps/agor-daemon/src/mcp/tools/environment.ts
@@ -87,7 +87,7 @@ export function registerEnvironmentTools(server: McpServer, ctx: McpContext): vo
     'agor_environment_health',
     {
       description:
-        'Check the health status of a branch environment by running its configured health command. Returns started_at timestamp and uptime_seconds when environment is starting or running.',
+        'Read a branch environment health status. Starting/running environments run the configured HTTP health probe; inactive environments are not restarted or enrolled in monitoring. Returns started_at and uptime_seconds while active.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
         branchId: mcpRequiredId('branchId', 'Branch'),

--- a/apps/agor-daemon/src/register-hooks.test.ts
+++ b/apps/agor-daemon/src/register-hooks.test.ts
@@ -43,6 +43,7 @@ import {
   shouldValidateRepoEnvironmentPayload,
   TENANT_IDENTITY_ONLY_SERVICE_PATHS,
   TENANT_OWNED_SERVICE_PATHS,
+  validateBranchEnvPolicyHook,
 } from './register-hooks';
 import { canReceiveMcpTokenForSession } from './utils/mcp-token-authorization';
 
@@ -472,6 +473,45 @@ describe('shouldValidateRepoEnvironmentPayload', () => {
   it('validates present repo environment payloads', () => {
     expect(shouldValidateRepoEnvironmentPayload({})).toBe(true);
     expect(shouldValidateRepoEnvironmentPayload('invalid shape')).toBe(true);
+  });
+});
+
+describe('branch environment materialization validation', () => {
+  it('does not reject branch creation when the rendered health URL is invalid', async () => {
+    const context = {
+      path: 'branches',
+      method: 'create',
+      data: {
+        start_command: 'pnpm dev',
+        stop_command: 'pkill -f pnpm',
+        health_check_url: 'not-an-http-url',
+      },
+      params: {},
+    } as HookContext;
+
+    await expect(
+      validateBranchEnvPolicyHook({
+        execution: { managed_envs_execution_mode: 'hybrid' },
+      })(context)
+    ).resolves.toBe(context);
+  });
+
+  it('still rejects unsafe rendered app URLs before persistence', async () => {
+    const context = {
+      path: 'branches',
+      method: 'create',
+      data: {
+        start_command: 'pnpm dev',
+        app_url: 'javascript:alert(1)',
+      },
+      params: {},
+    } as HookContext;
+
+    await expect(
+      validateBranchEnvPolicyHook({
+        execution: { managed_envs_execution_mode: 'hybrid' },
+      })(context)
+    ).rejects.toThrow('managed environment app URL');
   });
 });
 

--- a/apps/agor-daemon/src/register-hooks.test.ts
+++ b/apps/agor-daemon/src/register-hooks.test.ts
@@ -23,7 +23,7 @@ import {
   getCurrentTenantDatabaseScope,
   runWithTenantContext,
 } from '@agor/core/db';
-import { type HookContext, TaskStatus } from '@agor/core/types';
+import { type Branch, type HookContext, TaskStatus } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -494,6 +494,41 @@ describe('branch environment materialization validation', () => {
         execution: { managed_envs_execution_mode: 'hybrid' },
       })(context)
     ).resolves.toBe(context);
+  });
+
+  it('does not reject a materialization patch with an invalid rendered health URL', async () => {
+    const existing = {
+      branch_id: 'branch-1',
+      repo_id: 'repo-1',
+      name: 'branch-1',
+      path: '/tmp/branch-1',
+      ref: 'branch-1',
+      ref_type: 'branch',
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+      created_by: 'user-1',
+    } as Branch;
+    const get = vi.fn(async () => existing);
+    const context = {
+      path: 'branches',
+      method: 'patch',
+      id: existing.branch_id,
+      data: {
+        environment_variant: 'dev',
+        start_command: 'pnpm dev',
+        stop_command: 'pkill -f pnpm',
+        health_check_url: 'not-an-http-url',
+      },
+      params: {},
+      service: { get },
+    } as HookContext;
+
+    await expect(
+      validateBranchEnvPolicyHook({
+        execution: { managed_envs_execution_mode: 'hybrid' },
+      })(context)
+    ).resolves.toBe(context);
+    expect(get).toHaveBeenCalledWith(existing.branch_id, context.params);
   });
 
   it('still rejects unsafe rendered app URLs before persistence', async () => {

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -276,7 +276,7 @@ function branchEnvFieldsFromItem(item: Partial<Branch>) {
   };
 }
 
-function validateBranchEnvPolicyHook(config: DeepReadonly<AgorConfig>) {
+export function validateBranchEnvPolicyHook(config: DeepReadonly<AgorConfig>) {
   return async (context: HookContext) => {
     const items = Array.isArray(context.data) ? context.data : [context.data];
     const shouldValidate = (items as Array<Record<string, unknown>>).some((item) =>
@@ -298,8 +298,11 @@ function validateBranchEnvPolicyHook(config: DeepReadonly<AgorConfig>) {
           mode,
           'branch environment'
         );
+        // The app URL is rendered metadata consumed directly by clients, so it
+        // must be safe before persistence. The health URL is outbound runtime
+        // configuration: validate it at the observation boundary instead of
+        // making branch materialization depend on an inactive environment.
         validateRenderedManagedEnvUrlFields({
-          health: item.health_check_url,
           app: item.app_url,
         });
       } catch (error) {

--- a/apps/agor-daemon/src/services/branches.test.ts
+++ b/apps/agor-daemon/src/services/branches.test.ts
@@ -2102,7 +2102,7 @@ describe('BranchesService.create permission defaults', () => {
   );
 });
 
-describe('BranchesService explicit environment health', () => {
+describe('BranchesService environment health requests', () => {
   const originalFetch = globalThis.fetch;
 
   beforeEach(() => {
@@ -2158,6 +2158,67 @@ describe('BranchesService explicit environment health', () => {
       status: 'error',
       last_health_check: { status: 'healthy', message: 'HTTP 200' },
     });
+  });
+
+  it('does not probe an errored environment for an automatic observation', async () => {
+    const branch = {
+      branch_id: 'wt-health-error-automatic' as BranchID,
+      repo_id: 'repo-1',
+      name: 'wt-health-error-automatic',
+      path: '/tmp/wt-health-error-automatic',
+      branch_unique_id: 2,
+      health_check_url: 'http://localhost:3030/health',
+      environment_instance: { status: 'error' },
+    };
+    const app = {
+      get: () => ({}),
+      service(path: string) {
+        if (path === 'repos') return { get: vi.fn(async () => ({ repo_id: 'repo-1' })) };
+        throw new Error(`Unknown service: ${path}`);
+      },
+    } as unknown as Application;
+    const service = new BranchesService(createTenantScopeTestDb() as never, app);
+    vi.spyOn(service, 'get').mockResolvedValue(branch as never);
+    globalThis.fetch = vi.fn();
+
+    await expect(
+      service.checkHealth(branch.branch_id, undefined, { intent: 'automatic' })
+    ).resolves.toBe(branch);
+
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('returns a blocked diagnostic without logging a user-authored health URL', async () => {
+    const branch = {
+      branch_id: 'wt-health-blocked-url' as BranchID,
+      repo_id: 'repo-1',
+      name: 'wt-health-blocked-url',
+      path: '/tmp/wt-health-blocked-url',
+      branch_unique_id: 3,
+      health_check_url: 'http://169.254.169.254/latest?credential=secret',
+      environment_instance: { status: 'error' },
+    };
+    const app = {
+      get: () => ({}),
+      service(path: string) {
+        if (path === 'repos') return { get: vi.fn(async () => ({ repo_id: 'repo-1' })) };
+        throw new Error(`Unknown service: ${path}`);
+      },
+    } as unknown as Application;
+    const service = new BranchesService(createTenantScopeTestDb() as never, app);
+    vi.spyOn(service, 'get').mockResolvedValue(branch as never);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    globalThis.fetch = vi.fn();
+
+    const result = await service.checkHealth(branch.branch_id);
+
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+    expect(result.environment_instance?.last_health_check).toMatchObject({
+      status: 'unhealthy',
+      message: 'Health check URL blocked by security policy',
+    });
+    warn.mockRestore();
   });
 
   it.each([

--- a/apps/agor-daemon/src/services/branches.test.ts
+++ b/apps/agor-daemon/src/services/branches.test.ts
@@ -3,6 +3,7 @@ import {
   BranchRepository,
   type Database,
   GroupRepository,
+  generateId,
   KnowledgeNamespaceRepository,
   RepoRepository,
   runWithTenantDatabaseScope,
@@ -2101,14 +2102,14 @@ describe('BranchesService.create permission defaults', () => {
   );
 });
 
-describe('BranchesService environment health recovery', () => {
+describe('BranchesService explicit environment health', () => {
   const originalFetch = globalThis.fetch;
 
   beforeEach(() => {
     globalThis.fetch = originalFetch;
   });
 
-  it('recovers an errored environment to running when the health URL succeeds', async () => {
+  it('reports a healthy errored environment without reviving or persisting it', async () => {
     const branch = {
       branch_id: 'wt-health-recover' as BranchID,
       repo_id: 'repo-1',
@@ -2152,14 +2153,115 @@ describe('BranchesService environment health recovery', () => {
       branch.health_check_url,
       expect.objectContaining({ method: 'GET' })
     );
-    expect(updateEnvironment).toHaveBeenCalledWith(
-      branch.branch_id,
-      expect.objectContaining({
-        status: 'running',
-        last_health_check: expect.objectContaining({ status: 'healthy', message: 'HTTP 200' }),
-      }),
-      undefined
-    );
-    expect(result.environment_instance?.status).toBe('running');
+    expect(updateEnvironment).not.toHaveBeenCalled();
+    expect(result.environment_instance).toMatchObject({
+      status: 'error',
+      last_health_check: { status: 'healthy', message: 'HTTP 200' },
+    });
+  });
+
+  it.each([
+    { status: 'stopped' as const, archived: false },
+    { status: 'stopping' as const, archived: false },
+    { status: 'running' as const, archived: true },
+  ])('does not probe an inactive environment (%o)', async ({ status, archived }) => {
+    const branch = {
+      branch_id: `wt-health-${status}-${archived}` as BranchID,
+      repo_id: 'repo-1',
+      name: 'inactive-health',
+      path: '/tmp/inactive-health',
+      archived,
+      health_check_url: 'http://localhost:3030/health',
+      environment_instance: { status },
+    };
+    const app = {
+      get: () => ({}),
+      service(path: string) {
+        if (path === 'repos') return { get: vi.fn(async () => ({ repo_id: 'repo-1' })) };
+        throw new Error(`Unknown service: ${path}`);
+      },
+    } as unknown as Application;
+    const service = new BranchesService(createTenantScopeTestDb() as never, app);
+    vi.spyOn(service, 'get').mockResolvedValue(branch as never);
+    globalThis.fetch = vi.fn();
+
+    await expect(service.checkHealth(branch.branch_id)).resolves.toBe(branch);
+
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  dbTest('fences late health success across stop and archive races', async ({ db }) => {
+    const user = await new UsersRepository(db).create({
+      email: `${generateId()}@example.com`,
+      name: 'Health race',
+    });
+    const repo = await new RepoRepository(db).create({
+      repo_id: generateId(),
+      slug: `health-race-${generateId()}`,
+      name: 'Health race',
+      repo_type: 'remote',
+      remote_url: 'https://example.invalid/health-race.git',
+      local_path: `/tmp/${generateId()}`,
+      default_branch: 'main',
+    });
+    const branchRepo = new BranchRepository(db);
+    const branchesService = { emit: vi.fn() };
+    const app = {
+      get(name: string) {
+        return name === 'distributedWorkIdentity'
+          ? { instanceId: 'daemon-a', bootId: 'boot-a' }
+          : {};
+      },
+      service(path: string) {
+        if (path === 'repos') return { get: vi.fn(async () => repo) };
+        if (path === 'branches') return branchesService;
+        throw new Error(`Unknown service: ${path}`);
+      },
+    } as unknown as Application;
+    const service = new BranchesService(db as never, app);
+    vi.spyOn(service, 'get').mockImplementation(async (id) => {
+      const current = await branchRepo.findById(id);
+      if (!current) throw new Error('branch disappeared');
+      return current as never;
+    });
+
+    for (const [index, transition] of (['stop', 'archive'] as const).entries()) {
+      const branch = await branchRepo.create({
+        branch_id: generateId() as BranchID,
+        repo_id: repo.repo_id,
+        name: `health-race-${transition}`,
+        ref: `health-race-${transition}`,
+        branch_unique_id: 8_800_000 + index,
+        path: `/tmp/health-race-${transition}`,
+        created_by: user.user_id,
+        health_check_url: 'https://example.invalid/health',
+        environment_instance: { status: 'running' },
+      });
+      let finishFetch: (() => void) | undefined;
+      const fetchMock = vi.fn(
+        () =>
+          new Promise<Response>((resolve) => {
+            finishFetch = () => resolve(new Response('', { status: 200 }));
+          })
+      );
+      globalThis.fetch = fetchMock;
+
+      const health = service.checkHealth(branch.branch_id);
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+      await branchRepo.update(
+        branch.branch_id,
+        transition === 'stop' ? { environment_instance: { status: 'stopped' } } : { archived: true }
+      );
+      finishFetch?.();
+
+      const result = await health;
+      expect(result).toMatchObject(
+        transition === 'stop'
+          ? { environment_instance: { status: 'stopped' } }
+          : { archived: true, environment_instance: { status: 'running' } }
+      );
+      expect(result.environment_instance?.last_health_check).toBeUndefined();
+    }
+    expect(branchesService.emit).not.toHaveBeenCalled();
   });
 });

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -22,6 +22,9 @@ import {
   BoardRepository,
   BranchRepository,
   type BranchWithZoneAndSessions,
+  type EnvironmentHealthObservation,
+  EnvironmentHealthRepository,
+  generateId,
   getCurrentTenantId,
   KnowledgeNamespaceRepository,
   runWithTenantDatabaseScope,
@@ -2297,148 +2300,161 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
   /**
    * Custom method: Check health
    */
-  async checkHealth(id: BranchID, params?: BranchParams): Promise<BranchWithZoneAndSessions> {
+  async checkHealth(
+    id: BranchID,
+    params?: BranchParams,
+    internalOptions?: { signal?: AbortSignal; automatic?: boolean }
+  ): Promise<BranchWithZoneAndSessions> {
     const branch = await this.withTenantDatabase(params, () => this.get(id, params));
     const _repo = await this.withTenantDatabase(
       params,
       () => this.app.service('repos').get(branch.repo_id, params) as Promise<Repo>
     );
 
-    // Only check active environments, plus errored environments that may have been
-    // started successfully out-of-band. Allowing explicit health checks to recover
-    // from `error` prevents stale start failures from keeping a live environment red.
     const currentStatus = branch.environment_instance?.status;
-    const canProbeHealth =
-      currentStatus === 'running' || currentStatus === 'starting' || currentStatus === 'error';
-    if (!canProbeHealth) {
+    if (
+      branch.archived ||
+      (currentStatus !== 'running' && currentStatus !== 'starting' && currentStatus !== 'error')
+    ) {
       return branch;
     }
 
-    // Check if we have a health check URL (static field, not template)
-    if (!branch.health_check_url) {
-      // No health check configured - stay in 'starting' forever (manual intervention required)
-      // Don't auto-transition to 'running' without health check confirmation
-      const managedProcess = this.processes.get(id);
-      const isProcessAlive = managedProcess?.process && !managedProcess.process.killed;
-
-      return await this.updateEnvironment(
-        id,
-        {
+    // An explicit status request may still diagnose an errored environment,
+    // but an inactive lifecycle must not acquire monitoring ownership or be
+    // revived by that observation. Return the observation ephemerally.
+    if (currentStatus === 'error') {
+      const observation = await this.fetchEnvironmentHealthObservation(
+        branch,
+        internalOptions?.signal
+      );
+      if (!observation) return branch;
+      return {
+        ...branch,
+        environment_instance: {
+          ...branch.environment_instance,
+          status: currentStatus,
           last_health_check: {
             timestamp: new Date().toISOString(),
-            status: isProcessAlive ? 'healthy' : 'unknown',
-            message: isProcessAlive ? 'Process running' : 'No health check configured',
+            status: observation.status,
+            message: observation.message,
           },
         },
-        params
-      );
+      };
     }
 
-    // Use static health_check_url (initialized from template at branch creation)
-    const healthUrl = branch.health_check_url;
-
-    // Validate URL to prevent SSRF against cloud metadata or internal services
-    if (!isAllowedHealthCheckUrl(healthUrl)) {
-      console.warn(`⚠️ Blocked health check to disallowed URL: ${healthUrl}`);
-      return await this.updateEnvironment(
-        id,
-        {
-          last_health_check: {
-            timestamp: new Date().toISOString(),
-            status: 'unhealthy',
-            message: 'Health check URL blocked by security policy',
-          },
-        },
-        params
-      );
+    // Active observations leave the database while doing HTTP. A durable
+    // one-observation claim plus lifecycle generation fences the result from a
+    // concurrent stop, archive, delete, URL change, daemon, or replica.
+    const claimToken = generateId();
+    const identity = this.app.get('distributedWorkIdentity') ?? {
+      instanceId: `branches-service-${process.pid}`,
+      bootId: `branches-service-${process.pid}`,
+    };
+    const claimResult = await this.withTenantDatabase(params, () =>
+      new EnvironmentHealthRepository(this.db).claim({
+        branchId: id,
+        claimToken,
+        leaseDurationMs: ENVIRONMENT.HEALTH_CHECK_TIMEOUT_MS + 5_000,
+        identity,
+        ignoreCooldown: !internalOptions?.automatic,
+      })
+    );
+    if (claimResult.outcome !== 'claimed') {
+      return this.withTenantDatabase(params, () => this.get(id, params));
     }
-
-    // Track previous health status to detect changes
-    const previousHealthStatus = branch.environment_instance?.last_health_check?.status;
 
     try {
-      // Perform HTTP health check with timeout
-      const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), ENVIRONMENT.HEALTH_CHECK_TIMEOUT_MS);
+      const observation = await this.fetchEnvironmentHealthObservation(
+        branch,
+        internalOptions?.signal
+      );
+      if (!observation) {
+        return this.withTenantDatabase(params, () => this.get(id, params));
+      }
+      const commitResult = await this.withTenantDatabase(params, () =>
+        new EnvironmentHealthRepository(this.db).commit({
+          branchId: id,
+          claimToken,
+          environmentGeneration: claimResult.claim.environment_generation,
+          observation,
+        })
+      );
+      const current = await this.withTenantDatabase(params, () => this.get(id, params));
+      if (commitResult.outcome === 'committed' && commitResult.stateChanged) {
+        emitServiceEvent(this.app, {
+          path: 'branches',
+          event: 'patched',
+          data: current,
+          params,
+          id,
+        });
+      }
+      return current;
+    } finally {
+      await this.withTenantDatabase(params, () =>
+        new EnvironmentHealthRepository(this.db).release(id, claimToken)
+      ).catch(() => undefined);
+    }
+  }
 
+  private async fetchEnvironmentHealthObservation(
+    branch: Branch,
+    cancellationSignal?: AbortSignal
+  ): Promise<EnvironmentHealthObservation | null> {
+    const healthUrl = branch.health_check_url;
+    if (!healthUrl) {
+      const managedProcess = this.processes.get(branch.branch_id);
+      const isProcessAlive = Boolean(managedProcess?.process && !managedProcess.process.killed);
+      return {
+        status: 'unknown',
+        message: isProcessAlive
+          ? 'Process running; no health check configured'
+          : 'No health check configured',
+        recordWhileStarting: true,
+      };
+    }
+    if (!isAllowedHealthCheckUrl(healthUrl)) {
+      console.warn(`⚠️ Blocked health check to disallowed URL: ${healthUrl}`);
+      return {
+        status: 'unhealthy',
+        message: 'Health check URL blocked by security policy',
+        recordWhileStarting: true,
+      };
+    }
+
+    const controller = new AbortController();
+    let timedOut = false;
+    const cancel = () =>
+      controller.abort(cancellationSignal?.reason ?? new Error('Health check cancelled'));
+    if (cancellationSignal?.aborted) return null;
+    cancellationSignal?.addEventListener('abort', cancel, { once: true });
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      controller.abort(new Error('Health check timeout'));
+    }, ENVIRONMENT.HEALTH_CHECK_TIMEOUT_MS);
+    timeout.unref?.();
+    try {
       const response = await fetch(healthUrl, {
         signal: controller.signal,
         method: 'GET',
       });
-
-      clearTimeout(timeout);
-
-      const isHealthy = response.ok;
-      const newHealthStatus = isHealthy ? 'healthy' : 'unhealthy';
-
-      // Only log if health status changed
-      if (previousHealthStatus !== newHealthStatus) {
-        console.log(
-          `🏥 Health status changed for ${branch.name}: ${previousHealthStatus || 'unknown'} → ${newHealthStatus} (HTTP ${response.status})`
-        );
-      }
-
-      // If health check succeeds and we're in 'starting' or 'error' state,
-      // transition/recover to 'running'. The explicit 'error' recovery path matters
-      // when a lifecycle command failed or raced but the configured app is now live.
-      const shouldTransitionToRunning =
-        isHealthy && (currentStatus === 'starting' || currentStatus === 'error');
-
-      if (shouldTransitionToRunning) {
-        console.log(`✅ Successful health check for ${branch.name} - transitioning to 'running'`);
-      }
-
-      return await this.updateEnvironment(
-        id,
-        {
-          status: shouldTransitionToRunning ? 'running' : currentStatus,
-          last_health_check: {
-            timestamp: new Date().toISOString(),
-            status: newHealthStatus,
-            message: isHealthy
-              ? `HTTP ${response.status}`
-              : `HTTP ${response.status} ${response.statusText}`,
-          },
-        },
-        params
-      );
+      return {
+        status: response.ok ? 'healthy' : 'unhealthy',
+        message: response.ok
+          ? `HTTP ${response.status}`
+          : `HTTP ${response.status} ${response.statusText}`,
+        recordWhileStarting: true,
+      };
     } catch (error) {
-      // Health check failed
-      const message =
-        error instanceof Error
-          ? error.name === 'AbortError'
-            ? 'Timeout'
-            : error.message
-          : 'Unknown error';
-
-      // During 'starting' state, don't mark as unhealthy - keep retrying
-      // Only mark as unhealthy when transitioning from healthy->unhealthy in 'running' state
-      if (currentStatus === 'starting') {
-        // Don't update health check during startup - wait for first success
-        // This prevents the UI from showing unhealthy state while environment is still starting
-        return branch;
-      }
-
-      const newHealthStatus = 'unhealthy';
-
-      // Only log if health status changed or if this is an error
-      if (previousHealthStatus !== newHealthStatus) {
-        console.log(
-          `🏥 Health status changed for ${branch.name}: ${previousHealthStatus || 'unknown'} → ${newHealthStatus} (${message})`
-        );
-      }
-
-      return await this.updateEnvironment(
-        id,
-        {
-          last_health_check: {
-            timestamp: new Date().toISOString(),
-            status: 'unhealthy',
-            message,
-          },
-        },
-        params
-      );
+      if (cancellationSignal?.aborted) return null;
+      return {
+        status: 'unhealthy',
+        message: timedOut ? 'Timeout' : error instanceof Error ? error.message : 'Unknown error',
+        recordWhileStarting: false,
+      };
+    } finally {
+      clearTimeout(timeout);
+      cancellationSignal?.removeEventListener('abort', cancel);
     }
   }
 
@@ -2596,7 +2612,6 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
 
     await this.validateRenderedEnvironmentActions(snapshot);
     validateRenderedManagedEnvUrlFields({
-      health: snapshot.health,
       app: snapshot.app,
     });
 

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -136,6 +136,18 @@ interface ManagedProcess {
 }
 
 /**
+ * Identifies whether a health observation was requested by a user-facing
+ * status action or by the background lifecycle monitor.
+ *
+ * Explicit requests may bypass the periodic cooldown and may return an
+ * ephemeral diagnostic for an errored environment. Automatic observations
+ * are restricted to active lifecycle states.
+ */
+export type EnvironmentHealthCheckOptions =
+  | { intent: 'automatic'; signal?: AbortSignal }
+  | { intent: 'explicit'; signal?: AbortSignal };
+
+/**
  * Extended branches service with custom methods
  */
 export class BranchesService extends DrizzleService<Branch, Partial<Branch>, BranchParams> {
@@ -2303,7 +2315,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
   async checkHealth(
     id: BranchID,
     params?: BranchParams,
-    internalOptions?: { signal?: AbortSignal; automatic?: boolean }
+    internalOptions?: EnvironmentHealthCheckOptions
   ): Promise<BranchWithZoneAndSessions> {
     const branch = await this.withTenantDatabase(params, () => this.get(id, params));
     const _repo = await this.withTenantDatabase(
@@ -2323,6 +2335,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     // but an inactive lifecycle must not acquire monitoring ownership or be
     // revived by that observation. Return the observation ephemerally.
     if (currentStatus === 'error') {
+      if (internalOptions?.intent === 'automatic') return branch;
       const observation = await this.fetchEnvironmentHealthObservation(
         branch,
         internalOptions?.signal
@@ -2356,7 +2369,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
         claimToken,
         leaseDurationMs: ENVIRONMENT.HEALTH_CHECK_TIMEOUT_MS + 5_000,
         identity,
-        ignoreCooldown: !internalOptions?.automatic,
+        ignoreCooldown: internalOptions?.intent !== 'automatic',
       })
     );
     if (claimResult.outcome !== 'claimed') {
@@ -2414,7 +2427,6 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
       };
     }
     if (!isAllowedHealthCheckUrl(healthUrl)) {
-      console.warn(`⚠️ Blocked health check to disallowed URL: ${healthUrl}`);
       return {
         status: 'unhealthy',
         message: 'Health check URL blocked by security policy',

--- a/apps/agor-daemon/src/services/health-monitor.test.ts
+++ b/apps/agor-daemon/src/services/health-monitor.test.ts
@@ -58,7 +58,7 @@ describe('HealthMonitor tenant context', () => {
       query: { $limit: 1000 },
       paginate: false,
     });
-    monitor.cleanup();
+    await monitor.cleanup();
   });
 
   it('discovers active environments by tenant metadata on startup', async () => {
@@ -94,14 +94,14 @@ describe('HealthMonitor tenant context', () => {
     expect(branches.checkHealth).toHaveBeenCalledWith(
       'branch-tenant-a',
       { tenant: { tenant_id: 'tenant-a', source: 'auth_claim' } },
-      { signal: expect.any(AbortSignal), automatic: true }
+      { signal: expect.any(AbortSignal), intent: 'automatic' }
     );
     expect(branches.checkHealth).toHaveBeenCalledWith(
       'branch-tenant-b',
       { tenant: { tenant_id: 'tenant-b', source: 'auth_claim' } },
-      { signal: expect.any(AbortSignal), automatic: true }
+      { signal: expect.any(AbortSignal), intent: 'automatic' }
     );
-    monitor.cleanup();
+    await monitor.cleanup();
   });
 
   it('uses the configured static tenant for startup discovery refs without tenant metadata', async () => {
@@ -116,7 +116,7 @@ describe('HealthMonitor tenant context', () => {
     expect(branches.get).toHaveBeenCalledWith('branch-static', {
       tenant: { tenant_id: 'default', source: 'static' },
     });
-    monitor.cleanup();
+    await monitor.cleanup();
   });
 
   it('revalidates startup discovery refs and excludes an archived active row', async () => {
@@ -134,7 +134,7 @@ describe('HealthMonitor tenant context', () => {
 
     expect(monitor.getStatus().monitoringCount).toBe(0);
     expect(branches.checkHealth).not.toHaveBeenCalled();
-    monitor.cleanup();
+    await monitor.cleanup();
   });
 
   it('fails closed when required tenant metadata is missing for event-driven monitoring', async () => {
@@ -155,7 +155,7 @@ describe('HealthMonitor tenant context', () => {
 
     expect(branches.get).not.toHaveBeenCalled();
     expect(branches.checkHealth).not.toHaveBeenCalled();
-    monitor.cleanup();
+    await monitor.cleanup();
   });
 
   it('uses branch tenant_id for event-driven background health checks', async () => {
@@ -183,9 +183,9 @@ describe('HealthMonitor tenant context', () => {
     expect(branches.checkHealth).toHaveBeenCalledWith(
       'branch-tenant-a',
       { tenant: { tenant_id: 'tenant-a', source: 'auth_claim' } },
-      { signal: expect.any(AbortSignal), automatic: true }
+      { signal: expect.any(AbortSignal), intent: 'automatic' }
     );
-    monitor.cleanup();
+    await monitor.cleanup();
   });
 
   it('enters the branch tenant DB scope instead of inheriting stale timer scope', async () => {
@@ -223,7 +223,7 @@ describe('HealthMonitor tenant context', () => {
     await vi.waitFor(() => expect(branches.checkHealth).toHaveBeenCalledTimes(1));
 
     expect(ambientTenantIds).toEqual(['tenant-a', 'tenant-a']);
-    monitor.cleanup();
+    await monitor.cleanup();
   });
 
   it('deduplicates repeated lifecycle patches during the startup grace period', async () => {
@@ -245,7 +245,7 @@ describe('HealthMonitor tenant context', () => {
 
     await vi.advanceTimersByTimeAsync(ENVIRONMENT.HEALTH_CHECK_INTERVAL_MS * 2);
     await vi.waitFor(() => expect(branches.checkHealth).toHaveBeenCalledTimes(3));
-    monitor.cleanup();
+    await monitor.cleanup();
   });
 
   it('cancels a pending grace check when the environment stops', async () => {
@@ -267,7 +267,7 @@ describe('HealthMonitor tenant context', () => {
       ENVIRONMENT.STARTUP_GRACE_PERIOD_MS + ENVIRONMENT.HEALTH_CHECK_INTERVAL_MS
     );
     expect(branches.checkHealth).not.toHaveBeenCalled();
-    monitor.cleanup();
+    await monitor.cleanup();
   });
 
   it('cancels a pending grace check when an active environment is archived', async () => {
@@ -283,7 +283,7 @@ describe('HealthMonitor tenant context', () => {
       ENVIRONMENT.STARTUP_GRACE_PERIOD_MS + ENVIRONMENT.HEALTH_CHECK_INTERVAL_MS
     );
     expect(branches.checkHealth).not.toHaveBeenCalled();
-    monitor.cleanup();
+    await monitor.cleanup();
   });
 
   it('cancels a pending grace check when the branch is deleted', async () => {
@@ -299,7 +299,7 @@ describe('HealthMonitor tenant context', () => {
     );
     expect(monitor.getStatus().monitoringCount).toBe(0);
     expect(branches.checkHealth).not.toHaveBeenCalled();
-    monitor.cleanup();
+    await monitor.cleanup();
   });
 
   it.each(['stopped', 'stopping', 'error'] as const)(
@@ -315,7 +315,7 @@ describe('HealthMonitor tenant context', () => {
 
       expect(monitor.getStatus().monitoringCount).toBe(0);
       expect(branches.checkHealth).not.toHaveBeenCalled();
-      monitor.cleanup();
+      await monitor.cleanup();
     }
   );
 
@@ -330,7 +330,7 @@ describe('HealthMonitor tenant context', () => {
       await vi.advanceTimersByTimeAsync(ENVIRONMENT.STARTUP_GRACE_PERIOD_MS);
 
       await vi.waitFor(() => expect(branches.checkHealth).toHaveBeenCalledOnce());
-      monitor.cleanup();
+      await monitor.cleanup();
     }
   );
 
@@ -356,7 +356,9 @@ describe('HealthMonitor tenant context', () => {
     await vi.runAllTicks();
     await vi.advanceTimersByTimeAsync(ENVIRONMENT.HEALTH_CHECK_INTERVAL_MS);
     await vi.waitFor(() => expect(branches.checkHealth).toHaveBeenCalledTimes(2));
-    monitor.cleanup();
+    releaseCheck?.();
+    await vi.runAllTicks();
+    await monitor.cleanup();
   });
 
   it('cleanup cancels pending grace timers', async () => {
@@ -364,7 +366,7 @@ describe('HealthMonitor tenant context', () => {
     const monitor = new HealthMonitor(makeApp(branches) as never);
 
     branches.emit('patched', makeBranch({ environment_instance: { status: 'running' } }));
-    monitor.cleanup();
+    await monitor.cleanup();
 
     await vi.advanceTimersByTimeAsync(ENVIRONMENT.STARTUP_GRACE_PERIOD_MS);
     expect(branches.checkHealth).not.toHaveBeenCalled();
@@ -394,18 +396,21 @@ describe('HealthMonitor tenant context', () => {
     expect(signal?.aborted).toBe(true);
     expect(monitor.getStatus().monitoringCount).toBe(0);
 
-    monitor.cleanup();
+    await monitor.cleanup();
     branches.emit('patched', running);
     expect(monitor.getStatus().monitoringCount).toBe(0);
   });
 
-  it('cleanup aborts an in-flight check', async () => {
+  it('cleanup aborts and drains an in-flight check', async () => {
     const branches = new BranchServiceMock();
     let signal: AbortSignal | undefined;
+    let releaseCheck: (() => void) | undefined;
     branches.checkHealth.mockImplementation(
       async (_id: string, _params: unknown, options?: { signal?: AbortSignal }) => {
         signal = options?.signal;
-        await new Promise<void>((resolve) => signal?.addEventListener('abort', () => resolve()));
+        await new Promise<void>((resolve) => {
+          releaseCheck = resolve;
+        });
       }
     );
     const monitor = new HealthMonitor(makeApp(branches) as never);
@@ -414,9 +419,48 @@ describe('HealthMonitor tenant context', () => {
     await vi.advanceTimersByTimeAsync(ENVIRONMENT.STARTUP_GRACE_PERIOD_MS);
     await vi.waitFor(() => expect(branches.checkHealth).toHaveBeenCalledOnce());
 
-    monitor.cleanup();
+    let cleanupSettled = false;
+    const cleanup = monitor.cleanup().then(() => {
+      cleanupSettled = true;
+    });
 
     expect(signal?.aborted).toBe(true);
     expect(monitor.getStatus().monitoringCount).toBe(0);
+    await Promise.resolve();
+    expect(cleanupSettled).toBe(false);
+
+    releaseCheck?.();
+    await cleanup;
+    expect(cleanupSettled).toBe(true);
+  });
+
+  it('bounds cleanup draining when in-flight work ignores cancellation', async () => {
+    const branches = new BranchServiceMock();
+    let signal: AbortSignal | undefined;
+    branches.checkHealth.mockImplementation(
+      async (_id: string, _params: unknown, options?: { signal?: AbortSignal }) => {
+        signal = options?.signal;
+        await new Promise<void>(() => undefined);
+      }
+    );
+    const monitor = new HealthMonitor(makeApp(branches) as never, {
+      shutdownDrainTimeoutMs: 100,
+    });
+
+    branches.emit('patched', makeBranch({ environment_instance: { status: 'running' } }));
+    await vi.advanceTimersByTimeAsync(ENVIRONMENT.STARTUP_GRACE_PERIOD_MS);
+    await vi.waitFor(() => expect(branches.checkHealth).toHaveBeenCalledOnce());
+
+    let cleanupSettled = false;
+    const cleanup = monitor.cleanup().then(() => {
+      cleanupSettled = true;
+    });
+    expect(signal?.aborted).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(99);
+    expect(cleanupSettled).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    await cleanup;
+    expect(cleanupSettled).toBe(true);
   });
 });

--- a/apps/agor-daemon/src/services/health-monitor.test.ts
+++ b/apps/agor-daemon/src/services/health-monitor.test.ts
@@ -91,12 +91,16 @@ describe('HealthMonitor tenant context', () => {
     await vi.advanceTimersByTimeAsync(ENVIRONMENT.STARTUP_GRACE_PERIOD_MS);
 
     await vi.waitFor(() => expect(branches.checkHealth).toHaveBeenCalledTimes(2));
-    expect(branches.checkHealth).toHaveBeenCalledWith('branch-tenant-a', {
-      tenant: { tenant_id: 'tenant-a', source: 'auth_claim' },
-    });
-    expect(branches.checkHealth).toHaveBeenCalledWith('branch-tenant-b', {
-      tenant: { tenant_id: 'tenant-b', source: 'auth_claim' },
-    });
+    expect(branches.checkHealth).toHaveBeenCalledWith(
+      'branch-tenant-a',
+      { tenant: { tenant_id: 'tenant-a', source: 'auth_claim' } },
+      { signal: expect.any(AbortSignal), automatic: true }
+    );
+    expect(branches.checkHealth).toHaveBeenCalledWith(
+      'branch-tenant-b',
+      { tenant: { tenant_id: 'tenant-b', source: 'auth_claim' } },
+      { signal: expect.any(AbortSignal), automatic: true }
+    );
     monitor.cleanup();
   });
 
@@ -112,6 +116,24 @@ describe('HealthMonitor tenant context', () => {
     expect(branches.get).toHaveBeenCalledWith('branch-static', {
       tenant: { tenant_id: 'default', source: 'static' },
     });
+    monitor.cleanup();
+  });
+
+  it('revalidates startup discovery refs and excludes an archived active row', async () => {
+    const branches = new BranchServiceMock();
+    branches.get.mockResolvedValue(
+      makeBranch({ archived: true, environment_instance: { status: 'running' } })
+    );
+    const monitor = new HealthMonitor(makeApp(branches) as never, {
+      tenantId: 'default',
+      discoverActiveEnvironmentRefs: async () => [{ branchId: 'branch-archived' as never }],
+    });
+
+    await monitor.initialize();
+    await vi.advanceTimersByTimeAsync(ENVIRONMENT.STARTUP_GRACE_PERIOD_MS);
+
+    expect(monitor.getStatus().monitoringCount).toBe(0);
+    expect(branches.checkHealth).not.toHaveBeenCalled();
     monitor.cleanup();
   });
 
@@ -158,9 +180,11 @@ describe('HealthMonitor tenant context', () => {
     expect(branches.get).toHaveBeenCalledWith('branch-tenant-a', {
       tenant: { tenant_id: 'tenant-a', source: 'auth_claim' },
     });
-    expect(branches.checkHealth).toHaveBeenCalledWith('branch-tenant-a', {
-      tenant: { tenant_id: 'tenant-a', source: 'auth_claim' },
-    });
+    expect(branches.checkHealth).toHaveBeenCalledWith(
+      'branch-tenant-a',
+      { tenant: { tenant_id: 'tenant-a', source: 'auth_claim' } },
+      { signal: expect.any(AbortSignal), automatic: true }
+    );
     monitor.cleanup();
   });
 
@@ -246,6 +270,70 @@ describe('HealthMonitor tenant context', () => {
     monitor.cleanup();
   });
 
+  it('cancels a pending grace check when an active environment is archived', async () => {
+    const branches = new BranchServiceMock();
+    const monitor = new HealthMonitor(makeApp(branches) as never);
+    const branch = makeBranch({ environment_instance: { status: 'starting' } });
+
+    branches.emit('patched', branch);
+    branches.emit('patched', makeBranch({ ...branch, archived: true }));
+
+    expect(monitor.getStatus().monitoringCount).toBe(0);
+    await vi.advanceTimersByTimeAsync(
+      ENVIRONMENT.STARTUP_GRACE_PERIOD_MS + ENVIRONMENT.HEALTH_CHECK_INTERVAL_MS
+    );
+    expect(branches.checkHealth).not.toHaveBeenCalled();
+    monitor.cleanup();
+  });
+
+  it('cancels a pending grace check when the branch is deleted', async () => {
+    const branches = new BranchServiceMock();
+    const monitor = new HealthMonitor(makeApp(branches) as never);
+    const branch = makeBranch({ environment_instance: { status: 'running' } });
+
+    branches.emit('patched', branch);
+    branches.emit('removed', branch);
+
+    await vi.advanceTimersByTimeAsync(
+      ENVIRONMENT.STARTUP_GRACE_PERIOD_MS + ENVIRONMENT.HEALTH_CHECK_INTERVAL_MS
+    );
+    expect(monitor.getStatus().monitoringCount).toBe(0);
+    expect(branches.checkHealth).not.toHaveBeenCalled();
+    monitor.cleanup();
+  });
+
+  it.each(['stopped', 'stopping', 'error'] as const)(
+    'does not monitor an environment in %s state',
+    async (status) => {
+      const branches = new BranchServiceMock();
+      const monitor = new HealthMonitor(makeApp(branches) as never);
+
+      branches.emit('patched', makeBranch({ environment_instance: { status } }));
+      await vi.advanceTimersByTimeAsync(
+        ENVIRONMENT.STARTUP_GRACE_PERIOD_MS + ENVIRONMENT.HEALTH_CHECK_INTERVAL_MS
+      );
+
+      expect(monitor.getStatus().monitoringCount).toBe(0);
+      expect(branches.checkHealth).not.toHaveBeenCalled();
+      monitor.cleanup();
+    }
+  );
+
+  it.each(['starting', 'running'] as const)(
+    'monitors an environment in %s state',
+    async (status) => {
+      const branches = new BranchServiceMock();
+      branches.get.mockResolvedValue(makeBranch({ environment_instance: { status } }));
+      const monitor = new HealthMonitor(makeApp(branches) as never);
+
+      branches.emit('patched', makeBranch({ environment_instance: { status } }));
+      await vi.advanceTimersByTimeAsync(ENVIRONMENT.STARTUP_GRACE_PERIOD_MS);
+
+      await vi.waitFor(() => expect(branches.checkHealth).toHaveBeenCalledOnce());
+      monitor.cleanup();
+    }
+  );
+
   it('does not overlap slow health checks for the same branch', async () => {
     const branches = new BranchServiceMock();
     let releaseCheck: (() => void) | undefined;
@@ -280,6 +368,55 @@ describe('HealthMonitor tenant context', () => {
 
     await vi.advanceTimersByTimeAsync(ENVIRONMENT.STARTUP_GRACE_PERIOD_MS);
     expect(branches.checkHealth).not.toHaveBeenCalled();
+    expect(monitor.getStatus().monitoringCount).toBe(0);
+  });
+
+  it('stop aborts an in-flight check and cleanup unregisters lifecycle listeners', async () => {
+    const branches = new BranchServiceMock();
+    let signal: AbortSignal | undefined;
+    branches.checkHealth.mockImplementation(
+      async (_id: string, _params: unknown, options?: { signal?: AbortSignal }) => {
+        signal = options?.signal;
+        await new Promise<void>((resolve) => signal?.addEventListener('abort', () => resolve()));
+      }
+    );
+    const monitor = new HealthMonitor(makeApp(branches) as never);
+    const running = makeBranch({ environment_instance: { status: 'running' } });
+
+    branches.emit('patched', running);
+    await vi.advanceTimersByTimeAsync(ENVIRONMENT.STARTUP_GRACE_PERIOD_MS);
+    await vi.waitFor(() => expect(branches.checkHealth).toHaveBeenCalledOnce());
+
+    branches.emit(
+      'patched',
+      makeBranch({ branch_id: running.branch_id, environment_instance: { status: 'stopped' } })
+    );
+    expect(signal?.aborted).toBe(true);
+    expect(monitor.getStatus().monitoringCount).toBe(0);
+
+    monitor.cleanup();
+    branches.emit('patched', running);
+    expect(monitor.getStatus().monitoringCount).toBe(0);
+  });
+
+  it('cleanup aborts an in-flight check', async () => {
+    const branches = new BranchServiceMock();
+    let signal: AbortSignal | undefined;
+    branches.checkHealth.mockImplementation(
+      async (_id: string, _params: unknown, options?: { signal?: AbortSignal }) => {
+        signal = options?.signal;
+        await new Promise<void>((resolve) => signal?.addEventListener('abort', () => resolve()));
+      }
+    );
+    const monitor = new HealthMonitor(makeApp(branches) as never);
+
+    branches.emit('patched', makeBranch({ environment_instance: { status: 'running' } }));
+    await vi.advanceTimersByTimeAsync(ENVIRONMENT.STARTUP_GRACE_PERIOD_MS);
+    await vi.waitFor(() => expect(branches.checkHealth).toHaveBeenCalledOnce());
+
+    monitor.cleanup();
+
+    expect(signal?.aborted).toBe(true);
     expect(monitor.getStatus().monitoringCount).toBe(0);
   });
 });

--- a/apps/agor-daemon/src/services/health-monitor.ts
+++ b/apps/agor-daemon/src/services/health-monitor.ts
@@ -11,7 +11,10 @@
  * - Graceful cleanup on daemon shutdown
  */
 
-import { ENVIRONMENT } from '@agor/core/config';
+import {
+  DEFAULT_ENVIRONMENT_HEALTH_SHUTDOWN_DRAIN_TIMEOUT_MS,
+  ENVIRONMENT,
+} from '@agor/core/config';
 import {
   BranchRepository,
   getHiddenTenantId,
@@ -59,6 +62,8 @@ export interface HealthMonitorOptions {
   requireTenantParams?: boolean;
   /** Test seam for startup discovery. Production uses BranchRepository when db is provided. */
   discoverActiveEnvironmentRefs?: () => Promise<HealthMonitorActiveEnvironmentRef[]>;
+  /** Maximum time shutdown waits for aborted observations to settle. */
+  shutdownDrainTimeoutMs?: number;
 }
 
 interface HealthMonitorTimer {
@@ -83,8 +88,10 @@ export class HealthMonitor {
    * last interval was retained in the map; the others could never be stopped.
    */
   private timers = new Map<BranchID, HealthMonitorTimer>();
-  private checksInFlight = new Set<BranchID>();
-  private checkAbortControllers = new Map<BranchID, AbortController>();
+  private checksInFlight = new Map<
+    BranchID,
+    { controller: AbortController; work: Promise<void> }
+  >();
   private branchParams = new Map<BranchID, HealthMonitorParams>();
   private isShuttingDown = false;
   private defaultParams?: HealthMonitorParams;
@@ -93,6 +100,8 @@ export class HealthMonitor {
   private tenantId?: TenantID | string;
   private requireTenantParams: boolean;
   private discoverActiveEnvironmentRefs?: () => Promise<HealthMonitorActiveEnvironmentRef[]>;
+  private shutdownDrainTimeoutMs: number;
+  private cleanupPromise?: Promise<void>;
 
   private readonly onBranchPatched = (branch: Branch) => this.handleBranchUpdate(branch);
   private readonly onBranchCreated = (branch: Branch) => this.handleBranchUpdate(branch);
@@ -112,6 +121,8 @@ export class HealthMonitor {
         : undefined;
     this.requireTenantParams = options.requireTenantParams ?? false;
     this.discoverActiveEnvironmentRefs = options.discoverActiveEnvironmentRefs;
+    this.shutdownDrainTimeoutMs =
+      options.shutdownDrainTimeoutMs ?? DEFAULT_ENVIRONMENT_HEALTH_SHUTDOWN_DRAIN_TIMEOUT_MS;
     this.setupBranchListeners();
   }
 
@@ -225,24 +236,33 @@ export class HealthMonitor {
       else clearInterval(timer.handle);
       this.timers.delete(branchId);
     }
-    this.checkAbortControllers
+    this.checksInFlight
       .get(branchId)
-      ?.abort(new Error('Environment is no longer eligible for health monitoring'));
+      ?.controller.abort(new Error('Environment is no longer eligible for health monitoring'));
   }
 
   /**
    * Perform health check for a specific branch
    */
-  private async checkHealth(branchId: BranchID) {
+  private checkHealth(branchId: BranchID): Promise<void> {
     // `setInterval` does not await async callbacks. The normal HTTP timeout is
     // shorter than the poll interval, but DB stalls or executor/service delays
     // can exceed it. Never let two observations for one branch race and write a
     // stale healthy/unhealthy result over the newer one.
-    if (this.checksInFlight.has(branchId)) return;
-    this.checksInFlight.add(branchId);
+    const existing = this.checksInFlight.get(branchId);
+    if (existing) return existing.work;
     const controller = new AbortController();
-    this.checkAbortControllers.set(branchId, controller);
+    let work: Promise<void>;
+    work = this.performHealthCheck(branchId, controller).finally(() => {
+      if (this.checksInFlight.get(branchId)?.work === work) {
+        this.checksInFlight.delete(branchId);
+      }
+    });
+    this.checksInFlight.set(branchId, { controller, work });
+    return work;
+  }
 
+  private async performHealthCheck(branchId: BranchID, controller: AbortController): Promise<void> {
     try {
       const branchesService = this.app.service('branches') as unknown as BranchesServiceImpl;
 
@@ -282,7 +302,7 @@ export class HealthMonitor {
         // realtime patches.
         await branchesService.checkHealth(branchId, params as never, {
           signal: controller.signal,
-          automatic: true,
+          intent: 'automatic',
         });
       };
 
@@ -309,11 +329,6 @@ export class HealthMonitor {
         `❌ Health check failed for branch ${shortId(branchId)}:`,
         error instanceof Error ? error.message : error
       );
-    } finally {
-      this.checksInFlight.delete(branchId);
-      if (this.checkAbortControllers.get(branchId) === controller) {
-        this.checkAbortControllers.delete(branchId);
-      }
     }
   }
 
@@ -461,7 +476,8 @@ export class HealthMonitor {
    *
    * Called on daemon shutdown
    */
-  cleanup() {
+  cleanup(): Promise<void> {
+    if (this.cleanupPromise) return this.cleanupPromise;
     this.isShuttingDown = true;
 
     // Clear pending grace periods and active intervals.
@@ -472,15 +488,34 @@ export class HealthMonitor {
     }
 
     this.timers.clear();
-    for (const controller of this.checkAbortControllers.values()) {
+    const inFlight = [...this.checksInFlight.values()];
+    for (const { controller } of inFlight) {
       controller.abort(new Error('Environment health monitor is shutting down'));
     }
-    this.checkAbortControllers.clear();
     this.branchParams.clear();
     const branchesService = this.app.service('branches');
     branchesService.off('patched', this.onBranchPatched);
     branchesService.off('created', this.onBranchCreated);
     branchesService.off('removed', this.onBranchRemoved);
+
+    this.cleanupPromise = this.drainCleanup(inFlight, stoppedCount);
+    return this.cleanupPromise;
+  }
+
+  private async drainCleanup(
+    inFlight: Array<{ work: Promise<void> }>,
+    stoppedCount: number
+  ): Promise<void> {
+    const drain = Promise.allSettled(inFlight.map(({ work }) => work)).then(() => undefined);
+    let timeout: NodeJS.Timeout | undefined;
+    await Promise.race([
+      drain,
+      new Promise<void>((resolve) => {
+        timeout = setTimeout(resolve, this.shutdownDrainTimeoutMs);
+        timeout.unref?.();
+      }),
+    ]);
+    if (timeout) clearTimeout(timeout);
     console.log(`🏥 Health Monitor cleaned up (${stoppedCount} monitor(s) stopped)`);
   }
 

--- a/apps/agor-daemon/src/services/health-monitor.ts
+++ b/apps/agor-daemon/src/services/health-monitor.ts
@@ -1,12 +1,12 @@
 /**
  * Health Monitor Service
  *
- * Periodically checks health of running branch environments.
+ * Periodically checks health of non-archived starting/running branch environments.
  * Runs every 5 seconds and updates environment_instance.last_health_check.
  *
  * Features:
  * - Interval-based polling (5 seconds)
- * - Only monitors branches with status='running'
+ * - Only monitors non-archived branches with status='starting' or 'running'
  * - Automatic start/stop on environment state changes
  * - Graceful cleanup on daemon shutdown
  */
@@ -84,6 +84,7 @@ export class HealthMonitor {
    */
   private timers = new Map<BranchID, HealthMonitorTimer>();
   private checksInFlight = new Set<BranchID>();
+  private checkAbortControllers = new Map<BranchID, AbortController>();
   private branchParams = new Map<BranchID, HealthMonitorParams>();
   private isShuttingDown = false;
   private defaultParams?: HealthMonitorParams;
@@ -92,6 +93,13 @@ export class HealthMonitor {
   private tenantId?: TenantID | string;
   private requireTenantParams: boolean;
   private discoverActiveEnvironmentRefs?: () => Promise<HealthMonitorActiveEnvironmentRef[]>;
+
+  private readonly onBranchPatched = (branch: Branch) => this.handleBranchUpdate(branch);
+  private readonly onBranchCreated = (branch: Branch) => this.handleBranchUpdate(branch);
+  private readonly onBranchRemoved = (branch: Branch) => {
+    this.stopMonitoring(branch.branch_id);
+    this.branchParams.delete(branch.branch_id);
+  };
 
   constructor(app: Application, options: HealthMonitorOptions = {}) {
     this.app = app;
@@ -120,20 +128,13 @@ export class HealthMonitor {
     const branchesService = this.app.service('branches');
 
     // Listen for branch updates (start/stop/status changes)
-    branchesService.on('patched', (branch: Branch) => {
-      this.handleBranchUpdate(branch);
-    });
+    branchesService.on('patched', this.onBranchPatched);
 
     // Listen for branch creation (in case created with running status)
-    branchesService.on('created', (branch: Branch) => {
-      this.handleBranchUpdate(branch);
-    });
+    branchesService.on('created', this.onBranchCreated);
 
     // Listen for branch removal (cleanup monitoring)
-    branchesService.on('removed', (branch: Branch) => {
-      this.stopMonitoring(branch.branch_id);
-      this.branchParams.delete(branch.branch_id);
-    });
+    branchesService.on('removed', this.onBranchRemoved);
   }
 
   /**
@@ -144,7 +145,7 @@ export class HealthMonitor {
 
     const status = branch.environment_instance?.status;
 
-    if (status === 'running' || status === 'starting') {
+    if (!branch.archived && (status === 'running' || status === 'starting')) {
       // Start monitoring if not already monitored.
       // Monitor both 'running' and 'starting' - health checks will transition 'starting' → 'running'.
       const params = this.paramsForBranch(branch);
@@ -224,6 +225,9 @@ export class HealthMonitor {
       else clearInterval(timer.handle);
       this.timers.delete(branchId);
     }
+    this.checkAbortControllers
+      .get(branchId)
+      ?.abort(new Error('Environment is no longer eligible for health monitoring'));
   }
 
   /**
@@ -236,6 +240,8 @@ export class HealthMonitor {
     // stale healthy/unhealthy result over the newer one.
     if (this.checksInFlight.has(branchId)) return;
     this.checksInFlight.add(branchId);
+    const controller = new AbortController();
+    this.checkAbortControllers.set(branchId, controller);
 
     try {
       const branchesService = this.app.service('branches') as unknown as BranchesServiceImpl;
@@ -262,7 +268,7 @@ export class HealthMonitor {
 
         // Only check if still running or starting
         const status = branch.environment_instance?.status;
-        if (status !== 'running' && status !== 'starting') {
+        if (branch.archived || (status !== 'running' && status !== 'starting')) {
           // Silently stop monitoring (not an error - expected when env stops)
           // Start/stop logs are already handled in handleBranchUpdate()
           this.stopMonitoring(branchId);
@@ -274,7 +280,10 @@ export class HealthMonitor {
         // a db handle and tenant params, enter the same tenant DB/ALS scope the
         // scheduler uses before mutating branch environment state and emitting
         // realtime patches.
-        await branchesService.checkHealth(branchId, params as never);
+        await branchesService.checkHealth(branchId, params as never, {
+          signal: controller.signal,
+          automatic: true,
+        });
       };
 
       const tenantId = params?.tenant?.tenant_id;
@@ -302,6 +311,9 @@ export class HealthMonitor {
       );
     } finally {
       this.checksInFlight.delete(branchId);
+      if (this.checkAbortControllers.get(branchId) === controller) {
+        this.checkAbortControllers.delete(branchId);
+      }
     }
   }
 
@@ -341,8 +353,9 @@ export class HealthMonitor {
     // Start monitoring running or starting branches
     const activeBranches = branches.filter(
       (w) =>
-        w.environment_instance?.status === 'running' ||
-        w.environment_instance?.status === 'starting'
+        !w.archived &&
+        (w.environment_instance?.status === 'running' ||
+          w.environment_instance?.status === 'starting')
     );
 
     for (const branch of activeBranches) {
@@ -384,7 +397,7 @@ export class HealthMonitor {
         const loadAndStart = async () => {
           const branch = await branchesService.get(ref.branchId, params as never);
           const status = branch.environment_instance?.status;
-          if (status !== 'running' && status !== 'starting') return;
+          if (branch.archived || (status !== 'running' && status !== 'starting')) return;
           this.branchParams.set(branch.branch_id, tenantParamsFromBranch(branch) ?? params);
           this.startMonitoring(branch.branch_id, this.branchParams.get(branch.branch_id));
           activeCount += 1;
@@ -459,7 +472,15 @@ export class HealthMonitor {
     }
 
     this.timers.clear();
+    for (const controller of this.checkAbortControllers.values()) {
+      controller.abort(new Error('Environment health monitor is shutting down'));
+    }
+    this.checkAbortControllers.clear();
     this.branchParams.clear();
+    const branchesService = this.app.service('branches');
+    branchesService.off('patched', this.onBranchPatched);
+    branchesService.off('created', this.onBranchCreated);
+    branchesService.off('removed', this.onBranchRemoved);
     console.log(`🏥 Health Monitor cleaned up (${stoppedCount} monitor(s) stopped)`);
   }
 

--- a/apps/agor-docs/content/guide/environment-configuration.mdx
+++ b/apps/agor-docs/content/guide/environment-configuration.mdx
@@ -312,6 +312,28 @@ The reason members **cannot** hand-edit rendered commands: admins curate the set
 
 Start, Stop, Restart, Nuke, Logs, and Render controls require branch `all` permission or admin access. Health/status reads can remain available to users who can view the branch because they do not run the configured shell/log commands.
 
+### Health-check lifecycle
+
+Automatic health monitoring is active only while a non-archived environment is
+`starting` or `running`. A healthy `starting` observation promotes the durable
+state to `running`. Stop, failure, archive, and deletion remove the environment
+from monitoring; daemon startup reconciliation likewise rediscovers only
+non-archived `starting` and `running` rows.
+
+The rendered `health` value is stored as branch configuration even when it is
+not currently a usable URL. This keeps an inactive or optional managed
+environment from blocking branch and session creation. Agor validates the URL
+against its outbound-request policy immediately before an actual server-side
+probe. An unsafe target is never contacted and is reported as unhealthy while
+the environment is active.
+
+An explicit health/status request does not turn monitoring back on for a
+stopped, stopping, archived, or deleted environment. It may return a transient
+diagnostic probe for an environment already in `error`, but that result does not
+change durable lifecycle state. Active observations are fenced against
+concurrent stop, archive, delete, restart, and health-URL changes, so a late
+success cannot restore an older lifecycle state.
+
 ---
 
 ## Migration from pre-variants Agor

--- a/packages/core/src/db/repositories/branches.test.ts
+++ b/packages/core/src/db/repositories/branches.test.ts
@@ -63,6 +63,7 @@ function createBranchData(overrides?: {
   updated_at?: string;
   storage_mode?: 'worktree' | 'clone';
   clone_depth?: number;
+  archived?: boolean;
   permission_source?: 'board' | 'override';
   others_can?: 'none' | 'view' | 'session' | 'prompt' | 'all';
   others_fs_access?: 'none' | 'read' | 'write';
@@ -96,6 +97,7 @@ function createBranchData(overrides?: {
     updated_at: overrides?.updated_at,
     storage_mode: overrides?.storage_mode,
     clone_depth: overrides?.clone_depth,
+    archived: overrides?.archived,
     permission_source: overrides?.permission_source,
     others_can: overrides?.others_can,
     others_fs_access: overrides?.others_fs_access,
@@ -692,8 +694,17 @@ describe('BranchRepository.findActiveEnvironmentRefs', () => {
       await branchRepo.create(
         createBranchData({
           repo_id: repo.repo_id as UUID,
-          name: 'env-missing',
+          name: 'env-archived-running',
           branch_unique_id: 5,
+          archived: true,
+          environment_instance: { status: 'running' },
+        })
+      );
+      await branchRepo.create(
+        createBranchData({
+          repo_id: repo.repo_id as UUID,
+          name: 'env-missing',
+          branch_unique_id: 6,
         })
       );
 

--- a/packages/core/src/db/repositories/branches.ts
+++ b/packages/core/src/db/repositories/branches.ts
@@ -446,7 +446,9 @@ export class BranchRepository implements BaseRepository<Branch, Partial<Branch>>
     const statusExpr = sql`${jsonExtract(this.db, branches.data, 'environment_instance.status')}`;
     const rows = await select(this.db, columns)
       .from(branches)
-      .where(or(eq(statusExpr, 'running'), eq(statusExpr, 'starting')))
+      .where(
+        and(eq(branches.archived, false), or(eq(statusExpr, 'running'), eq(statusExpr, 'starting')))
+      )
       .all();
 
     return (rows as Array<{ branch_id: string; tenant_id?: unknown }>).map((row) => ({

--- a/packages/core/src/db/repositories/environment-health.test.ts
+++ b/packages/core/src/db/repositories/environment-health.test.ts
@@ -8,7 +8,13 @@ import { EnvironmentHealthRepository } from './environment-health';
 import { RepoRepository } from './repos';
 import { UsersRepository } from './users';
 
-async function seedStartingBranch(db: Database) {
+let branchUniqueId = 9_900_001;
+
+async function seedStartingBranch(
+  db: Database,
+  status: 'stopped' | 'starting' | 'running' | 'stopping' | 'error' = 'starting',
+  archived = false
+) {
   const user = await new UsersRepository(db).create({
     email: `${generateId()}@example.com`,
     name: 'Environment health fence',
@@ -27,15 +33,66 @@ async function seedStartingBranch(db: Database) {
     repo_id: repo.repo_id,
     name: `environment-health-${generateId()}`,
     ref: 'main',
-    branch_unique_id: 9_900_001,
+    branch_unique_id: branchUniqueId++,
     path: `/tmp/${generateId()}`,
     created_by: user.user_id,
     health_check_url: 'https://example.invalid/health',
-    environment_instance: { status: 'starting' },
+    archived,
+    environment_instance: { status },
   });
 }
 
 describe('EnvironmentHealthRepository lifecycle fencing', () => {
+  dbTest('admits only non-archived starting and running environments', async ({ db }) => {
+    const health = new EnvironmentHealthRepository(db);
+    for (const status of ['starting', 'running'] as const) {
+      const branch = await seedStartingBranch(db, status);
+      const result = await health.claim({
+        branchId: branch.branch_id,
+        claimToken: `active-${status}`,
+        leaseDurationMs: 30_000,
+        identity: { instanceId: 'daemon-a', bootId: 'boot-a' },
+      });
+      expect(result).toMatchObject({ outcome: 'claimed' });
+      if (result.outcome === 'claimed') {
+        await health.release(branch.branch_id, result.claim.claim_token);
+      }
+    }
+
+    for (const status of ['stopped', 'stopping', 'error'] as const) {
+      const branch = await seedStartingBranch(db, status);
+      await expect(
+        health.claim({
+          branchId: branch.branch_id,
+          claimToken: `inactive-${status}`,
+          leaseDurationMs: 30_000,
+          identity: { instanceId: 'daemon-a', bootId: 'boot-a' },
+        })
+      ).resolves.toEqual({ outcome: 'unavailable' });
+    }
+
+    const archived = await seedStartingBranch(db, 'running', true);
+    await expect(
+      health.claim({
+        branchId: archived.branch_id,
+        claimToken: 'archived',
+        leaseDurationMs: 30_000,
+        identity: { instanceId: 'daemon-a', bootId: 'boot-a' },
+      })
+    ).resolves.toEqual({ outcome: 'unavailable' });
+
+    const deleted = await seedStartingBranch(db, 'running');
+    await new BranchRepository(db).delete(deleted.branch_id);
+    await expect(
+      health.claim({
+        branchId: deleted.branch_id,
+        claimToken: 'deleted',
+        leaseDurationMs: 30_000,
+        identity: { instanceId: 'daemon-a', bootId: 'boot-a' },
+      })
+    ).resolves.toEqual({ outcome: 'unavailable' });
+  });
+
   dbTest('promotes healthy startup and records unhealthy running observations', async ({ db }) => {
     const branch = await seedStartingBranch(db);
     const branches = new BranchRepository(db);
@@ -154,6 +211,34 @@ describe('EnvironmentHealthRepository lifecycle fencing', () => {
     });
   });
 
+  dbTest('invalidates an in-flight result when the branch is archived', async ({ db }) => {
+    const branch = await seedStartingBranch(db, 'running');
+    const branches = new BranchRepository(db);
+    const health = new EnvironmentHealthRepository(db);
+    const claim = await health.claim({
+      branchId: branch.branch_id,
+      claimToken: 'before-archive',
+      leaseDurationMs: 30_000,
+      identity: { instanceId: 'daemon-a', bootId: 'boot-a' },
+    });
+    if (claim.outcome !== 'claimed') throw new Error('Expected initial claim');
+
+    await branches.update(branch.branch_id, { archived: true });
+
+    await expect(
+      health.commit({
+        branchId: branch.branch_id,
+        claimToken: claim.claim.claim_token,
+        environmentGeneration: claim.claim.environment_generation,
+        observation: { status: 'healthy', message: 'late HTTP 200', recordWhileStarting: true },
+      })
+    ).resolves.toEqual({ outcome: 'stale' });
+    expect(await branches.findById(branch.branch_id)).toMatchObject({
+      archived: true,
+      environment_instance: { status: 'running' },
+    });
+  });
+
   dbTest('enforces a durable cooldown after a completed observation', async ({ db }) => {
     const branch = await seedStartingBranch(db);
     const health = new EnvironmentHealthRepository(db);
@@ -176,5 +261,14 @@ describe('EnvironmentHealthRepository lifecycle fencing', () => {
         identity: { instanceId: 'daemon-b', bootId: 'boot-b' },
       })
     ).resolves.toMatchObject({ outcome: 'not_due' });
+
+    const explicit = await health.claim({
+      branchId: branch.branch_id,
+      claimToken: 'explicit-observation',
+      leaseDurationMs: 30_000,
+      identity: { instanceId: 'daemon-b', bootId: 'boot-b' },
+      ignoreCooldown: true,
+    });
+    expect(explicit).toMatchObject({ outcome: 'claimed' });
   });
 });

--- a/packages/core/src/db/repositories/environment-health.ts
+++ b/packages/core/src/db/repositories/environment-health.ts
@@ -151,6 +151,8 @@ export class EnvironmentHealthRepository {
     claimToken: string;
     leaseDurationMs: number;
     identity: DistributedWorkIdentity;
+    /** Explicit user probes may bypass cadence cooldown, never a live owner. */
+    ignoreCooldown?: boolean;
   }): Promise<EnvironmentHealthClaimResult> {
     this.validateClaimInput(input);
     return runDatabaseTransaction(
@@ -182,6 +184,7 @@ export class EnvironmentHealthRepository {
         // fleet-wide cooldown. An expired token means its owner died, so
         // takeover is admitted after lease expiry regardless of the cooldown.
         if (
+          !input.ignoreCooldown &&
           !row.environment_health_claim_token &&
           row.environment_health_next_observation_at &&
           new Date(row.environment_health_next_observation_at).getTime() > now.getTime()


### PR DESCRIPTION
## Summary

- stop validating rendered health URLs while materializing or re-rendering an inactive branch, so a bad optional managed-environment setting cannot block branch/session creation
- restrict automatic health monitoring and startup reconciliation to non-archived `starting`/`running` environments
- route standalone/manual active observations through the existing database claim, lease, lifecycle-generation, and fenced-commit layer
- abort standalone in-flight HTTP work on stop/archive/delete/shutdown and unregister monitor listeners during cleanup
- keep explicit error-state diagnostics useful without persisting the result or reviving monitoring

Closes #2514.

## Root cause

Branch materialization renders the repo environment snapshot in the executor and patches `health_check_url` onto the branch. The branch write hook added for managed-environment policy then eagerly called `validateRenderedManagedEnvUrlFields`, so an invalid rendered health URL threw `managed environment health must render to an allowed http(s) URL` while the filesystem was being created. The executor treated that patch failure as a materialization failure, blocking the branch and therefore the session flow even though no environment was active.

The lifecycle audit also found two standalone-only gaps:

1. archived rows whose durable status remained `starting`/`running` were accepted by event registration and restart discovery;
2. standalone/manual observations used the generic branch patch path after HTTP returned, so a late healthy response could overwrite a concurrent stop/archive state. The HA distributed monitor already used claims, leases, lifecycle generations, and compare-and-set commit fencing correctly.

## Resulting contract

| Durable branch/environment state | Automatic probe | Explicit health request | Durable health/lifecycle mutation |
| --- | :---: | :---: | :---: |
| non-archived `starting` | yes | yes | yes; healthy may promote to `running` |
| non-archived `running` | yes | yes | yes; fenced observation only |
| `stopping` / `stopped` | no | no outbound probe | no |
| `error` | no | optional transient diagnostic | no |
| archived (any status) | no | no outbound probe | no |
| deleted / missing | no | not found | no |
| no environment instance | no | no outbound probe | no |

Rendered health configuration is now persisted independently of lifecycle. The outbound URL policy is still enforced immediately before every actual server-side health request. Unsafe URLs are never contacted. Rendered app URLs remain eagerly validated because clients consume them directly.

For active checks, stop/archive/delete/restart/health-URL changes increment the environment generation and revoke the observation token. A late response therefore cannot restore `running` or replace newer health state. Explicit active checks may bypass the periodic cadence cooldown, but never a live owner/lease, so they do not duplicate an in-flight HA observation.

## Entry-point audit

- **standalone monitor:** exact state + archive gating, per-branch timer/in-flight dedupe, abort on lifecycle exit and cleanup
- **HA monitor:** existing global capability-scoped discovery, tenant-scoped claim, lease renewal, generation/token/expiry commit checks, bounded paging/concurrency/backoff, and shutdown drain remain authoritative
- **REST/MCP health:** share fenced active observation; stopped/stopping/archived do not probe; error diagnostics are response-only
- **startup reconciliation:** only non-archived `starting`/`running` rows are rediscovered and each ref is revalidated after load
- **start/stop/restart/nuke/archive/delete:** existing status/archive writes invalidate the generation/token; removal and inactive events cancel standalone monitoring
- **UI:** no branch-environment health polling was found; it consumes realtime branch patches. Daemon `/health` polling is unrelated server-version/auth health
- **execution modes:** health is daemon-side HTTP for shell, delegated, and webhook-only environments. In HA, distributed coordination remains PostgreSQL/RLS scoped

## Validation

Before the production change, regression tests reproduced:

- the exact materialization-hook rejection for `health_check_url: not-an-http-url`;
- an archived `starting` branch retaining its standalone grace timer;
- restart discovery returning an archived `running` row.

After the change:

- focused daemon tests: **174 passed**
- focused core repository tests: **49 passed**
- disposable PostgreSQL/RLS/HA lane: **139 passed, 0 failed, 0 skipped across 29 files**
  - includes two-replica single-request ownership, stale lifecycle fencing, shutdown/takeover, and cross-tenant isolation
- `@agor/core` and `@agor/daemon` typechecks: passed
- full Biome/design-system lint: passed (2,361 files; 330 fixture cases)
- multitenancy, daemon-filesystem, realtime, and short-ID boundary checks: passed

## Notes / residual risk

- standalone cadence is intentionally fixed at five seconds while active; HA retains its bounded durable cooldown and idle backoff
- health failures do not themselves transition an active environment to `error`; they update health state while lifecycle ownership remains with explicit start/stop flows
- archive currently treats the archive bit as authoritative for monitoring even if legacy data retains an active-looking environment status

