### PR TITLE
feat(mcp): wait for branch filesystem readiness

### DIFF
--- a/apps/agor-daemon/src/mcp/branch-filesystem-readiness.test.ts
+++ b/apps/agor-daemon/src/mcp/branch-filesystem-readiness.test.ts
@@ -37,9 +37,18 @@ describe('waitForBranchFilesystemReady', () => {
       const ready = branch('ready', { storage_mode: storageMode });
       const readBranch = vi.fn(async () => ready);
 
-      const result = await waitForBranchFilesystemReady({ branchId: 'short-id', readBranch });
+      const result = await waitForBranchFilesystemReady({
+        branchId: 'short-id',
+        readBranch,
+        now: () => 0,
+      });
 
-      expect(result).toMatchObject({ outcome: 'ready', branch: ready, elapsedMs: 0 });
+      expect(result).toMatchObject({
+        outcome: 'ready',
+        branch: ready,
+        elapsedMs: 0,
+        timeoutMs: 60_000,
+      });
       expect(readBranch).toHaveBeenCalledOnce();
     }
   );
@@ -149,13 +158,13 @@ describe('waitForBranchFilesystemReady', () => {
     expect(readBranch).toHaveBeenCalledOnce();
   });
 
-  it.each([999, 60_001, 1_000.5])('rejects invalid timeout %s', async (timeoutMs) => {
+  it.each([999, 300_001, 1_000.5])('rejects invalid timeout %s', async (timeoutMs) => {
     await expect(
       waitForBranchFilesystemReady({
         branchId: 'branch-id',
         readBranch: async () => branch('ready'),
         timeoutMs,
       })
-    ).rejects.toThrow(/timeoutMs must be an integer from 1000 to 60000/);
+    ).rejects.toThrow(/timeoutMs must be an integer from 1000 to 300000/);
   });
 });

--- a/apps/agor-daemon/src/mcp/branch-filesystem-readiness.test.ts
+++ b/apps/agor-daemon/src/mcp/branch-filesystem-readiness.test.ts
@@ -1,0 +1,161 @@
+import type { Branch, BranchID } from '@agor/core/types';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  BRANCH_FILESYSTEM_READY_POLL_INTERVAL_MS,
+  waitForBranchFilesystemReady,
+} from './branch-filesystem-readiness.js';
+
+function branch(
+  filesystemStatus: Branch['filesystem_status'],
+  overrides: Partial<Branch> = {}
+): Branch {
+  return {
+    branch_id: '01900000-0000-7000-8000-000000000001' as BranchID,
+    repo_id: '01900000-0000-7000-8000-000000000002',
+    branch_unique_id: 1,
+    name: 'feature',
+    branch: 'feature',
+    path: '/tmp/feature',
+    created_at: '2026-08-28T00:00:00.000Z',
+    updated_at: '2026-08-28T00:00:00.000Z',
+    created_by: '01900000-0000-7000-8000-000000000003',
+    archived: false,
+    filesystem_status: filesystemStatus,
+    ...overrides,
+  } as Branch;
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('waitForBranchFilesystemReady', () => {
+  it.each(['worktree', 'clone'] as const)(
+    'returns an already-ready %s branch immediately',
+    async (storageMode) => {
+      const ready = branch('ready', { storage_mode: storageMode });
+      const readBranch = vi.fn(async () => ready);
+
+      const result = await waitForBranchFilesystemReady({ branchId: 'short-id', readBranch });
+
+      expect(result).toMatchObject({ outcome: 'ready', branch: ready, elapsedMs: 0 });
+      expect(readBranch).toHaveBeenCalledOnce();
+    }
+  );
+
+  it('polls once per second and switches to the canonical ID after the first read', async () => {
+    vi.useFakeTimers();
+    const creating = branch('creating');
+    const ready = branch('ready');
+    const readBranch = vi.fn().mockResolvedValueOnce(creating).mockResolvedValueOnce(ready);
+
+    const waiting = waitForBranchFilesystemReady({ branchId: '01900000', readBranch });
+    await vi.advanceTimersByTimeAsync(BRANCH_FILESYSTEM_READY_POLL_INTERVAL_MS);
+
+    await expect(waiting).resolves.toMatchObject({ outcome: 'ready', branch: ready });
+    expect(readBranch.mock.calls).toEqual([['01900000'], ['01900000-0000-7000-8000-000000000001']]);
+  });
+
+  it('returns the authoritative failed branch and persisted error', async () => {
+    const failed = branch('failed', { error_message: 'safe materialization failure' });
+
+    await expect(
+      waitForBranchFilesystemReady({ branchId: failed.branch_id, readBranch: async () => failed })
+    ).resolves.toMatchObject({ outcome: 'failed', branch: failed });
+  });
+
+  it.each([
+    ['archived', branch('ready', { archived: true })],
+    ['preserved', branch('preserved')],
+    ['cleaned', branch('cleaned')],
+    ['deleted', branch('deleted')],
+  ] as const)('returns %s as an unavailable terminal state', async (reason, terminalBranch) => {
+    await expect(
+      waitForBranchFilesystemReady({
+        branchId: terminalBranch.branch_id,
+        readBranch: async () => terminalBranch,
+      })
+    ).resolves.toMatchObject({
+      outcome: 'unavailable',
+      unavailableReason: reason,
+      branch: terminalBranch,
+    });
+  });
+
+  it('times out without mutating or retrying a still-creating branch', async () => {
+    vi.useFakeTimers();
+    const creating = branch('creating');
+    const readBranch = vi.fn(async () => creating);
+
+    const waiting = waitForBranchFilesystemReady({
+      branchId: creating.branch_id,
+      readBranch,
+      timeoutMs: 1_000,
+    });
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await expect(waiting).resolves.toMatchObject({
+      outcome: 'timeout',
+      branch: creating,
+      timeoutMs: 1_000,
+    });
+    expect(readBranch).toHaveBeenCalledTimes(2);
+  });
+
+  it('cleans up its timer when the MCP request is cancelled', async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const creating = branch('creating');
+    const waiting = waitForBranchFilesystemReady({
+      branchId: creating.branch_id,
+      readBranch: async () => creating,
+      signal: controller.signal,
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    controller.abort(new Error('client disconnected'));
+
+    await expect(waiting).rejects.toThrow('client disconnected');
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('observes cancellation after an in-flight service read finishes', async () => {
+    let finishRead!: (value: Branch) => void;
+    const read = new Promise<Branch>((resolve) => {
+      finishRead = resolve;
+    });
+    const controller = new AbortController();
+    const waiting = waitForBranchFilesystemReady({
+      branchId: 'short-id',
+      readBranch: () => read,
+      signal: controller.signal,
+    });
+
+    controller.abort(new Error('cancelled'));
+    finishRead(branch('ready'));
+
+    await expect(waiting).rejects.toThrow('cancelled');
+  });
+
+  it('propagates tenant/RBAC read failures without polling again', async () => {
+    const readBranch = vi.fn(async () => {
+      throw new Error('Forbidden');
+    });
+
+    await expect(
+      waitForBranchFilesystemReady({ branchId: 'other-tenant', readBranch })
+    ).rejects.toThrow('Forbidden');
+    expect(readBranch).toHaveBeenCalledOnce();
+  });
+
+  it.each([999, 60_001, 1_000.5])('rejects invalid timeout %s', async (timeoutMs) => {
+    await expect(
+      waitForBranchFilesystemReady({
+        branchId: 'branch-id',
+        readBranch: async () => branch('ready'),
+        timeoutMs,
+      })
+    ).rejects.toThrow(/timeoutMs must be an integer from 1000 to 60000/);
+  });
+});

--- a/apps/agor-daemon/src/mcp/branch-filesystem-readiness.test.ts
+++ b/apps/agor-daemon/src/mcp/branch-filesystem-readiness.test.ts
@@ -47,7 +47,7 @@ describe('waitForBranchFilesystemReady', () => {
         outcome: 'ready',
         branch: ready,
         elapsedMs: 0,
-        timeoutMs: 60_000,
+        timeoutMs: 45_000,
       });
       expect(readBranch).toHaveBeenCalledOnce();
     }

--- a/apps/agor-daemon/src/mcp/branch-filesystem-readiness.ts
+++ b/apps/agor-daemon/src/mcp/branch-filesystem-readiness.ts
@@ -1,0 +1,131 @@
+import { type Branch, classifyBranchFilesystemReadiness } from '@agor/core/types';
+
+export const DEFAULT_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS = 30_000;
+export const MIN_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS = 1_000;
+export const MAX_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS = 60_000;
+export const BRANCH_FILESYSTEM_READY_POLL_INTERVAL_MS = 1_000;
+
+export type BranchFilesystemReadinessOutcome = 'ready' | 'timeout' | 'failed' | 'unavailable';
+
+export interface BranchFilesystemReadinessResult {
+  outcome: BranchFilesystemReadinessOutcome;
+  branch: Branch;
+  elapsedMs: number;
+  timeoutMs: number;
+  unavailableReason?: 'archived' | 'preserved' | 'cleaned' | 'deleted';
+}
+
+export interface WaitForBranchFilesystemReadyOptions {
+  /** UUIDv7 or short ID for the initial authorized service read. */
+  branchId: string;
+  readBranch: (branchId: string) => Promise<Branch>;
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+  signal?: AbortSignal;
+  now?: () => number;
+}
+
+function validateBounds(timeoutMs: number, pollIntervalMs: number): void {
+  if (
+    !Number.isSafeInteger(timeoutMs) ||
+    timeoutMs < MIN_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS ||
+    timeoutMs > MAX_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS
+  ) {
+    throw new RangeError(
+      `timeoutMs must be an integer from ${MIN_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS} to ${MAX_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS}`
+    );
+  }
+  if (!Number.isSafeInteger(pollIntervalMs) || pollIntervalMs <= 0) {
+    throw new RangeError('pollIntervalMs must be a positive integer');
+  }
+}
+
+function cancellationError(signal: AbortSignal): Error {
+  return signal.reason instanceof Error
+    ? signal.reason
+    : new Error('Branch filesystem readiness wait was cancelled');
+}
+
+function throwIfCancelled(signal?: AbortSignal): void {
+  if (signal?.aborted) throw cancellationError(signal);
+}
+
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  if (!signal) return new Promise((resolve) => setTimeout(resolve, ms));
+  throwIfCancelled(signal);
+
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      signal.removeEventListener('abort', onAbort);
+      reject(cancellationError(signal));
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+function unavailableReason(branch: Branch): BranchFilesystemReadinessResult['unavailableReason'] {
+  if (branch.archived) return 'archived';
+  if (
+    branch.filesystem_status === 'preserved' ||
+    branch.filesystem_status === 'cleaned' ||
+    branch.filesystem_status === 'deleted'
+  ) {
+    return branch.filesystem_status;
+  }
+  return undefined;
+}
+
+/**
+ * Poll authoritative branch rows until filesystem materialization is ready or
+ * reaches a terminal state. Reads are deliberately supplied by the caller so
+ * every observation goes through the normal tenant/RBAC service boundary.
+ * No database transaction or connection is retained during the polling sleep.
+ *
+ * The timeout bounds polling and sleep. An individual service read remains
+ * governed by the database's normal query timeout.
+ */
+export async function waitForBranchFilesystemReady(
+  options: WaitForBranchFilesystemReadyOptions
+): Promise<BranchFilesystemReadinessResult> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS;
+  const pollIntervalMs = options.pollIntervalMs ?? BRANCH_FILESYSTEM_READY_POLL_INTERVAL_MS;
+  validateBounds(timeoutMs, pollIntervalMs);
+
+  const now = options.now ?? Date.now;
+  const startedAt = now();
+  let requestedId = options.branchId;
+
+  while (true) {
+    throwIfCancelled(options.signal);
+    const branch = await options.readBranch(requestedId);
+    throwIfCancelled(options.signal);
+
+    // Short IDs are accepted at the boundary. Once authorized and resolved,
+    // use the authoritative full ID for subsequent reads.
+    requestedId = branch.branch_id;
+    const elapsedMs = Math.max(0, now() - startedAt);
+    const readiness = classifyBranchFilesystemReadiness(branch);
+
+    if (readiness === 'ready' || readiness === 'failed' || readiness === 'unavailable') {
+      return {
+        outcome: readiness,
+        branch,
+        elapsedMs,
+        timeoutMs,
+        ...(readiness === 'unavailable' ? { unavailableReason: unavailableReason(branch) } : {}),
+      };
+    }
+
+    const remainingMs = timeoutMs - elapsedMs;
+    if (remainingMs <= 0) {
+      return { outcome: 'timeout', branch, elapsedMs, timeoutMs };
+    }
+
+    await delay(Math.min(pollIntervalMs, remainingMs), options.signal);
+  }
+}

--- a/apps/agor-daemon/src/mcp/branch-filesystem-readiness.ts
+++ b/apps/agor-daemon/src/mcp/branch-filesystem-readiness.ts
@@ -1,6 +1,6 @@
 import { type Branch, classifyBranchFilesystemReadiness, type IdInput } from '@agor/core/types';
 
-export const DEFAULT_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS = 60_000;
+export const DEFAULT_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS = 45_000;
 export const MIN_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS = 1_000;
 export const MAX_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS = 5 * 60_000;
 export const BRANCH_FILESYSTEM_READY_POLL_INTERVAL_MS = 1_000;

--- a/apps/agor-daemon/src/mcp/branch-filesystem-readiness.ts
+++ b/apps/agor-daemon/src/mcp/branch-filesystem-readiness.ts
@@ -1,4 +1,4 @@
-import { type Branch, classifyBranchFilesystemReadiness } from '@agor/core/types';
+import { type Branch, classifyBranchFilesystemReadiness, type IdInput } from '@agor/core/types';
 
 export const DEFAULT_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS = 60_000;
 export const MIN_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS = 1_000;
@@ -17,8 +17,8 @@ export interface BranchFilesystemReadinessResult {
 
 export interface WaitForBranchFilesystemReadyOptions {
   /** UUIDv7 or short ID for the initial authorized service read. */
-  branchId: string;
-  readBranch: (branchId: string) => Promise<Branch>;
+  branchId: IdInput;
+  readBranch: (branchId: IdInput) => Promise<Branch>;
   timeoutMs?: number;
   pollIntervalMs?: number;
   signal?: AbortSignal;

--- a/apps/agor-daemon/src/mcp/branch-filesystem-readiness.ts
+++ b/apps/agor-daemon/src/mcp/branch-filesystem-readiness.ts
@@ -1,8 +1,8 @@
 import { type Branch, classifyBranchFilesystemReadiness } from '@agor/core/types';
 
-export const DEFAULT_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS = 30_000;
+export const DEFAULT_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS = 60_000;
 export const MIN_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS = 1_000;
-export const MAX_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS = 60_000;
+export const MAX_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS = 5 * 60_000;
 export const BRANCH_FILESYSTEM_READY_POLL_INTERVAL_MS = 1_000;
 
 export type BranchFilesystemReadinessOutcome = 'ready' | 'timeout' | 'failed' | 'unavailable';

--- a/apps/agor-daemon/src/mcp/server.test.ts
+++ b/apps/agor-daemon/src/mcp/server.test.ts
@@ -85,7 +85,7 @@ describe('MCP tool registry', () => {
     const expectedPropertiesByTool: Record<string, string[]> = {
       agor_sessions_prompt: ['sessionId', 'prompt', 'mode'],
       agor_boards_get: ['boardId'],
-      agor_branches_create: ['repoId', 'branchName', 'boardId'],
+      agor_branches_create: ['repoId', 'branchName', 'boardId', 'waitForReady', 'waitTimeoutMs'],
       agor_branches_wait_for_ready: ['branchId', 'waitTimeoutMs'],
       agor_kb_get: ['uri', 'namespace', 'path'],
       agor_execute_tool: ['tool_name', 'arguments'],

--- a/apps/agor-daemon/src/mcp/server.test.ts
+++ b/apps/agor-daemon/src/mcp/server.test.ts
@@ -86,6 +86,7 @@ describe('MCP tool registry', () => {
       agor_sessions_prompt: ['sessionId', 'prompt', 'mode'],
       agor_boards_get: ['boardId'],
       agor_branches_create: ['repoId', 'branchName', 'boardId'],
+      agor_branches_wait_for_ready: ['branchId', 'waitTimeoutMs'],
       agor_kb_get: ['uri', 'namespace', 'path'],
       agor_execute_tool: ['tool_name', 'arguments'],
     };

--- a/apps/agor-daemon/src/mcp/server.ts
+++ b/apps/agor-daemon/src/mcp/server.ts
@@ -154,8 +154,8 @@ Common workflows:
 Create a branch and start a session:
 1. agor_repos_list → get repoId
 2. agor_boards_list → get boardId
-3. agor_branches_create(repoId, boardId, branchName) → get branchId
-4. agor_branches_wait_for_ready(branchId) → continue only when _readiness.outcome is "ready"; safely call again after a timeout
+3. agor_branches_create(repoId, boardId, branchName, waitForReady:true) → continue only when _readiness.outcome is "ready"
+4. After a timeout, agor_branches_wait_for_ready(branchId) → safely call again as needed
 5. agor_sessions_create(branchId, agenticTool, initialPrompt)
 
 Delegate a subtask to a child agent:

--- a/apps/agor-daemon/src/mcp/server.ts
+++ b/apps/agor-daemon/src/mcp/server.ts
@@ -155,7 +155,8 @@ Create a branch and start a session:
 1. agor_repos_list → get repoId
 2. agor_boards_list → get boardId
 3. agor_branches_create(repoId, boardId, branchName) → get branchId
-4. agor_sessions_create(branchId, agenticTool, initialPrompt)
+4. agor_branches_wait_for_ready(branchId) → continue only when _readiness.outcome is "ready"; safely call again after a timeout
+5. agor_sessions_create(branchId, agenticTool, initialPrompt)
 
 Delegate a subtask to a child agent:
 1. agor_sessions_spawn(prompt) — inherits current branch, tracks parent-child genealogy

--- a/apps/agor-daemon/src/mcp/tools/branches.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.test.ts
@@ -25,7 +25,10 @@ vi.mock('../../utils/spawn-executor.js', async (importOriginal) => {
   };
 });
 
-type ToolHandler = (args: Record<string, unknown>) => Promise<{
+type ToolHandler = (
+  args: Record<string, unknown>,
+  requestContext?: { signal: AbortSignal }
+) => Promise<{
   content: Array<{ type: string; text: string }>;
   isError?: boolean;
 }>;
@@ -134,6 +137,158 @@ function registerAndCaptureUpdate(ctx: {
 afterEach(() => {
   vi.restoreAllMocks();
   vi.useRealTimers();
+});
+
+describe('agor_branches_wait_for_ready', () => {
+  const requestContext = () => ({ signal: new AbortController().signal });
+  const makeBranch = (filesystemStatus: string, overrides: Record<string, unknown> = {}) => ({
+    branch_id: '01900000-0000-7000-8000-000000000001',
+    filesystem_status: filesystemStatus,
+    archived: false,
+    path: '/worktrees/feature',
+    start_command: 'pnpm dev',
+    board_id: 'board-1',
+    ...overrides,
+  });
+
+  it('returns the refreshed authoritative branch on the already-ready fast path', async () => {
+    const baseServiceParams = {
+      authenticated: true,
+      provider: 'mcp',
+      user: { user_id: 'user-1', role: 'member' },
+      tenant: { tenant_id: 'tenant-1' },
+    };
+    const ready = makeBranch('ready');
+    const get = vi.fn(async () => ready);
+    const app = {
+      service(name: string) {
+        if (name === 'branches') return { get };
+        throw new Error(`Unexpected service call: ${name}`);
+      },
+    };
+    const waitForReady = registerAndCaptureHandler('agor_branches_wait_for_ready', {
+      app,
+      userId: 'user-1',
+      baseServiceParams,
+    });
+
+    const result = await waitForReady({ branchId: '01900000' }, requestContext());
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(result.isError).toBeUndefined();
+    expect(payload).toMatchObject({
+      branch: ready,
+      _readiness: { outcome: 'ready', poll_interval_ms: 1_000 },
+    });
+    expect(get).toHaveBeenCalledWith('01900000', baseServiceParams);
+  });
+
+  it('uses fresh authorized service reads until a creating branch is ready', async () => {
+    vi.useFakeTimers();
+    const creating = makeBranch('creating');
+    const ready = makeBranch('ready', { path: '/worktrees/feature-ready' });
+    const get = vi.fn().mockResolvedValueOnce(creating).mockResolvedValueOnce(ready);
+    const baseServiceParams = { provider: 'mcp', tenant: { tenant_id: 'tenant-1' } };
+    const app = {
+      service(name: string) {
+        if (name === 'branches') return { get };
+        throw new Error(`Unexpected service call: ${name}`);
+      },
+    };
+    const waitForReady = registerAndCaptureHandler('agor_branches_wait_for_ready', {
+      app,
+      userId: 'user-1',
+      baseServiceParams,
+    });
+
+    const waiting = waitForReady({ branchId: '01900000' }, requestContext());
+    await vi.advanceTimersByTimeAsync(1_000);
+    const result = await waiting;
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload.branch).toEqual(ready);
+    expect(get.mock.calls).toEqual([
+      ['01900000', baseServiceParams],
+      ['01900000-0000-7000-8000-000000000001', baseServiceParams],
+    ]);
+  });
+
+  it('returns a retryable structured timeout while preserving the creating branch', async () => {
+    vi.useFakeTimers();
+    const creating = makeBranch('creating');
+    const get = vi.fn(async () => creating);
+    const app = {
+      service(name: string) {
+        if (name === 'branches') return { get };
+        throw new Error(`Unexpected service call: ${name}`);
+      },
+    };
+    const waitForReady = registerAndCaptureHandler('agor_branches_wait_for_ready', {
+      app,
+      userId: 'user-1',
+    });
+
+    const waiting = waitForReady(
+      { branchId: creating.branch_id, waitTimeoutMs: 1_000 },
+      requestContext()
+    );
+    await vi.advanceTimersByTimeAsync(1_000);
+    const result = await waiting;
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(result.isError).toBeUndefined();
+    expect(payload).toMatchObject({
+      branch: creating,
+      _readiness: {
+        outcome: 'timeout',
+        timeout_ms: 1_000,
+        poll: {
+          tool: 'agor_branches_wait_for_ready',
+          arguments: { branchId: creating.branch_id },
+        },
+      },
+    });
+  });
+
+  it('returns the persisted safe failure as a structured terminal error', async () => {
+    const failed = makeBranch('failed', { error_message: 'clone authentication failed' });
+    const app = {
+      service(name: string) {
+        if (name === 'branches') return { get: vi.fn(async () => failed) };
+        throw new Error(`Unexpected service call: ${name}`);
+      },
+    };
+    const waitForReady = registerAndCaptureHandler('agor_branches_wait_for_ready', {
+      app,
+      userId: 'user-1',
+    });
+
+    const result = await waitForReady({ branchId: failed.branch_id }, requestContext());
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(result.isError).toBe(true);
+    expect(payload).toMatchObject({
+      branch: failed,
+      _readiness: { outcome: 'failed', message: 'clone authentication failed' },
+    });
+  });
+
+  it('enforces bounded MCP timeout inputs in the tool schema', () => {
+    const config = registerAndCaptureConfig('agor_branches_wait_for_ready', {
+      app: {},
+      userId: 'user-1',
+    });
+
+    expect(
+      config.inputSchema?.safeParse({ branchId: 'branch-1', waitTimeoutMs: 1_000 }).success
+    ).toBe(true);
+    expect(
+      config.inputSchema?.safeParse({ branchId: 'branch-1', waitTimeoutMs: 999 }).success
+    ).toBe(false);
+    expect(
+      config.inputSchema?.safeParse({ branchId: 'branch-1', waitTimeoutMs: 60_001 }).success
+    ).toBe(false);
+  });
 });
 
 describe('agor_branches_delete authorization boundary', () => {

--- a/apps/agor-daemon/src/mcp/tools/branches.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.test.ts
@@ -286,7 +286,7 @@ describe('agor_branches_wait_for_ready', () => {
       config.inputSchema?.safeParse({ branchId: 'branch-1', waitTimeoutMs: 999 }).success
     ).toBe(false);
     expect(
-      config.inputSchema?.safeParse({ branchId: 'branch-1', waitTimeoutMs: 60_001 }).success
+      config.inputSchema?.safeParse({ branchId: 'branch-1', waitTimeoutMs: 300_001 }).success
     ).toBe(false);
   });
 });
@@ -470,6 +470,39 @@ describe('agor_branches_update', () => {
 });
 
 describe('agor_branches_create', () => {
+  function waitFixture(options: {
+    name: string;
+    initial?: Record<string, unknown>;
+    observed?: Record<string, unknown>;
+  }) {
+    const branchId = '01900000-0000-7000-8000-000000000001';
+    const creating = {
+      branch_id: branchId,
+      name: options.name,
+      board_id: 'board-1',
+      filesystem_status: 'creating',
+      ...options.initial,
+    };
+    const observed = { ...creating, ...options.observed };
+    const createBranch = vi.fn(async () => creating);
+    const branchesGet = vi.fn(async () => observed);
+    const app = {
+      get: () => ({}),
+      service(name: string) {
+        if (name === 'repos') {
+          return {
+            get: vi.fn(async () => ({ repo_id: 'repo-1', default_branch: 'main' })),
+            createBranch,
+          };
+        }
+        if (name === 'boards') return { get: vi.fn(async () => ({ board_id: 'board-1' })) };
+        if (name === 'branches') return { get: branchesGet };
+        throw new Error(`Unexpected service call: ${name}`);
+      },
+    };
+    return { app, branchId, creating, observed, createBranch, branchesGet };
+  }
+
   it('passes acting MCP user params through to branch creation so ownership resolves to the prompter', async () => {
     const baseServiceParams = {
       authenticated: true,
@@ -516,6 +549,132 @@ describe('agor_branches_create', () => {
       expect.objectContaining({ name: 'user-b-feature', boardId: 'board-1' }),
       baseServiceParams
     );
+  });
+
+  it('optionally waits and returns the authoritative ready branch in the existing flat response', async () => {
+    const baseServiceParams = {
+      authenticated: true,
+      provider: 'mcp',
+      tenant: { tenant_id: 'tenant-1' },
+    };
+    const {
+      app,
+      branchId,
+      observed: ready,
+      branchesGet,
+    } = waitFixture({
+      name: 'waited-feature',
+      observed: {
+        filesystem_status: 'ready',
+        path: '/worktrees/waited-feature',
+        start_command: 'pnpm dev',
+      },
+    });
+    const create = registerAndCaptureHandler('agor_branches_create', {
+      app,
+      userId: 'user-1',
+      baseServiceParams,
+    });
+
+    const result = await create(
+      {
+        repoId: 'repo-1',
+        branchName: 'waited-feature',
+        boardId: 'board-1',
+        autoSuffix: false,
+        waitForReady: true,
+      },
+      { signal: new AbortController().signal }
+    );
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(result.isError).toBeUndefined();
+    expect(payload).toMatchObject({
+      ...ready,
+      _readiness: {
+        outcome: 'ready',
+        timeout_ms: 60_000,
+        poll_interval_ms: 1_000,
+      },
+    });
+    expect(payload).not.toHaveProperty('branch');
+    expect(branchesGet).toHaveBeenCalledWith(branchId, baseServiceParams);
+  });
+
+  it('returns a retryable timeout without undoing an opt-in creation', async () => {
+    vi.useFakeTimers();
+    const { app, branchId, creating, createBranch, branchesGet } = waitFixture({
+      name: 'slow-clone',
+      initial: { storage_mode: 'clone' },
+    });
+    const create = registerAndCaptureHandler('agor_branches_create', {
+      app,
+      userId: 'user-1',
+    });
+
+    const waiting = create(
+      {
+        repoId: 'repo-1',
+        branchName: 'slow-clone',
+        boardId: 'board-1',
+        autoSuffix: false,
+        storage_mode: 'clone',
+        waitForReady: true,
+        waitTimeoutMs: 1_000,
+      },
+      { signal: new AbortController().signal }
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(1_000);
+    const result = await waiting;
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(result.isError).toBeUndefined();
+    expect(payload).toMatchObject({
+      ...creating,
+      _readiness: {
+        outcome: 'timeout',
+        timeout_ms: 1_000,
+        poll: {
+          tool: 'agor_branches_wait_for_ready',
+          arguments: { branchId },
+        },
+      },
+    });
+    expect(createBranch).toHaveBeenCalledOnce();
+    expect(branchesGet).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns a persisted materialization failure without losing creation metadata', async () => {
+    const { app, observed: failed } = waitFixture({
+      name: 'failed-clone',
+      observed: {
+        filesystem_status: 'failed',
+        error_message: 'clone authentication failed',
+      },
+    });
+    const create = registerAndCaptureHandler('agor_branches_create', {
+      app,
+      userId: 'user-1',
+    });
+
+    const result = await create(
+      {
+        repoId: 'repo-1',
+        branchName: 'failed-clone',
+        boardId: 'board-1',
+        autoSuffix: false,
+        waitForReady: true,
+      },
+      { signal: new AbortController().signal }
+    );
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(result.isError).toBe(true);
+    expect(payload).toMatchObject({
+      ...failed,
+      _readiness: { outcome: 'failed', message: 'clone authentication failed' },
+    });
   });
 
   it('creates a one-shot teammate branch by writing teammate metadata into custom_context', async () => {
@@ -835,6 +994,25 @@ describe('agor_branches_create', () => {
 });
 
 describe('branch MCP input schemas', () => {
+  it('exposes an opt-in create wait with a one-second to five-minute timeout', () => {
+    const config = registerAndCaptureConfig('agor_branches_create', {
+      app: {},
+      userId: 'user-1',
+    });
+    const base = { repoId: 'repo-1', branchName: 'feature', boardId: 'board-1' };
+
+    expect(
+      config.inputSchema?.safeParse({
+        ...base,
+        waitForReady: true,
+        waitTimeoutMs: 300_000,
+      }).success
+    ).toBe(true);
+    expect(config.inputSchema?.safeParse({ ...base, waitTimeoutMs: 999 }).success).toBe(false);
+    expect(config.inputSchema?.safeParse({ ...base, waitTimeoutMs: 300_001 }).success).toBe(false);
+    expect(config.inputSchema?.safeParse({ ...base, waitForReady: 'yes' }).success).toBe(false);
+  });
+
   it('accepts boolean branch attention updates and rejects non-booleans', () => {
     const config = registerAndCaptureConfig('agor_branches_update', {
       app: {},

--- a/apps/agor-daemon/src/mcp/tools/branches.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.test.ts
@@ -1,8 +1,11 @@
 import * as configModule from '@agor/core/config';
 import { BranchRepository, CapabilityPolicyRepository } from '@agor/core/db';
-import { Forbidden } from '@agor/core/feathers';
+import { Forbidden, feathers } from '@agor/core/feathers';
+import type { Branch, BranchPermissionLevel } from '@agor/core/types';
 import type { McpServer } from '@modelcontextprotocol/server';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { DrizzleService, type Repository } from '../../adapters/drizzle.js';
+import { loadBranch } from '../../utils/branch-authorization.js';
 import { registerBranchTools } from './branches.js';
 
 vi.mock('../../utils/executor-delegated-home.js', () => ({
@@ -211,6 +214,68 @@ describe('agor_branches_wait_for_ready', () => {
       ['01900000', baseServiceParams],
       ['01900000-0000-7000-8000-000000000001', baseServiceParams],
     ]);
+    expect(get.mock.calls[0][1]).not.toBe(baseServiceParams);
+    expect(get.mock.calls[1][1]).not.toBe(get.mock.calls[0][1]);
+  });
+
+  it('uses pristine params so real Feathers RBAC hooks cannot pin the first branch row', async () => {
+    vi.useFakeTimers();
+    const creating = makeBranch('creating') as unknown as Branch;
+    const ready = makeBranch('ready', { path: '/worktrees/feature-ready' }) as unknown as Branch;
+    const findById = vi.fn().mockResolvedValueOnce(creating).mockResolvedValueOnce(ready);
+    const repository = {
+      findById,
+      findAll: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      isOwner: vi.fn(async () => false),
+      resolveUserPermission: vi.fn(async () => 'view' as BranchPermissionLevel),
+    } as unknown as Repository<Branch> & {
+      isOwner: (branchId: string, userId: string) => Promise<boolean>;
+      resolveUserPermission: (branch: Branch, userId: string) => Promise<BranchPermissionLevel>;
+    };
+    const app = feathers();
+    app.use(
+      'branches',
+      new DrizzleService<Branch>(repository, { id: 'branch_id', resourceType: 'Branch' })
+    );
+    app.service('branches').hooks({
+      before: { get: [loadBranch(repository as never)] },
+    });
+
+    // Optional current-Session authorization can already have populated these
+    // request-scoped hook caches before the tool starts. A shallow clone would
+    // carry the stale row into every observation.
+    const poisonedBaseParams = {
+      provider: 'mcp',
+      user: { user_id: 'user-1', email: 'user@example.test', role: 'member' },
+      branch: creating,
+      _agorPrefetchedRecord: {
+        id: creating.branch_id,
+        idField: 'branch_id',
+        record: creating,
+      },
+      _agorRbacCache: {
+        sessions: new Map(),
+        branches: new Map([[creating.branch_id, creating]]),
+        branchAccess: new Map(),
+      },
+    };
+    const waitForReady = registerAndCaptureHandler('agor_branches_wait_for_ready', {
+      app,
+      userId: 'user-1',
+      baseServiceParams: poisonedBaseParams,
+    });
+
+    const waiting = waitForReady({ branchId: '01900000' }, requestContext());
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(1_000);
+    const result = await waiting;
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload.branch).toEqual(ready);
+    expect(findById).toHaveBeenCalledTimes(2);
   });
 
   it('returns a retryable structured timeout while preserving the creating branch', async () => {
@@ -643,6 +708,7 @@ describe('agor_branches_create', () => {
     });
     expect(createBranch).toHaveBeenCalledOnce();
     expect(branchesGet).toHaveBeenCalledTimes(2);
+    expect(branchesGet.mock.calls[1][1]).not.toBe(branchesGet.mock.calls[0][1]);
   });
 
   it('returns a persisted materialization failure without losing creation metadata', async () => {

--- a/apps/agor-daemon/src/mcp/tools/branches.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.test.ts
@@ -2,7 +2,7 @@ import * as configModule from '@agor/core/config';
 import { BranchRepository, CapabilityPolicyRepository } from '@agor/core/db';
 import { Forbidden, feathers } from '@agor/core/feathers';
 import type { Branch, BranchPermissionLevel } from '@agor/core/types';
-import type { McpServer } from '@modelcontextprotocol/server';
+import type { McpServer, ServerContext } from '@modelcontextprotocol/server';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { DrizzleService, type Repository } from '../../adapters/drizzle.js';
 import { loadBranch } from '../../utils/branch-authorization.js';
@@ -30,7 +30,7 @@ vi.mock('../../utils/spawn-executor.js', async (importOriginal) => {
 
 type ToolHandler = (
   args: Record<string, unknown>,
-  requestContext?: { signal: AbortSignal }
+  requestContext?: ServerContext
 ) => Promise<{
   content: Array<{ type: string; text: string }>;
   isError?: boolean;
@@ -45,6 +45,10 @@ type ToolConfig = {
       | { success: false; error: { issues: Array<{ message: string }> } };
   };
 };
+
+function requestContext(signal = new AbortController().signal): ServerContext {
+  return { mcpReq: { signal } } as ServerContext;
+}
 
 function registerAndCaptureHandler(
   toolName: string,
@@ -143,7 +147,6 @@ afterEach(() => {
 });
 
 describe('agor_branches_wait_for_ready', () => {
-  const requestContext = () => ({ signal: new AbortController().signal });
   const makeBranch = (filesystemStatus: string, overrides: Record<string, unknown> = {}) => ({
     branch_id: '01900000-0000-7000-8000-000000000001',
     filesystem_status: filesystemStatus,
@@ -313,6 +316,34 @@ describe('agor_branches_wait_for_ready', () => {
         },
       },
     });
+  });
+
+  it('stops polling when the MCP request is cancelled', async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const creating = makeBranch('creating');
+    const get = vi.fn(async () => creating);
+    const app = {
+      service(name: string) {
+        if (name === 'branches') return { get };
+        throw new Error(`Unexpected service call: ${name}`);
+      },
+    };
+    const waitForReady = registerAndCaptureHandler('agor_branches_wait_for_ready', {
+      app,
+      userId: 'user-1',
+    });
+
+    const waiting = waitForReady(
+      { branchId: creating.branch_id },
+      requestContext(controller.signal)
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    controller.abort(new Error('client disconnected'));
+
+    await expect(waiting).rejects.toThrow('client disconnected');
+    expect(get).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it('returns the persisted safe failure as a structured terminal error', async () => {
@@ -568,6 +599,22 @@ describe('agor_branches_create', () => {
     return { app, branchId, creating, observed, createBranch, branchesGet };
   }
 
+  it('rejects waitTimeoutMs unless waitForReady is enabled', async () => {
+    const create = registerAndCaptureHandler('agor_branches_create', {
+      app: {},
+      userId: 'user-1',
+    });
+
+    await expect(
+      create({
+        repoId: 'repo-1',
+        branchName: 'feature',
+        boardId: 'board-1',
+        waitTimeoutMs: 1_000,
+      })
+    ).rejects.toThrow('waitTimeoutMs requires waitForReady=true');
+  });
+
   it('passes acting MCP user params through to branch creation so ownership resolves to the prompter', async () => {
     const baseServiceParams = {
       authenticated: true,
@@ -649,7 +696,7 @@ describe('agor_branches_create', () => {
         autoSuffix: false,
         waitForReady: true,
       },
-      { signal: new AbortController().signal }
+      requestContext()
     );
     const payload = JSON.parse(result.content[0].text);
 
@@ -658,7 +705,7 @@ describe('agor_branches_create', () => {
       ...ready,
       _readiness: {
         outcome: 'ready',
-        timeout_ms: 60_000,
+        timeout_ms: 45_000,
         poll_interval_ms: 1_000,
       },
     });
@@ -687,7 +734,7 @@ describe('agor_branches_create', () => {
         waitForReady: true,
         waitTimeoutMs: 1_000,
       },
-      { signal: new AbortController().signal }
+      requestContext()
     );
     await vi.advanceTimersByTimeAsync(0);
     await vi.advanceTimersByTimeAsync(1_000);
@@ -732,7 +779,7 @@ describe('agor_branches_create', () => {
         autoSuffix: false,
         waitForReady: true,
       },
-      { signal: new AbortController().signal }
+      requestContext()
     );
     const payload = JSON.parse(result.content[0].text);
 

--- a/apps/agor-daemon/src/mcp/tools/branches.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.ts
@@ -14,7 +14,7 @@ import type {
 import { getTeammateConfig, isTeammate } from '@agor/core/types';
 import { computeZoneRelativePosition } from '@agor/core/utils/board-placement';
 import { normalizeOptionalHttpUrl } from '@agor/core/utils/url';
-import type { McpServer } from '@modelcontextprotocol/server';
+import type { McpServer, ServerContext } from '@modelcontextprotocol/server';
 import { z } from 'zod';
 import type {
   BoardsServiceImpl,
@@ -150,18 +150,8 @@ function readinessResponse(result: BranchFilesystemReadinessResult): {
   return { readiness, isError: true };
 }
 
-function mcpRequestSignal(requestContext: unknown): AbortSignal | undefined {
-  if (!requestContext || typeof requestContext !== 'object') return undefined;
-  const signal = (requestContext as { signal?: unknown }).signal;
-  if (
-    !signal ||
-    typeof signal !== 'object' ||
-    typeof (signal as AbortSignal).aborted !== 'boolean' ||
-    typeof (signal as AbortSignal).addEventListener !== 'function'
-  ) {
-    return undefined;
-  }
-  return signal as AbortSignal;
+function mcpRequestSignal(requestContext: ServerContext): AbortSignal {
+  return requestContext.mcpReq.signal;
 }
 
 /**
@@ -746,7 +736,7 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
               'Use the separate retry-safe agor_branches_wait_for_ready tool to recover from timeouts.'
           ),
         waitTimeoutMs: branchFilesystemReadyWaitTimeoutSchema.describe(
-          `Maximum milliseconds to wait when waitForReady=true (default ${DEFAULT_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS}, max ${MAX_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS}). Ignored otherwise.`
+          `Maximum milliseconds to wait when waitForReady=true (default ${DEFAULT_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS}, max ${MAX_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS}). Requires waitForReady=true; waits longer than the MCP client's request deadline require a matching client timeout.`
         ),
         teammate: z
           .object({
@@ -785,6 +775,10 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
       }),
     },
     async (args, requestContext) => {
+      if (args.waitTimeoutMs !== undefined && args.waitForReady !== true) {
+        throw new Error('waitTimeoutMs requires waitForReady=true.');
+      }
+
       const repoId = await resolveRepoId(ctx, coerceString(args.repoId)!);
       let branchName = coerceString(args.branchName)!;
       const originalName = branchName;

--- a/apps/agor-daemon/src/mcp/tools/branches.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.ts
@@ -164,6 +164,23 @@ function mcpRequestSignal(requestContext: unknown): AbortSignal | undefined {
   return signal as AbortSignal;
 }
 
+/**
+ * Feathers authorization hooks cache loaded records on params for the duration
+ * of one service call. A readiness wait spans multiple observations, so every
+ * read needs a pristine params object or it can reuse the first branch row.
+ * Whitelist the trusted MCP identity fields instead of cloning hook-added data
+ * that may already be present after optional Session authorization.
+ */
+function freshMcpServiceParams(ctx: McpContext): McpContext['baseServiceParams'] {
+  const { authenticated, provider, tenant, user } = ctx.baseServiceParams;
+  return {
+    ...(user ? { user: { ...user } } : {}),
+    ...(authenticated !== undefined ? { authenticated } : {}),
+    ...(provider !== undefined ? { provider } : {}),
+    ...(tenant ? { tenant: { ...tenant } } : {}),
+  };
+}
+
 function parseCleanupCutoff(args: { archivedBefore?: string; archivedOlderThanDays?: number }): {
   cutoff: Date;
   source: 'archivedBefore' | 'archivedOlderThanDays';
@@ -301,7 +318,7 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
         readBranch: (branchId) =>
           branches.get(
             branchId,
-            ctx.baseServiceParams as Parameters<BranchesServiceImpl['get']>[1]
+            freshMcpServiceParams(ctx) as Parameters<BranchesServiceImpl['get']>[1]
           ),
       });
 
@@ -986,7 +1003,10 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
             readBranch: (branchId) =>
               ctx.app
                 .service('branches')
-                .get(branchId, ctx.baseServiceParams as Parameters<BranchesServiceImpl['get']>[1]),
+                .get(
+                  branchId,
+                  freshMcpServiceParams(ctx) as Parameters<BranchesServiceImpl['get']>[1]
+                ),
           })
         : undefined;
 

--- a/apps/agor-daemon/src/mcp/tools/branches.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.ts
@@ -26,6 +26,13 @@ import { issueExecutorCommandToken } from '../../services/session-token-service.
 import { isSuperAdmin } from '../../utils/branch-authorization.js';
 import { resolveDelegatedExecutionHomeKey } from '../../utils/executor-delegated-home.js';
 import { getDaemonUrl, requestExecutor } from '../../utils/spawn-executor.js';
+import {
+  BRANCH_FILESYSTEM_READY_POLL_INTERVAL_MS,
+  DEFAULT_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS,
+  MAX_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS,
+  MIN_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS,
+  waitForBranchFilesystemReady,
+} from '../branch-filesystem-readiness.js';
 import { branchCapabilityPolicySchema } from '../capability-policy-schema.js';
 import {
   resolveBoardId,
@@ -86,6 +93,27 @@ function containsTeammateKnowledgeConfigMutation(customContext: unknown): boolea
 
 function normalizeFilesystemStatus(branch: Branch): CleanupCandidateFilesystemStatus {
   return branch.filesystem_status ?? 'ready';
+}
+
+function readinessPoll(branchId: string) {
+  return {
+    tool: 'agor_branches_wait_for_ready',
+    arguments: { branchId },
+  };
+}
+
+function mcpRequestSignal(requestContext: unknown): AbortSignal | undefined {
+  if (!requestContext || typeof requestContext !== 'object') return undefined;
+  const signal = (requestContext as { signal?: unknown }).signal;
+  if (
+    !signal ||
+    typeof signal !== 'object' ||
+    typeof (signal as AbortSignal).aborted !== 'boolean' ||
+    typeof (signal as AbortSignal).addEventListener !== 'function'
+  ) {
+    return undefined;
+  }
+  return signal as AbortSignal;
 }
 
 function parseCleanupCutoff(args: { archivedBefore?: string; archivedOlderThanDays?: number }): {
@@ -195,6 +223,96 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
         .service('branches/:id/permissions')
         .find({ ...ctx.baseServiceParams, route: { id: branch.branch_id } });
       return textResult({ ...branch, permissions });
+    }
+  );
+
+  server.registerTool(
+    'agor_branches_wait_for_ready',
+    {
+      description:
+        'Wait for asynchronous branch filesystem materialization before creating a session. ' +
+        'This read-only, retry-safe tool performs an immediate authorized read, then polls the shared database once per second. ' +
+        'It returns the authoritative refreshed branch when ready, a structured terminal error if creation failed or the branch became unavailable, ' +
+        'or a timeout result that preserves the branch so this tool can be called again. Branch creation itself remains asynchronous.',
+      annotations: { readOnlyHint: true, idempotentHint: true },
+      inputSchema: z.object({
+        branchId: mcpRequiredId('branchId', 'Branch'),
+        waitTimeoutMs: z
+          .number({ error: 'waitTimeoutMs must be a number when provided.' })
+          .int('waitTimeoutMs must be an integer.')
+          .min(
+            MIN_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS,
+            `waitTimeoutMs must be at least ${MIN_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS}.`
+          )
+          .max(
+            MAX_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS,
+            `waitTimeoutMs must be at most ${MAX_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS}.`
+          )
+          .optional()
+          .describe(
+            `Maximum milliseconds to wait (default ${DEFAULT_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS}, max ${MAX_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS}). ` +
+              'For longer clone/materialization jobs, safely call this read-only tool again.'
+          ),
+      }),
+    },
+    async (args, requestContext) => {
+      const timeoutMs = args.waitTimeoutMs ?? DEFAULT_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS;
+      const branches = ctx.app.service('branches');
+      const result = await waitForBranchFilesystemReady({
+        branchId: args.branchId,
+        timeoutMs,
+        signal: mcpRequestSignal(requestContext),
+        readBranch: (branchId) =>
+          branches.get(
+            branchId,
+            ctx.baseServiceParams as Parameters<BranchesServiceImpl['get']>[1]
+          ),
+      });
+
+      const baseReadiness = {
+        outcome: result.outcome,
+        elapsed_ms: result.elapsedMs,
+        timeout_ms: result.timeoutMs,
+        poll_interval_ms: BRANCH_FILESYSTEM_READY_POLL_INTERVAL_MS,
+      };
+
+      if (result.outcome === 'ready') {
+        return textResult({
+          branch: result.branch,
+          _readiness: {
+            ...baseReadiness,
+            message: 'Branch filesystem is ready for session creation.',
+          },
+        });
+      }
+
+      if (result.outcome === 'timeout') {
+        return textResult({
+          branch: result.branch,
+          _readiness: {
+            ...baseReadiness,
+            message:
+              'Timed out while the branch filesystem is still being created. The wait did not modify or cancel materialization; call this tool again before creating a session.',
+            poll: readinessPoll(result.branch.branch_id),
+          },
+        });
+      }
+
+      const message =
+        result.outcome === 'failed'
+          ? result.branch.error_message || 'Branch filesystem creation failed.'
+          : `Branch filesystem is unavailable (${result.unavailableReason ?? 'terminal state'}).`;
+      return {
+        ...textResult({
+          branch: result.branch,
+          _readiness: {
+            ...baseReadiness,
+            ...(result.unavailableReason ? { reason: result.unavailableReason } : {}),
+            message,
+          },
+        }),
+        isError: true,
+      };
     }
   );
 
@@ -495,6 +613,8 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
         'and branchName to your desired unique name (e.g., sourceBranch="issue-282", branchName="issue-282-review-1"). ' +
         'Use zoneId to place the branch in a specific zone (pin only, no trigger). ' +
         'For zone trigger behavior (prompt templates), use agor_branches_set_zone after creation. ' +
+        'Filesystem materialization continues asynchronously; call the retry-safe ' +
+        'agor_branches_wait_for_ready tool before creating the first session. ' +
         'To create a long-lived Agor teammate (a persistent AI teammate that manages other branches ' +
         'and maintains memory), pass the teammate object — this is the ONLY supported way to make a ' +
         'teammate via MCP. Teammate status cannot be toggled later with agor_branches_update. ' +

--- a/apps/agor-daemon/src/mcp/tools/branches.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.ts
@@ -28,6 +28,7 @@ import { resolveDelegatedExecutionHomeKey } from '../../utils/executor-delegated
 import { getDaemonUrl, requestExecutor } from '../../utils/spawn-executor.js';
 import {
   BRANCH_FILESYSTEM_READY_POLL_INTERVAL_MS,
+  type BranchFilesystemReadinessResult,
   DEFAULT_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS,
   MAX_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS,
   MIN_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS,
@@ -100,6 +101,53 @@ function readinessPoll(branchId: string) {
     tool: 'agor_branches_wait_for_ready',
     arguments: { branchId },
   };
+}
+
+const branchFilesystemReadyWaitTimeoutSchema = z
+  .number({ error: 'waitTimeoutMs must be a number when provided.' })
+  .int('waitTimeoutMs must be an integer.')
+  .min(
+    MIN_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS,
+    `waitTimeoutMs must be at least ${MIN_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS}.`
+  )
+  .max(
+    MAX_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS,
+    `waitTimeoutMs must be at most ${MAX_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS}.`
+  )
+  .optional()
+  .describe(
+    `Maximum milliseconds to wait (default ${DEFAULT_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS}, max ${MAX_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS}).`
+  );
+
+function readinessResponse(result: BranchFilesystemReadinessResult): {
+  readiness: Record<string, unknown>;
+  isError: boolean;
+} {
+  const readiness: Record<string, unknown> = {
+    outcome: result.outcome,
+    elapsed_ms: result.elapsedMs,
+    timeout_ms: result.timeoutMs,
+    poll_interval_ms: BRANCH_FILESYSTEM_READY_POLL_INTERVAL_MS,
+  };
+
+  if (result.outcome === 'ready') {
+    readiness.message = 'Branch filesystem is ready for session creation.';
+    return { readiness, isError: false };
+  }
+
+  if (result.outcome === 'timeout') {
+    readiness.message =
+      'Timed out while the branch filesystem is still being created. The wait did not modify or cancel materialization; call agor_branches_wait_for_ready before creating a session.';
+    readiness.poll = readinessPoll(result.branch.branch_id);
+    return { readiness, isError: false };
+  }
+
+  readiness.message =
+    result.outcome === 'failed'
+      ? result.branch.error_message || 'Branch filesystem creation failed.'
+      : `Branch filesystem is unavailable (${result.unavailableReason ?? 'terminal state'}).`;
+  if (result.unavailableReason) readiness.reason = result.unavailableReason;
+  return { readiness, isError: true };
 }
 
 function mcpRequestSignal(requestContext: unknown): AbortSignal | undefined {
@@ -237,22 +285,10 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
       annotations: { readOnlyHint: true, idempotentHint: true },
       inputSchema: z.object({
         branchId: mcpRequiredId('branchId', 'Branch'),
-        waitTimeoutMs: z
-          .number({ error: 'waitTimeoutMs must be a number when provided.' })
-          .int('waitTimeoutMs must be an integer.')
-          .min(
-            MIN_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS,
-            `waitTimeoutMs must be at least ${MIN_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS}.`
-          )
-          .max(
-            MAX_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS,
-            `waitTimeoutMs must be at most ${MAX_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS}.`
-          )
-          .optional()
-          .describe(
-            `Maximum milliseconds to wait (default ${DEFAULT_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS}, max ${MAX_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS}). ` +
-              'For longer clone/materialization jobs, safely call this read-only tool again.'
-          ),
+        waitTimeoutMs: branchFilesystemReadyWaitTimeoutSchema.describe(
+          `Maximum milliseconds to wait (default ${DEFAULT_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS}, max ${MAX_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS}). ` +
+            'For longer clone/materialization jobs, safely call this read-only tool again.'
+        ),
       }),
     },
     async (args, requestContext) => {
@@ -269,49 +305,10 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
           ),
       });
 
-      const baseReadiness = {
-        outcome: result.outcome,
-        elapsed_ms: result.elapsedMs,
-        timeout_ms: result.timeoutMs,
-        poll_interval_ms: BRANCH_FILESYSTEM_READY_POLL_INTERVAL_MS,
-      };
-
-      if (result.outcome === 'ready') {
-        return textResult({
-          branch: result.branch,
-          _readiness: {
-            ...baseReadiness,
-            message: 'Branch filesystem is ready for session creation.',
-          },
-        });
-      }
-
-      if (result.outcome === 'timeout') {
-        return textResult({
-          branch: result.branch,
-          _readiness: {
-            ...baseReadiness,
-            message:
-              'Timed out while the branch filesystem is still being created. The wait did not modify or cancel materialization; call this tool again before creating a session.',
-            poll: readinessPoll(result.branch.branch_id),
-          },
-        });
-      }
-
-      const message =
-        result.outcome === 'failed'
-          ? result.branch.error_message || 'Branch filesystem creation failed.'
-          : `Branch filesystem is unavailable (${result.unavailableReason ?? 'terminal state'}).`;
+      const formatted = readinessResponse(result);
       return {
-        ...textResult({
-          branch: result.branch,
-          _readiness: {
-            ...baseReadiness,
-            ...(result.unavailableReason ? { reason: result.unavailableReason } : {}),
-            message,
-          },
-        }),
-        isError: true,
+        ...textResult({ branch: result.branch, _readiness: formatted.readiness }),
+        ...(formatted.isError ? { isError: true } : {}),
       };
     }
   );
@@ -613,8 +610,8 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
         'and branchName to your desired unique name (e.g., sourceBranch="issue-282", branchName="issue-282-review-1"). ' +
         'Use zoneId to place the branch in a specific zone (pin only, no trigger). ' +
         'For zone trigger behavior (prompt templates), use agor_branches_set_zone after creation. ' +
-        'Filesystem materialization continues asynchronously; call the retry-safe ' +
-        'agor_branches_wait_for_ready tool before creating the first session. ' +
+        'Filesystem materialization is asynchronous by default. Set waitForReady=true to wait for a bounded ' +
+        'authoritative result in this call, or use the retry-safe agor_branches_wait_for_ready tool separately. ' +
         'To create a long-lived Agor teammate (a persistent AI teammate that manages other branches ' +
         'and maintains memory), pass the teammate object — this is the ONLY supported way to make a ' +
         'teammate via MCP. Teammate status cannot be toggled later with agor_branches_update. ' +
@@ -723,6 +720,17 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
             'Common shallow value: 100. Trade-off: smaller disk footprint, but ' +
             '`git log` past N commits is broken and some rebase operations fail.'
         ),
+        waitForReady: z
+          .boolean()
+          .optional()
+          .describe(
+            'Wait for filesystem materialization before returning (default: false). ' +
+              'This is an opt-in convenience on a non-idempotent create; if the client loses the response, creation still continues. ' +
+              'Use the separate retry-safe agor_branches_wait_for_ready tool to recover from timeouts.'
+          ),
+        waitTimeoutMs: branchFilesystemReadyWaitTimeoutSchema.describe(
+          `Maximum milliseconds to wait when waitForReady=true (default ${DEFAULT_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS}, max ${MAX_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS}). Ignored otherwise.`
+        ),
         teammate: z
           .object({
             displayName: z
@@ -759,7 +767,7 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
           ),
       }),
     },
-    async (args) => {
+    async (args, requestContext) => {
       const repoId = await resolveRepoId(ctx, coerceString(args.repoId)!);
       let branchName = coerceString(args.branchName)!;
       const originalName = branchName;
@@ -970,8 +978,23 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
         ctx.baseServiceParams
       );
 
+      const readinessResult = args.waitForReady
+        ? await waitForBranchFilesystemReady({
+            branchId: branch.branch_id,
+            timeoutMs: args.waitTimeoutMs ?? DEFAULT_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS,
+            signal: mcpRequestSignal(requestContext),
+            readBranch: (branchId) =>
+              ctx.app
+                .service('branches')
+                .get(branchId, ctx.baseServiceParams as Parameters<BranchesServiceImpl['get']>[1]),
+          })
+        : undefined;
+
       // Build response with appropriate notes
-      const response: Record<string, unknown> = { ...branch };
+      const response: Record<string, unknown> = { ...(readinessResult?.branch ?? branch) };
+
+      const formattedReadiness = readinessResult ? readinessResponse(readinessResult) : undefined;
+      if (formattedReadiness) response._readiness = formattedReadiness.readiness;
 
       if (branchName !== originalName) {
         response._note = `Name '${originalName}' was already taken. Created as '${branchName}' instead (autoSuffix applied).`;
@@ -1013,7 +1036,10 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
           'Use agor_branches_set_zone to pin this branch to a specific zone and optionally trigger zone prompt templates.';
       }
 
-      return textResult(response);
+      return {
+        ...textResult(response),
+        ...(formattedReadiness?.isError ? { isError: true } : {}),
+      };
     }
   );
 

--- a/apps/agor-daemon/src/mcp/tools/branches.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.ts
@@ -294,6 +294,7 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
         branchId: mcpRequiredId('branchId', 'Branch'),
         waitTimeoutMs: branchFilesystemReadyWaitTimeoutSchema.describe(
           `Maximum milliseconds to wait (default ${DEFAULT_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS}, max ${MAX_BRANCH_FILESYSTEM_READY_WAIT_TIMEOUT_MS}). ` +
+            "Waits longer than the MCP client's request deadline require a matching client timeout. " +
             'For longer clone/materialization jobs, safely call this read-only tool again.'
         ),
       }),

--- a/apps/agor-docs/content/guide/branches.mdx
+++ b/apps/agor-docs/content/guide/branches.mdx
@@ -89,13 +89,19 @@ Branch creation records the branch and dispatches worktree or clone materializat
 The create response can therefore contain `filesystem_status: "creating"`; REST and UI creation are
 not blocked while Git work completes.
 
-MCP orchestrators should call `agor_branches_wait_for_ready` before creating the first session. The
-read-only tool checks immediately, then performs a fresh tenant- and RBAC-scoped branch read once per
-second. It waits for 30 seconds by default and accepts a bounded `waitTimeoutMs` from 1–60 seconds.
-Long clones can safely repeat the wait call. A timeout preserves the branch and does not cancel or
-retry materialization; terminal failures return the refreshed branch and its persisted safe error.
-Client cancellation only stops further polling. No database transaction or connection is retained
-between reads; each individual read remains subject to the daemon's normal database query timeout.
+MCP callers can set `waitForReady: true` on `agor_branches_create` to wait in the creation call, or
+use the retry-safe `agor_branches_wait_for_ready` tool before creating the first session. Waiting is
+opt-in, so existing MCP callers—and all REST and UI callers—remain asynchronous. Both paths check
+immediately, then perform a fresh tenant- and RBAC-scoped branch read once per second. They wait for
+60 seconds by default and accept a bounded `waitTimeoutMs` from 1 second to 5 minutes.
+
+The standalone wait tool is the safer choice when request replay is possible: branch creation is not
+idempotent, and losing a waited create response does not cancel the branch that was already created.
+Long clones can safely repeat the read-only wait call. A timeout preserves the branch and does not
+cancel or retry materialization; terminal failures return the refreshed branch and its persisted safe
+error. Client cancellation only stops further polling. No database transaction or connection is
+retained between reads; each individual read remains subject to the daemon's normal database query
+timeout.
 
 ---
 

--- a/apps/agor-docs/content/guide/branches.mdx
+++ b/apps/agor-docs/content/guide/branches.mdx
@@ -93,7 +93,8 @@ MCP callers can set `waitForReady: true` on `agor_branches_create` to wait in th
 use the retry-safe `agor_branches_wait_for_ready` tool before creating the first session. Waiting is
 opt-in, so existing MCP callers—and all REST and UI callers—remain asynchronous. Both paths check
 immediately, then perform a fresh tenant- and RBAC-scoped branch read once per second. They wait for
-60 seconds by default and accept a bounded `waitTimeoutMs` from 1 second to 5 minutes.
+45 seconds by default and accept a bounded `waitTimeoutMs` from 1 second to 5 minutes. Values longer
+than the MCP client's request deadline require that client or host deadline to be raised as well.
 
 The standalone wait tool is the safer choice when request replay is possible: branch creation is not
 idempotent, and losing a waited create response does not cancel the branch that was already created.

--- a/apps/agor-docs/content/guide/branches.mdx
+++ b/apps/agor-docs/content/guide/branches.mdx
@@ -83,6 +83,22 @@ Sessions, tasks, comments, and artifacts all reference a branch. **The branch is
 
 ---
 
+## Asynchronous filesystem readiness
+
+Branch creation records the branch and dispatches worktree or clone materialization asynchronously.
+The create response can therefore contain `filesystem_status: "creating"`; REST and UI creation are
+not blocked while Git work completes.
+
+MCP orchestrators should call `agor_branches_wait_for_ready` before creating the first session. The
+read-only tool checks immediately, then performs a fresh tenant- and RBAC-scoped branch read once per
+second. It waits for 30 seconds by default and accepts a bounded `waitTimeoutMs` from 1–60 seconds.
+Long clones can safely repeat the wait call. A timeout preserves the branch and does not cancel or
+retry materialization; terminal failures return the refreshed branch and its persisted safe error.
+Client cancellation only stops further polling. No database transaction or connection is retained
+between reads; each individual read remains subject to the daemon's normal database query timeout.
+
+---
+
 ## Storage modes
 
 When you create a branch, Agor can materialize its working directory in two ways:

--- a/apps/agor-docs/content/guide/internal-mcp.mdx
+++ b/apps/agor-docs/content/guide/internal-mcp.mdx
@@ -97,8 +97,9 @@ For a retry-safe flow—particularly when a non-idempotent create request might 
 2. `agor_branches_wait_for_ready`; repeat after a structured timeout when necessary.
 3. Call `agor_sessions_create` only when `_readiness.outcome` is `"ready"`.
 
-Both wait paths check immediately and then once per second. The default wait is 60 seconds and a
-single call is capped at 5 minutes. After a timeout, keep the returned branch ID and safely call the
+Both wait paths check immediately and then once per second. The default wait is 45 seconds and a
+single call is capped at 5 minutes. Values longer than the MCP client's request deadline require a
+matching client or host timeout. After a timeout, keep the returned branch ID and safely call the
 read-only wait tool again. Losing a waited create response does not cancel the already-created branch,
 so do not blindly replay branch creation.
 

--- a/apps/agor-docs/content/guide/internal-mcp.mdx
+++ b/apps/agor-docs/content/guide/internal-mcp.mdx
@@ -87,6 +87,16 @@ This self-awareness is what lets agents behave like team members instead of deta
 
 ## Automation Examples
 
+Branch materialization is asynchronous. An orchestrator that creates a branch and immediately starts
+a session should use this retry-safe sequence:
+
+1. `agor_branches_create` and retain the returned branch ID.
+2. `agor_branches_wait_for_ready`; repeat after a structured timeout when necessary.
+3. Call `agor_sessions_create` only when `_readiness.outcome` is `"ready"`.
+
+The wait tool checks immediately and then once per second. Its default wait is 30 seconds and a single
+call is capped at 60 seconds, so a slow multi-minute clone does not require one long-lived MCP request.
+
 - **Repository bootstrap:** "Clone this GitHub repo, create a branch off `main`, and start the dev environment automatically."
 - **Zone-based workflows:** "Create a 'Human PR Review' zone on the board, positioned based on existing zones, with a trigger that prompts for review feedback."
 - **Mass subsession fan-out:** "Read `context/js-to-ts-refactor`, split the file list, create a subsession per chunk, and report back when done."

--- a/apps/agor-docs/content/guide/internal-mcp.mdx
+++ b/apps/agor-docs/content/guide/internal-mcp.mdx
@@ -87,15 +87,20 @@ This self-awareness is what lets agents behave like team members instead of deta
 
 ## Automation Examples
 
-Branch materialization is asynchronous. An orchestrator that creates a branch and immediately starts
-a session should use this retry-safe sequence:
+Branch materialization is asynchronous by default. For the most discoverable one-call flow, an
+orchestrator can pass `waitForReady: true` (and optionally `waitTimeoutMs`) to
+`agor_branches_create`, then create a session only when `_readiness.outcome` is `"ready"`.
+
+For a retry-safe flow—particularly when a non-idempotent create request might be replayed—use:
 
 1. `agor_branches_create` and retain the returned branch ID.
 2. `agor_branches_wait_for_ready`; repeat after a structured timeout when necessary.
 3. Call `agor_sessions_create` only when `_readiness.outcome` is `"ready"`.
 
-The wait tool checks immediately and then once per second. Its default wait is 30 seconds and a single
-call is capped at 60 seconds, so a slow multi-minute clone does not require one long-lived MCP request.
+Both wait paths check immediately and then once per second. The default wait is 60 seconds and a
+single call is capped at 5 minutes. After a timeout, keep the returned branch ID and safely call the
+read-only wait tool again. Losing a waited create response does not cancel the already-created branch,
+so do not blindly replay branch creation.
 
 - **Repository bootstrap:** "Clone this GitHub repo, create a branch off `main`, and start the dev environment automatically."
 - **Zone-based workflows:** "Create a 'Human PR Review' zone on the board, positioned based on existing zones, with a trigger that prompts for review feedback."

--- a/apps/agor-ui/src/utils/waitForBranchFilesystemReady.ts
+++ b/apps/agor-ui/src/utils/waitForBranchFilesystemReady.ts
@@ -1,3 +1,4 @@
+import { classifyBranchFilesystemReadiness } from '@agor/core/types';
 import type { AgorClient, Branch } from '@agor-live/client';
 
 export interface WaitForBranchFilesystemReadyOptions {
@@ -16,7 +17,7 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 export async function waitForBranchFilesystemReady(
   client: AgorClient | null | undefined,
   branchId: string,
-  { timeoutMs = 30_000, intervalMs = 500 }: WaitForBranchFilesystemReadyOptions = {}
+  { timeoutMs = 30_000, intervalMs = 1_000 }: WaitForBranchFilesystemReadyOptions = {}
 ): Promise<void> {
   if (!client) return;
 
@@ -26,16 +27,20 @@ export async function waitForBranchFilesystemReady(
   while (Date.now() < deadline) {
     const branch = (await client.service('branches').get(branchId)) as Branch;
     lastStatus = branch.filesystem_status;
+    const readiness = classifyBranchFilesystemReadiness(branch);
 
-    // Legacy rows may not have a filesystem_status; treat missing as ready.
-    if (!lastStatus || lastStatus === 'ready') return;
+    if (readiness === 'ready') return;
 
-    if (lastStatus === 'failed') {
+    if (readiness === 'failed') {
       throw new Error(branch.error_message || 'Branch filesystem creation failed');
     }
 
-    if (lastStatus === 'deleted' || lastStatus === 'cleaned' || lastStatus === 'preserved') {
-      throw new Error(`Branch filesystem is ${lastStatus}`);
+    if (readiness === 'unavailable') {
+      throw new Error(
+        branch.archived
+          ? 'Branch is archived'
+          : `Branch filesystem is ${lastStatus ?? 'unavailable'}`
+      );
     }
 
     await sleep(intervalMs);

--- a/packages/core/src/types/branch.ts
+++ b/packages/core/src/types/branch.ts
@@ -444,6 +444,35 @@ export interface Branch {
   dangerously_allow_session_sharing?: boolean;
 }
 
+export type BranchFilesystemReadinessState = 'pending' | 'ready' | 'failed' | 'unavailable';
+
+/**
+ * Classify whether a branch can safely host filesystem-backed work.
+ *
+ * Keep this interpretation shared between UI and automation callers. Legacy
+ * rows without a filesystem status are ready; archived or cleaned-up branches
+ * are terminal and unavailable.
+ */
+export function classifyBranchFilesystemReadiness(
+  branch: Pick<Branch, 'archived' | 'filesystem_status'>
+): BranchFilesystemReadinessState {
+  if (branch.archived) return 'unavailable';
+
+  switch (branch.filesystem_status) {
+    case undefined:
+    case 'ready':
+      return 'ready';
+    case 'creating':
+      return 'pending';
+    case 'failed':
+      return 'failed';
+    case 'preserved':
+    case 'cleaned':
+    case 'deleted':
+      return 'unavailable';
+  }
+}
+
 /**
  * Ordered permission levels for branch RBAC (least → most privileged).
  *


### PR DESCRIPTION
## Summary

Add first-class bounded branch-filesystem readiness waiting for MCP orchestrators without making REST, UI, or existing MCP creation synchronous.

The most discoverable path is now an **opt-in** convenience on `agor_branches_create`:

```text
agor_branches_create({ ..., waitForReady: true, waitTimeoutMs? })
```

The PR also provides the read-only, retry-safe `agor_branches_wait_for_ready` tool for asynchronous callers, timeout recovery, and slow clones.

## API and timing

```text
# Existing behavior: unchanged and asynchronous
agor_branches_create(...) -> branch, commonly filesystem_status="creating"

# Discoverable one-call convenience
agor_branches_create({ ..., waitForReady: true, waitTimeoutMs? })
  -> authoritative flat branch response plus _readiness

# Retry-safe follow-up
agor_branches_wait_for_ready({ branchId, waitTimeoutMs? })
  -> { branch, _readiness }

agor_sessions_create(...) only after _readiness.outcome="ready"
```

- `waitForReady` defaults to `false`, preserving compatibility
- immediate first read; no fixed startup sleep
- 1-second polling cadence
- 45-second default wait (leaves delivery headroom under common 60-second MCP request deadlines)
- caller-configurable 1-second to 5-minute bound; waits longer than the client request deadline require a matching client/host timeout
- `waitTimeoutMs` is accepted on create only with `waitForReady: true`
- after a timeout, retain the branch ID and safely call the read-only wait tool again

Waiting on create is intentionally opt-in because creation is non-idempotent: if a client loses the response, branch materialization still continues and blindly retrying create can produce a suffixed duplicate. Callers concerned about replay should keep create asynchronous and use the standalone wait tool.

## Behavior

- returns the authoritative refreshed branch, including filesystem path, commands, and board association
- preserves the existing flat create response shape; waited creates add `_readiness`
- returns promptly for already-ready, failed, archived, preserved, cleaned, and deleted branches
- reports persisted branch creation errors in a structured terminal result
- timeout preserves the branch and returns a retry instruction; it never deletes, retries, or cancels materialization
- MCP cancellation clears the polling timer and stops future reads; an in-flight service read remains governed by the daemon's existing database timeout
- every observation uses a pristine tenant/RBAC-scoped Feathers params object, preventing request-local hook caches from pinning the first row and letting HA replicas converge through the shared database
- no database transaction or connection is retained while sleeping

Polling is intentional: filesystem state is persisted and shared across replicas, whereas process-local realtime notification would still require a durable fallback. One indexed read per waiting caller per second keeps the mechanism simple and bounded.

## Scope reduction

This supersedes the earlier, broader version of the PR. It still avoids:

- changing REST or UI creation semantics
- making MCP creation wait by default
- generic database/repository cancellation plumbing
- private Drizzle/postgres.js cancellation access
- changes to shared branch authorization, tenant, or database infrastructure

The resulting change is 999 additions / 16 deletions across 10 files, versus 2,222 additions / 78 deletions across 23 files previously. Most added lines are focused tests.

## Validation

- `pnpm i`
- `pnpm check`
- 135 focused daemon/MCP tests across readiness, branches, environment compatibility, and MCP server contracts
- focused daemon typecheck
- docs production build
- `git diff --check`

The standard PR PostgreSQL integration job covers the non-superuser RLS lane; the local PostgreSQL test URLs are not configured in this worktree.


