### PR TITLE
fix(branches): stop clone-mode branches borrowing objects the sandbox hides

### DIFF
--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -1030,8 +1030,13 @@ function createExecuteHandler(
         const branch = await branchRepo.findById(session.branch_id);
         if (!branch?.path) return undefined;
         let baseRepoPath: string | undefined;
-        // Only linked worktrees need the shared git dir; a self-standing clone
-        // carries its own `.git` inside the branch dir.
+        // Only linked worktrees need the shared git dir; a clone carries its
+        // own `.git` inside the branch dir — EXCEPT for its object store when
+        // it was created with `git clone --reference`, which leaves an
+        // alternates pointer into `<data_home>/repos/<slug>/.git/objects`.
+        // The daemon refuses to create that pointer when this sandbox would
+        // hide it (see `shouldUseCloneReferencePath`), so a clone-mode branch
+        // needs nothing mounted from `repos/`.
         if (branch.storage_mode !== 'clone' && branch.repo_id) {
           const repo = await new RepoRepository(tenantDb).findById(branch.repo_id);
           baseRepoPath = repo?.local_path ?? undefined;

--- a/apps/agor-daemon/src/services/terminals.ts
+++ b/apps/agor-daemon/src/services/terminals.ts
@@ -282,6 +282,12 @@ export class TerminalsService {
         : undefined;
     let principalBranchAccess: 'write' | 'read' | 'none' = 'write';
     if (sandboxCfg?.enabled === true) {
+      // Only linked worktrees need the shared git dir bound in. A clone-mode
+      // branch carries its own `.git` — EXCEPT for its object store when it was
+      // created with `git clone --reference`, which leaves an alternates
+      // pointer into `<data_home>/repos/<slug>/.git/objects`. The daemon
+      // refuses to create that pointer when this sandbox would hide it (see
+      // `shouldUseCloneReferencePath`), so nothing extra is mounted here.
       if (branch.storage_mode !== 'clone' && branch.repo_id) {
         sandboxBaseRepoPath = await this.withTenantDatabase((tenantDb) =>
           new RepoRepository(tenantDb)

--- a/apps/agor-daemon/src/utils/clone-reference.test.ts
+++ b/apps/agor-daemon/src/utils/clone-reference.test.ts
@@ -1,0 +1,77 @@
+import type { AgorConfig } from '@agor/core/config';
+import type { DeepReadonly } from '@agor/core/types';
+import { describe, expect, it } from 'vitest';
+import { shouldUseCloneReferencePath } from './clone-reference';
+
+const asConfig = (config: AgorConfig): DeepReadonly<AgorConfig> =>
+  config as DeepReadonly<AgorConfig>;
+
+describe('shouldUseCloneReferencePath', () => {
+  it('borrows base objects by default', () => {
+    // Every existing install has no branch_storage block at all. The
+    // `--reference` disk win must survive this change untouched.
+    expect(shouldUseCloneReferencePath(asConfig({}))).toBe(true);
+    expect(shouldUseCloneReferencePath(asConfig({ execution: {} }))).toBe(true);
+    expect(
+      shouldUseCloneReferencePath(
+        asConfig({ execution: { branch_storage: { default_mode: 'clone' } } })
+      )
+    ).toBe(true);
+  });
+
+  it('still borrows when the operator explicitly opts in', () => {
+    expect(
+      shouldUseCloneReferencePath(
+        asConfig({ execution: { branch_storage: { borrow_base_objects: true } } })
+      )
+    ).toBe(true);
+  });
+
+  it('drops the borrow when borrow_base_objects is false', () => {
+    // The escape hatch for deployments whose sessions run in a mount that
+    // has no `repos/` directory: an alternates pointer into the daemon's
+    // base clone would make every later git command in the branch fail with
+    // "unable to normalize alternate object path".
+    expect(
+      shouldUseCloneReferencePath(
+        asConfig({ execution: { branch_storage: { borrow_base_objects: false } } })
+      )
+    ).toBe(false);
+  });
+
+  it('drops the borrow when executors are declared to have no base repository', () => {
+    // `base_repository: 'unavailable'` is the operator already asserting the
+    // exact topology that breaks alternates — honour it without making them
+    // also remember a second knob.
+    expect(
+      shouldUseCloneReferencePath(
+        asConfig({ execution: { executor_storage: { base_repository: 'unavailable' } } })
+      )
+    ).toBe(false);
+  });
+
+  it('keeps borrowing for shared and replica-local base repositories', () => {
+    // Both of these assert the base checkout IS reachable from executors,
+    // so the alternates pointer resolves and the disk win is safe.
+    for (const base_repository of ['shared', 'replica-local'] as const) {
+      expect(
+        shouldUseCloneReferencePath(
+          asConfig({ execution: { executor_storage: { base_repository } } })
+        )
+      ).toBe(true);
+    }
+  });
+
+  it('lets the explicit knob disable borrowing even on a shared base repository', () => {
+    expect(
+      shouldUseCloneReferencePath(
+        asConfig({
+          execution: {
+            branch_storage: { borrow_base_objects: false },
+            executor_storage: { base_repository: 'shared' },
+          },
+        })
+      )
+    ).toBe(false);
+  });
+});

--- a/apps/agor-daemon/src/utils/clone-reference.test.ts
+++ b/apps/agor-daemon/src/utils/clone-reference.test.ts
@@ -50,9 +50,27 @@ describe('shouldUseCloneReferencePath', () => {
     ).toBe(false);
   });
 
+  it('lets base_repository: unavailable outrank an explicit opt-in', () => {
+    // Nothing an operator writes here can make a base checkout they have
+    // declared absent appear inside an executor, so the assertion wins.
+    expect(
+      shouldUseCloneReferencePath(
+        asConfig({
+          execution: {
+            branch_storage: { borrow_base_objects: true },
+            executor_storage: { base_repository: 'unavailable' },
+          },
+        })
+      )
+    ).toBe(false);
+  });
+
   it('keeps borrowing for shared and replica-local base repositories', () => {
-    // Both of these assert the base checkout IS reachable from executors,
-    // so the alternates pointer resolves and the disk win is safe.
+    // `shared` asserts the base checkout is reachable from executors.
+    // `replica-local` only asserts it sits on the replica's own disk — under
+    // `execution_topology: external` that is NOT a reachability claim, so it
+    // is treated as "no signal" (borrow preserved) rather than as proof the
+    // borrow is safe. Operators in that shape use the explicit knob.
     for (const base_repository of ['shared', 'replica-local'] as const) {
       expect(
         shouldUseCloneReferencePath(
@@ -73,5 +91,90 @@ describe('shouldUseCloneReferencePath', () => {
         })
       )
     ).toBe(false);
+  });
+
+  // ── the regression `915c8b1cd` introduced and `0a077e6c2` cemented ────────
+  //
+  // `git.branch.add` is a daemon-internal executor spawn and is never
+  // sandbox-wrapped, so its `existsSync(referencePath)` probe passes and the
+  // alternates pointer is written. The `prompt` / `zellij.attach` spawns that
+  // later run git inside that branch ARE wrapped, and the `per_user` overlay
+  // masks the whole daemon `.agor` tree — `repos/` included. Every git command
+  // in the branch then dies on "unable to normalize alternate object path".
+  describe('executor sandbox', () => {
+    const sandboxed = (
+      sandbox: NonNullable<NonNullable<AgorConfig['execution']>['sandbox']>,
+      branch_storage?: NonNullable<AgorConfig['execution']>['branch_storage']
+    ): DeepReadonly<AgorConfig> =>
+      asConfig({ execution: { sandbox, ...(branch_storage ? { branch_storage } : {}) } });
+
+    it('drops the borrow under a per_user sandbox home', () => {
+      expect(shouldUseCloneReferencePath(sandboxed({ enabled: true, home_mode: 'per_user' }))).toBe(
+        false
+      );
+    });
+
+    it('keeps borrowing under a shared sandbox home', () => {
+      // Shared mode keeps bubblewrap's `--ro-bind / /`, so `<data_home>/repos`
+      // is still readable and the alternates pointer resolves.
+      expect(shouldUseCloneReferencePath(sandboxed({ enabled: true, home_mode: 'shared' }))).toBe(
+        true
+      );
+      // `shared` is also the default when home_mode is omitted.
+      expect(shouldUseCloneReferencePath(sandboxed({ enabled: true }))).toBe(true);
+    });
+
+    it('drops the borrow for the unix_user_mode: sandbox named mode', () => {
+      // `loadConfig` folds this mode into `{ enabled: true, home_mode:
+      // 'per_user', fail_if_unavailable: true }`, so the effective config the
+      // daemon holds is already covered by the case above. A daemon started
+      // with a caller-supplied `DaemonStartOptions.config` skips that
+      // projection, so key off the named mode directly too.
+      expect(
+        shouldUseCloneReferencePath(asConfig({ execution: { unix_user_mode: 'sandbox' } }))
+      ).toBe(false);
+      expect(
+        shouldUseCloneReferencePath(
+          asConfig({
+            execution: {
+              unix_user_mode: 'sandbox',
+              sandbox: { enabled: true, home_mode: 'per_user' },
+            },
+          })
+        )
+      ).toBe(false);
+    });
+
+    it('keeps borrowing for non-sandbox unix user modes', () => {
+      for (const unix_user_mode of ['simple', 'delegated'] as const) {
+        expect(shouldUseCloneReferencePath(asConfig({ execution: { unix_user_mode } }))).toBe(true);
+      }
+    });
+
+    it('ignores a per_user home when the sandbox is not enabled', () => {
+      expect(shouldUseCloneReferencePath(sandboxed({ home_mode: 'per_user' }))).toBe(true);
+      expect(
+        shouldUseCloneReferencePath(sandboxed({ enabled: false, home_mode: 'per_user' }))
+      ).toBe(true);
+    });
+
+    it('lets an explicit opt-in override the per_user inference', () => {
+      // The operator can make the base clone reachable inside the sandbox
+      // (`execution.sandbox.extra_allow_write`), so an explicit `true` is
+      // honoured rather than silently ignored.
+      expect(
+        shouldUseCloneReferencePath(
+          sandboxed({ enabled: true, home_mode: 'per_user' }, { borrow_base_objects: true })
+        )
+      ).toBe(true);
+    });
+
+    it('keeps an explicit opt-out under a shared sandbox home', () => {
+      expect(
+        shouldUseCloneReferencePath(
+          sandboxed({ enabled: true, home_mode: 'shared' }, { borrow_base_objects: false })
+        )
+      ).toBe(false);
+    });
   });
 });

--- a/apps/agor-daemon/src/utils/clone-reference.ts
+++ b/apps/agor-daemon/src/utils/clone-reference.ts
@@ -1,4 +1,4 @@
-import type { AgorConfig } from '@agor/core/config';
+import { type AgorConfig, SANDBOX_HOME_MODE_DEFAULT } from '@agor/core/config';
 import type { DeepReadonly } from '@agor/core/types';
 
 /**
@@ -12,8 +12,7 @@ import type { DeepReadonly } from '@agor/core/types';
  * base clone has to be readable from wherever sessions run, not merely from
  * wherever the branch happened to be materialized.
  *
- * When those two contexts differ — containerized / templated executors that
- * only mount the branch workspace — every git command in the branch dies:
+ * When those two contexts differ, every git command in the branch dies:
  *
  * ```
  * error: unable to normalize alternate object path: /…/.agor/repos/<org>/<repo>/.git/objects
@@ -21,25 +20,71 @@ import type { DeepReadonly } from '@agor/core/types';
  * fatal: Failed to traverse parents of commit <sha>
  * ```
  *
- * `createBranchAsClone`'s `referencePath` probe cannot defend against this:
- * it runs in the process performing the clone, where the path *is* visible,
- * while the alternates are consumed later somewhere it is not. Hence an
- * operator-level decision rather than a runtime probe.
+ * `createBranchAsClone`'s `referencePath` probe cannot defend against this: it
+ * runs in the process performing the clone, where the path *is* visible, while
+ * the alternates are consumed later somewhere it is not. `git.branch.add` in
+ * particular is a daemon-internal command spawn and is NEVER sandbox-wrapped
+ * (`utils/sandbox-wrap.ts`), whereas the `prompt` / `zellij.attach` spawns that
+ * later run git inside the branch always are. Hence a decision made from
+ * configuration rather than from a runtime probe.
  *
- * Borrowing is disabled when either:
- *  - `execution.branch_storage.borrow_base_objects: false` — explicit opt-out.
- *  - `execution.executor_storage.base_repository: 'unavailable'` — the
- *    operator has already declared the base checkout invisible to executors,
- *    which is exactly the topology where alternates cannot resolve.
+ * Resolution order (first match wins):
+ *  1. `execution.branch_storage.borrow_base_objects: false` — explicit opt-out.
+ *  2. `execution.executor_storage.base_repository: 'unavailable'` — the
+ *     operator has already declared the base checkout absent for executors.
+ *     No other setting can conjure it back, so this outranks an explicit `true`.
+ *  3. `execution.branch_storage.borrow_base_objects: true` — explicit opt-in.
+ *     The operator owns making the path reachable from sandboxed sessions (for
+ *     example `execution.sandbox.extra_allow_write: [<data_home>/repos]`).
+ *  4. `execution.sandbox.enabled` + `home_mode: per_user` (or the
+ *     `unix_user_mode: sandbox` named mode that forces exactly that) —
+ *     inferred opt-out. That overlay hides the entire daemon `.agor` tree,
+ *     `repos/` included, and re-exposes only the branch, the managed
+ *     agentic-tools dir, and (for worktree-mode branches only) the base repo's
+ *     `.git`. A clone-mode branch with an alternates pointer is therefore
+ *     permanently broken inside it. `home_mode: shared` keeps `--ro-bind / /`,
+ *     so the base clone stays readable there and the borrow is safe.
+ *  5. Otherwise borrow — the behavior every existing install has.
  *
- * Default stays `true`, preserving the behavior every existing install has.
+ * Case 4 is the regression this function was reintroduced to cover. It used to
+ * be spelled `unix_user_mode !== 'strict'`; `915c8b1cd` replaced strict mode
+ * with the bubblewrap sandbox without updating this gate, and `0a077e6c2`
+ * ("remove Unix impersonation machinery") then collapsed the whole function to
+ * `return true`, removing the last way to turn the borrow off.
  */
 export function shouldUseCloneReferencePath(config: DeepReadonly<AgorConfig>): boolean {
-  if (config.execution?.branch_storage?.borrow_base_objects === false) {
+  const borrowBaseObjects = config.execution?.branch_storage?.borrow_base_objects;
+  if (borrowBaseObjects === false) {
     return false;
   }
   if (config.execution?.executor_storage?.base_repository === 'unavailable') {
     return false;
   }
-  return true;
+  if (borrowBaseObjects === true) {
+    return true;
+  }
+  return !executorSandboxHidesBaseClone(config);
+}
+
+/**
+ * True when the configured executor sandbox will mask `<data_home>/repos` from
+ * the sessions that run git inside the branch.
+ *
+ * Mirrors `resolveBwrapArgs`' per-user branch (`@agor/core/config/sandbox-policy`):
+ * the owner-home overlay hides the daemon data root by construction and only
+ * re-exposes the branch, agentic-tools, and worktree-mode base `.git`. Shared
+ * home mode keeps the read-only root bind, so the base clone stays readable.
+ *
+ * `unix_user_mode: sandbox` is checked directly as well as via the folded
+ * `execution.sandbox` block. The core config loader normally projects that
+ * named mode into `{ enabled: true, home_mode: 'per_user',
+ * fail_if_unavailable: true }`, but a daemon started with a caller-supplied
+ * `DaemonStartOptions.config` skips that projection, and this predicate must
+ * not silently weaken there.
+ */
+function executorSandboxHidesBaseClone(config: DeepReadonly<AgorConfig>): boolean {
+  if (config.execution?.unix_user_mode === 'sandbox') return true;
+  const sandbox = config.execution?.sandbox;
+  if (sandbox?.enabled !== true) return false;
+  return (sandbox.home_mode ?? SANDBOX_HOME_MODE_DEFAULT) === 'per_user';
 }

--- a/apps/agor-daemon/src/utils/clone-reference.ts
+++ b/apps/agor-daemon/src/utils/clone-reference.ts
@@ -5,10 +5,41 @@ import type { DeepReadonly } from '@agor/core/types';
  * Decide whether clone-mode branch creation should borrow objects from the
  * managed base clone via `git clone --reference`.
  *
- * Local execution no longer impersonates host Unix users, so every supported
- * mode can use the daemon-managed object cache.
+ * The borrow replaces the new clone's `.git/objects` with an `alternates`
+ * pointer at `<data_home>/repos/<slug>/.git/objects`. That is a large disk
+ * win, but it is also a *durable* dependency: the pointer is baked in at
+ * create time and re-read by every later git command in that branch. So the
+ * base clone has to be readable from wherever sessions run, not merely from
+ * wherever the branch happened to be materialized.
+ *
+ * When those two contexts differ — containerized / templated executors that
+ * only mount the branch workspace — every git command in the branch dies:
+ *
+ * ```
+ * error: unable to normalize alternate object path: /…/.agor/repos/<org>/<repo>/.git/objects
+ * error: Could not read <sha>
+ * fatal: Failed to traverse parents of commit <sha>
+ * ```
+ *
+ * `createBranchAsClone`'s `referencePath` probe cannot defend against this:
+ * it runs in the process performing the clone, where the path *is* visible,
+ * while the alternates are consumed later somewhere it is not. Hence an
+ * operator-level decision rather than a runtime probe.
+ *
+ * Borrowing is disabled when either:
+ *  - `execution.branch_storage.borrow_base_objects: false` — explicit opt-out.
+ *  - `execution.executor_storage.base_repository: 'unavailable'` — the
+ *    operator has already declared the base checkout invisible to executors,
+ *    which is exactly the topology where alternates cannot resolve.
+ *
+ * Default stays `true`, preserving the behavior every existing install has.
  */
 export function shouldUseCloneReferencePath(config: DeepReadonly<AgorConfig>): boolean {
-  void config;
+  if (config.execution?.branch_storage?.borrow_base_objects === false) {
+    return false;
+  }
+  if (config.execution?.executor_storage?.base_repository === 'unavailable') {
+    return false;
+  }
   return true;
 }

--- a/apps/agor-docs/content/guide/branches.mdx
+++ b/apps/agor-docs/content/guide/branches.mdx
@@ -101,7 +101,7 @@ execution:
     # Optional: reject clone_depth and require complete history.
     allow_shallow_clones: false
     # Optional: stop clone-mode branches from borrowing objects from the
-    # daemon's base clone. See "Borrowed objects" below.
+    # daemon's base clone. Usually inferred — see "Borrowed objects" below.
     borrow_base_objects: false
 ```
 
@@ -133,16 +133,41 @@ fatal: Failed to traverse parents of commit <sha>
 ```
 
 Set `borrow_base_objects: false` on those deployments. Every clone-mode branch then carries its own
-complete object store: more disk, no cross-mount dependency. The default (`true`) is correct for
-single-mount installs, which is most of them.
+complete object store: more disk, no cross-mount dependency.
 
-Agor also disables the borrow automatically when
-[`execution.executor_storage.base_repository`](/guide/containerized-execution) is `unavailable` —
-that setting is already an operator assertion that executors cannot see the base checkout.
+Agor turns the borrow off by itself in two cases, so most operators never touch the setting:
 
-The setting only affects branches created after the change. An existing branch that was cloned with
-a borrow it cannot resolve has to be recreated (or have `.git/objects/info/alternates` removed and
-its objects refetched).
+- **`execution.sandbox` is enabled with `home_mode: per_user`** — including `unix_user_mode:
+  sandbox`, which forces exactly that. The owner-home overlay deliberately hides the entire daemon
+  `.agor` tree — `repos/` included — and re-exposes only the branch and the managed agentic-tools
+  directory. Branch creation itself is never sandboxed, so without this the daemon would happily
+  write a pointer its own sessions cannot follow.
+- **[`execution.executor_storage.base_repository`](/guide/containerized-execution) is
+  `unavailable`** — already an operator assertion that executors cannot see the base checkout.
+
+Setting `borrow_base_objects: true` explicitly overrides the sandbox inference, for operators who
+have made the base clone reachable another way (for example
+`execution.sandbox.extra_allow_write: ['<data_home>/repos']`). `base_repository: unavailable` is not
+overridable.
+
+#### Repairing a branch that already has an unresolvable borrow
+
+The setting only affects branches created after the change. An existing branch keeps its pointer.
+
+Do **not** just delete `.git/objects/info/alternates` — the borrowed objects were never copied into
+the branch, so removing the pointer leaves the repository with no objects at all (`fatal: bad object
+HEAD`) and loses any commit that was never pushed. Materialize the objects first, from a context
+where the base clone **is** readable (the daemon host, not a sandboxed session):
+
+```bash
+cd <data_home>/worktrees/<repo>/<branch>
+git repack -a -d          # copies borrowed objects into a local pack — no -l/--local
+rm -f .git/objects/info/alternates
+git fsck --connectivity-only   # verify before trusting it
+```
+
+Recreating the branch also works, but it allocates a new `branch_id` and orphans anything bound to
+the old one (schedules, gateway channels).
 
 ---
 

--- a/apps/agor-docs/content/guide/branches.mdx
+++ b/apps/agor-docs/content/guide/branches.mdx
@@ -124,7 +124,7 @@ That pointer is baked in at create time and re-read by **every** later git comma
 It therefore requires the base clone to be readable from wherever **sessions** run — not merely from
 wherever the branch was materialized. If sessions execute in a different mount (a containerized or
 templated executor that only binds the branch workspace and never `repos/`), git in that branch
-fails permanently:
+breaks as soon as a session touches it:
 
 ```
 error: unable to normalize alternate object path: /…/.agor/repos/<org>/<repo>/.git/objects
@@ -132,13 +132,19 @@ error: Could not read <sha>
 fatal: Failed to traverse parents of commit <sha>
 ```
 
+On a freshly created branch that is total: `git status`, `git log`, `git show` and `git commit` all
+exit non-zero on `fatal: bad object HEAD` before the agent can do anything. A later `git fetch` or
+`git pull` against a reachable remote can quietly backfill the missing objects and make the branch
+look healthy again — but the pointer is still there, still unresolvable, and still erroring on every
+command, and anything git could not re-download from the remote stays lost.
+
 Set `borrow_base_objects: false` on those deployments. Every clone-mode branch then carries its own
 complete object store: more disk, no cross-mount dependency.
 
 Agor turns the borrow off by itself in two cases, so most operators never touch the setting:
 
-- **`execution.sandbox` is enabled with `home_mode: per_user`** — including `unix_user_mode:
-  sandbox`, which forces exactly that. The owner-home overlay deliberately hides the entire daemon
+- **`execution.sandbox` is enabled with `home_mode: per_user`** — which the named
+  `unix_user_mode: sandbox` mode forces. The owner-home overlay deliberately hides the entire daemon
   `.agor` tree — `repos/` included — and re-exposes only the branch and the managed agentic-tools
   directory. Branch creation itself is never sandboxed, so without this the daemon would happily
   write a pointer its own sessions cannot follow.
@@ -147,17 +153,22 @@ Agor turns the borrow off by itself in two cases, so most operators never touch 
 
 Setting `borrow_base_objects: true` explicitly overrides the sandbox inference, for operators who
 have made the base clone reachable another way (for example
-`execution.sandbox.extra_allow_write: ['<data_home>/repos']`). `base_repository: unavailable` is not
-overridable.
+`execution.sandbox.extra_allow_write: ['<data_home>/repos']` — note that is a read-**write** bind,
+so a session could rewrite the object store every other borrowed branch depends on).
+`base_repository: unavailable` is not overridable.
 
 #### Repairing a branch that already has an unresolvable borrow
 
 The setting only affects branches created after the change. An existing branch keeps its pointer.
 
-Do **not** just delete `.git/objects/info/alternates` — the borrowed objects were never copied into
-the branch, so removing the pointer leaves the repository with no objects at all (`fatal: bad object
-HEAD`) and loses any commit that was never pushed. Materialize the objects first, from a context
-where the base clone **is** readable (the daemon host, not a sandboxed session):
+Do **not** just delete `.git/objects/info/alternates`. The borrowed objects were never copied into
+the branch, so dropping the pointer strands everything that lived behind it. On a branch with no
+in-session commits that is every object (`fatal: bad object HEAD`). On one that has been worked in,
+the session's own commits survive as local objects but their history does not, so git can no longer
+walk them out — `git push` and `git format-patch` both die on `Could not read <sha>` /
+`fatal: Failed to traverse parents of commit <sha>`, and the unpushed work is unrecoverable.
+Materialize the objects first, from a context where the base clone **is** readable (the daemon host,
+not a sandboxed session):
 
 ```bash
 cd <data_home>/worktrees/<repo>/<branch>

--- a/apps/agor-docs/content/guide/branches.mdx
+++ b/apps/agor-docs/content/guide/branches.mdx
@@ -100,6 +100,9 @@ execution:
       - clone
     # Optional: reject clone_depth and require complete history.
     allow_shallow_clones: false
+    # Optional: stop clone-mode branches from borrowing objects from the
+    # daemon's base clone. See "Borrowed objects" below.
+    borrow_base_objects: false
 ```
 
 If `branch_storage` is omitted, Agor keeps the backwards-compatible default: `worktree` is selected by default and both `worktree` and `clone` are available. When an operator restricts `allowed_modes`, the create-branch UI disables unavailable options and the daemon rejects disallowed API/MCP requests.
@@ -108,6 +111,38 @@ If `branch_storage` is omitted, Agor keeps the backwards-compatible default: `wo
 `clone_depth`; callers must omit the field to create a full clone. This is independent of mount
 topology: both full and shallow clones are self-standing, while a native worktree always requires
 the registered base repository's Git metadata.
+
+### Borrowed objects (`borrow_base_objects`)
+
+By default, clone-mode branches are created with `git clone --reference` against the daemon-managed
+base clone at `<data_home>/repos/<slug>/`. Instead of copying the whole object store, the new branch
+gets an `alternates` pointer into it — per-branch `.git/` drops from "full pack copy" to a few MB.
+Only immutable objects are shared; `.git/config`, remotes, and credentials stay branch-local, so the
+isolation clone mode buys is preserved.
+
+That pointer is baked in at create time and re-read by **every** later git command in the branch.
+It therefore requires the base clone to be readable from wherever **sessions** run — not merely from
+wherever the branch was materialized. If sessions execute in a different mount (a containerized or
+templated executor that only binds the branch workspace and never `repos/`), git in that branch
+fails permanently:
+
+```
+error: unable to normalize alternate object path: /…/.agor/repos/<org>/<repo>/.git/objects
+error: Could not read <sha>
+fatal: Failed to traverse parents of commit <sha>
+```
+
+Set `borrow_base_objects: false` on those deployments. Every clone-mode branch then carries its own
+complete object store: more disk, no cross-mount dependency. The default (`true`) is correct for
+single-mount installs, which is most of them.
+
+Agor also disables the borrow automatically when
+[`execution.executor_storage.base_repository`](/guide/containerized-execution) is `unavailable` —
+that setting is already an operator assertion that executors cannot see the base checkout.
+
+The setting only affects branches created after the change. An existing branch that was cloned with
+a borrow it cannot resolve has to be recreated (or have `.git/objects/info/alternates` removed and
+its objects refetched).
 
 ---
 

--- a/apps/agor-docs/content/guide/containerized-execution.mdx
+++ b/apps/agor-docs/content/guide/containerized-execution.mdx
@@ -78,8 +78,13 @@ execution:
 Otherwise clone-mode branches are created with an `alternates` pointer into a base clone the
 executor cannot read, and every git command inside the branch fails with
 `unable to normalize alternate object path`. Declaring
-`execution.executor_storage.base_repository: unavailable` implies the same thing. See
-[Borrowed objects](/guide/branches) for the full explanation.
+`execution.executor_storage.base_repository: unavailable` implies the same thing.
+
+This one has to be declared: Agor infers it automatically for its own bubblewrap sandbox, but it
+cannot inspect an external launcher's mounts. Branch materialization runs on the daemon host, where
+the base clone is visible, so nothing detects the mismatch at create time — the failure only shows
+up later, inside sessions. See [Borrowed objects](/guide/branches) for the full explanation and for
+how to repair a branch that already has an unresolvable pointer.
 
 ## Shared Filesystem Setup
 

--- a/apps/agor-docs/content/guide/containerized-execution.mdx
+++ b/apps/agor-docs/content/guide/containerized-execution.mdx
@@ -66,6 +66,21 @@ A delegated executor must receive trusted `{tenant_id}` and `{user_id}` values a
 
 The daemon validates its declared storage contract but cannot prove the external substrate's claims. Use an immutable image, least-privilege service identity, tenant-separated storage, and explicit Stop/orphan cleanup.
 
+If your executors mount the branch workspace but **not** the daemon's `repos/` directory, also turn
+off the clone-mode object borrow:
+
+```yaml
+execution:
+  branch_storage:
+    borrow_base_objects: false
+```
+
+Otherwise clone-mode branches are created with an `alternates` pointer into a base clone the
+executor cannot read, and every git command inside the branch fails with
+`unable to normalize alternate object path`. Declaring
+`execution.executor_storage.base_repository: unavailable` implies the same thing. See
+[Borrowed objects](/guide/branches) for the full explanation.
+
 ## Shared Filesystem Setup
 
 ### Persistence Must Match the Database

--- a/packages/core/src/config/config-manager.test.ts
+++ b/packages/core/src/config/config-manager.test.ts
@@ -499,6 +499,33 @@ describe('loadConfig', () => {
     await expect(loadConfig()).rejects.toThrow(/preserve_canonical_home_alias must be a boolean/);
   });
 
+  it('accepts branch_storage.borrow_base_objects and rejects a non-boolean value', async () => {
+    // The escape hatch for deployments whose executors cannot see the
+    // daemon's repos/ mount; must survive the strict unknown-key sweep.
+    const agorDir = path.join(tempDir, '.agor');
+    const configPath = path.join(agorDir, 'config.yaml');
+    await fs.mkdir(agorDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      'execution:\n  branch_storage:\n    borrow_base_objects: false\n',
+      'utf-8'
+    );
+
+    await expect(loadConfig()).resolves.toMatchObject({
+      execution: { branch_storage: { borrow_base_objects: false } },
+    });
+
+    await fs.writeFile(
+      configPath,
+      'execution:\n  branch_storage:\n    borrow_base_objects: "false"\n',
+      'utf-8'
+    );
+    __resetConfigCacheForTests();
+    await expect(loadConfig()).rejects.toThrow(
+      /execution\.branch_storage\.borrow_base_objects must be a boolean/
+    );
+  });
+
   describe('AGOR_UNKNOWN_CONFIG_KEYS forward-compatibility policy', () => {
     const writeConfigWithFutureKey = async () => {
       const agorDir = path.join(tempDir, '.agor');

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -831,6 +831,7 @@ function validateConfig(config: AgorConfig): void {
     'default_mode',
     'allowed_modes',
     'allow_shallow_clones',
+    'borrow_base_objects',
   ]);
   only(config.execution?.sandbox, 'execution.sandbox', [
     'enabled',
@@ -899,6 +900,12 @@ function validateConfig(config: AgorConfig): void {
     throw new Error(
       'Config error: execution.branch_storage.allow_shallow_clones must be a boolean'
     );
+  }
+  if (
+    config.execution?.branch_storage?.borrow_base_objects !== undefined &&
+    typeof config.execution.branch_storage.borrow_base_objects !== 'boolean'
+  ) {
+    throw new Error('Config error: execution.branch_storage.borrow_base_objects must be a boolean');
   }
   only(config.security, 'security', ['csp', 'cors', 'git_config_parameters']);
   only(config.security?.csp, 'security.csp', [

--- a/packages/core/src/config/sandbox-policy.test.ts
+++ b/packages/core/src/config/sandbox-policy.test.ts
@@ -370,4 +370,25 @@ describe('resolveBwrapArgs — home_mode: per_user', () => {
   it('FAILS CLOSED (throws) when per_user is set but no store resolved — no silent shared fallback', () => {
     expect(() => resolveBwrapArgs({ home_mode: 'per_user' }, CTX)).toThrow(/fail closed/i);
   });
+
+  // Contract relied upon by `shouldUseCloneReferencePath`
+  // (apps/agor-daemon/src/utils/clone-reference.ts): a clone-mode branch gets
+  // NO `baseRepoPath` from the daemon (register-services.ts / terminals.ts skip
+  // it for `storage_mode === 'clone'`), so under this overlay nothing under
+  // `<data_home>/repos` is reachable. A `git clone --reference` alternates
+  // pointer into the base clone is therefore permanently unresolvable here —
+  // which is why the daemon must not create one for this deployment shape.
+  //
+  // If this ever changes (repos re-exposed to clone-mode branches), revisit
+  // that gate: the borrow would become safe again.
+  it('leaves the base object store unreachable for a clone-mode branch (no baseRepoPath)', () => {
+    const args = resolveBwrapArgs(
+      { home_mode: 'per_user' },
+      { ...PER_USER_CTX, baseRepoPath: undefined }
+    );
+    // The overlay hides <data_home> wholesale…
+    expect(hasTriple(args, '--bind', STORE, '/home/agor')).toBe(true);
+    // …and nothing re-exposes the base clone or its object store.
+    expect(args.some((arg) => arg.startsWith('/home/agor/.agor/repos'))).toBe(false);
+  });
 });

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -856,24 +856,35 @@ export interface AgorBranchStorageSettings {
   /**
    * Whether clone-mode branches may borrow objects from the daemon-managed
    * base clone via `git clone --reference` (an `alternates` pointer into
-   * `<data_home>/repos/<slug>/.git/objects`). Defaults to `true` — on a
-   * single-mount install this is a large disk win and nothing else changes.
+   * `<data_home>/repos/<slug>/.git/objects`). On a single-mount install this
+   * is a large disk win and nothing else changes.
    *
-   * Set `false` when sessions run somewhere the daemon's `repos/` directory
-   * is not mounted (containerized / templated executors that only bind the
-   * branch workspace). The alternates pointer is baked into the branch at
-   * create time and consumed by every later `git` command, so a branch
-   * created with a borrow it cannot resolve is permanently broken:
+   * The alternates pointer is baked into the branch at create time and
+   * consumed by every later `git` command, so a branch created with a borrow
+   * it cannot resolve is permanently broken:
    *
    * ```
    * error: unable to normalize alternate object path: /…/.agor/repos/<org>/<repo>/.git/objects
    * fatal: Failed to traverse parents of commit <sha>
    * ```
    *
+   * Tri-state — leave unset unless you have a reason:
+   *  - unset (default): borrow, unless Agor can see that sessions will not be
+   *    able to resolve the pointer. Today that inference fires for
+   *    `execution.sandbox.enabled` + `home_mode: per_user`, whose owner-home
+   *    overlay hides the whole daemon `.agor` tree including `repos/`.
+   *  - `false`: never borrow. Use this for containerized / templated executors
+   *    that bind only the branch workspace — Agor cannot inspect an external
+   *    substrate's mounts, so it has to be told.
+   *  - `true`: always borrow, even where Agor would have inferred otherwise.
+   *    You are asserting the base clone is reachable from sessions (for
+   *    example via `execution.sandbox.extra_allow_write`).
+   *
+   * `execution.executor_storage.base_repository: 'unavailable'` outranks all
+   * three: it asserts the base checkout does not exist for executors at all.
+   *
    * Disabling costs disk (each branch carries a full object store) and buys
-   * mount-independence. Implied by
-   * `execution.executor_storage.base_repository: 'unavailable'`, which
-   * already asserts that executors cannot see the base checkout.
+   * mount-independence.
    */
   borrow_base_objects?: boolean;
 }

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -852,6 +852,30 @@ export interface AgorBranchStorageSettings {
    * carry complete history.
    */
   allow_shallow_clones?: boolean;
+
+  /**
+   * Whether clone-mode branches may borrow objects from the daemon-managed
+   * base clone via `git clone --reference` (an `alternates` pointer into
+   * `<data_home>/repos/<slug>/.git/objects`). Defaults to `true` — on a
+   * single-mount install this is a large disk win and nothing else changes.
+   *
+   * Set `false` when sessions run somewhere the daemon's `repos/` directory
+   * is not mounted (containerized / templated executors that only bind the
+   * branch workspace). The alternates pointer is baked into the branch at
+   * create time and consumed by every later `git` command, so a branch
+   * created with a borrow it cannot resolve is permanently broken:
+   *
+   * ```
+   * error: unable to normalize alternate object path: /…/.agor/repos/<org>/<repo>/.git/objects
+   * fatal: Failed to traverse parents of commit <sha>
+   * ```
+   *
+   * Disabling costs disk (each branch carries a full object store) and buys
+   * mount-independence. Implied by
+   * `execution.executor_storage.base_repository: 'unavailable'`, which
+   * already asserts that executors cannot see the base checkout.
+   */
+  borrow_base_objects?: boolean;
 }
 
 /** Consistency of the effective user's home across executor invocations. */

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -1201,6 +1201,14 @@ export interface CreateBranchAsCloneOptions {
    * correct. Git rejects shallow reference repositories outright, so this is
    * part of the correctness fallback rather than only an optimization.
    *
+   * That probe only covers *this* process's view. The alternates pointer it
+   * writes is consumed by every later git command in the branch, possibly
+   * from a different mount (a session executor that binds the branch
+   * workspace but not the daemon's `repos/`). Nothing observable here can
+   * predict that, so the cross-mount case is an operator decision instead:
+   * `execution.branch_storage.borrow_base_objects: false` makes the daemon
+   * stop passing a `referencePath` at all.
+   *
    * NEVER paired with `--dissociate`: dissociate copies all reachable
    * objects out of the reference into the new clone (~equivalent to a
    * naïve clone), defeating the purpose. See design doc §5.

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -1202,16 +1202,22 @@ export interface CreateBranchAsCloneOptions {
    * part of the correctness fallback rather than only an optimization.
    *
    * That probe only covers *this* process's view. The alternates pointer it
-   * writes is consumed by every later git command in the branch, possibly
-   * from a different mount (a session executor that binds the branch
-   * workspace but not the daemon's `repos/`). Nothing observable here can
-   * predict that, so the cross-mount case is an operator decision instead:
-   * `execution.branch_storage.borrow_base_objects: false` makes the daemon
-   * stop passing a `referencePath` at all.
+   * writes is consumed by every later git command in the branch, from a
+   * context that may not see `<path>` at all — Agor's own `git.branch.add`
+   * runs unsandboxed while the sessions that later run git in that branch are
+   * bubblewrap-wrapped, and `sandbox.home_mode: per_user` masks the daemon's
+   * `repos/`. Nothing observable here can predict that, so the decision is
+   * made from configuration upstream: `shouldUseCloneReferencePath`
+   * (apps/agor-daemon/src/utils/clone-reference.ts) stops the daemon passing a
+   * `referencePath` at all for those deployments.
    *
-   * NEVER paired with `--dissociate`: dissociate copies all reachable
-   * objects out of the reference into the new clone (~equivalent to a
-   * naïve clone), defeating the purpose. See design doc §5.
+   * NEVER paired with `--dissociate` for the normal path: dissociate repacks
+   * the borrowed objects into the new clone, so the disk win is gone
+   * (~equivalent to a naïve clone) even though the network transfer is still
+   * saved. See design doc §5. It remains the right tool for *repairing* a
+   * clone whose borrow already turned out to be unresolvable — `git repack -a
+   * -d` (no `-l`, which would exclude exactly the borrowed objects) followed
+   * by deleting `.git/objects/info/alternates`.
    *
    * Operational caveat: `git gc --prune=now` against the reference can
    * orphan objects that branches' alternates pointers still depend on.


### PR DESCRIPTION
## Symptom

Found on a live sandboxed deployment where **assistant branches could never refresh their skills**. Git inside a freshly created clone-mode branch fails from the first command a session runs:

```
error: unable to normalize alternate object path: /var/lib/agor/home/agorpg/.agor/repos/<org>/<repo>/.git/objects
error: Could not read <sha>
fatal: Failed to traverse parents of commit <sha>
```

Executor sessions on that deployment see only `~/.agor/{agentic-tools,config.yaml,worktrees}` — there is no `repos/` in their mount. The only known workaround was deleting and recreating the branch, which changes `branch_id` and orphans every schedule and gateway channel bound to it.

## Root cause

Clone-mode branch creation passes `git clone --reference <base clone>`. Over a real transport that leaves the new branch with **no object store of its own at all** — just `.git/objects/info/alternates` pointing at `<data_home>/repos/<slug>/.git/objects`. That pointer is baked in at create time and re-read by every later git command in the branch, so it needs the base clone readable from wherever *sessions* run, not merely from wherever the branch was materialized.

Two commits combined to produce the deployment shape where that is false:

- **`915c8b1cd`** *"filesystem-sandbox isolation + `unix_user_mode: sandbox` (strict replacement)"* introduced `execution.sandbox` with `home_mode: per_user`, whose owner-home overlay hides the entire daemon `.agor` tree — `repos/` included — and re-exposes only the branch, the managed agentic-tools dir, and (for `storage_mode !== 'clone'` branches only) the base repo's `.git`. It did **not** touch `shouldUseCloneReferencePath`, which still read `unix_user_mode !== 'strict'`. Since `strict` still existed alongside the new mode, operators migrating `strict` → `sandbox` silently re-enabled the borrow inside the very overlay that hides its target.
- **`0a077e6c2`** *"remove Unix impersonation machinery"* then collapsed the function to `return true`, reasoning *"Local execution no longer impersonates host Unix users, so every supported mode can use the daemon-managed object cache."* That is correct about **identity** and silent about **mount topology**, and it removed the last way to turn the borrow off.

### Why the existing `referencePath` fallback can't catch it

`createBranchAsClone` already probes the path (`existsSync` + shallow check) and drops `--reference` when it fails. But that probe runs **in the process performing the clone**, and `git.branch.add` carries no `cwd` in its payload — so `spawn-executor.ts` never bubblewrap-wraps it and the probe passes. The `prompt` / `zellij.attach` spawns that later run git *in that branch* always are wrapped, and cannot resolve the pointer. The probe is checking the right path on the wrong filesystem; no hardening there (including a post-clone "are the alternates resolvable?" check) can see the failure, because everything it can observe is fine.

## The fix

`shouldUseCloneReferencePath` becomes an ordered resolution:

| # | Condition | Borrow |
|---|-----------|--------|
| 1 | `branch_storage.borrow_base_objects: false` | no |
| 2 | `executor_storage.base_repository: 'unavailable'` | no |
| 3 | `branch_storage.borrow_base_objects: true` | yes |
| 4 | sandbox enabled + `home_mode: per_user` (or `unix_user_mode: sandbox`) | no |
| 5 | otherwise | yes |

**Case 4 is what actually fixes the reported deployment**, with no config change: that deployment is not an external substrate, it is Agor's own bubblewrap sandbox, and Agor already knows its own mount policy. Explicit `true` outranks it because an operator *can* make the base clone reachable (`sandbox.extra_allow_write`). `base_repository: unavailable` is not overridable — no setting conjures back an absent checkout. `home_mode: shared` keeps bubblewrap's `--ro-bind / /`, so the base clone stays readable and the borrow remains safe there.

**Case 1** is the new `execution.branch_storage.borrow_base_objects` knob, for the case Agor *cannot* infer: an external/templated executor whose mounts the daemon cannot inspect. It has to be declared.

`unix_user_mode: sandbox` is checked directly as well as through the folded `execution.sandbox` block, because a daemon started with a caller-supplied `DaemonStartOptions.config` skips that projection (`index.ts:188`).

Default is unchanged for every install without a sandbox. When the borrow is off, `createBranchAsClone` simply receives no `referencePath` and runs a plain full clone: more disk, no cross-mount dependency.

## Verification

Reproduced end-to-end against git 2.50.1 — real-transport `--reference` clone, base clone then hidden the way the `per_user` overlay hides it:

- The borrowed branch has **0 local objects**, only `objects/info/alternates`.
- With the base hidden, on a fresh branch: `git status`, `git log`, `git show`, `git commit` all exit 128 on `fatal: bad object HEAD`; `git stash` trips a git internal assertion (exit 134).
- With in-session commits, `git push` reproduces the reported pair exactly: `error: Could not read <sha>` / `fatal: Failed to traverse parents of commit <sha>`.
- **Counterfactual**: an otherwise identical clone built *without* `--reference` survives the same hiding with every command at exit 0.
- Chain is gated with no bypass: `shouldUseCloneReferencePath` → `useReference` → `referencePath` → `--reference`. `createBranchAsClone` has one caller, and `git.branch.add` has exactly two spawners (`repos.createBranch`, `branches.unarchive`) — both gated.

One nuance worth recording, and now documented: the breakage is not always *permanent*. A later `fetch`/`pull` against a reachable remote silently backfills the objects and makes the branch look healthy, while the unresolvable pointer and its per-command error remain. Anything git cannot re-download stays lost.

## Docs

- `guide/branches.mdx` — new "Borrowed objects" section: what the borrow buys, the exact failure, when to disable, and a **verified repair runbook** for branches that already have an unresolvable pointer.
- `guide/containerized-execution.mdx` — pointer in "Storage and identity requirements", noting this one must be *declared* because Agor cannot inspect an external launcher's mounts.
- Expanded the `referencePath` doc comment in `packages/git` to state why its own probe cannot cover the cross-mount case.

**Repair correction (important).** The obvious fix — delete `.git/objects/info/alternates` — destroys the branch, and an earlier draft of this PR recommended it. Empirically: on a fresh branch it strands every object (`fatal: bad object HEAD`); once a session has committed, those commits survive locally but their history does not, so `git push` and `git format-patch` die on `Failed to traverse parents` and the unpushed work is unrecoverable. The working sequence, run where the base clone *is* readable, is `git repack -a -d` (**not** `-l`/`--local`, which excludes exactly the borrowed objects) and only then removing the pointer. Both the failure and the fix are verified.

## Also in this PR

- Corrected two sandbox call-site comments (`register-services.ts`, `terminals.ts`) claiming a clone "carries its own `.git`". That is false for a `--reference` clone, and it is the assumption that produced this bug.
- Corrected the test comment asserting `base_repository: 'replica-local'` proves executor reachability. Under `execution_topology: external` it does not; it is treated as no signal rather than as proof.
- Noted in `packages/git` that `--dissociate` still saves the network transfer (only the disk win is lost) and is the right tool for repairing an already-broken borrow.

## Test coverage

- **`apps/agor-daemon/src/utils/clone-reference.test.ts`** (new, 14 tests) — default/explicit borrow, both opt-outs and their precedence, and the sandbox cases that pin the `915c8b1cd` regression (`per_user` vs `shared` home, the `unix_user_mode: sandbox` named mode, sandbox-not-enabled, and explicit-`true` override).
- **`packages/core/src/config/sandbox-policy.test.ts`** — new case pinning that a clone-mode branch gets nothing under `<data_home>/repos` in the `per_user` overlay. That is the contract the new inference depends on; if it ever changes, this test says so.
- **`packages/core/src/config/config-manager.test.ts`** — the new key survives the strict unknown-key sweep, and a non-boolean value is rejected with a clear message.

Results: `clone-reference.test.ts` 14/14 · `packages/core/src/config` 793/793 (26 files) · `pnpm typecheck` 21/21 · `pnpm lint` clean.

## Scope

Deliberately small: no UI surface (unlike `allow_shallow_clones`, this has no user-facing form implication), no startup heuristics, no automatic repair of already-broken branches. The setting affects branches created after the change; existing broken branches need the documented repack runbook or a recreate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
