### PR TITLE
feat(opencode): add OrcaRouter as a curated OpenCode provider

### DIFF
--- a/apps/agor-docs/content/guide/sdk-comparison.mdx
+++ b/apps/agor-docs/content/guide/sdk-comparison.mdx
@@ -807,6 +807,7 @@ OpenCode supports 75+ providers. Connect them in Settings → OpenCode Providers
 - **Anthropic** (Claude Sonnet, Opus, Haiku)
 - **Google** (Gemini models)
 - **GitHub Copilot** (via Pro+ subscription, near-unlimited usage)
+- **[OrcaRouter](https://www.orcarouter.ai)** (gateway to many models through one `orcarouter/auto` route; connect with an `ORCAROUTER_API_KEY`)
 - **Self-hosted** (Ollama, vLLM, etc.)
 - **Many more** (any OpenAI-compatible endpoint)
 

--- a/packages/agentic-tool-opencode/src/shared/known-models.test.ts
+++ b/packages/agentic-tool-opencode/src/shared/known-models.test.ts
@@ -92,4 +92,26 @@ describe('OpenCode known model catalog', () => {
       ]),
     });
   });
+
+  it('offers curated OrcaRouter models only with saved credential evidence', () => {
+    const disconnected = createOpenCodeKnownModelCatalog(new Set());
+    const configured = createOpenCodeKnownModelCatalog(new Set(['orcarouter']));
+
+    expect(disconnected.providers.find(({ id }) => id === 'orcarouter')).toMatchObject({
+      availableForSelection: false,
+    });
+    expect(configured.suggestedSelection).toEqual({
+      providerId: 'orcarouter',
+      modelId: 'orcarouter/auto',
+    });
+    expect(configured.providers.find(({ id }) => id === 'orcarouter')).toMatchObject({
+      name: 'OrcaRouter',
+      availableForSelection: true,
+      suggestedModel: 'orcarouter/auto',
+      models: expect.arrayContaining([
+        expect.objectContaining({ id: 'orcarouter/auto' }),
+        expect.objectContaining({ id: 'orcarouter/fusion' }),
+      ]),
+    });
+  });
 });

--- a/packages/agentic-tool-opencode/src/shared/known-models.ts
+++ b/packages/agentic-tool-opencode/src/shared/known-models.ts
@@ -80,6 +80,17 @@ const KNOWN_PROVIDERS = [
     ]),
   },
   {
+    id: 'orcarouter',
+    name: 'OrcaRouter',
+    availableWithoutCredentials: false,
+    suggestedModel: 'orcarouter/auto',
+    models: activeModels([
+      ['orcarouter/auto', 'OrcaRouter Auto'],
+      ['orcarouter/fusion', 'OrcaRouter Fusion'],
+      ['orcarouter/fusion-flash', 'OrcaRouter Fusion Flash'],
+    ]),
+  },
+  {
     id: 'opencode',
     name: 'OpenCode Zen',
     availableWithoutCredentials: true,

--- a/packages/core/src/telemetry/model-normalization.ts
+++ b/packages/core/src/telemetry/model-normalization.ts
@@ -18,6 +18,7 @@ const KNOWN_PROVIDER_VALUES = new Set([
   'gemini',
   'opencode',
   'openrouter',
+  'orcarouter',
   'local',
   'ollama',
 ]);

--- a/packages/core/src/telemetry/telemetry.test.ts
+++ b/packages/core/src/telemetry/telemetry.test.ts
@@ -64,7 +64,9 @@ describe('open-source telemetry payload hygiene', () => {
   it('normalizes providers and model families without preserving custom names', () => {
     expect(normalizeTelemetryProvider('Gemini')).toBe('google');
     expect(normalizeTelemetryProvider('AcmeInternal')).toBe('other');
+    expect(normalizeTelemetryProvider('OrcaRouter')).toBe('orcarouter');
     expect(normalizeTelemetryModelFamily('claude-sonnet-4-5')).toBe('claude-sonnet');
+    expect(normalizeTelemetryModelFamily('orcarouter/auto')).toBe('custom');
     expect(normalizeTelemetryModelFamily('acme-prod-secure-westus')).toBe('custom');
   });
 


### PR DESCRIPTION
## Summary

Add [OrcaRouter](https://www.orcarouter.ai) as a curated OpenCode provider in Agor so it shows up by name in the model selector, telemetry, and provider docs — instead of relying on generic OpenAI-compatible entry.

- **Curated catalog** (`packages/agentic-tool-opencode/src/shared/known-models.ts`): add an `orcarouter` provider entry (name **OrcaRouter**, `ORCAROUTER_API_KEY`-gated, suggested model `orcarouter/auto`, models `orcarouter/auto` / `orcarouter/fusion` / `orcarouter/fusion-flash`). Consistent with the existing `openai` / `anthropic` / `kimi-for-coding` entries.
- **Telemetry** (`packages/core/src/telemetry/model-normalization.ts`): recognize `orcarouter` as a known provider value so OpenCode sessions normalize instead of collapsing to `other`.
- **Docs** (`apps/agor-docs/content/guide/sdk-comparison.mdx`): list OrcaRouter in the OpenCode provider configuration section with a brand link.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Why / context

Agor's curated OpenCode provider catalog already names the providers users can pick in the model selector. Adding OrcaRouter there makes the gateway visible and selectable by name, mirroring how the project lists OpenAI/Anthropic/Google.

## Implementation notes

The provider is OpenAI-compatible at `https://api.orcarouter.ai/v1`, uses a `Bearer` `sk-orca-…` key, and exposes routing models under the `orcarouter/` prefix. No changes to the OpenCode runtime wiring are needed — OpenCode natively resolves the provider through models.dev; this PR surfaces it in Agor's curated UI and telemetry.

## Validation / test plan

- [x] `pnpm --filter @agor/agentic-tool-opencode test` — 145 passed
- [x] `pnpm --filter @agor/core test` — 3768 passed (telemetry suite green)
- [x] `pnpm --filter @agor/core typecheck` / `pnpm --filter @agor/agentic-tool-opencode typecheck` — clean
- [x] `biome check` on changed files — clean
- [x] Live check: `POST https://api.orcarouter.ai/v1/chat/completions` with `orcarouter/auto` → HTTP 200; all three registered models confirmed present in the OrcaRouter model list

Disclosure: I'm an engineer on the OrcaRouter team.
