### PR TITLE
fix(board-comments): derive reaction author from authenticated caller

### DIFF
--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -3472,12 +3472,19 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       app,
       '/board-comments/:id/toggle-reaction',
       {
-        async create(data: { user_id: string; emoji: string }, params: RouteParams) {
+        async create(data: { emoji: string }, params: RouteParams) {
           const id = params.route?.id;
           if (!id) throw new Error('Comment ID required');
-          if (!data.user_id) throw new Error('user_id required');
           if (!data.emoji) throw new Error('emoji required');
-          const updated = await boardCommentsService.toggleReaction(id, data, params);
+          // Derive the reactor from the authenticated caller; never trust a
+          // client-supplied user_id (previously spoofable: react as any user).
+          const userId = params.user?.user_id as string | undefined;
+          if (!userId) throw new Error('Authentication required');
+          const updated = await boardCommentsService.toggleReaction(
+            id,
+            { user_id: userId, emoji: data.emoji },
+            params
+          );
           emitServiceEvent(app, {
             path: 'board-comments',
             event: 'patched',

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -1874,8 +1874,9 @@ function AppContent() {
     if (!client) return;
     try {
       // Use the custom route for toggling reactions
+      // The server derives the reactor from the authenticated session; do not
+      // send a client user_id (it is ignored).
       await client.service(`board-comments/${commentId}/toggle-reaction`).create({
-        user_id: user?.user_id || 'unknown',
         emoji,
       });
     } catch (error) {


### PR DESCRIPTION
The toggle-reaction route passed the client-supplied data.user_id straight into
toggleReaction, so a caller could add/remove reactions as any user_id. Use the
authenticated params.user.user_id instead and ignore any client-supplied value.
Finding: AGOR-AC01 (reaction spoof).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
