### PR TITLE
refactor(client): simplify public exports

### DIFF
--- a/packages/client/scripts/validate-pack-artifact.mjs
+++ b/packages/client/scripts/validate-pack-artifact.mjs
@@ -2,6 +2,7 @@
 
 import { execFileSync, execSync } from 'node:child_process';
 import {
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readdirSync,
@@ -14,6 +15,7 @@ import {
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
 
 const packageDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const tempDir = mkdtempSync(path.join(os.tmpdir(), 'agor-client-pack-'));
@@ -21,6 +23,18 @@ const tempDir = mkdtempSync(path.join(os.tmpdir(), 'agor-client-pack-'));
 function fail(message) {
   console.error(`❌ ${message}`);
   process.exitCode = 1;
+}
+
+function commandErrorMessage(error) {
+  if (!(error instanceof Error)) {
+    return String(error);
+  }
+
+  const commandError = error;
+  const diagnostics = [commandError.stdout, commandError.stderr]
+    .map((output) => (output ? String(output).trim() : ''))
+    .filter(Boolean);
+  return [error.message, ...diagnostics].join('\n');
 }
 
 function listFilesRecursive(dir) {
@@ -66,16 +80,31 @@ const dependencySections = [
   ['optionalDependencies', packedManifest.optionalDependencies ?? {}],
 ];
 
+const privateWorkspacePackagePattern =
+  /^@agor\/(?:core|agentic-tools|agentic-tool-opencode)(?:\/|$)/;
+
 for (const [sectionName, deps] of dependencySections) {
   for (const [name, version] of Object.entries(deps)) {
     if (typeof version === 'string' && version.startsWith('workspace:')) {
       fail(`Packed manifest contains workspace protocol in ${sectionName}: ${name}=${version}`);
     }
+    if (privateWorkspacePackagePattern.test(name)) {
+      fail(`Packed manifest contains private workspace package in ${sectionName}: ${name}`);
+    }
   }
 }
 
-if (packedManifest.dependencies && Object.hasOwn(packedManifest.dependencies, '@agor/core')) {
-  fail('Packed manifest must not contain @agor/core as a runtime dependency');
+function findPrivateWorkspaceModuleReference(content) {
+  const moduleInfo = ts.preProcessFile(content, true, true);
+  const references = [
+    ...moduleInfo.importedFiles,
+    ...moduleInfo.typeReferenceDirectives,
+    ...moduleInfo.libReferenceDirectives,
+    ...moduleInfo.referencedFiles,
+  ];
+  return references
+    .map((reference) => reference.fileName)
+    .find((specifier) => privateWorkspacePackagePattern.test(specifier));
 }
 
 const packedFiles = listFilesRecursive(packedRoot);
@@ -84,23 +113,50 @@ const typeFiles = packedFiles.filter(
   (file) => file.endsWith('.d.ts') || file.endsWith('.d.cts') || file.endsWith('.d.mts')
 );
 
-// Matches imports of private workspace packages, but not comments or doc-strings.
-const workspaceImportPattern =
-  /(?:^|[\s;])(?:import|export|require)\s.*['"]@agor\/(?:core|agentic-tools|agentic-tool-opencode)(?:\/[^'"]*)?['"]/m;
-
 for (const file of runtimeFiles) {
   const content = readFileSync(file, 'utf8');
-  if (workspaceImportPattern.test(content)) {
+  const privateReference = findPrivateWorkspaceModuleReference(content);
+  if (privateReference) {
     fail(
-      `Runtime artifact still references a workspace package: ${path.relative(packedRoot, file)}`
+      `Runtime artifact still references private workspace package ${privateReference}: ${path.relative(packedRoot, file)}`
     );
   }
 }
 
 for (const file of typeFiles) {
   const content = readFileSync(file, 'utf8');
-  if (workspaceImportPattern.test(content)) {
-    fail(`Type artifact still references a workspace package: ${path.relative(packedRoot, file)}`);
+  const privateReference = findPrivateWorkspaceModuleReference(content);
+  if (privateReference) {
+    fail(
+      `Type artifact still references private workspace package ${privateReference}: ${path.relative(packedRoot, file)}`
+    );
+  }
+}
+
+const privateReferenceProbe = "type Leaked = import('@agor/core/types').Session;";
+if (findPrivateWorkspaceModuleReference(privateReferenceProbe) !== '@agor/core/types') {
+  fail('Private workspace reference detector does not recognize declaration import() types');
+}
+
+const packedNodeModules = path.join(packedRoot, 'node_modules');
+mkdirSync(packedNodeModules, { recursive: true });
+const linkedDependencies = new Set();
+for (const [sectionName, deps] of dependencySections) {
+  for (const name of Object.keys(deps)) {
+    if (linkedDependencies.has(name)) {
+      continue;
+    }
+    const source = path.join(packageDir, 'node_modules', ...name.split('/'));
+    if (!existsSync(source)) {
+      if (sectionName !== 'optionalDependencies') {
+        fail(`Installed package is missing packed ${sectionName} dependency: ${name}`);
+      }
+      continue;
+    }
+    const destination = path.join(packedNodeModules, ...name.split('/'));
+    mkdirSync(path.dirname(destination), { recursive: true });
+    symlinkSync(source, destination, 'junction');
+    linkedDependencies.add(name);
   }
 }
 
@@ -114,11 +170,6 @@ const requiredRuntimeExports = [
   'REPO_SLUG_PATTERN',
 ];
 try {
-  symlinkSync(
-    path.join(packageDir, 'node_modules'),
-    path.join(packedRoot, 'node_modules'),
-    'junction'
-  );
   execFileSync(process.execPath, [
     '--input-type=module',
     '-e',
@@ -126,7 +177,7 @@ try {
   ]);
 } catch (error) {
   fail(
-    `Packed client entrypoint failed or is missing public runtime exports: ${error instanceof Error ? error.message : String(error)}`
+    `Packed client entrypoint failed or is missing public runtime exports: ${commandErrorMessage(error)}`
   );
 }
 
@@ -208,9 +259,7 @@ void (undefined as unknown as PublicClientTypes);
     }
   );
 } catch (error) {
-  fail(
-    `Packed client declarations are missing public client types: ${error instanceof Error ? error.message : String(error)}`
-  );
+  fail(`Packed client declarations are missing public client types: ${commandErrorMessage(error)}`);
 }
 
 try {

--- a/packages/client/scripts/validate-pack-artifact.mjs
+++ b/packages/client/scripts/validate-pack-artifact.mjs
@@ -80,8 +80,7 @@ const dependencySections = [
   ['optionalDependencies', packedManifest.optionalDependencies ?? {}],
 ];
 
-const privateWorkspacePackagePattern =
-  /^@agor\/(?:core|agentic-tools|agentic-tool-opencode)(?:\/|$)/;
+const privateWorkspacePackagePattern = /^@agor\//;
 
 for (const [sectionName, deps] of dependencySections) {
   for (const [name, version] of Object.entries(deps)) {
@@ -133,8 +132,8 @@ for (const file of typeFiles) {
   }
 }
 
-const privateReferenceProbe = "type Leaked = import('@agor/core/types').Session;";
-if (findPrivateWorkspaceModuleReference(privateReferenceProbe) !== '@agor/core/types') {
+const privateReferenceProbe = "type Leaked = import('@agor/git').GitRepo;";
+if (findPrivateWorkspaceModuleReference(privateReferenceProbe) !== '@agor/git') {
   fail('Private workspace reference detector does not recognize declaration import() types');
 }
 

--- a/packages/client/scripts/validate-pack-artifact.mjs
+++ b/packages/client/scripts/validate-pack-artifact.mjs
@@ -1,7 +1,16 @@
 #!/usr/bin/env node
 
 import { execFileSync, execSync } from 'node:child_process';
-import { mkdtempSync, readdirSync, readFileSync, rmSync, symlinkSync, unlinkSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -49,6 +58,7 @@ try {
 const packedRoot = path.join(tempDir, 'package');
 const packedManifestPath = path.join(packedRoot, 'package.json');
 const packedManifest = JSON.parse(readFileSync(packedManifestPath, 'utf8'));
+const consumerRoot = path.join(tempDir, 'consumer');
 
 const dependencySections = [
   ['dependencies', packedManifest.dependencies ?? {}],
@@ -94,11 +104,14 @@ for (const file of typeFiles) {
   }
 }
 
-const requiredCompatibilityExports = [
+const requiredRuntimeExports = [
   'TOOL_API_KEY_NAMES',
   'AGENTIC_TOOL_DISPLAY_NAMES',
   'AGENTIC_TOOL_KEY_CREATION_URL',
   'AGENTIC_TOOL_CAPABILITIES',
+  'shortId',
+  'isValidSlug',
+  'REPO_SLUG_PATTERN',
 ];
 try {
   symlinkSync(
@@ -109,11 +122,94 @@ try {
   execFileSync(process.execPath, [
     '--input-type=module',
     '-e',
-    `const {createRequire}=await import('node:module'); const require=createRequire(import.meta.url); const clients=[require(${JSON.stringify(path.join(packedRoot, 'dist/index.cjs'))}), await import(${JSON.stringify(path.join(packedRoot, 'dist/index.js'))})]; for (const client of clients) for (const name of ${JSON.stringify(requiredCompatibilityExports)}) { if (!(name in client)) throw new Error('Missing runtime export: ' + name); }`,
+    `const {createRequire}=await import('node:module'); const require=createRequire(import.meta.url); const clients=[require(${JSON.stringify(path.join(packedRoot, 'dist/index.cjs'))}), await import(${JSON.stringify(path.join(packedRoot, 'dist/index.js'))})]; for (const client of clients) for (const name of ${JSON.stringify(requiredRuntimeExports)}) { if (!(name in client)) throw new Error('Missing runtime export: ' + name); }`,
   ]);
 } catch (error) {
   fail(
-    `Packed client entrypoint failed or is missing agentic-tool compatibility exports: ${error instanceof Error ? error.message : String(error)}`
+    `Packed client entrypoint failed or is missing public runtime exports: ${error instanceof Error ? error.message : String(error)}`
+  );
+}
+
+try {
+  const consumerPackageDir = path.join(consumerRoot, 'node_modules', '@agor-live', 'client');
+  mkdirSync(path.dirname(consumerPackageDir), { recursive: true });
+  symlinkSync(packedRoot, consumerPackageDir, 'junction');
+  writeFileSync(
+    path.join(consumerRoot, 'consumer.ts'),
+    `import { createClient, createRestClient } from '@agor-live/client';
+import type * as Client from '@agor-live/client';
+
+const socketClient: Client.AgorClient = createClient('http://localhost:3030', false);
+const reactiveClient: Client.ReactiveAgorClient = createClient('http://localhost:3030', false);
+const restClient: Promise<Client.AuthenticatedAgorClient> = createRestClient();
+
+async function useAuthentication(client: Client.AuthenticatedAgorClient) {
+  await client.authenticate();
+  await client.reAuthenticate();
+  await client.logout();
+}
+
+type PublicClientTypes = [
+  Client.AgorService<Client.Session>,
+  Client.BoardsService,
+  Client.BranchesService,
+  Client.ClientInput<Client.Session>,
+  Client.FindResult<Client.Task>,
+  Client.GatewayChannelsService,
+  Client.MessagesService,
+  Client.PaginatedResult<Client.Session>,
+  Client.ReposCloneService,
+  Client.ReposLocalService,
+  Client.ReposService,
+  Client.SchedulesService,
+  Client.ServiceTypes,
+  Client.SessionPromptOptions,
+  Client.SessionsService,
+  Client.TaskRunOptions,
+  Client.TaskRunRequest,
+  Client.TasksClientHelpers,
+  Client.TasksService,
+  Client.TemplateRenderRequest,
+  Client.TemplateRenderResponse,
+  Client.TemplatesService,
+];
+
+void socketClient;
+void reactiveClient;
+void restClient;
+void useAuthentication;
+void (undefined as unknown as PublicClientTypes);
+`
+  );
+  writeFileSync(
+    path.join(consumerRoot, 'tsconfig.json'),
+    `${JSON.stringify(
+      {
+        compilerOptions: {
+          module: 'NodeNext',
+          moduleResolution: 'NodeNext',
+          noEmit: true,
+          skipLibCheck: true,
+          strict: true,
+          target: 'ES2022',
+        },
+        include: ['consumer.ts'],
+      },
+      null,
+      2
+    )}\n`
+  );
+  execFileSync(
+    process.execPath,
+    [path.join(packageDir, '..', '..', 'node_modules', 'typescript', 'bin', 'tsc')],
+    {
+      cwd: consumerRoot,
+      stdio: 'pipe',
+    }
+  );
+} catch (error) {
+  fail(
+    `Packed client declarations are missing public client types: ${error instanceof Error ? error.message : String(error)}`
   );
 }
 
@@ -127,5 +223,5 @@ try {
 }
 
 if (!process.exitCode) {
-  console.log('✅ npm pack artifact is standalone (no private workspace references)');
+  console.log('✅ npm pack artifact is standalone and its public client types are consumable');
 }

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -44,23 +44,8 @@ import {
   type ToolExecutionState,
 } from './reactive-session';
 
-export type {
-  AgorClient,
-  AgorService,
-  BoardsService,
-  BranchesService,
-  ClientInput,
-  FindResult,
-  GatewayChannelsService,
-  MessagesService,
-  ReposCloneService,
-  ReposLocalService,
-  ReposService,
-  SchedulesService,
-  ServiceTypes,
-  SessionsService,
-  TasksService,
-} from '@agor/core/client';
+// @agor/core/client is the canonical browser-safe client surface. Keep this
+// wildcard so new public core client types do not require a synchronized list.
 export * from '@agor/core/client';
 
 // Derive this public alias from the function we wrap instead of asking the DTS
@@ -78,13 +63,6 @@ export const AGENTIC_TOOL_KEY_CREATION_URL: Partial<Record<AgenticToolName, stri
   PRIVATE_AGENTIC_TOOL_KEY_CREATION_URL;
 export const AGENTIC_TOOL_CAPABILITIES: Record<AgenticToolName, AgenticToolCapabilities> =
   PRIVATE_AGENTIC_TOOL_CAPABILITIES;
-// `shortId` is the canonical display helper (always SHORT_ID_LENGTH chars).
-// Use it for any UUID rendered to a user — URLs, pills, logs, notifications.
-// `toShortId(id, length)` is the lower-level primitive for rare cases that
-// need a non-canonical length (e.g. `findMinimumPrefixLength`).
-export { shortId } from '@agor/core/client';
-export { isValidSlug, REPO_SLUG_PATTERN } from '@agor/core/config/browser';
-export type { PaginatedResult } from '@agor/core/types';
 export * from './models';
 export type {
   ReactiveAgorClient,

--- a/packages/core/src/types/feathers.ts
+++ b/packages/core/src/types/feathers.ts
@@ -7,15 +7,7 @@
  * Re-exports FeathersJS types so daemon doesn't need direct dependencies.
  */
 
-import type {
-  HookContext as FeathersHookContext,
-  Id,
-  NullableId,
-  Paginated,
-  Params,
-  Service,
-  ServiceMethods,
-} from '@feathersjs/feathers';
+import type { HookContext as FeathersHookContext, Paginated, Params } from '@feathersjs/feathers';
 
 // ============================================================================
 // Re-exported FeathersJS Types (for daemon usage without direct import)
@@ -30,7 +22,14 @@ import type {
  * - Version control (core manages Feathers version)
  * - Easier mocking/testing
  */
-export type { Id, NullableId, Paginated, Params, Service, ServiceMethods };
+export type {
+  Id,
+  NullableId,
+  Paginated,
+  Params,
+  Service,
+  ServiceMethods,
+} from '@feathersjs/feathers';
 
 // ============================================================================
 // Authentication Types


### PR DESCRIPTION
## Linked issue

N/A

## Summary

- make `@agor/core/client` the single canonical re-export for the core client surface
- retain the derived `AuthenticatedAgorClient` alias so standalone declaration bundling remains deterministic
- compile a TypeScript consumer against the packed `@agor-live/client` artifact to guard named public types and REST authentication methods
- remove the Rollup declaration warning caused by import-then-re-export Feathers types

## Why / context

`@agor-live/client` maintained a manually synchronized list of core client types alongside `export * from '@agor/core/client'`. The list duplicated the wildcard surface and could drift as core added public client types. Directly relying on the wildcard previously exposed a declaration-bundler missing-export edge case for `AuthenticatedAgorClient`, so this keeps that alias derived from the wrapped REST factory while removing the redundant list.

## Implementation notes

- Runtime wrappers and package-owned compatibility constants are unchanged.
- `shortId`, `isValidSlug`, `REPO_SLUG_PATTERN`, `PaginatedResult`, and the former explicit client types remain exported through `@agor/core/client`.
- Pack validation checks both ESM and CJS runtime exports, rejects private workspace imports, and typechecks a consumer through the extracted package boundary.
- The Feathers type cleanup changes only re-export syntax; it does not change the exported type names or contracts.

## Validation / test plan

- [x] `pnpm i`
- [x] `pnpm check`
- [x] `pnpm --filter @agor-live/client test` (43 tests)
- [x] `pnpm --filter @agor-live/client check:pack`
- [x] clean dependency-ordered `@agor-live/client` package build

## Risks / rollout / rollback

Low risk and intended to be non-breaking. The public names removed from explicit forwarding are still provided by the canonical core wildcard, and the packed-package consumer test covers the expected named type surface. Rollback is a normal revert of this PR.

## Out of scope / follow-ups

No unrelated core API or client behavior changes.
