### PR TITLE
feat(onboarding): personal, template-aware first-session prompt

### DIFF
--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -774,6 +774,9 @@ function AppContent() {
       // Goals drive the first-session prompt; [] (skipped) yields the generic
       // follow-the-user guidance. Passed straight from the wizard.
       goals: result.goals,
+      // Template persona and MCP agency for the first-session opener.
+      templateId: result.templateId,
+      canManageIntegrations: canManageMcp,
       user: {
         name: currentUser.name,
         email: currentUser.email,

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -774,9 +774,8 @@ function AppContent() {
       // Goals drive the first-session prompt; [] (skipped) yields the generic
       // follow-the-user guidance. Passed straight from the wizard.
       goals: result.goals,
-      // Template persona and MCP agency for the first-session opener.
+      // Template persona for the first-session opener.
       templateId: result.templateId,
-      canManageIntegrations: canManageMcp,
       user: {
         name: currentUser.name,
         email: currentUser.email,

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -19,7 +19,7 @@ import type {
   UpdateUserInput,
   User,
 } from '@agor-live/client';
-import { hasMinimumRole, PermissionScope, ROLES } from '@agor-live/client';
+import { hasMinimumRole, PermissionScope } from '@agor-live/client';
 import { Layout, theme, Upload } from 'antd';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import {
@@ -36,6 +36,7 @@ import { useAppNavigation } from '../../hooks/useAppNavigation';
 import { useBoardTitle } from '../../hooks/useBoardTitle';
 import { useEventStream } from '../../hooks/useEventStream';
 import { useFaviconStatus } from '../../hooks/useFaviconStatus';
+import { findFrameworkRepo } from '../../hooks/useFrameworkRepo';
 import { useLocalStorage } from '../../hooks/useLocalStorage';
 import { useRecentBoards } from '../../hooks/useRecentBoards';
 import { useSettingsRoute } from '../../hooks/useSettingsRoute';
@@ -73,7 +74,7 @@ import {
   buildTeammateFirstSessionTitle,
 } from '../../utils/teammateBootstrapPrompt';
 import { createTeammateBranch } from '../../utils/teammateCreation';
-import { getTemplateBySourceBranch } from '../../utils/teammateTemplates';
+import { getTemplateForFrameworkSource } from '../../utils/teammateTemplates';
 import { getUserDefaultConfigurationSource } from '../AgenticToolConfigurationPicker/useAgenticConfigurationSources';
 import { AppHeader } from '../AppHeader';
 import type { BoardTeammatePanelTab } from '../BoardTeammatePanel';
@@ -1027,6 +1028,12 @@ export const App: React.FC<AppProps> = ({
       );
     }
 
+    const template = getTemplateForFrameworkSource({
+      sourceBranch: result.sourceBranch,
+      selectedRepoId: result.repoId,
+      frameworkRepoId: findFrameworkRepo(agorStore.getState().repoById)?.[0],
+    });
+
     const sessionConfig: NewSessionConfig = {
       branch_id: branch.branch_id,
       agent: result.agent,
@@ -1038,10 +1045,9 @@ export const App: React.FC<AppProps> = ({
         description: result.description,
         userName: user?.name,
         userEmail: user?.email,
-        // Recover the persona from the branch the teammate was cut from so the
-        // opener adopts it here too (this path carries no explicit template id).
-        templateId: getTemplateBySourceBranch(result.sourceBranch)?.id,
-        canManageIntegrations: hasMinimumRole(user?.role, ROLES.ADMIN),
+        // This path carries no explicit template id, so recover the persona
+        // only when the source belongs to the detected framework repository.
+        templateId: template?.id,
       }),
       modelConfig: result.modelConfig,
       effort: result.effort,

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -19,7 +19,7 @@ import type {
   UpdateUserInput,
   User,
 } from '@agor-live/client';
-import { hasMinimumRole, PermissionScope } from '@agor-live/client';
+import { hasMinimumRole, PermissionScope, ROLES } from '@agor-live/client';
 import { Layout, theme, Upload } from 'antd';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import {
@@ -73,6 +73,7 @@ import {
   buildTeammateFirstSessionTitle,
 } from '../../utils/teammateBootstrapPrompt';
 import { createTeammateBranch } from '../../utils/teammateCreation';
+import { getTemplateBySourceBranch } from '../../utils/teammateTemplates';
 import { getUserDefaultConfigurationSource } from '../AgenticToolConfigurationPicker/useAgenticConfigurationSources';
 import { AppHeader } from '../AppHeader';
 import type { BoardTeammatePanelTab } from '../BoardTeammatePanel';
@@ -1037,6 +1038,10 @@ export const App: React.FC<AppProps> = ({
         description: result.description,
         userName: user?.name,
         userEmail: user?.email,
+        // Recover the persona from the branch the teammate was cut from so the
+        // opener adopts it here too (this path carries no explicit template id).
+        templateId: getTemplateBySourceBranch(result.sourceBranch)?.id,
+        canManageIntegrations: hasMinimumRole(user?.role, ROLES.ADMIN),
       }),
       modelConfig: result.modelConfig,
       effort: result.effort,

--- a/apps/agor-ui/src/utils/seedOnboardingTeammate.test.ts
+++ b/apps/agor-ui/src/utils/seedOnboardingTeammate.test.ts
@@ -155,6 +155,30 @@ describe('seedOnboardingTeammate', () => {
     expect(onWarn).not.toHaveBeenCalled();
   });
 
+  it('threads the template persona and admin MCP agency into the first-session prompt', async () => {
+    createTeammateBranchMock.mockResolvedValue({
+      branch_id: 'branch-1',
+      board_id: 'board-1',
+    } as Branch);
+    startTeammateBootstrapSessionMock.mockResolvedValue('session-1');
+
+    const { input } = setup({
+      goals: [],
+      templateId: 'legal-analyst',
+      canManageIntegrations: true,
+    });
+    await seedOnboardingTeammate(input);
+
+    const sessionArg = startTeammateBootstrapSessionMock.mock.calls[0][0];
+    const initialPrompt = (sessionArg.sessionConfig as { initialPrompt: string }).initialPrompt;
+    // Template persona surfaces in context and drives the personal opener even
+    // though no goal was picked.
+    expect(initialPrompt).toContain('- Created from the Legal Analyst template.');
+    expect(initialPrompt).toMatch(/Open as yourself: one warm line/);
+    // Admin gets the "set it up yourself" MCP agency line.
+    expect(initialPrompt).toMatch(/offer to set it up for them yourself/i);
+  });
+
   it('forwards the template source branch to createTeammateBranch', async () => {
     createTeammateBranchMock.mockResolvedValue({
       branch_id: 'branch-1',

--- a/apps/agor-ui/src/utils/seedOnboardingTeammate.test.ts
+++ b/apps/agor-ui/src/utils/seedOnboardingTeammate.test.ts
@@ -155,7 +155,7 @@ describe('seedOnboardingTeammate', () => {
     expect(onWarn).not.toHaveBeenCalled();
   });
 
-  it('threads the template persona and admin MCP agency into the first-session prompt', async () => {
+  it('threads the template persona and routed integration guidance into the first-session prompt', async () => {
     createTeammateBranchMock.mockResolvedValue({
       branch_id: 'branch-1',
       board_id: 'board-1',
@@ -165,7 +165,6 @@ describe('seedOnboardingTeammate', () => {
     const { input } = setup({
       goals: [],
       templateId: 'legal-analyst',
-      canManageIntegrations: true,
     });
     await seedOnboardingTeammate(input);
 
@@ -175,8 +174,11 @@ describe('seedOnboardingTeammate', () => {
     // though no goal was picked.
     expect(initialPrompt).toContain('- Created from the Legal Analyst template.');
     expect(initialPrompt).toMatch(/Open as yourself: one warm line/);
-    // Admin gets the "set it up yourself" MCP agency line.
-    expect(initialPrompt).toMatch(/offer to set it up for them yourself/i);
+    // The official MCP route keeps safe, session-scoped agency while GitHub
+    // remains native repository access rather than an invented MCP install.
+    expect(initialPrompt).toContain('https://mcp.slack.com/mcp');
+    expect(initialPrompt).toMatch(/use session scope and attach it to this session/i);
+    expect(initialPrompt).toContain('GitHub: use the repository already connected to Agor');
   });
 
   it('forwards the template source branch to createTeammateBranch', async () => {

--- a/apps/agor-ui/src/utils/seedOnboardingTeammate.ts
+++ b/apps/agor-ui/src/utils/seedOnboardingTeammate.ts
@@ -30,6 +30,10 @@ Framework source branch from the chosen gallery template. Undefined falls
   suggestedIntegrations?: OnboardingIntegrationRecommendation[];
   /** Onboarding goal ids (order-preserving, primary first); [] when skipped. */
   goals?: string[];
+  /** Chosen gallery template id (persona); null/undefined = blank starter. */
+  templateId?: string | null;
+  /** Whether the acting user can connect MCP servers themselves (admin+). */
+  canManageIntegrations?: boolean;
   user?: { name?: string | null; email?: string | null } | null;
   client: AgorClient | null;
   repoById: TeammateCreationDeps['repoById'];
@@ -219,7 +223,9 @@ export async function seedOnboardingTeammate(
           userName: input.user?.name,
           userEmail: input.user?.email,
           goals: input.goals,
+          templateId: input.templateId,
           suggestedIntegrations: input.suggestedIntegrations,
+          canManageIntegrations: input.canManageIntegrations,
         }),
       },
       onCreateSession: input.onCreateSession,

--- a/apps/agor-ui/src/utils/seedOnboardingTeammate.ts
+++ b/apps/agor-ui/src/utils/seedOnboardingTeammate.ts
@@ -32,8 +32,6 @@ Framework source branch from the chosen gallery template. Undefined falls
   goals?: string[];
   /** Chosen gallery template id (persona); null/undefined = blank starter. */
   templateId?: string | null;
-  /** Whether the acting user can connect MCP servers themselves (admin+). */
-  canManageIntegrations?: boolean;
   user?: { name?: string | null; email?: string | null } | null;
   client: AgorClient | null;
   repoById: TeammateCreationDeps['repoById'];
@@ -225,7 +223,6 @@ export async function seedOnboardingTeammate(
           goals: input.goals,
           templateId: input.templateId,
           suggestedIntegrations: input.suggestedIntegrations,
-          canManageIntegrations: input.canManageIntegrations,
         }),
       },
       onCreateSession: input.onCreateSession,

--- a/apps/agor-ui/src/utils/teammateBootstrapPrompt.test.ts
+++ b/apps/agor-ui/src/utils/teammateBootstrapPrompt.test.ts
@@ -80,7 +80,10 @@ describe('buildTeammateBootstrapPrompt', () => {
 
     expect(prompt).toContain('- Created from the Legal Analyst template.');
     expect(prompt).toMatch(/Open as yourself: one warm line, in your persona's voice/);
-    expect(prompt).toContain('set up to help Max with what they picked');
+    expect(prompt).toContain('set up as a Legal Analyst to help Max');
+    expect(prompt).toMatch(/ground the opening in the template's remit/i);
+    expect(prompt).not.toContain('see "What the user wants" above');
+    expect(prompt).not.toMatch(/specific to that goal/i);
     expect(prompt).toContain('- End with a single clear next step.');
     // Not the single-question fallback.
     expect(prompt).not.toMatch(/ask exactly one specific question about what/i);
@@ -102,31 +105,29 @@ describe('buildTeammateBootstrapPrompt', () => {
     expect(unknown).not.toContain('Created from the');
   });
 
-  it('lists suggested integrations and gives admins the "set it up yourself" MCP line', () => {
+  it('preserves the reviewed setup route for every suggested integration', () => {
     const prompt = buildTeammateBootstrapPrompt({
       displayName: 'Board Bot',
-      canManageIntegrations: true,
       suggestedIntegrations: [
         ONBOARDING_INTEGRATION_RECOMMENDATIONS.slack,
         ONBOARDING_INTEGRATION_RECOMMENDATIONS.github,
+        ONBOARDING_INTEGRATION_RECOMMENDATIONS.sentry,
       ],
     });
-    expect(prompt).toContain('- Suggested tools and connections: Slack, GitHub');
-    expect(prompt).toMatch(/offer to set it up for them yourself/i);
-    expect(prompt).toContain('Settings -> MCP');
-    expect(prompt).not.toMatch(/a workspace admin has to connect it/i);
-    expect(prompt).toContain(DOCS_HOOK);
-  });
+    expect(prompt).toContain('- Suggested tools and connections: Slack, GitHub, Sentry');
 
-  it('tells non-admins that an admin must connect, without pointing at MCP settings', () => {
-    const prompt = buildTeammateBootstrapPrompt({
-      displayName: 'Board Bot',
-      canManageIntegrations: false,
-      suggestedIntegrations: [ONBOARDING_INTEGRATION_RECOMMENDATIONS.slack],
-    });
-    expect(prompt).toMatch(/a workspace admin has to connect it/i);
-    expect(prompt).toContain("Don't send this user to the admin-only MCP settings screen");
-    expect(prompt).not.toMatch(/offer to set it up for them yourself/i);
+    expect(prompt).toContain('Slack: first check whether a configured server is already available');
+    expect(prompt).toContain('https://mcp.slack.com/mcp');
+    expect(prompt).toMatch(/use session scope and attach it to this session/i);
+    expect(prompt).toMatch(/workspace member policy/i);
+    expect(prompt).not.toMatch(/admin-only MCP settings/i);
+
+    expect(prompt).toContain('GitHub: use the repository already connected to Agor');
+    expect(prompt).toContain('Do not describe this as an MCP or Marketplace install');
+
+    expect(prompt).toContain('Sentry: use the reviewed Marketplace entry io.sentry/mcp');
+    expect(prompt).toMatch(/do not bypass the catalog by registering a guessed endpoint/i);
+    expect(prompt).toContain(DOCS_HOOK);
   });
 
   it('drops the MCP line for empty / whitespace-only integration lists, keeps the docs hook', () => {

--- a/apps/agor-ui/src/utils/teammateBootstrapPrompt.test.ts
+++ b/apps/agor-ui/src/utils/teammateBootstrapPrompt.test.ts
@@ -6,6 +6,9 @@ import {
   buildTeammateFirstSessionTitle,
 } from './teammateBootstrapPrompt';
 
+const LEAD_LINE = 'Your first message sets the working relationship.';
+const DOCS_HOOK = 'link the single most relevant one instead of pasting a how-to';
+
 describe('buildTeammateBootstrapPrompt', () => {
   it('names the first session in plain language (CP-23: no "bootstrap"/"onboarding" jargon)', () => {
     const withEmoji = buildTeammateFirstSessionTitle({ displayName: 'Rusty', emoji: '🤖' });
@@ -28,12 +31,17 @@ describe('buildTeammateBootstrapPrompt', () => {
     expect(prompt).toContain('- AI teammate description: Reviews pull requests');
     expect(prompt).toContain('- User: Max <max@example.com>');
     expect(prompt).toContain('Read ONBOARDING.md if it exists; otherwise, read BOOTSTRAP.md');
-    // No goal supplied → neutral opener, not the primary-goal one.
-    expect(prompt).toContain('Ask exactly one specific question');
-    expect(prompt).not.toContain('take the primary goal above');
-    expect(prompt).not.toMatch(/\{\{\s*#?\/?\s*(assistant|user)\b/);
-    // No goals supplied → no goal-guidance block.
+    // The personal lead line and docs hook are always emitted.
+    expect(prompt).toContain(LEAD_LINE);
+    expect(prompt).toContain(DOCS_HOOK);
+    // No goal and no template → the single-question fallback opener.
+    expect(prompt).toMatch(
+      /ask exactly one specific question about what Max is working on right now/i
+    );
+    // No goals supplied → no goal-guidance block and no template context line.
     expect(prompt).not.toContain('What the user wants:');
+    expect(prompt).not.toContain('Created from the');
+    expect(prompt).not.toMatch(/\{\{\s*#?\/?\s*(assistant|user)\b/);
   });
 
   it('normalizes fallback identity values in the prompt context', () => {
@@ -48,67 +56,110 @@ describe('buildTeammateBootstrapPrompt', () => {
     });
   });
 
-  it('omits optional user, description and goal lines when absent', () => {
+  it('omits optional user, description, template and goal lines when absent', () => {
     const prompt = buildTeammateBootstrapPrompt({ displayName: 'Board Bot', emoji: '🧭' });
 
     expect(prompt).toContain('- AI teammate: Board Bot 🧭');
     expect(prompt).not.toContain('AI teammate description:');
     expect(prompt).not.toContain('- User:');
     expect(prompt).not.toContain('- User email:');
+    expect(prompt).not.toContain('Created from the');
     expect(prompt).not.toContain('What the user wants:');
+    // With no name, the fallback opener addresses "the user".
+    expect(prompt).toMatch(/what the user is working on right now/i);
     expect(prompt).not.toMatch(/\{\{\s*#?\/?\s*(assistant|user)\b/);
   });
 
-  it('renders capability-aware suggested-integration guidance (CP-11)', () => {
+  it('surfaces the chosen template title in Context and opens personally on template alone', () => {
+    const prompt = buildTeammateBootstrapPrompt({
+      displayName: 'Counsel',
+      userName: 'Max',
+      // No goals at all, only a template → the personal opener must still fire.
+      templateId: 'legal-analyst',
+    });
+
+    expect(prompt).toContain('- Created from the Legal Analyst template.');
+    expect(prompt).toMatch(/Open as yourself: one warm line, in your persona's voice/);
+    expect(prompt).toContain('set up to help Max with what they picked');
+    expect(prompt).toContain('- End with a single clear next step.');
+    // Not the single-question fallback.
+    expect(prompt).not.toMatch(/ask exactly one specific question about what/i);
+  });
+
+  it('treats the blank starter as no template (no persona, fallback opener)', () => {
     const prompt = buildTeammateBootstrapPrompt({
       displayName: 'Board Bot',
+      templateId: 'blank',
+    });
+    expect(prompt).not.toContain('Created from the');
+    expect(prompt).toMatch(/ask exactly one specific question about what/i);
+
+    // An unknown template id is likewise ignored.
+    const unknown = buildTeammateBootstrapPrompt({
+      displayName: 'Board Bot',
+      templateId: 'nope',
+    });
+    expect(unknown).not.toContain('Created from the');
+  });
+
+  it('lists suggested integrations and gives admins the "set it up yourself" MCP line', () => {
+    const prompt = buildTeammateBootstrapPrompt({
+      displayName: 'Board Bot',
+      canManageIntegrations: true,
       suggestedIntegrations: [
         ONBOARDING_INTEGRATION_RECOMMENDATIONS.slack,
         ONBOARDING_INTEGRATION_RECOMMENDATIONS.github,
-        ONBOARDING_INTEGRATION_RECOMMENDATIONS.sentry,
       ],
     });
-    expect(prompt).toContain('- Suggested tools and connections: Slack, GitHub, Sentry');
-    // The integrations are not just listed — the teammate is told to propose them.
-    expect(prompt).toMatch(/when one of these would unlock the first win/i);
-    expect(prompt).toContain('Sentry: direct the user to Marketplace');
-    expect(prompt).toContain(
-      'Slack: direct the user to Settings → MCP Servers and use the official endpoint https://mcp.slack.com/mcp'
-    );
-    expect(prompt).toContain('Do not call this a Marketplace entry');
-    expect(prompt).toContain('GitHub: use the repository already connected to Agor');
-    expect(prompt).toContain('Do not describe this as an MCP or Marketplace install');
+    expect(prompt).toContain('- Suggested tools and connections: Slack, GitHub');
+    expect(prompt).toMatch(/offer to set it up for them yourself/i);
+    expect(prompt).toContain('Settings -> MCP');
+    expect(prompt).not.toMatch(/a workspace admin has to connect it/i);
+    expect(prompt).toContain(DOCS_HOOK);
+  });
 
-    // Empty / whitespace-only lists drop the line AND the proposal instruction.
+  it('tells non-admins that an admin must connect, without pointing at MCP settings', () => {
+    const prompt = buildTeammateBootstrapPrompt({
+      displayName: 'Board Bot',
+      canManageIntegrations: false,
+      suggestedIntegrations: [ONBOARDING_INTEGRATION_RECOMMENDATIONS.slack],
+    });
+    expect(prompt).toMatch(/a workspace admin has to connect it/i);
+    expect(prompt).toContain("Don't send this user to the admin-only MCP settings screen");
+    expect(prompt).not.toMatch(/offer to set it up for them yourself/i);
+  });
+
+  it('drops the MCP line for empty / whitespace-only integration lists, keeps the docs hook', () => {
     const emptyList = buildTeammateBootstrapPrompt({
       displayName: 'Board Bot',
       suggestedIntegrations: [],
     });
     expect(emptyList).not.toContain('Suggested tools and connections');
-    expect(emptyList).not.toMatch(/when a suggested integration would unlock that win/i);
+    expect(emptyList).not.toMatch(/would unlock the win/i);
+    expect(emptyList).toContain(DOCS_HOOK);
 
     const whitespaceOnly = buildTeammateBootstrapPrompt({
       displayName: 'Board Bot',
-      suggestedIntegrations: [
-        {
-          ...ONBOARDING_INTEGRATION_RECOMMENDATIONS.linear,
-          name: '  ',
-        },
-      ],
+      suggestedIntegrations: [{ ...ONBOARDING_INTEGRATION_RECOMMENDATIONS.linear, name: '  ' }],
     });
     expect(whitespaceOnly).not.toContain('Suggested tools and connections');
 
     const absent = buildTeammateBootstrapPrompt({ displayName: 'Board Bot' });
     expect(absent).not.toContain('Suggested tools and connections');
+    expect(absent).not.toMatch(/would unlock the win/i);
   });
 
-  it('renders goal-driven guidance for a single goal', () => {
+  it('renders goal-driven guidance and the personal opener for a single goal', () => {
     const prompt = buildTeammateBootstrapPrompt({
       displayName: 'Board Bot',
       goals: ['ship-without-busywork'],
     });
     expect(prompt).toContain('What the user wants:');
     expect(prompt).toContain(findOnboardingGoal('ship-without-busywork')?.bootstrapLine ?? '');
+    // A resolved goal → personal opener (act, don't interview).
+    expect(prompt).toMatch(/Open as yourself: one warm line/);
+    expect(prompt).toMatch(/take one concrete first-win step now and show the result/i);
+    expect(prompt).not.toMatch(/ask exactly one specific question about what/i);
   });
 
   it('concatenates both goal lines and a bridging line for two goals', () => {
@@ -119,40 +170,28 @@ describe('buildTeammateBootstrapPrompt', () => {
     expect(prompt).toContain(findOnboardingGoal('hand-off-build')?.bootstrapLine ?? '');
     expect(prompt).toContain(findOnboardingGoal('dig-into-anything')?.bootstrapLine ?? '');
     expect(prompt).toMatch(/do not ask which matters more/i);
+    expect(prompt).toMatch(/Open as yourself: one warm line/);
   });
 
-  it('renders a follow-the-user guidance line when onboarding was skipped (empty goals)', () => {
+  it('falls back to the single-question opener when onboarding was skipped (empty goals)', () => {
     const prompt = buildTeammateBootstrapPrompt({ displayName: 'Board Bot', goals: [] });
+    // The goal block still tells the teammate to follow the user's lead...
     expect(prompt).toContain('What the user wants:');
     expect(prompt).toMatch(/follow their lead/i);
+    // ...and the opener asks exactly one question rather than claiming a goal.
+    expect(prompt).toMatch(/ask exactly one specific question about what/i);
+    expect(prompt).not.toMatch(/Open as yourself: one warm line/);
   });
 
-  it('uses one executable ask-or-act strategy based on whether a goal resolves', () => {
-    // Real goal → act immediately when possible, otherwise ask only one question.
-    const withGoal = buildTeammateBootstrapPrompt({
-      displayName: 'Board Bot',
-      goals: ['ship-without-busywork'],
-    });
-    expect(withGoal).toMatch(/if live context is sufficient, perform one concrete first-win/i);
-    expect(withGoal).toMatch(/if essential context is missing, ask exactly one specific question/i);
-    expect(withGoal.match(/Canonical opening strategy:/g)).toHaveLength(1);
-
-    // Skip (empty goals): the opener must NOT claim a primary goal — that would
-    // contradict the "follow their lead / do not assume a goal" guidance above.
-    const skipped = buildTeammateBootstrapPrompt({ displayName: 'Board Bot', goals: [] });
-    expect(skipped).not.toContain('take the primary goal above');
-    expect(skipped).toMatch(/do not assume a goal/i);
-    expect(skipped).toMatch(/ask exactly one specific question/i);
-
-    // Non-onboarding teammate (no goals block at all): no primary goal exists,
-    // so the opener must not reference "the primary goal above".
-    const nonOnboarding = buildTeammateBootstrapPrompt({ displayName: 'Board Bot' });
-    expect(nonOnboarding).not.toContain('take the primary goal above');
-    expect(nonOnboarding).toMatch(/do not assume a goal/i);
-
-    // All-unknown goal ids resolve to nothing → treated like a skip, no primary goal.
+  it('does not claim a primary goal when goals resolve to nothing', () => {
+    // All-unknown ids resolve to nothing → treated like a skip.
     const unknown = buildTeammateBootstrapPrompt({ displayName: 'Board Bot', goals: ['nope'] });
-    expect(unknown).not.toContain('take the primary goal above');
-    expect(unknown).toMatch(/do not assume a goal/i);
+    expect(unknown).toMatch(/ask exactly one specific question about what/i);
+    expect(unknown).not.toMatch(/Open as yourself: one warm line/);
+
+    // Non-onboarding teammate (no goals block at all): same fallback opener.
+    const nonOnboarding = buildTeammateBootstrapPrompt({ displayName: 'Board Bot' });
+    expect(nonOnboarding).toMatch(/ask exactly one specific question about what/i);
+    expect(nonOnboarding).not.toMatch(/Open as yourself: one warm line/);
   });
 });

--- a/apps/agor-ui/src/utils/teammateBootstrapPrompt.ts
+++ b/apps/agor-ui/src/utils/teammateBootstrapPrompt.ts
@@ -25,11 +25,6 @@ export interface TeammateBootstrapPromptInput {
   templateId?: string | null;
   /** Goal-tailored tools/connections with their real Agor setup surface. */
   suggestedIntegrations?: OnboardingIntegrationRecommendation[] | null;
-  /**
-   * Whether the acting user can connect MCP servers themselves (admin+). Drives
-   * whether the opener offers to set a connection up, or defers to an admin.
-   */
-  canManageIntegrations?: boolean | null;
 }
 
 export interface TeammateBootstrapPromptContext {
@@ -48,8 +43,6 @@ export interface TeammateBootstrapPromptContext {
   /** Chosen template's title; present only when a real (non-blank) template resolved. */
   templateTitle?: string;
   suggestedIntegrations?: OnboardingIntegrationRecommendation[];
-  /** True when the acting user can connect MCP servers themselves. */
-  canManageIntegrations?: boolean;
   firstSession: true;
 }
 
@@ -108,11 +101,8 @@ function formatTeammateBootstrapPrompt(context: TeammateBootstrapPromptContext):
     'Your first message sets the working relationship. Make it personal and easy to scan: a short intro, then the value, then one real step. No wall of text, and no generic "what do you want to do?" interview.'
   );
 
-  // A picked goal OR a template persona is enough to open personally; only the
-  // no-goal, no-template case falls back to the single-question opener.
-  const personalOpen = context.hasPrimaryGoal || Boolean(context.templateTitle);
   const userName = context.user?.name;
-  if (personalOpen) {
+  if (context.hasPrimaryGoal) {
     const helpTarget = userName ?? 'them';
     lines.push(
       `- Open as yourself: one warm line, in your persona's voice, naming who you are and that you're set up to help ${helpTarget} with what they picked (see "What the user wants" above). If your template persona and the user's goal diverge, lead with the user's goal.`
@@ -124,6 +114,18 @@ function formatTeammateBootstrapPrompt(context: TeammateBootstrapPromptContext):
       '- Then act: take one concrete first-win step now and show the result. If one essential fact blocks you, make one specific offer or ask one specific question, never a generic one.'
     );
     lines.push('- End with a single clear next step.');
+  } else if (context.templateTitle) {
+    const helpTarget = userName ?? 'them';
+    lines.push(
+      `- Open as yourself: one warm line, in your persona's voice, naming who you are and that you're set up as a ${context.templateTitle} to help ${helpTarget}. Ground the opening in the template's remit; do not claim the user chose a goal.`
+    );
+    lines.push(
+      "- Then 2-3 short bullets on how you'll help within that remit: concrete capabilities, not a catalog."
+    );
+    lines.push(
+      '- Then act: take one concrete first-win step grounded in the template if live context supports it. If one essential fact blocks a useful step, ask one specific question tied to the template remit, never a generic one.'
+    );
+    lines.push('- End with a single clear next step.');
   } else {
     const workingTarget = userName ?? 'the user';
     lines.push(
@@ -133,10 +135,27 @@ function formatTeammateBootstrapPrompt(context: TeammateBootstrapPromptContext):
 
   if (context.suggestedIntegrations?.length) {
     lines.push(
-      context.canManageIntegrations
-        ? "When a connection would unlock the win, say in one plain line what it unlocks, then offer to set it up for them yourself: register and connect it through the MCP tools or a secure credential flow, never asking for a secret in chat. Tell them they can review or disable it anytime under Settings -> MCP. Don't just point at the settings screen, and don't wait to be asked."
-        : "When a connection would unlock the win, name it and what it unlocks, but explain a workspace admin has to connect it. Don't send this user to the admin-only MCP settings screen."
+      'When one of these would unlock the first win, name it, explain what it unlocks, and use only its setup route below. Do not wait to be asked, do not invent an endpoint, and do not treat every connection as MCP:'
     );
+    for (const integration of context.suggestedIntegrations) {
+      switch (integration.setup.surface) {
+        case 'marketplace':
+          lines.push(
+            `- ${integration.name}: use the reviewed Marketplace entry ${integration.setup.catalogEntryName}. Ask the user to connect it there; do not bypass the catalog by registering a guessed endpoint through MCP tools.`
+          );
+          break;
+        case 'mcp-settings':
+          lines.push(
+            `- ${integration.name}: first check whether a configured server is already available. If not, offer to register the official endpoint ${integration.setup.endpoint} through the MCP tools only after the user agrees; use session scope and attach it to this session unless they explicitly ask for workspace-wide setup. Let the service enforce the current user's workspace member policy, and explain any policy refusal instead of assuming only admins can configure MCP. Never ask for a secret in chat; if OAuth requires browser action, send the user to Settings -> MCP Servers for that action. Do not call this a Marketplace entry, and keep gateway channels separate.`
+          );
+          break;
+        case 'connected-repository':
+          lines.push(
+            `- ${integration.name}: use the repository already connected to Agor, or ask which repository to add. Do not describe this as an MCP or Marketplace install.`
+          );
+          break;
+      }
+    }
   }
 
   lines.push(
@@ -155,7 +174,6 @@ export function buildTeammateBootstrapPromptContext({
   goals,
   templateId,
   suggestedIntegrations,
-  canManageIntegrations,
 }: TeammateBootstrapPromptInput): TeammateBootstrapPromptContext {
   const normalizedUserName = userName?.trim();
   const normalizedUserEmail = userEmail?.trim();
@@ -190,7 +208,6 @@ export function buildTeammateBootstrapPromptContext({
     ...(goals?.some((id) => findOnboardingGoal(id)) ? { hasPrimaryGoal: true } : {}),
     ...(templateTitle ? { templateTitle } : {}),
     ...(normalizedIntegrations?.length ? { suggestedIntegrations: normalizedIntegrations } : {}),
-    ...(canManageIntegrations ? { canManageIntegrations: true } : {}),
     firstSession: true,
   };
 }

--- a/apps/agor-ui/src/utils/teammateBootstrapPrompt.ts
+++ b/apps/agor-ui/src/utils/teammateBootstrapPrompt.ts
@@ -3,6 +3,7 @@ import {
   findOnboardingGoal,
   type OnboardingIntegrationRecommendation,
 } from './onboardingGoals';
+import { BLANK_TEMPLATE_ID, getTeammateTemplate } from './teammateTemplates';
 
 export interface TeammateBootstrapPromptInput {
   displayName: string;
@@ -16,8 +17,19 @@ export interface TeammateBootstrapPromptInput {
    * teammates; omit entirely for teammates created outside onboarding.
    */
   goals?: string[] | null;
+  /**
+   * Gallery template id (persona) the teammate was created from, if any. A real
+   * (non-blank) template's title is surfaced as context and switches the opener
+   * to the personal, persona-led path even when no goal was picked.
+   */
+  templateId?: string | null;
   /** Goal-tailored tools/connections with their real Agor setup surface. */
   suggestedIntegrations?: OnboardingIntegrationRecommendation[] | null;
+  /**
+   * Whether the acting user can connect MCP servers themselves (admin+). Drives
+   * whether the opener offers to set a connection up, or defers to an admin.
+   */
+  canManageIntegrations?: boolean | null;
 }
 
 export interface TeammateBootstrapPromptContext {
@@ -33,7 +45,11 @@ export interface TeammateBootstrapPromptContext {
   /** Goal-driven guidance lines; present when goals were supplied. */
   goalGuidance?: string[];
   hasPrimaryGoal?: boolean;
+  /** Chosen template's title; present only when a real (non-blank) template resolved. */
+  templateTitle?: string;
   suggestedIntegrations?: OnboardingIntegrationRecommendation[];
+  /** True when the acting user can connect MCP servers themselves. */
+  canManageIntegrations?: boolean;
   firstSession: true;
 }
 
@@ -54,6 +70,10 @@ function formatTeammateBootstrapPrompt(context: TeammateBootstrapPromptContext):
 
   if (context.teammate.description) {
     lines.push(`- AI teammate description: ${context.teammate.description}`);
+  }
+
+  if (context.templateTitle) {
+    lines.push(`- Created from the ${context.templateTitle} template.`);
   }
 
   if (context.user?.name) {
@@ -83,39 +103,45 @@ function formatTeammateBootstrapPrompt(context: TeammateBootstrapPromptContext):
     'Read ONBOARDING.md if it exists; otherwise, read BOOTSTRAP.md. Then respond to the user using the supplied context and live Agor state.'
   );
   lines.push('');
-  lines.push('Canonical opening strategy:');
+  lines.push('Open the first session well:');
   lines.push(
-    context.hasPrimaryGoal
-      ? '- Start on the primary goal. If live context is sufficient, perform one concrete first-win action now and report the result. If essential context is missing, ask exactly one specific question, then act immediately on the answer. Do not conduct an interview.'
-      : '- Do not assume a goal. Ask exactly one specific question about what the user is working on now, then take the first concrete action their answer enables. Do not conduct an interview.'
+    'Your first message sets the working relationship. Make it personal and easy to scan: a short intro, then the value, then one real step. No wall of text, and no generic "what do you want to do?" interview.'
   );
-  if (context.suggestedIntegrations?.length) {
-    // The route is part of each recommendation because these capabilities do
-    // not all live in Marketplace. Never invent a catalog install for a custom
-    // MCP endpoint or for Agor's native repository support.
+
+  // A picked goal OR a template persona is enough to open personally; only the
+  // no-goal, no-template case falls back to the single-question opener.
+  const personalOpen = context.hasPrimaryGoal || Boolean(context.templateTitle);
+  const userName = context.user?.name;
+  if (personalOpen) {
+    const helpTarget = userName ?? 'them';
     lines.push(
-      'When one of these would unlock the first win, name it, explain what it unlocks, and use only its setup route below. Do not wait to be asked:'
+      `- Open as yourself: one warm line, in your persona's voice, naming who you are and that you're set up to help ${helpTarget} with what they picked (see "What the user wants" above). If your template persona and the user's goal diverge, lead with the user's goal.`
     );
-    for (const integration of context.suggestedIntegrations) {
-      switch (integration.setup.surface) {
-        case 'marketplace':
-          lines.push(
-            `- ${integration.name}: direct the user to Marketplace. If workspace policy prevents them from connecting it, explain that an admin must change the MCP member policy or install it.`
-          );
-          break;
-        case 'mcp-settings':
-          lines.push(
-            `- ${integration.name}: direct the user to Settings → MCP Servers and use the official endpoint ${integration.setup.endpoint}. Do not call this a Marketplace entry; gateway channels are a separate prompt/notification surface.`
-          );
-          break;
-        case 'connected-repository':
-          lines.push(
-            `- ${integration.name}: use the repository already connected to Agor, or ask which repository to add. Do not describe this as an MCP or Marketplace install.`
-          );
-          break;
-      }
-    }
+    lines.push(
+      "- Then 2-3 short bullets on how you'll help, specific to that goal: concrete capabilities, not a catalog."
+    );
+    lines.push(
+      '- Then act: take one concrete first-win step now and show the result. If one essential fact blocks you, make one specific offer or ask one specific question, never a generic one.'
+    );
+    lines.push('- End with a single clear next step.');
+  } else {
+    const workingTarget = userName ?? 'the user';
+    lines.push(
+      `- Open as yourself in one line, then ask exactly one specific question about what ${workingTarget} is working on right now, and act on the answer immediately. Do not interview.`
+    );
   }
+
+  if (context.suggestedIntegrations?.length) {
+    lines.push(
+      context.canManageIntegrations
+        ? "When a connection would unlock the win, say in one plain line what it unlocks, then offer to set it up for them yourself: register and connect it through the MCP tools or a secure credential flow, never asking for a secret in chat. Tell them they can review or disable it anytime under Settings -> MCP. Don't just point at the settings screen, and don't wait to be asked."
+        : "When a connection would unlock the win, name it and what it unlocks, but explain a workspace admin has to connect it. Don't send this user to the admin-only MCP settings screen."
+    );
+  }
+
+  lines.push(
+    'When a relevant doc exists (check Agor Knowledge, or a "Further reading" pointer in your ONBOARDING.md), link the single most relevant one instead of pasting a how-to.'
+  );
 
   return lines.join('\n');
 }
@@ -127,13 +153,20 @@ export function buildTeammateBootstrapPromptContext({
   userName,
   userEmail,
   goals,
+  templateId,
   suggestedIntegrations,
+  canManageIntegrations,
 }: TeammateBootstrapPromptInput): TeammateBootstrapPromptContext {
   const normalizedUserName = userName?.trim();
   const normalizedUserEmail = userEmail?.trim();
   const normalizedIntegrations = suggestedIntegrations?.filter(
     (integration) => integration.name.trim().length > 0
   );
+  // The blank starter is "no template" — never surface it as a persona.
+  const templateTitle =
+    templateId && templateId !== BLANK_TEMPLATE_ID
+      ? getTeammateTemplate(templateId)?.title
+      : undefined;
 
   return {
     teammate: {
@@ -155,7 +188,9 @@ export function buildTeammateBootstrapPromptContext({
     // Only lead with the primary-goal opener when a goal actually resolves — an
     // empty (skip) or all-unknown goals array has no primary goal to act on.
     ...(goals?.some((id) => findOnboardingGoal(id)) ? { hasPrimaryGoal: true } : {}),
+    ...(templateTitle ? { templateTitle } : {}),
     ...(normalizedIntegrations?.length ? { suggestedIntegrations: normalizedIntegrations } : {}),
+    ...(canManageIntegrations ? { canManageIntegrations: true } : {}),
     firstSession: true,
   };
 }

--- a/apps/agor-ui/src/utils/teammateTemplates.test.ts
+++ b/apps/agor-ui/src/utils/teammateTemplates.test.ts
@@ -7,6 +7,7 @@ import {
   getCategoryColor,
   getTeammateTemplate,
   getTemplateBySourceBranch,
+  getTemplateForFrameworkSource,
   recommendedTemplateIds,
   resolveTemplateSourceBranch,
   TEAMMATE_GALLERY_CARDS,
@@ -158,6 +159,33 @@ describe('getTemplateBySourceBranch', () => {
 
   it('returns undefined for an unrecognized branch', () => {
     expect(getTemplateBySourceBranch('feature/whatever')).toBeUndefined();
+  });
+});
+
+describe('getTemplateForFrameworkSource', () => {
+  it('recovers a template only for the detected framework repository', () => {
+    expect(
+      getTemplateForFrameworkSource({
+        sourceBranch: 'template/legal-analyst',
+        selectedRepoId: 'repo-framework',
+        frameworkRepoId: 'repo-framework',
+      })?.id
+    ).toBe('legal-analyst');
+
+    expect(
+      getTemplateForFrameworkSource({
+        sourceBranch: 'template/legal-analyst',
+        selectedRepoId: 'repo-unrelated',
+        frameworkRepoId: 'repo-framework',
+      })
+    ).toBeUndefined();
+    expect(
+      getTemplateForFrameworkSource({
+        sourceBranch: 'template/legal-analyst',
+        selectedRepoId: 'repo-framework',
+        frameworkRepoId: undefined,
+      })
+    ).toBeUndefined();
   });
 });
 

--- a/apps/agor-ui/src/utils/teammateTemplates.test.ts
+++ b/apps/agor-ui/src/utils/teammateTemplates.test.ts
@@ -6,6 +6,7 @@ import {
   galleryCardsForFilter,
   getCategoryColor,
   getTeammateTemplate,
+  getTemplateBySourceBranch,
   recommendedTemplateIds,
   resolveTemplateSourceBranch,
   TEAMMATE_GALLERY_CARDS,
@@ -133,6 +134,30 @@ describe('resolveTemplateSourceBranch', () => {
     expect(resolveTemplateSourceBranch(BLANK_TEMPLATE_ID)).toBeUndefined();
     expect(resolveTemplateSourceBranch(null)).toBeUndefined();
     expect(() => resolveTemplateSourceBranch('nope')).toThrow('Unknown teammate template id: nope');
+  });
+});
+
+describe('getTemplateBySourceBranch', () => {
+  it('recovers the template from its contract source branch', () => {
+    expect(getTemplateBySourceBranch('template/legal-analyst')?.id).toBe('legal-analyst');
+    expect(getTemplateBySourceBranch('template/deal-desk-revops-analyst')?.id).toBe('deal-desk');
+    // Round-trips with resolveTemplateSourceBranch for every real template.
+    for (const template of TEAMMATE_TEMPLATES) {
+      expect(getTemplateBySourceBranch(template.sourceBranch)?.id).toBe(template.id);
+    }
+  });
+
+  it('treats blank/main and empty input as "no template"', () => {
+    expect(getTemplateBySourceBranch(BLANK_TEMPLATE.sourceBranch)).toBeUndefined(); // 'main'
+    expect(getTemplateBySourceBranch('main')).toBeUndefined();
+    expect(getTemplateBySourceBranch('  ')).toBeUndefined();
+    expect(getTemplateBySourceBranch('')).toBeUndefined();
+    expect(getTemplateBySourceBranch(null)).toBeUndefined();
+    expect(getTemplateBySourceBranch(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for an unrecognized branch', () => {
+    expect(getTemplateBySourceBranch('feature/whatever')).toBeUndefined();
   });
 });
 

--- a/apps/agor-ui/src/utils/teammateTemplates.ts
+++ b/apps/agor-ui/src/utils/teammateTemplates.ts
@@ -221,6 +221,24 @@ export function getTemplateBySourceBranch(
 }
 
 /**
+ * Recover a template only when a manual teammate was cut from the detected
+ * framework repository. Source-branch names are not globally meaningful: an
+ * unrelated repository may legitimately have the same branch name.
+ */
+export function getTemplateForFrameworkSource({
+  sourceBranch,
+  selectedRepoId,
+  frameworkRepoId,
+}: {
+  sourceBranch?: string | null;
+  selectedRepoId?: string | null;
+  frameworkRepoId?: string | null;
+}): TeammateTemplate | undefined {
+  if (!selectedRepoId || selectedRepoId !== frameworkRepoId) return undefined;
+  return getTemplateBySourceBranch(sourceBranch);
+}
+
+/**
  * Authoritative goal → recommended template mapping, in priority order. Goal
  * ids come from ONBOARDING_GOALS (onboardingGoals.ts). A goal that maps to no
  * template lists []. This is the single source of truth for recommendations.

--- a/apps/agor-ui/src/utils/teammateTemplates.ts
+++ b/apps/agor-ui/src/utils/teammateTemplates.ts
@@ -205,6 +205,22 @@ export function resolveTemplateSourceBranch(id?: string | null): string | undefi
 }
 
 /**
+ * The template a teammate was cut from, matched by its `sourceBranch`.
+ *
+ * Inverse of `resolveTemplateSourceBranch`: given the branch a teammate now
+ * lives on, recover the template (and its persona) it came from. A blank or
+ * `main` source branch is the framework repo default, not a real template, so
+ * it resolves to undefined. Pure and side-effect-free.
+ */
+export function getTemplateBySourceBranch(
+  sourceBranch?: string | null
+): TeammateTemplate | undefined {
+  const branch = sourceBranch?.trim();
+  if (!branch || branch === BLANK_TEMPLATE.sourceBranch) return undefined;
+  return TEAMMATE_TEMPLATES.find((template) => template.sourceBranch === branch);
+}
+
+/**
  * Authoritative goal → recommended template mapping, in priority order. Goal
  * ids come from ONBOARDING_GOALS (onboardingGoals.ts). A goal that maps to no
  * template lists []. This is the single source of truth for recommendations.


### PR DESCRIPTION
## What

The teammate **first-session prompt** now opens personally instead of running a generic *"what do you want to do?"* interview. Concretely, the first message:

- **Opens personally** — a short intro in the teammate's persona voice, the value specific to the user's goal, then one real first step. No wall of text.
- **Adopts the chosen template's persona** — the selected gallery template's title is surfaced in the prompt Context (`- Created from the <Title> template.`) and switches the opener to the warm, persona-led path *even when no goal was picked*.
- **Proposes MCP connections with agency** — for admins, the teammate offers to set a connection up itself (through MCP tools or a secure credential flow, never asking for a secret in chat) instead of pointing at Settings; non-admins are told an admin has to connect it, without being sent to the admin-only screen.
- **Adds a docs hook** — links the single most relevant doc (Agor Knowledge or an `ONBOARDING.md` "Further reading" pointer) rather than pasting a how-to.

## Why

A first message that leads with the user's goal and takes a concrete first-win step builds a working relationship immediately; a generic interview does not. The selected template already carries a persona — this threads it into the opener so the teammate sounds like what the user picked.

## Changes

- `teammateBootstrapPrompt.ts` — add `templateId` + `canManageIntegrations` inputs; replace the thin "Canonical opening strategy" with the "Open the first session well" block (personal vs single-question fallback); admin/non-admin MCP line; always-on docs hook.
- `teammateTemplates.ts` — add pure `getTemplateBySourceBranch` (blank/`main` → `undefined`).
- Thread the selected template (and MCP agency) end-to-end through the onboarding seed path (`seedOnboardingTeammate` / `App.tsx`) and the non-onboarding create path (`components/App/App.tsx`, recovering the persona from the source branch). The wizard already carried `templateId` through `onComplete`.

<img width="1600" height="5392" alt="c224f0a4-0178-4a22-89ac-da6bb2061d2f" src="https://github.com/user-attachments/assets/32cc26c8-0f4e-4cd0-b795-f4ceedaacbc4" />


## Tests / checks

- `pnpm --filter agor-ui vitest run` on touched files — **49 passing** (bootstrap prompt, templates, seed).
- `pnpm --filter agor-ui typecheck` — clean.
- Biome — clean.

Follows up #2461 (onboarding gallery + 4-step wizard reflow), which shipped without this first-session-prompt improvement.