### PR TITLE
fix(health): don't follow redirects on env health-check fetch

### DIFF
--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -2449,6 +2449,11 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
       const response = await fetch(healthUrl, {
         signal: controller.signal,
         method: 'GET',
+        // Do not follow redirects: an otherwise-allowed health URL could 302 to
+        // a link-local metadata endpoint (169.254.169.254), bypassing
+        // isAllowedHealthCheckUrl. A 3xx returns not-ok and is reported
+        // unhealthy. Mirrors the managed-env webhook fetch.
+        redirect: 'manual',
       });
       return {
         status: response.ok ? 'healthy' : 'unhealthy',

--- a/apps/agor-daemon/src/services/distributed-health-monitor.ts
+++ b/apps/agor-daemon/src/services/distributed-health-monitor.ts
@@ -483,6 +483,9 @@ export class DistributedHealthMonitor {
       const response = await this.fetchHealth(healthUrl, {
         method: 'GET',
         signal: controller.signal,
+        // Do not follow redirects (see branches.ts): the distributed/managed
+        // path is where a 302 to a link-local metadata endpoint matters most.
+        redirect: 'manual',
       });
       return {
         status: response.ok ? 'healthy' : 'unhealthy',


### PR DESCRIPTION
isAllowedHealthCheckUrl is a string-prefix validator, so an allowed health URL
that 302-redirects to a link-local metadata endpoint (169.254.169.254) would be
followed, bypassing validation. Set redirect:'manual' so a 3xx returns not-ok
and is reported unhealthy. Applied to BOTH the standalone (branches.ts) and the
distributed/managed (distributed-health-monitor.ts) health paths.
Finding: AGOR-HEALTH-SSRF.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
