### PR TITLE
fix(config): validate the executor response protocol/origin pairing after env projection, not on raw YAML

### DIFF
--- a/packages/core/src/config/config-manager.test.ts
+++ b/packages/core/src/config/config-manager.test.ts
@@ -11,6 +11,7 @@ import {
   __resetConfigCacheForTests,
   AtomicConfigPublicationUnsupportedError,
   assertValidEffectiveExecutionConfig,
+  assertValidRawConfig,
   ConfigAlreadyExistsError,
   createInitialConfig,
   ensureBranchCloneDepthAllowed,
@@ -329,6 +330,40 @@ describe('assertValidEffectiveExecutionConfig', () => {
         },
       })
     ).not.toThrow();
+  });
+
+  it('boots the shared-yaml/per-replica-env executor response split', () => {
+    // Regression: one config.yaml declares external_protocol for every
+    // replica while the exact origin arrives only via
+    // AGOR_EXECUTOR_RESPONSE_ORIGIN_URL (Kubernetes downward-API Pod IP). The
+    // raw validation must accept it, and after environment projection the
+    // effective config must pass with the env-supplied origin.
+    const rawYamlForm: AgorConfig = {
+      execution: {
+        executor_command_template: 'launcher -- {command}',
+        executor_response: { external_protocol: 'executor-response-v1' },
+      },
+    };
+    expect(() => assertValidRawConfig(rawYamlForm)).not.toThrow();
+
+    const resolved = resolveEffectiveConfig(rawYamlForm, {
+      AGOR_EXECUTOR_RESPONSE_ORIGIN_URL: 'http://10.35.69.131:3030',
+    });
+    expect(resolved.execution?.executor_response?.origin_url).toBe('http://10.35.69.131:3030');
+    expect(() => assertValidEffectiveExecutionConfig(resolved)).not.toThrow();
+  });
+
+  it('still requires an origin for the declared protocol on the effective config', () => {
+    // Without an origin from YAML or environment, the declared protocol is
+    // unusable; the effective-config gate keeps the raw parser's former
+    // guarantee, one projection step later.
+    expect(() =>
+      assertValidEffectiveExecutionConfig({
+        execution: {
+          executor_response: { external_protocol: 'executor-response-v1' },
+        },
+      })
+    ).toThrow(/external_protocol requires an exact origin_url/);
   });
 
   it('rejects sandboxing combined with an external executor template', () => {

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -1526,6 +1526,18 @@ export function assertValidEffectiveExecutionConfig(config: AgorConfig): void {
 
   const response = resolveExecutorResponseConfig(execution.executor_response);
 
+  // Enforced here, NOT in the raw config.yaml parse: one shared config.yaml
+  // legitimately declares the protocol while each replica's exact origin
+  // arrives via AGOR_EXECUTOR_RESPONSE_ORIGIN_URL, so the pairing is only
+  // decidable after environment projection.
+  if (response.externalProtocol && !response.originUrl) {
+    throw new Error(
+      'execution.executor_response.external_protocol requires an exact origin_url: set ' +
+        'execution.executor_response.origin_url or the AGOR_EXECUTOR_RESPONSE_ORIGIN_URL ' +
+        'environment variable for this daemon replica.'
+    );
+  }
+
   if (execution.unix_user_mode === 'delegated' && !execution.executor_command_template) {
     throw new Error(
       "execution.unix_user_mode 'delegated' requires execution.executor_command_template so execution is actually delegated to an external substrate."

--- a/packages/core/src/config/executor-response.test.ts
+++ b/packages/core/src/config/executor-response.test.ts
@@ -54,9 +54,22 @@ describe('executor response config', () => {
     [{ origin_url: 'redis://internal' }, /http/i],
     [{ origin_url: 'https://user:secret@internal' }, /credentials/i],
     [{ origin_url: 'https://internal/path' }, /without a path/i],
-    [{ external_protocol: 'executor-response-v1' }, /requires.*origin_url/i],
   ] as const)('rejects unsafe config %#', (input, pattern) => {
     expect(() => resolveExecutorResponseConfig(input)).toThrow(pattern);
+  });
+
+  it('accepts a protocol declaration without an origin (raw config.yaml form)', () => {
+    // One shared config.yaml declares the protocol; each replica's exact
+    // origin arrives via AGOR_EXECUTOR_RESPONSE_ORIGIN_URL. The pairing is
+    // enforced post-projection by assertValidEffectiveExecutionConfig, so the
+    // parser itself must not reject the env-completed deployment form.
+    expect(resolveExecutorResponseConfig({ external_protocol: 'executor-response-v1' })).toEqual({
+      maxResponseBytes: EXECUTOR_RESPONSE_DEFAULT_MAX_BYTES,
+      maxActiveRequests: EXECUTOR_RESPONSE_DEFAULT_MAX_ACTIVE,
+      defaultTimeoutMs: EXECUTOR_RESPONSE_DEFAULT_TIMEOUT_MS,
+      timeoutByCommand: {},
+      externalProtocol: 'executor-response-v1',
+    });
   });
 
   it('uses command override, call-specific default, then global default', () => {

--- a/packages/core/src/config/executor-response.ts
+++ b/packages/core/src/config/executor-response.ts
@@ -85,10 +85,13 @@ export function resolveExecutorResponseConfig(
       `execution.executor_response.external_protocol must be '${EXECUTOR_RESPONSE_PROTOCOL}'`
     );
   }
+  // Deliberately no external_protocol/origin_url pairing check here: this
+  // parser also validates raw config.yaml, where a deployment may declare the
+  // protocol while the replica-exact origin arrives only later via
+  // AGOR_EXECUTOR_RESPONSE_ORIGIN_URL (one shared config.yaml, per-Pod env).
+  // The pairing is enforced on the effective config by
+  // assertValidEffectiveExecutionConfig, after environment projection.
   const originUrl = normalizeOrigin(raw?.origin_url);
-  if (raw?.external_protocol && !originUrl) {
-    throw new Error('execution.executor_response.external_protocol requires an exact origin_url');
-  }
   return {
     maxResponseBytes: resolveSafeIntegerInRange(raw?.max_response_bytes, {
       defaultValue: EXECUTOR_RESPONSE_DEFAULT_MAX_BYTES,


### PR DESCRIPTION
## Problem

The deployment topology #2494 itself was built for — `external_protocol` declared once in a shared `config.yaml`, each replica's exact `origin_url` injected via `AGOR_EXECUTOR_RESPONSE_ORIGIN_URL` (Kubernetes downward-API Pod IP, wired by agor-cloud #382) — **cannot boot on current main**.

`parseAndValidateConfig` → `validateConfig` runs on the **raw YAML**, and its call to `resolveExecutorResponseConfig` (config-manager.ts:819) throws `execution.executor_response.external_protocol requires an exact origin_url` (executor-response.ts:90) — **before** `resolveEffectiveConfig` ever merges the env-supplied origin (config-manager.ts:~1443). The env override that #2494 added is unreachable behind #2494's own validation.

Observed live on the agor-cloud sandbox Cell: the pod carries `POD_IP` + `AGOR_EXECUTOR_RESPONSE_ORIGIN_URL=http://$(POD_IP):3030` exactly as the chart renders them, and the daemon still crashes at startup with that error. Every daemon image built from main after `accfe50cd` CrashLoops under a template-enabled Cell render.

## Fix

Move the protocol⇒origin pairing requirement from the raw parser to `assertValidEffectiveExecutionConfig` — the function documented (and called, `apps/agor-daemon/src/index.ts:202`) to run on the **resolved effective config**, where environment-derived settings are visible.

- `resolveExecutorResponseConfig` keeps every check that is decidable pre-projection: protocol value, origin syntax/shape when present, timeout/limit bounds. Only the pairing throw moves.
- `assertValidEffectiveExecutionConfig` now enforces the pairing **unconditionally** (not just when `executor_command_template` is set), so the raw parser's former guarantee is preserved one projection step later — a declared protocol with no origin from YAML *or* env still refuses to boot, with a message that names both sources.

Nothing downstream loses protection: the `executor_command_template` check still requires protocol + origin, and `spawn-executor.ts` keeps its own runtime guard (`externalProtocol !== EXECUTOR_RESPONSE_PROTOCOL || !originUrl`).

## Tests

- New end-to-end regression: raw config with template + protocol and **no** origin passes `assertValidRawConfig`, then `resolveEffectiveConfig` with `AGOR_EXECUTOR_RESPONSE_ORIGIN_URL` merges the origin and `assertValidEffectiveExecutionConfig` passes — the exact shape that crashed in sandbox.
- New: effective gate still rejects a declared protocol with no origin anywhere.
- New: parser accepts the protocol-only raw form (replacing the removed error-table row that asserted the old throw).
- `packages/core` config suites: 169 passed. `agor-daemon` spawn-executor.configured: 54 passed. `tsc --noEmit` on packages/core produces byte-identical output with and without this change (the `src/git/*` errors are pre-existing).

## Deploy note (agor-cloud)

No agor-cloud changes needed. The already-deployed chart render is correct; once this lands, build images from main and create/apply a new Release. Releases built from main between `accfe50cd` and this fix cannot boot on template-enabled Cells and should not be applied.
