### PR TITLE
fix(tenancy): register kb/graph as a tenant-owned service path

### DIFF
--- a/apps/agor-daemon/src/register-hooks.test.ts
+++ b/apps/agor-daemon/src/register-hooks.test.ts
@@ -392,7 +392,12 @@ describe('tenant-owned service registration', () => {
 
   it('wraps Knowledge policy and indexing admin services in tenant database scope', () => {
     expect(TENANT_OWNED_SERVICE_PATHS).toEqual(
-      expect.arrayContaining(['kb/settings', 'kb/indexing/status', 'kb/indexing/reindex'])
+      expect.arrayContaining([
+        'kb/graph',
+        'kb/settings',
+        'kb/indexing/status',
+        'kb/indexing/reindex',
+      ])
     );
   });
 });

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -480,6 +480,7 @@ export const TENANT_OWNED_SERVICE_PATHS = [
   'session-env-selections',
   'kb/namespaces',
   'kb/documents',
+  'kb/graph',
   'kb/document-edits',
   'kb/versions',
   'kb/search',


### PR DESCRIPTION
kb/graph was registered and given a role hook but omitted from
TENANT_OWNED_SERVICE_PATHS, so in hosted mode a kb/graph query runs without an
active tenant DB scope and throws MissingTenantDatabaseScopeError (breaks the
KB-graph feature; fail-closed, not a leak). Add it to the registry and the
completeness test. Finding: AGOR-TENANTREG.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
