### PR TITLE
fix(codex): disable native multi-agent orchestration

### DIFF
--- a/apps/agor-docs/content/guide/sdk-comparison.mdx
+++ b/apps/agor-docs/content/guide/sdk-comparison.mdx
@@ -9,6 +9,15 @@ import { ScrollTable } from '../../components/ScrollTable';
 
 Agor integrates with multiple AI coding agents. Each SDK has different capabilities based on their native features and API design.
 
+> **Codex subagent policy:** Agor disables Codex's native multi-agent feature for every
+> Agor-launched Codex process with the per-process SDK override
+> `features.multi_agent=false`. Agor does not edit `~/.codex/config.toml`, and the
+> override leaves unrelated user, project, model, and feature configuration intact. Use
+> [Agor sessions and subsessions](/guide/sessions) for delegation so child work, genealogy,
+> status, and callbacks remain observable. Agor's version-aligned Codex package pins an
+> SDK/CLI pair that supports this switch; an incompatible CLI configuration fails the Task
+> rather than silently enabling native subagents.
+
 ## Feature Matrix
 
 <ScrollTable>

--- a/apps/agor-docs/content/guide/sessions.mdx
+++ b/apps/agor-docs/content/guide/sessions.mdx
@@ -130,7 +130,10 @@ If you've used [Claude Code's subagent feature](https://docs.claudecode.com/suba
 | **Hierarchical spawning**     | No                               | Children can spawn their own children |
 | **Multi-tool support**        | Claude Code only                 | Claude, Codex, Gemini, OpenCode       |
 
-**Crucially**, neither Codex, Gemini, nor OpenCode SDKs natively support spawning subsessions. **Agor unlocks this for all supported agents.**
+Codex also has a native multi-agent feature, but Agor deliberately disables it in
+Agor-launched Codex processes. Use Agor subsessions instead: they keep child work visible in
+the session tree and provide durable status and callback semantics. Agor provides the same
+observable orchestration boundary for every supported agent.
 
 ---
 

--- a/packages/executor/src/sdk-handlers/codex/launch-policy.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/launch-policy.test.ts
@@ -1,0 +1,54 @@
+import type { CodexOptions } from '@agor/core/sdk';
+import { describe, expect, it } from 'vitest';
+import { applyAgorCodexLaunchPolicy } from './launch-policy.js';
+
+type CodexConfigObject = NonNullable<CodexOptions['config']>;
+
+describe('applyAgorCodexLaunchPolicy', () => {
+  it('disables native multi-agent while preserving every unrelated override', () => {
+    const config: CodexConfigObject = {
+      features: {
+        goals: false,
+        memories: true,
+        multi_agent: true,
+      },
+      model_instructions_file: '/tmp/agor-instructions.md',
+      mcp_servers: {
+        agor: {
+          url: 'http://localhost:3030/mcp',
+        },
+      },
+    };
+
+    expect(applyAgorCodexLaunchPolicy(config)).toEqual({
+      features: {
+        goals: false,
+        memories: true,
+        multi_agent: false,
+      },
+      model_instructions_file: '/tmp/agor-instructions.md',
+      mcp_servers: {
+        agor: {
+          url: 'http://localhost:3030/mcp',
+        },
+      },
+    });
+    expect(config.features).toEqual({
+      goals: false,
+      memories: true,
+      multi_agent: true,
+    });
+  });
+
+  it('creates the required per-process override when no other config exists', () => {
+    expect(applyAgorCodexLaunchPolicy(undefined)).toEqual({
+      features: { multi_agent: false },
+    });
+  });
+
+  it('fails clearly instead of dropping the policy when features cannot be merged', () => {
+    expect(() => applyAgorCodexLaunchPolicy({ features: true } as CodexConfigObject)).toThrow(
+      'Cannot launch Codex with Agor policy: config.features must be an object so features.multi_agent can be disabled'
+    );
+  });
+});

--- a/packages/executor/src/sdk-handlers/codex/launch-policy.ts
+++ b/packages/executor/src/sdk-handlers/codex/launch-policy.ts
@@ -1,0 +1,36 @@
+import type { CodexOptions } from '@agor/core/sdk';
+
+type CodexConfigObject = NonNullable<CodexOptions['config']>;
+
+function isCodexConfigObject(value: unknown): value is CodexConfigObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Apply Agor-owned Codex process policy without changing the user's
+ * `~/.codex/config.toml`.
+ *
+ * The Codex SDK flattens this object into per-process
+ * `--config features.multi_agent=false`. That override intentionally wins over
+ * user configuration while every unrelated config key, including other
+ * feature flags, remains intact.
+ */
+export function applyAgorCodexLaunchPolicy(
+  config: CodexConfigObject | undefined
+): CodexConfigObject {
+  const features = config?.features;
+  if (features !== undefined && !isCodexConfigObject(features)) {
+    throw new Error(
+      'Cannot launch Codex with Agor policy: config.features must be an object so features.multi_agent can be disabled'
+    );
+  }
+
+  return {
+    ...config,
+    features: {
+      ...features,
+      // Agor sessions/subsessions are the supported, observable orchestration boundary.
+      multi_agent: false,
+    },
+  };
+}

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
@@ -459,7 +459,7 @@ describe('CodexPromptService - prompt flow client initialization', () => {
       expectedApps: undefined,
     },
   ])(
-    'builds session config for $name permissions and uses the configured accessor',
+    'builds policy-enforced session config for $name permissions and uses the configured accessor',
     async ({
       persistedPermissionMode,
       promptPermissionMode,
@@ -504,7 +504,7 @@ describe('CodexPromptService - prompt flow client initialization', () => {
           ...(persistedPermissionMode ? { mode: persistedPermissionMode } : {}),
           codex: codexPermissions,
         },
-        model_config: { effort: 'medium' },
+        model_config: { model: 'gpt-5.4', effort: 'medium' },
         mcp_token: 'test-token',
       });
       mockSessionsRepo.update.mockResolvedValue(undefined);
@@ -533,7 +533,7 @@ describe('CodexPromptService - prompt flow client initialization', () => {
       expect(mockInstanceCount).toBe(1);
       expect(mockInstanceConfigs).toEqual([
         {
-          features: { goals: false },
+          features: { goals: false, multi_agent: false },
           model_instructions_file: '/tmp/agor-codex-instructions-flow.md',
           mcp_servers: {
             agor: {
@@ -548,6 +548,7 @@ describe('CodexPromptService - prompt flow client initialization', () => {
         threadId: 'mock-thread-id',
       });
       expect(mockStartThreadOptions.at(-1)).toMatchObject({
+        model: 'gpt-5.4',
         modelReasoningEffort: 'medium',
       });
     }

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -58,6 +58,7 @@ import type { PermissionMode, SessionID, TaskID, UserID } from '../../types.js';
 import { resolveContextUserId } from '../base/context-user.js';
 import type { TasksService } from '../base/index.js';
 import { forkCodexThreadViaAppServer } from './app-server-client.js';
+import { applyAgorCodexLaunchPolicy } from './launch-policy.js';
 import { extractCodexContextSnapshotFromEvent, extractCodexTokenUsage } from './usage.js';
 
 type CodexSdkReasoningEffort = NonNullable<
@@ -412,7 +413,9 @@ export class CodexPromptService {
    * `env` object is provided, so we forward all other vars explicitly.
    *
    * API-key mode omits `env` entirely so the SDK inherits `process.env`
-   * normally and injects `CODEX_API_KEY` itself.
+   * normally and injects `CODEX_API_KEY` itself. Agor's product policy is
+   * applied here, at the one SDK launch boundary shared by every Codex
+   * executor topology.
    */
   private buildCodexOptions(
     apiKey: string | undefined,
@@ -424,7 +427,7 @@ export class CodexPromptService {
     const options: ConstructorParameters<typeof CodexSdk.Codex>[0] = {
       ...(apiKey ? { apiKey } : {}),
       ...(baseUrl ? { baseUrl } : {}),
-      ...(config ? { config } : {}),
+      config: applyAgorCodexLaunchPolicy(config),
     };
 
     if (useSubscription) {


### PR DESCRIPTION
## Summary

- enforce `features.multi_agent=false` for every Codex executor session launched by Agor
- apply the policy at the shared Codex client configuration boundary while preserving unrelated user and model configuration
- fail clearly when the configured Codex interface cannot express the policy instead of falling back to native subagents
- document Agor sessions and subsessions as the supported, observable orchestration mechanism
- add focused coverage for policy precedence and configuration preservation

## Compatibility

- verified against the pinned `@openai/codex-sdk` and Codex CLI version `0.144.0`
- does not read or mutate a user's global `~/.codex/config.toml`
- applies to all execution topologies that use the shared Codex handler
- existing sessions receive the policy on their next Agor-launched Codex turn

## Testing

- `pnpm i`
- `pnpm check`
- `env -u AGOR_OUTER_SANDBOX AGOR_MANAGED_AGENTIC_TOOLS=0 pnpm --filter @agor/executor exec vitest run src/sdk-handlers/codex/launch-policy.test.ts src/sdk-handlers/codex/prompt-service.test.ts` (73 tests passed)
