### PR TITLE
fix(onboarding): qualify teammate template source refs

### DIFF
--- a/apps/agor-daemon/src/declarations.ts
+++ b/apps/agor-daemon/src/declarations.ts
@@ -226,6 +226,7 @@ export interface ReposServiceImpl extends Service<Repo, Partial<Repo>, FeathersP
       createBranch?: boolean;
       pullLatest?: boolean;
       sourceBranch?: string;
+      sourceRemoteUrl?: string;
       issue_url?: string;
       pull_request_url?: string;
       boardId: string;

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -3503,6 +3503,8 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           refType?: 'branch' | 'tag';
           pullLatest?: boolean;
           sourceBranch?: string;
+          /** Remote that owns sourceBranch when it differs from the destination repo. */
+          sourceRemoteUrl?: string;
           issue_url?: string;
           pull_request_url?: string;
           boardId: string;

--- a/apps/agor-daemon/src/services/branches.test.ts
+++ b/apps/agor-daemon/src/services/branches.test.ts
@@ -904,6 +904,27 @@ describe('BranchesService environment start async behavior', () => {
 });
 
 describe('BranchesService.patch primary teammate invariants', () => {
+  it('rejects changing the trusted template remote after creation', async () => {
+    const branchId = 'teammate-template-remote' as BranchID;
+    const { service, repository } = createPatchHarness({
+      current: {
+        branch_id: branchId,
+        board_id: 'board-a' as BoardID,
+        base_remote_url: 'https://github.com/preset-io/agor-teammate.git',
+      },
+      updated: {
+        branch_id: branchId,
+        board_id: 'board-a' as BoardID,
+        base_remote_url: 'https://attacker.example/template.git',
+      },
+    });
+
+    await expect(
+      service.patch(branchId, { base_remote_url: 'https://attacker.example/template.git' })
+    ).rejects.toThrow(/immutable/);
+    expect(repository.update).not.toHaveBeenCalled();
+  });
+
   it('clears the old primary and sets the new board primary when a teammate moves boards', async () => {
     const boardA = 'board-a' as BoardID;
     const boardB = 'board-b' as BoardID;

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -70,6 +70,7 @@ import {
   BRANCH_ENVIRONMENT_CLEARABLE_FIELDS,
   getTeammateConfig,
   isTeammate,
+  TEAMMATE_FRAMEWORK_REPO_URL,
 } from '@agor/core/types';
 import { resolveHostIpAddress } from '@agor/core/utils/host-ip';
 import { isAllowedHealthCheckUrl } from '@agor/core/utils/url';
@@ -673,6 +674,14 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
    */
   private async applyBranchCreateDefaults(data: Partial<Branch>): Promise<Partial<Branch>> {
     const withDefaults: Partial<Branch> = { ...data };
+    if (
+      withDefaults.base_remote_url !== undefined &&
+      withDefaults.base_remote_url !== TEAMMATE_FRAMEWORK_REPO_URL
+    ) {
+      throw new BadRequest(
+        'base_remote_url is restricted to the canonical Agor teammate template repository.'
+      );
+    }
     const config = this.app.get('config');
     const { defaultMode } = resolveBranchStorageConfig(config);
     const storageMode = withDefaults.storage_mode ?? defaultMode;
@@ -1046,6 +1055,9 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     data: Partial<Branch>,
     params?: BranchParams
   ): Promise<BranchWithZoneAndSessions> {
+    if (Object.hasOwn(data, 'base_remote_url')) {
+      throw new BadRequest('base_remote_url is immutable after branch creation.');
+    }
     // Get current branch to check type/board changes
     const currentBranch = await super.get(id, params);
     await this.assertCanMutateTeammateKnowledgeConfig(currentBranch, data, params);

--- a/apps/agor-daemon/src/services/repos.test.ts
+++ b/apps/agor-daemon/src/services/repos.test.ts
@@ -253,7 +253,7 @@ describe('ReposService.createBranch Git lifecycle execution', () => {
     expect(result).toEqual(failedBranch);
   });
 
-  it('does not attach a delegated user to daemon-owned Git lifecycle work', async () => {
+  it('persists a sanitized cross-repo base without attaching delegated Git work', async () => {
     executorMocks.spawnExecutorFireAndForget.mockClear();
 
     const repo = {
@@ -299,7 +299,8 @@ describe('ReposService.createBranch Git lifecycle execution', () => {
         name: branch.name,
         ref: branch.name,
         createBranch: true,
-        sourceBranch: 'main',
+        sourceBranch: 'template/deal-desk-revops-analyst',
+        sourceRemoteUrl: 'https://token:secret@github.com/preset-io/agor-teammate.git',
         boardId: '550e8400-e29b-41d4-a716-446655440003',
         position: { x: 10, y: 20 },
         storage_mode: 'worktree',
@@ -309,10 +310,53 @@ describe('ReposService.createBranch Git lifecycle execution', () => {
       } as never
     );
 
+    expect(branches.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        base_ref: 'template/deal-desk-revops-analyst',
+        base_remote_url: 'https://github.com/preset-io/agor-teammate.git',
+      }),
+      expect.anything()
+    );
     expect(executorMocks.spawnExecutorFireAndForget).toHaveBeenCalledWith(
       expect.objectContaining({ command: 'git.branch.add' }),
       expect.not.objectContaining({ delegatedHomeKey: expect.anything() })
     );
+  });
+
+  it('rejects a client-selected template remote before persisting a branch', async () => {
+    executorMocks.spawnExecutorFireAndForget.mockClear();
+    const branches = { create: vi.fn(), find: vi.fn(async () => []) };
+    const app = {
+      get: () => ({}),
+      service: vi.fn((name: string) => {
+        if (name === 'branches') return branches;
+        throw new Error(`Unexpected service: ${name}`);
+      }),
+    } as unknown as Application;
+    const service = new ReposService({} as never, app);
+    vi.spyOn(service, 'get').mockResolvedValue({
+      repo_id: '550e8400-e29b-41d4-a716-446655440001',
+      slug: 'preset-io/agor-teammate-private',
+      local_path: '/managed/repos/agor-teammate-private',
+      default_branch: 'main',
+    } as never);
+
+    await expect(
+      service.createBranch(
+        '550e8400-e29b-41d4-a716-446655440001',
+        {
+          name: 'forged-template-source',
+          ref: 'forged-template-source',
+          createBranch: true,
+          sourceBranch: 'template/deal-desk-revops-analyst',
+          sourceRemoteUrl: 'https://attacker.example/template.git',
+          boardId: '550e8400-e29b-41d4-a716-446655440003',
+        },
+        { user: { user_id: '550e8400-e29b-41d4-a716-446655440004' } } as never
+      )
+    ).rejects.toThrow(/canonical Agor teammate template repository/);
+    expect(branches.create).not.toHaveBeenCalled();
+    expect(executorMocks.spawnExecutorFireAndForget).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -46,7 +46,7 @@ import type {
   UserID,
   UUID,
 } from '@agor/core/types';
-import { hasMinimumRole, ROLES } from '@agor/core/types';
+import { hasMinimumRole, ROLES, TEAMMATE_FRAMEWORK_REPO_URL } from '@agor/core/types';
 import { DrizzleService } from '../adapters/drizzle';
 import type { BranchesServiceImpl } from '../declarations.js';
 import { emitHaNativeSocketEvent, tenantChannelName } from '../realtime/routing.js';
@@ -613,6 +613,8 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
       createBranch?: boolean;
       pullLatest?: boolean;
       sourceBranch?: string;
+      /** Remote that owns sourceBranch when it differs from the destination repo. */
+      sourceRemoteUrl?: string;
       issue_url?: string;
       pull_request_url?: string;
       boardId: string;
@@ -642,6 +644,28 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
     }
 
     const repo = await this.get(id, params);
+
+    let baseRemoteUrl: string | undefined;
+    if (data.sourceRemoteUrl) {
+      if (!data.createBranch || !data.sourceBranch) {
+        throw new BadRequest(
+          'sourceRemoteUrl requires createBranch=true and a sourceBranch to qualify.'
+        );
+      }
+      baseRemoteUrl = stripGitUrlCredentials(data.sourceRemoteUrl);
+      if (!isValidGitUrl(baseRemoteUrl)) {
+        throw new BadRequest(`Invalid sourceRemoteUrl: ${redactGitUrlCredentials(baseRemoteUrl)}`);
+      }
+      if (baseRemoteUrl !== TEAMMATE_FRAMEWORK_REPO_URL) {
+        throw new BadRequest(
+          'sourceRemoteUrl must identify the canonical Agor teammate template repository.'
+        );
+      }
+      // Persist the server-owned constant rather than a client spelling of it.
+      // The executor may attach the caller's Git credential to this host, so
+      // this must never become an arbitrary client-selected outbound target.
+      baseRemoteUrl = TEAMMATE_FRAMEWORK_REPO_URL;
+    }
 
     console.log('🔍 RepoService.createBranch - repo lookup result:', {
       repo_id: repo.repo_id,
@@ -786,6 +810,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
         ref: data.ref,
         ref_type: data.refType,
         base_ref: data.sourceBranch,
+        base_remote_url: baseRemoteUrl,
         new_branch: data.createBranch ?? false,
         branch_unique_id: branchUniqueId,
         filesystem_status: 'creating', // Will be set to 'ready' by executor

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -894,6 +894,7 @@ function AppContent() {
       teammateName: result.teammateName,
       teammateEmoji: result.teammateEmoji,
       sourceBranch: result.sourceBranch,
+      sourceRemoteUrl: result.sourceRemoteUrl,
       agent: result.agent,
       suggestedIntegrations: result.suggestedIntegrations,
       // Goals drive the first-session prompt; [] (skipped) yields the generic
@@ -1599,6 +1600,7 @@ function AppContent() {
       refType?: 'branch' | 'tag';
       createBranch: boolean;
       sourceBranch: string;
+      sourceRemoteUrl?: string;
       pullLatest: boolean;
       issue_url?: string;
       pull_request_url?: string;
@@ -1621,6 +1623,7 @@ function AppContent() {
         createBranch: data.createBranch,
         pullLatest: data.pullLatest, // Fetch latest from remote before creating
         sourceBranch: data.sourceBranch, // Base new branch on specified source branch
+        sourceRemoteUrl: data.sourceRemoteUrl, // Qualify a cross-repository base ref
         issue_url: data.issue_url,
         pull_request_url: data.pull_request_url,
         boardId: data.boardId, // Optional: add to board

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -207,6 +207,7 @@ export interface AppProps {
       refType?: 'branch' | 'tag';
       createBranch: boolean;
       sourceBranch: string;
+      sourceRemoteUrl?: string;
       pullLatest: boolean;
       issue_url?: string;
       pull_request_url?: string;

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -751,6 +751,7 @@ describe('OnboardingWizard', () => {
           teammateName: 'Rusty',
           teammateEmoji: '⚖️',
           sourceBranch: 'template/legal-analyst',
+          sourceRemoteUrl: 'https://github.com/preset-io/agor-teammate.git',
           templateId: 'legal-analyst',
         })
       )
@@ -844,6 +845,7 @@ describe('OnboardingWizard', () => {
         teammateName: 'Rusty',
         teammateEmoji: '🤖',
         sourceBranch: undefined,
+        sourceRemoteUrl: undefined,
         templateId: null,
         agent: 'claude-code',
         // Goals were skipped → the default MCP suggestion set flows through, and
@@ -951,6 +953,7 @@ describe('OnboardingWizard', () => {
         teammateName: undefined,
         teammateEmoji: '🤖',
         sourceBranch: undefined,
+        sourceRemoteUrl: undefined,
         templateId: null,
         agent: null,
         suggestedIntegrations: mergeGoalIntegrationRecs([]),
@@ -1031,6 +1034,7 @@ describe('OnboardingWizard', () => {
         teammateName: 'Rusty',
         templateId: 'legal-analyst',
         sourceBranch: 'template/legal-analyst',
+        sourceRemoteUrl: 'https://github.com/preset-io/agor-teammate.git',
       })
     );
   });
@@ -1084,6 +1088,7 @@ describe('OnboardingWizard', () => {
         boardId: 'board-resume',
         templateId: 'blank',
         sourceBranch: undefined,
+        sourceRemoteUrl: undefined,
       })
     );
   });

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -39,6 +39,7 @@ import {
   BLANK_TEMPLATE_ID,
   getTeammateTemplate,
   resolveTemplateSourceBranch,
+  resolveTemplateSourceRemoteUrl,
   type TeammateGalleryCardId,
 } from '../../utils/teammateTemplates';
 import { type CodexAuthFallback, CodexDeviceSignIn, CodexImportAuthJson } from '../CodexAuth';
@@ -344,6 +345,8 @@ export interface OnboardingCompletionResult {
   teammateEmoji?: string;
   /** Framework source branch from the chosen template; undefined = repo default. */
   sourceBranch?: string;
+  /** Remote that owns sourceBranch; the teammate's destination repo remains unchanged. */
+  sourceRemoteUrl?: string;
   /** Chosen gallery template id (persona); null/undefined = blank starter. */
   templateId?: string | null;
   /** Agent selected in the LLM step, used for the teammate's bootstrap session. */
@@ -987,6 +990,7 @@ export function OnboardingWizard({
             // Framework source branch from the chosen gallery template; undefined
             // (blank / no pick) falls back to the repo default branch.
             sourceBranch: resolveTemplateSourceBranch(selectedTemplateId),
+            sourceRemoteUrl: resolveTemplateSourceRemoteUrl(selectedTemplateId),
             templateId: selectedTemplateId,
             agent: selectedAgent,
             suggestedIntegrations,

--- a/apps/agor-ui/src/hooks/useFrameworkRepo.ts
+++ b/apps/agor-ui/src/hooks/useFrameworkRepo.ts
@@ -1,8 +1,13 @@
-import type { Repo } from '@agor-live/client';
+import {
+  type Repo,
+  TEAMMATE_FRAMEWORK_REPO_SLUG,
+  TEAMMATE_FRAMEWORK_REPO_URL,
+} from '@agor-live/client';
 import { useMemo } from 'react';
 
-export const FRAMEWORK_REPO_SLUG = 'preset-io/agor-teammate';
-export const FRAMEWORK_REPO_URL = 'https://github.com/preset-io/agor-teammate.git';
+/** Back-compatible UI aliases for the domain-owned framework identifiers. */
+export const FRAMEWORK_REPO_SLUG = TEAMMATE_FRAMEWORK_REPO_SLUG;
+export const FRAMEWORK_REPO_URL = TEAMMATE_FRAMEWORK_REPO_URL;
 
 /**
  * Match predicate with priority ordering:

--- a/apps/agor-ui/src/utils/seedOnboardingTeammate.test.ts
+++ b/apps/agor-ui/src/utils/seedOnboardingTeammate.test.ts
@@ -242,11 +242,17 @@ describe('seedOnboardingTeammate', () => {
     } as Branch);
     startTeammateBootstrapSessionMock.mockResolvedValue(completeInitialization);
 
-    const { input } = setup({ sourceBranch: 'template/legal-analyst' });
+    const { input } = setup({
+      sourceBranch: 'template/legal-analyst',
+      sourceRemoteUrl: 'https://github.com/preset-io/agor-teammate.git',
+    });
     await seedOnboardingTeammate(input);
 
     expect(createTeammateBranchMock).toHaveBeenCalledWith(
-      expect.objectContaining({ sourceBranch: 'template/legal-analyst' }),
+      expect.objectContaining({
+        sourceBranch: 'template/legal-analyst',
+        sourceRemoteUrl: 'https://github.com/preset-io/agor-teammate.git',
+      }),
       expect.anything()
     );
   });

--- a/apps/agor-ui/src/utils/seedOnboardingTeammate.ts
+++ b/apps/agor-ui/src/utils/seedOnboardingTeammate.ts
@@ -22,6 +22,8 @@ export interface SeedOnboardingTeammateInput {
    * rather than blocking completion.
    */
   sourceBranch?: string;
+  /** Remote that owns sourceBranch when a built-in template is not on the destination remote. */
+  sourceRemoteUrl?: string;
   /**
    * Agent chosen in the LLM step. `null`/`undefined` means the user skipped that
    * step and has no credentials, so no bootstrap session is started.
@@ -186,6 +188,7 @@ export async function seedOnboardingTeammate(input: SeedOnboardingTeammateInput)
             emoji: input.teammateEmoji,
             repoId: input.frameworkRepo.repo_id,
             sourceBranch: input.sourceBranch,
+            sourceRemoteUrl: input.sourceRemoteUrl,
             boardId: input.boardId,
             createdViaOnboarding: true,
           },

--- a/apps/agor-ui/src/utils/teammateCreation.test.ts
+++ b/apps/agor-ui/src/utils/teammateCreation.test.ts
@@ -96,4 +96,48 @@ describe('createTeammateBranch', () => {
     });
     expect(onUpdateBranch).not.toHaveBeenCalled();
   });
+
+  it('qualifies a template ref with its source remote while keeping the private repo as destination', async () => {
+    const repo = makeRepo({
+      slug: 'preset-io/agor-teammate-private',
+      remote_url: 'https://github.com/preset-io/agor-teammate-private.git',
+    });
+    const branch = makeBranch({ board_id: 'board-1' });
+    const onCreateBranch = vi.fn().mockResolvedValue(branch);
+    const boardsService = {
+      ensureTeammateWelcomeNote: vi.fn().mockResolvedValue({}),
+      setPrimaryTeammate: vi.fn().mockResolvedValue({}),
+    };
+    const client = {
+      service: vi.fn((name: string) => {
+        if (name === 'boards') return boardsService;
+        throw new Error(`Unexpected service: ${name}`);
+      }),
+    };
+
+    await createTeammateBranch(
+      {
+        displayName: 'Deal Desk',
+        repoId: repo.repo_id,
+        boardId: 'board-1',
+        sourceBranch: 'template/deal-desk-revops-analyst',
+        sourceRemoteUrl: 'https://github.com/preset-io/agor-teammate.git',
+        createdViaOnboarding: true,
+      },
+      {
+        client: client as never,
+        repoById: new Map([[repo.repo_id, repo]]),
+        onCreateBranch,
+        onUpdateBranch: vi.fn(),
+      }
+    );
+
+    expect(onCreateBranch).toHaveBeenCalledWith(
+      repo.repo_id,
+      expect.objectContaining({
+        sourceBranch: 'template/deal-desk-revops-analyst',
+        sourceRemoteUrl: 'https://github.com/preset-io/agor-teammate.git',
+      })
+    );
+  });
 });

--- a/apps/agor-ui/src/utils/teammateCreation.ts
+++ b/apps/agor-ui/src/utils/teammateCreation.ts
@@ -9,6 +9,8 @@ export interface TeammateCreationInput {
   repoId: string;
   branchName?: string;
   sourceBranch?: string;
+  /** Remote that owns sourceBranch when it differs from the destination repo. */
+  sourceRemoteUrl?: string;
   /**
    * Reuse an existing board for the teammate instead of creating a new one.
    * The onboarding wizard already creates a board in its workspace step, so it
@@ -30,6 +32,7 @@ export interface TeammateCreationDeps {
       ref: string;
       createBranch: boolean;
       sourceBranch: string;
+      sourceRemoteUrl?: string;
       pullLatest: boolean;
       boardId?: string;
       custom_context?: Record<string, unknown>;
@@ -105,6 +108,7 @@ export async function createTeammateBranch(
     ref: branchName,
     createBranch: true,
     sourceBranch,
+    ...(input.sourceRemoteUrl ? { sourceRemoteUrl: input.sourceRemoteUrl } : {}),
     pullLatest: true,
     boardId,
     custom_context: { teammate: teammateConfig },

--- a/apps/agor-ui/src/utils/teammateTemplates.test.ts
+++ b/apps/agor-ui/src/utils/teammateTemplates.test.ts
@@ -10,6 +10,7 @@ import {
   getTemplateForFrameworkSource,
   recommendedTemplateIds,
   resolveTemplateSourceBranch,
+  resolveTemplateSourceRemoteUrl,
   TEAMMATE_GALLERY_CARDS,
   TEAMMATE_TEMPLATES,
   TEMPLATE_CATEGORIES,
@@ -26,8 +27,17 @@ describe('TEAMMATE_TEMPLATES', () => {
       expect(template.emoji.length).toBeGreaterThan(0);
       // The parallel agor-teammate workstream keys off these exact names.
       expect(template.sourceBranch).toMatch(/^template\//);
+      expect(template.sourceRemoteUrl).toBe('https://github.com/preset-io/agor-teammate.git');
       expect(typeof template.icon).toBe('object');
     }
+  });
+
+  it('qualifies real template refs with their source remote but leaves blank on the destination', () => {
+    expect(resolveTemplateSourceRemoteUrl('deal-desk')).toBe(
+      'https://github.com/preset-io/agor-teammate.git'
+    );
+    expect(resolveTemplateSourceRemoteUrl(BLANK_TEMPLATE_ID)).toBeUndefined();
+    expect(resolveTemplateSourceRemoteUrl()).toBeUndefined();
   });
 
   it('pins the exact source-branch contract names', () => {

--- a/apps/agor-ui/src/utils/teammateTemplates.ts
+++ b/apps/agor-ui/src/utils/teammateTemplates.ts
@@ -1,3 +1,4 @@
+import { TEAMMATE_FRAMEWORK_REPO_URL } from '@agor-live/client';
 import {
   AimOutlined,
   BuildOutlined,
@@ -51,7 +52,11 @@ export interface TeammateTemplate {
   emoji: string;
   /** Branch in the framework repo the teammate is cut from. */
   sourceBranch: string;
+  /** Remote that owns sourceBranch when it differs from the teammate's destination repo. */
+  sourceRemoteUrl?: string;
 }
+
+const BUILT_IN_TEMPLATE_SOURCE = { sourceRemoteUrl: TEAMMATE_FRAMEWORK_REPO_URL } as const;
 
 /**
  * The three category buckets, in display order. Single source of truth for the
@@ -88,6 +93,7 @@ export const TEAMMATE_TEMPLATES = [
     category: 'grow',
     emoji: '🔭',
     sourceBranch: 'template/competitive-analyst',
+    ...BUILT_IN_TEMPLATE_SOURCE,
   },
   {
     id: 'product-manager',
@@ -98,6 +104,7 @@ export const TEAMMATE_TEMPLATES = [
     category: 'build',
     emoji: '🧭',
     sourceBranch: 'template/product-manager',
+    ...BUILT_IN_TEMPLATE_SOURCE,
   },
   {
     id: 'chief-of-staff',
@@ -108,6 +115,7 @@ export const TEAMMATE_TEMPLATES = [
     category: 'operate',
     emoji: '🗂️',
     sourceBranch: 'template/chief-of-staff',
+    ...BUILT_IN_TEMPLATE_SOURCE,
   },
   {
     id: 'financial-analyst',
@@ -118,6 +126,7 @@ export const TEAMMATE_TEMPLATES = [
     category: 'operate',
     emoji: '🧮',
     sourceBranch: 'template/financial-analyst',
+    ...BUILT_IN_TEMPLATE_SOURCE,
   },
   {
     id: 'deal-desk',
@@ -127,6 +136,7 @@ export const TEAMMATE_TEMPLATES = [
     category: 'grow',
     emoji: '📐',
     sourceBranch: 'template/deal-desk-revops-analyst',
+    ...BUILT_IN_TEMPLATE_SOURCE,
   },
   {
     id: 'sales-outbound',
@@ -137,6 +147,7 @@ export const TEAMMATE_TEMPLATES = [
     category: 'grow',
     emoji: '🎯',
     sourceBranch: 'template/sales-outbound-analyst',
+    ...BUILT_IN_TEMPLATE_SOURCE,
   },
   {
     id: 'legal-analyst',
@@ -147,6 +158,7 @@ export const TEAMMATE_TEMPLATES = [
     category: 'operate',
     emoji: '⚖️',
     sourceBranch: 'template/legal-analyst',
+    ...BUILT_IN_TEMPLATE_SOURCE,
   },
   {
     id: 'builder',
@@ -156,6 +168,7 @@ export const TEAMMATE_TEMPLATES = [
     category: 'build',
     emoji: '🛠️',
     sourceBranch: 'template/builder',
+    ...BUILT_IN_TEMPLATE_SOURCE,
   },
 ] as const satisfies readonly TeammateTemplate[];
 
@@ -202,6 +215,16 @@ export function resolveTemplateSourceBranch(id?: string | null): string | undefi
     throw new Error(`Unknown teammate template id: ${id}`);
   }
   return template.sourceBranch;
+}
+
+/** Remote that owns the selected template ref; blank/no selection uses the destination repo. */
+export function resolveTemplateSourceRemoteUrl(id?: string | null): string | undefined {
+  if (!id || id === BLANK_TEMPLATE_ID) return undefined;
+  const template = getTeammateTemplate(id);
+  if (!template) {
+    throw new Error(`Unknown teammate template id: ${id}`);
+  }
+  return 'sourceRemoteUrl' in template ? template.sourceRemoteUrl : undefined;
 }
 
 /**

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -486,6 +486,8 @@ export interface ReposService extends AgorService<Repo> {
       createBranch?: boolean;
       pullLatest?: boolean;
       sourceBranch?: string;
+      /** Remote that owns sourceBranch when it differs from this destination repo. */
+      sourceRemoteUrl?: string;
       issue_url?: string;
       pull_request_url?: string;
       boardId: string;

--- a/packages/core/src/db/repositories/branches.test.ts
+++ b/packages/core/src/db/repositories/branches.test.ts
@@ -49,6 +49,7 @@ function createBranchData(overrides?: {
   board_id?: UUID;
   created_by?: UUID;
   base_ref?: string;
+  base_remote_url?: string;
   base_sha?: string;
   last_commit_sha?: string;
   tracking_branch?: string;
@@ -83,6 +84,7 @@ function createBranchData(overrides?: {
     board_id: overrides?.board_id,
     created_by: overrides?.created_by ?? (generateId() as UUID),
     base_ref: overrides?.base_ref,
+    base_remote_url: overrides?.base_remote_url,
     base_sha: overrides?.base_sha,
     last_commit_sha: overrides?.last_commit_sha,
     tracking_branch: overrides?.tracking_branch,
@@ -188,6 +190,7 @@ describe('BranchRepository.create', () => {
       repo_id: repo.repo_id,
       board_id: boardId,
       base_ref: 'main',
+      base_remote_url: 'https://github.com/example/template-source.git',
       base_sha: 'abc123',
       last_commit_sha: 'def456',
       tracking_branch: 'origin/feature',
@@ -211,6 +214,7 @@ describe('BranchRepository.create', () => {
     expect(created.created_by).toBe(data.created_by);
     expect(created.board_id).toBe(boardId);
     expect(created.base_ref).toBe('main');
+    expect(created.base_remote_url).toBe('https://github.com/example/template-source.git');
     expect(created.base_sha).toBe('abc123');
     expect(created.last_commit_sha).toBe('def456');
     expect(created.tracking_branch).toBe('origin/feature');

--- a/packages/core/src/db/repositories/branches.ts
+++ b/packages/core/src/db/repositories/branches.ts
@@ -217,6 +217,7 @@ export class BranchRepository implements BaseRepository<Branch, Partial<Branch>>
       data: {
         path: branch.path!,
         base_ref: branch.base_ref,
+        base_remote_url: branch.base_remote_url,
         base_sha: branch.base_sha,
         last_commit_sha: branch.last_commit_sha,
         tracking_branch: branch.tracking_branch,

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -816,6 +816,7 @@ export const branches = pgTable(
 
         // Git state (current)
         base_ref?: string; // Branch this diverged from (e.g., "main")
+        base_remote_url?: string; // Optional remote that owns base_ref
         base_sha?: string; // SHA at branch creation
         last_commit_sha?: string; // Latest commit
         tracking_branch?: string; // Remote tracking branch

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -775,6 +775,7 @@ export const branches = sqliteTable(
 
         // Git state (current)
         base_ref?: string; // Branch this diverged from (e.g., "main")
+        base_remote_url?: string; // Optional remote that owns base_ref
         base_sha?: string; // SHA at branch creation
         last_commit_sha?: string; // Latest commit
         tracking_branch?: string; // Remote tracking branch

--- a/packages/core/src/git/index.test.ts
+++ b/packages/core/src/git/index.test.ts
@@ -30,6 +30,7 @@ import {
   listGitWorktrees,
   pruneGitWorktrees,
   removeGitWorktree,
+  restoreBranchFilesystem,
 } from './index';
 
 /**
@@ -76,6 +77,43 @@ async function createBareRepo(dirPath: string): Promise<void> {
   await fs.mkdir(dirPath, { recursive: true });
   const git = simpleGit(dirPath);
   await git.init(['--bare', '--initial-branch=main']);
+}
+
+const DEAL_DESK_TEMPLATE_BRANCH = 'template/deal-desk-revops-analyst';
+const DEAL_DESK_TEMPLATE_TAG = 'deal-desk-v1';
+
+/**
+ * Reproduce the onboarding topology: the destination private remote has only
+ * main while the public template remote owns the selected template branch.
+ */
+async function createSeparatedTemplateRemotes(tempDir: string): Promise<{
+  destinationRemote: string;
+  sourceRemote: string;
+}> {
+  const destinationRemote = path.join(tempDir, 'agor-teammate-private.git');
+  const sourceRemote = path.join(tempDir, 'agor-teammate.git');
+  await createBareRepo(destinationRemote);
+  await createBareRepo(sourceRemote);
+
+  const destinationSeed = path.join(tempDir, 'destination-seed');
+  await createTestRepo(destinationSeed);
+  await simpleGit(destinationSeed).addRemote('origin', destinationRemote);
+  await simpleGit(destinationSeed).push('origin', 'main');
+
+  const sourceSeed = path.join(tempDir, 'template-seed');
+  await createTestRepo(sourceSeed);
+  const sourceGit = simpleGit(sourceSeed);
+  await sourceGit.addRemote('origin', sourceRemote);
+  await sourceGit.push('origin', 'main');
+  await sourceGit.checkoutLocalBranch(DEAL_DESK_TEMPLATE_BRANCH);
+  await fs.writeFile(path.join(sourceSeed, 'ONBOARDING.md'), '# Deal Desk', 'utf-8');
+  await sourceGit.add('ONBOARDING.md');
+  await sourceGit.commit('Add deal desk teammate template');
+  await sourceGit.push('origin', DEAL_DESK_TEMPLATE_BRANCH);
+  await sourceGit.addTag(DEAL_DESK_TEMPLATE_TAG);
+  await sourceGit.push('origin', `refs/tags/${DEAL_DESK_TEMPLATE_TAG}`);
+
+  return { destinationRemote, sourceRemote };
 }
 
 /**
@@ -560,6 +598,99 @@ describe('createBranch', () => {
       .then(() => true)
       .catch(() => false);
     expect(featureFileExists).toBe(true);
+  });
+
+  it('creates a worktree from a template ref missing on the destination remote', async () => {
+    const { destinationRemote, sourceRemote } = await createSeparatedTemplateRemotes(tempDir);
+    await simpleGit().clone(destinationRemote, repoDir);
+
+    // This is the production regression: the preferred private destination
+    // intentionally does not publish public template/* refs.
+    expect(
+      (
+        await simpleGit().listRemote(['--heads', destinationRemote, DEAL_DESK_TEMPLATE_BRANCH])
+      ).trim()
+    ).toBe('');
+
+    await createBranch(
+      repoDir,
+      branchDir,
+      'private-ponc',
+      true,
+      true,
+      DEAL_DESK_TEMPLATE_BRANCH,
+      undefined,
+      'branch',
+      sourceRemote
+    );
+
+    expect(await getCurrentBranch(branchDir)).toBe('private-ponc');
+    expect(await fs.readFile(path.join(branchDir, 'ONBOARDING.md'), 'utf-8')).toBe('# Deal Desk');
+    expect(await getRemoteUrl(repoDir)).toBe(destinationRemote);
+    expect(
+      (
+        await simpleGit(repoDir).raw(['for-each-ref', '--format=%(refname)', 'refs/agor/base'])
+      ).trim()
+    ).toBe('');
+  });
+
+  it('does not leave a temporary source ref when the target path already exists', async () => {
+    const { destinationRemote, sourceRemote } = await createSeparatedTemplateRemotes(tempDir);
+    await simpleGit().clone(destinationRemote, repoDir);
+    await fs.mkdir(branchDir);
+
+    await expect(
+      createBranch(
+        repoDir,
+        branchDir,
+        'private-existing',
+        true,
+        true,
+        DEAL_DESK_TEMPLATE_BRANCH,
+        undefined,
+        'branch',
+        sourceRemote
+      )
+    ).rejects.toThrow(/already exists/);
+
+    expect(
+      (
+        await simpleGit(repoDir).raw(['for-each-ref', '--format=%(refname)', 'refs/agor/base'])
+      ).trim()
+    ).toBe('');
+  });
+
+  it('restores from a cross-repo tag when the destination branch is definitively absent', async () => {
+    const { destinationRemote, sourceRemote } = await createSeparatedTemplateRemotes(tempDir);
+    await simpleGit().clone(destinationRemote, repoDir);
+
+    const result = await restoreBranchFilesystem(
+      repoDir,
+      branchDir,
+      'private-from-tag',
+      DEAL_DESK_TEMPLATE_TAG,
+      undefined,
+      sourceRemote,
+      'tag'
+    );
+
+    expect(result).toEqual({ success: true, strategy: 'create' });
+    expect(await getCurrentBranch(branchDir)).toBe('private-from-tag');
+    expect(await fs.readFile(path.join(branchDir, 'ONBOARDING.md'), 'utf-8')).toBe('# Deal Desk');
+  });
+
+  it('does not treat a destination lookup failure as an absent branch during restore', async () => {
+    await createTestRepo(repoDir);
+    await simpleGit(repoDir).addRemote('origin', path.join(tempDir, 'missing-origin.git'));
+
+    const result = await restoreBranchFilesystem(repoDir, branchDir, 'private-work', 'main');
+
+    expect(result).toMatchObject({
+      success: false,
+      strategy: 'checkout',
+      error: expect.stringContaining("Cannot determine whether branch 'private-work' exists"),
+    });
+    await expect(fs.access(branchDir)).rejects.toThrow();
   });
 
   it('should handle pullLatest parameter', async () => {
@@ -1491,6 +1622,53 @@ describe('createBranchAsClone', () => {
     const cloned = simpleGit(targetPath);
     const remoteBranches = await cloned.branch(['-r']);
     expect(remoteBranches.all).not.toContain('origin/my-new-feature');
+  });
+
+  it('clones a template ref from its source while keeping the private destination as origin', async () => {
+    const { destinationRemote, sourceRemote } = await createSeparatedTemplateRemotes(tempDir);
+    const targetPath = path.join(tempDir, 'private-ponc');
+
+    expect(
+      (
+        await simpleGit().listRemote(['--heads', destinationRemote, DEAL_DESK_TEMPLATE_BRANCH])
+      ).trim()
+    ).toBe('');
+
+    const result = await createBranchAsClone({
+      remoteUrl: sourceRemote,
+      originRemoteUrl: destinationRemote,
+      targetPath,
+      ref: DEAL_DESK_TEMPLATE_BRANCH,
+      newBranchName: 'private-ponc',
+    });
+
+    expect(result).toEqual({ path: targetPath, ref: 'private-ponc' });
+    expect(await fs.readFile(path.join(targetPath, 'ONBOARDING.md'), 'utf-8')).toBe('# Deal Desk');
+    expect(await getRemoteUrl(targetPath)).toBe(destinationRemote);
+    const cloned = simpleGit(targetPath);
+    expect(await cloned.getConfig('remote.origin.fetch')).toMatchObject({
+      value: '+refs/heads/*:refs/remotes/origin/*',
+    });
+    expect((await cloned.branch()).all).not.toContain(DEAL_DESK_TEMPLATE_BRANCH);
+    expect((await cloned.branch(['-r'])).all).not.toContain(`origin/${DEAL_DESK_TEMPLATE_BRANCH}`);
+  });
+
+  it('clones a template tag from its source without trying to delete it as a local branch', async () => {
+    const { destinationRemote, sourceRemote } = await createSeparatedTemplateRemotes(tempDir);
+    const targetPath = path.join(tempDir, 'private-tag-template');
+
+    const result = await createBranchAsClone({
+      remoteUrl: sourceRemote,
+      originRemoteUrl: destinationRemote,
+      targetPath,
+      ref: DEAL_DESK_TEMPLATE_TAG,
+      newBranchName: 'private-from-tag',
+    });
+
+    expect(result).toEqual({ path: targetPath, ref: 'private-from-tag' });
+    expect(await getCurrentBranch(targetPath)).toBe('private-from-tag');
+    expect(await fs.readFile(path.join(targetPath, 'ONBOARDING.md'), 'utf-8')).toBe('# Deal Desk');
+    expect(await getRemoteUrl(targetPath)).toBe(destinationRemote);
   });
 
   it('rejects newBranchName that fails ref validation', async () => {

--- a/packages/core/src/types/branch.ts
+++ b/packages/core/src/types/branch.ts
@@ -163,6 +163,17 @@ export interface Branch {
   base_ref?: string;
 
   /**
+   * Remote that owns {@link base_ref} when the branch was seeded from a
+   * different repository than {@link repo_id}.
+   *
+   * The branch's configured `origin` still comes from `repo_id`; this field
+   * only qualifies the creation base so cross-repository templates can be
+   * materialized and later restored without pretending the ref exists on the
+   * destination remote.
+   */
+  base_remote_url?: string;
+
+  /**
    * SHA at branch creation (base commit)
    *
    * Tracks where this branch started.
@@ -750,6 +761,10 @@ export interface RepoEnvironment {
 export type RepoEnvironmentConfig = RepoEnvironmentConfigV1;
 
 // ===== Teammates =====
+
+/** Public framework repository that owns Agor's built-in teammate templates. */
+export const TEAMMATE_FRAMEWORK_REPO_SLUG = 'preset-io/agor-teammate';
+export const TEAMMATE_FRAMEWORK_REPO_URL = 'https://github.com/preset-io/agor-teammate.git';
 
 export type TeammateKnowledgeGrantAccess = 'none' | 'read' | 'write';
 export interface TeammateKnowledgeGrant {

--- a/packages/executor/src/commands/git.executor-managed.test.ts
+++ b/packages/executor/src/commands/git.executor-managed.test.ts
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   deleteRepoDirectory: vi.fn(),
   cloneRepo: vi.fn(),
   createBranchAsClone: vi.fn(),
+  isRemoteRefVisibleForClone: vi.fn(),
   getReposDir: vi.fn(() => '/safe/repos'),
   addConfig: vi.fn(),
   gitRaw: vi.fn(),
@@ -49,6 +50,7 @@ vi.mock('../git/index.js', async () => {
     createGit: vi.fn(() => ({ git: { addConfig: mocks.addConfig, raw: mocks.gitRaw } })),
     cloneRepo: mocks.cloneRepo,
     createBranchAsClone: mocks.createBranchAsClone,
+    isRemoteRefVisibleForClone: mocks.isRemoteRefVisibleForClone,
     deleteBranchDirectory: mocks.deleteBranchDirectory,
     deleteRepoDirectory: mocks.deleteRepoDirectory,
     isValidGitRepo: mocks.isValidGitRepo,
@@ -194,6 +196,7 @@ beforeEach(() => {
     defaultBranch: 'main',
   });
   mocks.createBranchAsClone.mockResolvedValue({ path: '/trusted/branch', ref: 'main' });
+  mocks.isRemoteRefVisibleForClone.mockResolvedValue(false);
   mocks.isValidGitRepo.mockResolvedValue(true);
   mocks.getDefaultBranch.mockResolvedValue('main');
   mocks.getRemoteUrl.mockResolvedValue('https://user:secret@example.com/org/repo.git');
@@ -261,6 +264,7 @@ describe('managed executor git/fs commands', () => {
         name: 'feature',
         ref: 'trusted-ref',
         base_ref: 'trusted-base',
+        base_remote_url: 'https://github.com/preset-io/agor-teammate.git',
         new_branch: true,
         ref_type: 'branch',
         storage_mode: 'clone',
@@ -286,7 +290,8 @@ describe('managed executor git/fs commands', () => {
     expect(result.success).toBe(true);
     expect(mocks.createBranchAsClone).toHaveBeenCalledWith(
       expect.objectContaining({
-        remoteUrl: 'https://example.com/trusted/repo.git',
+        remoteUrl: 'https://github.com/preset-io/agor-teammate.git',
+        originRemoteUrl: 'https://example.com/trusted/repo.git',
         ref: 'trusted-base',
         newBranchName: 'trusted-ref',
         depth: 42,
@@ -296,6 +301,171 @@ describe('managed executor git/fs commands', () => {
     expect(patchedBranches).toContainEqual({ filesystem_status: 'ready' });
     expect(renderedBranches).toEqual([branchId]);
     expect(patchedBranches.some((patch) => 'start_command' in patch)).toBe(false);
+  });
+
+  it('restores a clone from the destination branch when it has already been pushed', async () => {
+    createClient({
+      repo: {
+        repo_id: repoId,
+        local_path: '/trusted/repo',
+        remote_url: 'https://github.com/preset-io/agor-teammate-private.git',
+      },
+      branch: {
+        branch_id: branchId,
+        repo_id: repoId,
+        path: '/trusted/branch',
+        name: 'private-ponc',
+        ref: 'private-ponc',
+        base_ref: 'template/deal-desk-revops-analyst',
+        base_remote_url: 'https://github.com/preset-io/agor-teammate.git',
+        new_branch: true,
+        ref_type: 'branch',
+        storage_mode: 'clone',
+      },
+    });
+    mocks.isRemoteRefVisibleForClone.mockResolvedValueOnce(true);
+
+    const result = await handleGitBranchAdd(
+      {
+        command: 'git.branch.add',
+        sessionToken: 'tenant-token',
+        params: { branchId, repoId, restoreMode: true },
+      },
+      {}
+    );
+
+    expect(result.success).toBe(true);
+    expect(mocks.isRemoteRefVisibleForClone).toHaveBeenCalledWith(
+      expect.objectContaining({
+        remoteUrl: 'https://github.com/preset-io/agor-teammate-private.git',
+        ref: 'private-ponc',
+        refType: 'branch',
+      })
+    );
+    expect(mocks.createBranchAsClone).toHaveBeenCalledWith(
+      expect.objectContaining({
+        remoteUrl: 'https://github.com/preset-io/agor-teammate-private.git',
+        ref: 'private-ponc',
+      })
+    );
+    expect(mocks.createBranchAsClone.mock.calls[0]?.[0]).not.toHaveProperty('originRemoteUrl');
+    expect(mocks.createBranchAsClone.mock.calls[0]?.[0]).not.toHaveProperty('newBranchName');
+  });
+
+  it('falls back to the qualified template only when the destination branch is absent', async () => {
+    createClient({
+      repo: {
+        repo_id: repoId,
+        local_path: '/trusted/repo',
+        remote_url: 'https://github.com/preset-io/agor-teammate-private.git',
+      },
+      branch: {
+        branch_id: branchId,
+        repo_id: repoId,
+        path: '/trusted/branch',
+        name: 'private-ponc',
+        ref: 'private-ponc',
+        base_ref: 'template/deal-desk-revops-analyst',
+        base_remote_url: 'https://github.com/preset-io/agor-teammate.git',
+        new_branch: true,
+        ref_type: 'branch',
+        storage_mode: 'clone',
+      },
+    });
+
+    const result = await handleGitBranchAdd(
+      {
+        command: 'git.branch.add',
+        sessionToken: 'tenant-token',
+        params: { branchId, repoId, restoreMode: true },
+      },
+      {}
+    );
+
+    expect(result.success).toBe(true);
+    expect(mocks.createBranchAsClone).toHaveBeenCalledWith(
+      expect.objectContaining({
+        remoteUrl: 'https://github.com/preset-io/agor-teammate.git',
+        originRemoteUrl: 'https://github.com/preset-io/agor-teammate-private.git',
+        ref: 'template/deal-desk-revops-analyst',
+        newBranchName: 'private-ponc',
+      })
+    );
+  });
+
+  it('does not replace a destination branch when the restore preflight fails', async () => {
+    createClient({
+      repo: {
+        repo_id: repoId,
+        local_path: '/trusted/repo',
+        remote_url: 'https://github.com/preset-io/agor-teammate-private.git',
+      },
+      branch: {
+        branch_id: branchId,
+        repo_id: repoId,
+        path: '/trusted/branch',
+        name: 'private-ponc',
+        ref: 'private-ponc',
+        base_ref: 'template/deal-desk-revops-analyst',
+        base_remote_url: 'https://github.com/preset-io/agor-teammate.git',
+        new_branch: true,
+        ref_type: 'branch',
+        storage_mode: 'clone',
+      },
+    });
+    mocks.isRemoteRefVisibleForClone.mockRejectedValueOnce(new Error('destination unavailable'));
+
+    const result = await handleGitBranchAdd(
+      {
+        command: 'git.branch.add',
+        sessionToken: 'tenant-token',
+        params: { branchId, repoId, restoreMode: true },
+      },
+      {}
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      error: { message: expect.stringContaining('destination unavailable') },
+    });
+    expect(mocks.createBranchAsClone).not.toHaveBeenCalled();
+  });
+
+  it('rejects a forged persisted template remote before filesystem materialization', async () => {
+    createClient({
+      repo: {
+        repo_id: repoId,
+        local_path: '/trusted/repo',
+        remote_url: 'https://github.com/preset-io/agor-teammate-private.git',
+      },
+      branch: {
+        branch_id: branchId,
+        repo_id: repoId,
+        path: '/trusted/branch',
+        name: 'private-ponc',
+        ref: 'private-ponc',
+        base_ref: 'template/deal-desk-revops-analyst',
+        base_remote_url: 'https://attacker.example/template.git',
+        new_branch: true,
+        ref_type: 'branch',
+        storage_mode: 'clone',
+      },
+    });
+
+    const result = await handleGitBranchAdd(
+      {
+        command: 'git.branch.add',
+        sessionToken: 'tenant-token',
+        params: { branchId, repoId },
+      },
+      {}
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      error: { message: expect.stringContaining('Refusing untrusted base_remote_url') },
+    });
+    expect(mocks.createBranchAsClone).not.toHaveBeenCalled();
   });
 
   it('denies missing tenant-scoped repo before filesystem materialization', async () => {

--- a/packages/executor/src/commands/git.ts
+++ b/packages/executor/src/commands/git.ts
@@ -18,6 +18,7 @@ import { dirname, isAbsolute, join, resolve } from 'node:path';
 import { getReposDir } from '@agor/core/config';
 import { parseAgorYml, writeAgorYml } from '@agor/core/config/node';
 import { shortId } from '@agor/core/db';
+import { TEAMMATE_FRAMEWORK_REPO_URL } from '@agor/core/types';
 import { diagnoseGit } from '@agor/git';
 import { appendGitConfigParameterPairs } from '../git/config-parameters.js';
 import {
@@ -33,6 +34,7 @@ import {
   ensureGitRemoteUrl,
   getDefaultBranch,
   getRemoteUrl,
+  isRemoteRefVisibleForClone,
   isValidGitRepo,
   redactGitUrlCredentials,
   removeGitWorktree,
@@ -862,6 +864,14 @@ export async function handleGitBranchAdd(
     const storageMode = branchRecord.storage_mode ?? 'worktree';
     const cloneDepth = branchRecord.clone_depth;
     const remoteUrl = repo.remote_url ? stripGitUrlCredentials(repo.remote_url) : undefined;
+    const baseRemoteUrl = branchRecord.base_remote_url
+      ? stripGitUrlCredentials(branchRecord.base_remote_url)
+      : undefined;
+    if (baseRemoteUrl && baseRemoteUrl !== TEAMMATE_FRAMEWORK_REPO_URL) {
+      throw new Error(
+        'Refusing untrusted base_remote_url: only the canonical Agor teammate template repository is allowed.'
+      );
+    }
     const referencePath = payload.params.useReference ? repo.local_path : undefined;
 
     if (!repoPath && storageMode === 'worktree') {
@@ -890,17 +900,38 @@ export async function handleGitBranchAdd(
       // helper fork off the cloned tip. When checking out an existing
       // branch, just clone the ref directly. The helper owns both flows so
       // the executor handler doesn't have to orchestrate post-clone git ops.
-      const cloneRef = shouldCreateBranch ? sourceBranch || branch : branch;
+      let cloneRef = branch;
+      let cloneRemoteUrl = remoteUrl;
+      let newBranchName: string | undefined;
+
+      if (shouldCreateBranch) {
+        const restoreFromDestination = restoreMode
+          ? await isRemoteRefVisibleForClone({
+              remoteUrl,
+              ref: branch,
+              refType: 'branch',
+              env,
+            })
+          : false;
+
+        if (!restoreFromDestination) {
+          cloneRef = sourceBranch || branch;
+          cloneRemoteUrl = baseRemoteUrl || remoteUrl;
+          newBranchName = branch !== cloneRef ? branch : undefined;
+        }
+      }
       console.log(
-        `[git.branch.add] Using createBranchAsClone (remote=${redactGitUrlCredentials(remoteUrl)}, ` +
-          `ref=${cloneRef}${shouldCreateBranch && branch !== cloneRef ? `, newBranch=${branch}` : ''}, ` +
+        `[git.branch.add] Using createBranchAsClone (sourceRemote=${redactGitUrlCredentials(cloneRemoteUrl)}, ` +
+          `origin=${redactGitUrlCredentials(remoteUrl)}, ` +
+          `ref=${cloneRef}${newBranchName ? `, newBranch=${newBranchName}` : ''}, ` +
           `depth=${cloneDepth ?? 'full'}, referenceHint=${referencePath ?? 'none'})`
       );
       await createBranchAsClone({
-        remoteUrl,
+        remoteUrl: cloneRemoteUrl,
+        ...(cloneRemoteUrl !== remoteUrl ? { originRemoteUrl: remoteUrl } : {}),
         targetPath: branchPath,
         ref: cloneRef,
-        ...(shouldCreateBranch && branch !== cloneRef ? { newBranchName: branch } : {}),
+        ...(newBranchName ? { newBranchName } : {}),
         depth: cloneDepth,
         // Pass the daemon's hint through unconditionally. The helper does
         // the existsSync check on the executor's filesystem and falls back
@@ -915,7 +946,15 @@ export async function handleGitBranchAdd(
       console.log(
         `[git.branch.add] Using restoreBranchFilesystem (branch: ${branch}, base: ${sourceBranch})`
       );
-      const result = await restoreBranchFilesystem(repoPath, branchPath, branch, sourceBranch, env);
+      const result = await restoreBranchFilesystem(
+        repoPath,
+        branchPath,
+        branch,
+        sourceBranch,
+        env,
+        baseRemoteUrl,
+        refType || 'branch'
+      );
       if (!result.success) {
         throw new Error(`restoreBranchFilesystem failed: ${result.error}`);
       }
@@ -929,7 +968,8 @@ export async function handleGitBranchAdd(
         true, // pullLatest
         sourceBranch,
         env,
-        refType
+        refType,
+        baseRemoteUrl
       );
     }
 

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -5,6 +5,7 @@
  * Supports SSH keys, user environment variables (GITHUB_TOKEN), and system credential helpers.
  */
 
+import { randomUUID } from 'node:crypto';
 import { existsSync, type Stats } from 'node:fs';
 import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { basename, dirname, isAbsolute, join, resolve } from 'node:path';
@@ -989,7 +990,9 @@ export async function createBranch(
   pullLatest: boolean = true,
   sourceBranch?: string,
   env?: Record<string, string>,
-  refType?: 'branch' | 'tag'
+  refType?: 'branch' | 'tag',
+  /** Remote that owns sourceBranch when it differs from repoPath's origin. */
+  sourceRemoteUrl?: string
 ): Promise<void> {
   console.log('🔍 createBranch called with:', {
     repoPath,
@@ -999,6 +1002,7 @@ export async function createBranch(
     pullLatest,
     sourceBranch,
     refType,
+    sourceRemoteUrl: sourceRemoteUrl ? redactGitUrlCredentials(sourceRemoteUrl) : sourceRemoteUrl,
   });
 
   if (!repoPath) {
@@ -1034,18 +1038,56 @@ export async function createBranch(
     await validateGitRef(sourceBranch);
   }
 
+  const safeSourceRemoteUrl = sourceRemoteUrl ? stripGitUrlCredentials(sourceRemoteUrl) : undefined;
+  if (safeSourceRemoteUrl && (!createBranch || !sourceBranch)) {
+    throw new Error('sourceRemoteUrl requires createBranch=true and a sourceBranch');
+  }
+  if (
+    safeSourceRemoteUrl &&
+    (safeSourceRemoteUrl.startsWith('-') || /[\0\r\n]/.test(safeSourceRemoteUrl))
+  ) {
+    throw new Error('Invalid sourceRemoteUrl');
+  }
+
   // Derive the auth-header host from the repo's origin remote so the same
   // refactor works against GitHub Enterprise / self-hosted forges without
   // per-deployment config. Skip the extra `git remote -v` spawn when there's
   // no token to scope (the host would be unused).
   const hasToken = !!(env?.GITHUB_TOKEN ?? env?.GH_TOKEN);
-  const authHost = hasToken ? await resolveAuthHost(repoPath) : undefined;
+  const authHost = hasToken
+    ? safeSourceRemoteUrl
+      ? parseHostFromGitUrl(safeSourceRemoteUrl)
+      : await resolveAuthHost(repoPath)
+    : undefined;
   const { git } = createGit(repoPath, env, authHost);
 
   let fetchSucceeded = false;
+  let effectiveSourceBranch = sourceBranch;
+  let temporarySourceRef: string | undefined;
 
-  // Pull latest from remote if requested
-  if (pullLatest) {
+  // When the base ref belongs to another repository, fetch exactly that ref
+  // into an operation-local namespace. Do not add a persistent remote: origin
+  // must remain the destination repository for future pushes and restores.
+  if (safeSourceRemoteUrl && sourceBranch) {
+    const namespace = refType === 'tag' ? 'refs/tags' : 'refs/heads';
+    temporarySourceRef = `refs/agor/base/${randomUUID()}`;
+    try {
+      await git.fetch([safeSourceRemoteUrl, `+${namespace}/${sourceBranch}:${temporarySourceRef}`]);
+    } catch (error) {
+      // A failed fetch is normally atomic, but clean defensively in case the
+      // transport updated the temporary ref before failing later.
+      try {
+        await git.raw(['update-ref', '-d', temporarySourceRef]);
+      } catch {
+        // Preserve the authoritative fetch failure.
+      }
+      throw error;
+    }
+    effectiveSourceBranch = temporarySourceRef;
+    console.log(
+      `✅ Fetched base ${namespace}/${sourceBranch} from ${redactGitUrlCredentials(safeSourceRemoteUrl)}`
+    );
+  } else if (pullLatest) {
     try {
       // Fetch branches, and tags only if working with a tag
       const fetchArgs = refType === 'tag' ? ['origin', '--tags'] : ['origin'];
@@ -1093,7 +1135,7 @@ export async function createBranch(
     branchPath,
     ref,
     createBranch,
-    sourceBranch,
+    sourceBranch: effectiveSourceBranch,
     refType,
     fetchSucceeded,
   });
@@ -1103,37 +1145,50 @@ export async function createBranch(
   }
 
   try {
-    await git.raw(worktreeAddArgs);
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
+    try {
+      await git.raw(worktreeAddArgs);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
 
-    // Handle stale branch from previously deleted branch
-    if (createBranch && errorMessage.includes('already exists')) {
-      console.warn(
-        `⚠️  Branch '${ref}' already exists. Checking if it's orphaned (stale from a deleted branch)...`
-      );
+      // Handle stale branch from previously deleted branch
+      if (createBranch && errorMessage.includes('already exists')) {
+        console.warn(
+          `⚠️  Branch '${ref}' already exists. Checking if it's orphaned (stale from a deleted branch)...`
+        );
 
-      // Check if the branch is in use by another git worktree
-      const worktrees = await listGitWorktrees(repoPath);
-      const branchInUse = worktrees.some((wt) => wt.ref === ref);
+        // Check if the branch is in use by another git worktree
+        const worktrees = await listGitWorktrees(repoPath);
+        const branchInUse = worktrees.some((wt) => wt.ref === ref);
 
-      if (branchInUse) {
-        throw new Error(
-          `A branch named '${ref}' already exists and is in use by another branch. ` +
-            `Please choose a different name.`
+        if (branchInUse) {
+          throw new Error(
+            `A branch named '${ref}' already exists and is in use by another branch. ` +
+              `Please choose a different name.`
+          );
+        }
+
+        // Branch exists but is orphaned — delete it and retry.
+        // `git branch -D` doesn't support `--`; ref was validated above.
+        console.log(`🧹 Deleting orphaned branch '${ref}' and retrying branch creation...`);
+        await git.raw(['branch', '-D', ref]);
+
+        // Retry the branch creation
+        await git.raw(worktreeAddArgs);
+        console.log(`✅ Successfully created branch after cleaning up stale branch '${ref}'`);
+      } else {
+        throw error;
+      }
+    }
+  } finally {
+    if (temporarySourceRef) {
+      try {
+        await git.raw(['update-ref', '-d', temporarySourceRef]);
+      } catch (error) {
+        console.warn(
+          `⚠️  Failed to clean temporary base ref '${temporarySourceRef}':`,
+          error instanceof Error ? error.message : String(error)
         );
       }
-
-      // Branch exists but is orphaned — delete it and retry.
-      // `git branch -D` doesn't support `--`; ref was validated above.
-      console.log(`🧹 Deleting orphaned branch '${ref}' and retrying branch creation...`);
-      await git.raw(['branch', '-D', ref]);
-
-      // Retry the branch creation
-      await git.raw(worktreeAddArgs);
-      console.log(`✅ Successfully created branch after cleaning up stale branch '${ref}'`);
-    } else {
-      throw error;
     }
   }
 
@@ -1157,6 +1212,11 @@ export async function createBranch(
 export interface CreateBranchAsCloneOptions {
   /** Remote URL to clone from (https://, ssh://, git@host:path, file://, or local path). */
   remoteUrl: string;
+  /**
+   * Destination URL to retain as origin after cloning from remoteUrl.
+   * Use when the base ref is hosted by a separate template repository.
+   */
+  originRemoteUrl?: string;
   /** Absolute path where the new clone should land. Must not already exist. */
   targetPath: string;
   /**
@@ -1256,14 +1316,16 @@ export interface AssertRemoteRefVisibleForCloneOptions {
 }
 
 /**
- * Preflight a clone-mode base ref before Agor persists any branch/session
- * records. Clone mode can only materialise refs visible from the clone remote
- * (typically `origin`); a local-only branch in the daemon's base clone is not
- * cloneable via `git clone --branch`.
+ * Check whether a clone-mode ref is visible from a remote.
+ *
+ * An empty, successful `ls-remote` means the ref is absent. Transport,
+ * authentication, and other lookup failures are deliberately thrown so a
+ * restore caller never mistakes an unavailable destination for a missing
+ * branch and replaces it with a fresh base.
  */
-export async function assertRemoteRefVisibleForClone(
+export async function isRemoteRefVisibleForClone(
   options: AssertRemoteRefVisibleForCloneOptions
-): Promise<void> {
+): Promise<boolean> {
   const remoteUrl = stripGitUrlCredentials(options.remoteUrl);
   const refType = options.refType ?? 'branch';
   const ref = options.ref;
@@ -1294,10 +1356,24 @@ export async function assertRemoteRefVisibleForClone(
     );
   }
 
-  if (output.trim().length === 0) {
+  return output.trim().length > 0;
+}
+
+/**
+ * Preflight a clone-mode base ref before Agor persists any branch/session
+ * records. Clone mode can only materialise refs visible from the clone remote
+ * (typically `origin`); a local-only branch in the daemon's base clone is not
+ * cloneable via `git clone --branch`.
+ */
+export async function assertRemoteRefVisibleForClone(
+  options: AssertRemoteRefVisibleForCloneOptions
+): Promise<void> {
+  if (!(await isRemoteRefVisibleForClone(options))) {
+    const remoteUrl = stripGitUrlCredentials(options.remoteUrl);
+    const refType = options.refType ?? 'branch';
     throw new Error(
-      `Clone mode cannot clone local-only or missing ${refType} '${ref}' because it is not visible on ` +
-        `the remote ${redactGitUrlCredentials(remoteUrl)}. Push '${ref}' to origin, choose a remote ` +
+      `Clone mode cannot clone local-only or missing ${refType} '${options.ref}' because it is not visible on ` +
+        `the remote ${redactGitUrlCredentials(remoteUrl)}. Push '${options.ref}' to origin, choose a remote ` +
         `${refType}, or use storage_mode='worktree' if it is enabled.`
     );
   }
@@ -1334,6 +1410,9 @@ export async function createBranchAsClone(
 ): Promise<CreateBranchAsCloneResult> {
   const { targetPath, ref, newBranchName, depth, referencePath, env } = options;
   const remoteUrl = stripGitUrlCredentials(options.remoteUrl);
+  const originRemoteUrl = options.originRemoteUrl
+    ? stripGitUrlCredentials(options.originRemoteUrl)
+    : undefined;
   const singleBranch = options.singleBranch ?? true;
 
   if (!remoteUrl) {
@@ -1343,6 +1422,9 @@ export async function createBranchAsClone(
     console.warn(
       `🔒 Stripped credentials from clone-mode remote URL before use: ${redactGitUrlCredentials(options.remoteUrl)}`
     );
+  }
+  if (options.originRemoteUrl && !originRemoteUrl) {
+    throw new Error('originRemoteUrl is required when provided');
   }
   if (!targetPath) {
     throw new Error('targetPath is required');
@@ -1433,6 +1515,40 @@ export async function createBranchAsClone(
     finalRef = newBranchName;
   }
 
+  // A template repository may own the base ref while the newly-created
+  // branch belongs to a private destination repository. Clone the former to
+  // materialize the right content, then restore origin to the latter so
+  // future push/pull operations never target the template repository.
+  if (originRemoteUrl && originRemoteUrl !== remoteUrl) {
+    await ensureGitRemoteUrl(targetPath, 'origin', originRemoteUrl, env);
+    const { git: cloneGit } = createGit(targetPath, env);
+
+    // `--single-branch` leaves origin's fetch refspec pinned to the template
+    // branch. Once origin points at the destination, that refspec would make
+    // ordinary fetches ignore every destination branch. Reset it to the
+    // normal full-heads mapping and remove remote-tracking refs that describe
+    // the template source, not the newly configured origin.
+    await cloneGit.raw([
+      'config',
+      '--replace-all',
+      'remote.origin.fetch',
+      '+refs/heads/*:refs/remotes/origin/*',
+    ]);
+    const staleOriginRefs = (
+      await cloneGit.raw(['for-each-ref', '--format=%(refname)', 'refs/remotes/origin'])
+    )
+      .split('\n')
+      .map((value) => value.trim())
+      .filter(Boolean);
+    for (const staleOriginRef of staleOriginRefs) {
+      await cloneGit.raw(['update-ref', '-d', staleOriginRef]);
+    }
+    const localBranches = await cloneGit.branchLocal();
+    if (newBranchName && localBranches.all.includes(ref)) {
+      await cloneGit.deleteLocalBranch(ref, true);
+    }
+  }
+
   await addSafeDirectoryBestEffort(targetPath, '[createBranchAsClone]');
 
   return { path: targetPath, ref: finalRef };
@@ -1470,13 +1586,17 @@ export interface RestoreBranchResult {
  * @param ref - Branch name to restore
  * @param baseRef - Fallback base branch (e.g., 'main') if ref doesn't exist on remote
  * @param env - Optional environment variables for git operations (GITHUB_TOKEN, etc.)
+ * @param baseRemoteUrl - Optional remote that owns baseRef when it differs from origin
+ * @param baseRefType - Namespace of baseRef when creating the fallback branch
  */
 export async function restoreBranchFilesystem(
   repoPath: string,
   branchPath: string,
   ref: string,
   baseRef: string,
-  env?: Record<string, string>
+  env?: Record<string, string>,
+  baseRemoteUrl?: string,
+  baseRefType: 'branch' | 'tag' = 'branch'
 ): Promise<RestoreBranchResult> {
   // Validate refs early — this function both passes them to createBranch
   // (which re-validates) and to ls-remote (which does not).
@@ -1511,13 +1631,29 @@ export async function restoreBranchFilesystem(
   try {
     const lsRemoteOutput = await git.listRemote(['--heads', 'origin', ref]);
     branchExistsOnRemote = lsRemoteOutput.trim().length > 0;
-  } catch {
-    // ls-remote failed, fall through to local branch check
+  } catch (error) {
+    // A cached remote-tracking branch is still safe to restore while the
+    // destination is temporarily unavailable. Without one, however, the
+    // failure is not evidence that the branch is absent: creating from the
+    // template could discard work that was already pushed to the destination.
     try {
       const branches = await git.branch(['-r']);
       branchExistsOnRemote = branches.all.includes(`origin/${ref}`);
+      if (!branchExistsOnRemote) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          success: false,
+          strategy: 'checkout',
+          error: `Cannot determine whether branch '${ref}' exists on origin: ${message}`,
+        };
+      }
     } catch {
-      // Can't determine remote state
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        success: false,
+        strategy: 'checkout',
+        error: `Cannot determine whether branch '${ref}' exists on origin: ${message}`,
+      };
     }
   }
 
@@ -1532,7 +1668,17 @@ export async function restoreBranchFilesystem(
 
     // Branch doesn't exist on remote — create new branch from base ref
     console.log(`[restoreBranch] Branch '${ref}' not on remote, creating from base '${baseRef}'`);
-    await createBranch(repoPath, branchPath, ref, true, true, baseRef, env);
+    await createBranch(
+      repoPath,
+      branchPath,
+      ref,
+      true,
+      true,
+      baseRef,
+      env,
+      baseRefType,
+      baseRemoteUrl
+    );
     return { success: true, strategy: 'create' };
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary

- qualify built-in onboarding template refs with the public `preset-io/agor-teammate` source remote while keeping the selected/private teammate repository as the branch destination and `origin`
- materialize cross-repository bases in both worktree and self-standing clone storage, with cleanup and branch/tag support
- preserve pushed destination branches during restore; only fall back to the template after an authoritative "missing" result
- restrict the source remote to Agor's canonical template repository at the daemon and executor boundaries

## Root cause

#2461 correctly began passing the selected `template/*` ref through onboarding, but the branch creation boundary still treated `sourceBranch` as a ref on the selected destination repository. `useFrameworkRepo` intentionally prefers `agor-assistant-private` / `agor-teammate-private`; those repos do not publish the public gallery's template refs. The executor therefore ran the equivalent of:

```text
git clone --branch template/deal-desk-revops-analyst <private destination>
```

and failed even though the chosen ref exists in `preset-io/agor-teammate`.

This change keeps `repo_id` and `origin` pointed at the private destination, while persisting the separately-qualified, canonical public remote that owns `base_ref`. It deliberately does not fall back to destination `main`, because that would report success while creating the wrong teammate playbook.

## Validation

- `@agor/git`, `@agor/core`, `@agor/executor`, `@agor/daemon`, and `@agor-live/client` typechecks
- UI source typecheck with source package conditions (the standard isolated-worktree UI build typecheck still lacks prebuilt `packages/client/dist/*.d.ts`)
- core Git integration: 95 passed, including missing destination template ref in worktree and clone storage, origin retention, tag bases, temporary-ref cleanup, and safe restore behavior
- core BranchRepository: 43 passed (managed SQLite-style test database, with an isolated HOME)
- executor managed Git: 20 passed
- daemon repos + branches: 68 passed
- onboarding wizard/template/creation/seed UI: 89 passed
- Biome, `git diff --check`, and multitenancy boundary check
- managed SQLite environment: full browser onboarding selected Deal Desk against a private destination missing the template ref; the branch reached `ready`, retained the private destination as `origin`, and contained the Deal Desk onboarding content
- Playwright MCP was unavailable, so the repository's installed Playwright 1.62.1 was used. Full-flow monitoring found no failed/network-error responses; a final post-change page smoke returned HTTP 200 with no console errors, page errors, failed requests, or HTTP >=400 responses. The full flow only emitted existing Ant Design deprecation warnings.

## Reviews

Two independent pre-final reviews were completed: correctness/merge gating and architecture/system fit. Findings around restore precedence, cross-remote tag behavior, and the credential-bearing remote boundary were addressed and validation rerun.
