### PR TITLE
refactor(multitenancy): simplify tenant write scope

### DIFF
--- a/apps/agor-daemon/src/register-routes.board-comments.test.ts
+++ b/apps/agor-daemon/src/register-routes.board-comments.test.ts
@@ -289,9 +289,10 @@ describe('tenant-scoped custom-route registration', () => {
     installed: {
       around?: { all?: Array<(context: HookContext, next: () => Promise<void>) => Promise<void>> };
     },
-    next: () => Promise<void>
+    next: () => Promise<void>,
+    method = 'create'
   ) {
-    const context = { method: 'create', params: {}, data: {} } as HookContext;
+    const context = { method, params: {}, data: {} } as HookContext;
     const run = (installed.around?.all ?? []).reduceRight<() => Promise<void>>(
       (inner, hook) => () => hook(context, inner),
       next
@@ -334,5 +335,23 @@ describe('tenant-scoped custom-route registration', () => {
       code: 503,
     });
     expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('does not over-gate a recognized custom read on the installed route boundary', async () => {
+    const execute = vi.fn(async () => [
+      {
+        value_text: JSON.stringify({
+          generation: 'gate-generation',
+          acquiredAt: '2026-08-21T00:00:00.000Z',
+        }),
+      },
+    ]);
+    const { installed } = installRoute(execute);
+    const handler = vi.fn(async () => undefined);
+
+    await runInstalledAroundHooks(installed ?? {}, handler, 'getPrimaryTeammate');
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(execute).toHaveBeenCalledOnce();
   });
 });

--- a/apps/agor-daemon/src/register-routes.prompt-scope.test.ts
+++ b/apps/agor-daemon/src/register-routes.prompt-scope.test.ts
@@ -5,14 +5,14 @@ import { describe, expect, it } from 'vitest';
 describe('prompt and widget transaction scopes', () => {
   const source = readFileSync(join(__dirname, 'register-routes.ts'), 'utf8');
 
-  it('uses the long-route identity scope and short Task repository units for prompt admission', () => {
+  it('uses long-route admission and short Task repository units without a duplicate gate check', () => {
     const promptStart = source.indexOf("'/sessions/:id/prompt'");
     const promptEnd = source.indexOf("'/tasks/:id/run'", promptStart);
     const prompt = source.slice(promptStart - 100, promptEnd);
 
     expect(promptStart).toBeGreaterThan(0);
     expect(prompt).toContain('registerLongAuthenticatedRoute(');
-    expect(prompt).toContain('assertTenantWriteAdmission(db, promptTenantId)');
+    expect(prompt).not.toContain('assertTenantWriteAdmission(');
     expect(prompt).toContain('bindRepositoryToTenantUnitOfWork(db, new TaskRepository(db))');
     expect(prompt).toContain(
       'isAgenticToolEnabledForTenant(db, promptTenantId, activeAgenticTool)'

--- a/apps/agor-daemon/src/register-routes.prompt-scope.test.ts
+++ b/apps/agor-daemon/src/register-routes.prompt-scope.test.ts
@@ -12,6 +12,7 @@ describe('prompt and widget transaction scopes', () => {
 
     expect(promptStart).toBeGreaterThan(0);
     expect(prompt).toContain('registerLongAuthenticatedRoute(');
+    expect(prompt).toContain('assertTenantWriteAdmission(db, promptTenantId)');
     expect(prompt).toContain('bindRepositoryToTenantUnitOfWork(db, new TaskRepository(db))');
     expect(prompt).toContain(
       'isAgenticToolEnabledForTenant(db, promptTenantId, activeAgenticTool)'

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -215,11 +215,12 @@ import { buildTaskLaunchState } from './utils/task-launch-state.js';
 import { normalizeMessageSource, runExistingTask } from './utils/task-runner.js';
 import { isAgenticToolEnabledForTenant } from './utils/tenant-agentic-tool-validation.js';
 import {
-  createFreshTenantWriteDatabaseRunner,
+  assertTenantWriteAdmission,
   createTenantDatabaseScopeAroundHook,
   createTenantWriteAdmissionAroundHook,
   createTenantWriteGateAroundHook,
   deferWithTenantContext,
+  withFreshTenantWrite,
 } from './utils/tenant-db-scope.js';
 import {
   createUploadMiddleware,
@@ -1786,9 +1787,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         }
         const promptTenantId = getCurrentTenantId();
         if (!promptTenantId) throw new Error('Missing active tenant context for prompt admission');
-        await runWithTenantDatabaseScope(db, promptTenantId, (tenantDb) =>
-          assertTenantWritable(tenantDb, promptTenantId)
-        );
+        await assertTenantWriteAdmission(db, promptTenantId);
 
         // Derive external provenance server-side. Only provider-less,
         // daemon-internal producers may preserve an explicit gateway source.
@@ -2919,10 +2918,9 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         if (!id) throw new Error('Session ID required');
         const body = data && typeof data === 'object' ? (data as Record<string, unknown>) : {};
         const sessionsServiceWithHooks = app.service('sessions') as unknown as SessionsServiceImpl;
-        const runInFreshTerminationTenantWriteDatabase = createFreshTenantWriteDatabaseRunner(
-          db,
-          getCurrentTenantId()
-        );
+        const terminationTenantId = getCurrentTenantId();
+        const runInFreshTerminationTenantWriteDatabase = <T>(work: () => Promise<T>) =>
+          withFreshTenantWrite(db, terminationTenantId, work);
         const session = await inCurrentTenantDatabaseScope(() =>
           app.service('sessions').get(id, params)
         );

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -215,7 +215,6 @@ import { buildTaskLaunchState } from './utils/task-launch-state.js';
 import { normalizeMessageSource, runExistingTask } from './utils/task-runner.js';
 import { isAgenticToolEnabledForTenant } from './utils/tenant-agentic-tool-validation.js';
 import {
-  assertTenantWriteAdmission,
   createTenantDatabaseScopeAroundHook,
   createTenantWriteAdmissionAroundHook,
   createTenantWriteGateAroundHook,
@@ -1787,7 +1786,6 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         }
         const promptTenantId = getCurrentTenantId();
         if (!promptTenantId) throw new Error('Missing active tenant context for prompt admission');
-        await assertTenantWriteAdmission(db, promptTenantId);
 
         // Derive external provenance server-side. Only provider-less,
         // daemon-internal producers may preserve an explicit gateway source.

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -230,7 +230,7 @@ import {
 import { resolveOwnerHomeStore, resolveSandboxStoragePaths } from './utils/sandbox-context.js';
 import { type SpawnExecutorOptions, spawnExecutor } from './utils/spawn-executor.js';
 import { classifyExecutorExit } from './utils/task-launch-state.js';
-import { createFreshTenantWriteDatabaseRunner } from './utils/tenant-db-scope.js';
+import { withFreshTenantWrite } from './utils/tenant-db-scope.js';
 
 /**
  * Interface for dependencies needed by service registration.
@@ -1016,10 +1016,8 @@ function createExecuteHandler(
     );
 
     const taskId = data.taskId;
-    const runInFreshTerminationTenantWriteDatabase = createFreshTenantWriteDatabaseRunner(
-      db,
-      tenantId
-    );
+    const runInFreshTerminationTenantWriteDatabase = <T>(work: () => Promise<T>) =>
+      withFreshTenantWrite(db, tenantId, work);
 
     // Get branch path (+ authoritative base repo path for the sandbox) and, for
     // RBAC-aware mounting, the session OWNER's effective filesystem access to

--- a/apps/agor-daemon/src/services/repos.test.ts
+++ b/apps/agor-daemon/src/services/repos.test.ts
@@ -59,18 +59,17 @@ const executorMocks = vi.hoisted(() => ({
 }));
 const delegatedHomeMocks = vi.hoisted(() => ({ resolve: vi.fn(async () => undefined) }));
 const tenantScopeMocks = vi.hoisted(() => {
-  const runFreshWrite = vi.fn(async (work: () => Promise<unknown>) => work());
-  return {
-    runFreshWrite,
-    createFreshTenantWriteDatabaseRunner: vi.fn(() => runFreshWrite),
-  };
+  const withFreshTenantWrite = vi.fn(
+    async (_db: unknown, _tenantId: string, work: () => Promise<unknown>) => work()
+  );
+  return { withFreshTenantWrite };
 });
 vi.mock('../utils/executor-delegated-home.js', () => ({
   resolveDelegatedExecutionHomeKey: delegatedHomeMocks.resolve,
 }));
 vi.mock('../utils/tenant-db-scope.js', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../utils/tenant-db-scope.js')>()),
-  createFreshTenantWriteDatabaseRunner: tenantScopeMocks.createFreshTenantWriteDatabaseRunner,
+  withFreshTenantWrite: tenantScopeMocks.withFreshTenantWrite,
 }));
 vi.mock('../utils/spawn-executor.js', () => {
   return {
@@ -81,8 +80,7 @@ vi.mock('../utils/spawn-executor.js', () => {
 });
 
 beforeEach(() => {
-  tenantScopeMocks.runFreshWrite.mockClear();
-  tenantScopeMocks.createFreshTenantWriteDatabaseRunner.mockClear();
+  tenantScopeMocks.withFreshTenantWrite.mockClear();
 });
 
 describe('ReposService.addLocalRepository executor boundary', () => {
@@ -425,11 +423,11 @@ describe('ReposService.cloneRepository Git lifecycle execution', () => {
 
     await spawnOptions?.onExit?.(17);
 
-    expect(tenantScopeMocks.createFreshTenantWriteDatabaseRunner).toHaveBeenCalledWith(
+    expect(tenantScopeMocks.withFreshTenantWrite).toHaveBeenCalledWith(
       db,
-      'tenant-a'
+      'tenant-a',
+      expect.any(Function)
     );
-    expect(tenantScopeMocks.runFreshWrite).toHaveBeenCalledOnce();
     expect(repos.get).toHaveBeenCalledWith(current.repo_id);
     expect(repos.patch).toHaveBeenCalledWith(current.repo_id, {
       clone_status: 'failed',

--- a/apps/agor-daemon/src/services/repos.ts
+++ b/apps/agor-daemon/src/services/repos.ts
@@ -58,7 +58,7 @@ import {
   requestExecutor,
   spawnExecutorFireAndForget,
 } from '../utils/spawn-executor.js';
-import { createFreshTenantWriteDatabaseRunner } from '../utils/tenant-db-scope.js';
+import { withFreshTenantWrite } from '../utils/tenant-db-scope.js';
 import { issueExecutorCommandToken } from './session-token-service.js';
 
 /**
@@ -405,7 +405,7 @@ export class ReposService extends DrizzleService<Repo, Partial<Repo>, RepoParams
             // write-gated tenant unit. Standalone SQLite retains its historical
             // unscoped internal-service behavior.
             if (tenantId) {
-              await createFreshTenantWriteDatabaseRunner(this.db, tenantId)(resolveDurableFailure);
+              await withFreshTenantWrite(this.db, tenantId, resolveDurableFailure);
             } else {
               await resolveDurableFailure();
             }

--- a/apps/agor-daemon/src/services/task-runtime-reconciler.ts
+++ b/apps/agor-daemon/src/services/task-runtime-reconciler.ts
@@ -19,7 +19,7 @@ import { TaskStatus } from '@agor/core/types';
 import type { Application, TasksServiceImpl } from '../declarations.js';
 import { getTrackedExecutor } from '../executor-tracking.js';
 import { requestExecutorTermination } from '../termination-coordinator.js';
-import { createFreshTenantWriteDatabaseRunner } from '../utils/tenant-db-scope.js';
+import { withFreshTenantWrite } from '../utils/tenant-db-scope.js';
 
 export const EXECUTOR_HEARTBEAT_LOST_MESSAGE =
   'Executor heartbeat lost; the executor may have crashed or disconnected.';
@@ -231,7 +231,7 @@ export class TaskRuntimeReconciler {
     tenantId: TenantID | string,
     work: () => Promise<T>
   ): Promise<T> {
-    return createFreshTenantWriteDatabaseRunner(this.options.db, tenantId)(work);
+    return withFreshTenantWrite(this.options.db, tenantId, work);
   }
 
   private async reconcileDispatchTimeout(

--- a/apps/agor-daemon/src/services/tasks.sdk-health.test.ts
+++ b/apps/agor-daemon/src/services/tasks.sdk-health.test.ts
@@ -2,16 +2,13 @@ import { type SdkFailure, TaskStatus } from '@agor/core/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const beginExecutorTermination = vi.hoisted(() => vi.fn());
-const withFreshTenantWriteDatabase = vi.hoisted(() =>
-  vi.fn(async (work: () => Promise<unknown>) => work())
-);
-const createFreshTenantWriteDatabaseRunner = vi.hoisted(() =>
-  vi.fn(() => withFreshTenantWriteDatabase)
+const withFreshTenantWrite = vi.hoisted(() =>
+  vi.fn(async (_db: unknown, _tenantId: string, work: () => Promise<unknown>) => work())
 );
 vi.mock('../termination-coordinator.js', () => ({ beginExecutorTermination }));
 vi.mock('../utils/tenant-db-scope.js', () => ({
-  createFreshTenantWriteDatabaseRunner,
   deferWithTenantContext: vi.fn(),
+  withFreshTenantWrite,
 }));
 
 import { TasksService } from './tasks.js';
@@ -53,8 +50,7 @@ function serviceFor(current = task, observationAccepted = true) {
 describe('TasksService SDK health reports', () => {
   beforeEach(() => {
     beginExecutorTermination.mockReset();
-    withFreshTenantWriteDatabase.mockClear();
-    createFreshTenantWriteDatabaseRunner.mockClear();
+    withFreshTenantWrite.mockClear();
   });
 
   it('persists observe-only evidence without lifecycle side effects', async () => {
@@ -113,16 +109,20 @@ describe('TasksService SDK health reports', () => {
       { tenant: { tenant_id: 'tenant-a' } } as never
     );
 
-    expect(createFreshTenantWriteDatabaseRunner).toHaveBeenCalledWith({}, 'tenant-a');
     expect(beginExecutorTermination).toHaveBeenCalledWith(
       expect.objectContaining({
         taskId: task.task_id,
         cause: 'sdk_health_failure',
         signalDelayMs: 25,
         sdkFailure: expect.objectContaining({ termination: 'requested' }),
-        runInFreshTenantWriteDatabase: withFreshTenantWriteDatabase,
+        runInFreshTenantWriteDatabase: expect.any(Function),
       })
     );
+    const runFreshWrite = beginExecutorTermination.mock.calls[0][0]
+      .runInFreshTenantWriteDatabase as (work: () => Promise<unknown>) => Promise<unknown>;
+    const work = vi.fn(async () => 'written');
+    await expect(runFreshWrite(work)).resolves.toBe('written');
+    expect(withFreshTenantWrite).toHaveBeenCalledWith({}, 'tenant-a', work);
   });
 
   it('rejects terminal, disconnected, disabled, and authority-escalating reports', async () => {

--- a/apps/agor-daemon/src/services/tasks.termination-report.test.ts
+++ b/apps/agor-daemon/src/services/tasks.termination-report.test.ts
@@ -3,11 +3,8 @@ import { TaskStatus } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
 
 const requestExecutorTermination = vi.hoisted(() => vi.fn().mockResolvedValue({}));
-const withFreshTenantWriteDatabase = vi.hoisted(() =>
-  vi.fn(async (work: () => Promise<unknown>) => work())
-);
-const createFreshTenantWriteDatabaseRunner = vi.hoisted(() =>
-  vi.fn(() => withFreshTenantWriteDatabase)
+const withFreshTenantWrite = vi.hoisted(() =>
+  vi.fn(async (_db: unknown, _tenantId: string, work: () => Promise<unknown>) => work())
 );
 const deferred = vi.hoisted(
   () =>
@@ -21,7 +18,6 @@ vi.mock('../termination-coordinator.js', () => ({
   requestExecutorTermination,
 }));
 vi.mock('../utils/tenant-db-scope.js', () => ({
-  createFreshTenantWriteDatabaseRunner,
   deferWithTenantContext: (
     params: unknown,
     work: () => Promise<void>,
@@ -30,6 +26,7 @@ vi.mock('../utils/tenant-db-scope.js', () => ({
     deferred.work = work;
     deferred.schedule(params, onError);
   },
+  withFreshTenantWrite,
 }));
 
 import { TasksService } from './tasks';
@@ -68,8 +65,7 @@ describe('TasksService executor termination report', () => {
       task_id: task.task_id,
       requested_at: requestedAt,
     });
-    expect(createFreshTenantWriteDatabaseRunner).toHaveBeenCalledWith({}, 'tenant-a');
-    expect(withFreshTenantWriteDatabase).toHaveBeenCalledOnce();
+    expect(withFreshTenantWrite).toHaveBeenCalledWith({}, 'tenant-a', expect.any(Function));
     expect(emit).toHaveBeenCalledWith('patched', task, expect.objectContaining({ path: 'tasks' }));
     expect(deferred.schedule).toHaveBeenCalledWith(
       expect.objectContaining({ tenant: { tenant_id: 'tenant-a' } }),
@@ -84,8 +80,13 @@ describe('TasksService executor termination report', () => {
         taskId: task.task_id,
         cause: 'user_stop',
         params: expect.objectContaining({ provider: undefined }),
-        runInFreshTenantWriteDatabase: withFreshTenantWriteDatabase,
+        runInFreshTenantWriteDatabase: expect.any(Function),
       })
     );
+    const runFreshWrite = requestExecutorTermination.mock.calls[0][0]
+      .runInFreshTenantWriteDatabase as (work: () => Promise<unknown>) => Promise<unknown>;
+    const work = vi.fn(async () => 'written');
+    await expect(runFreshWrite(work)).resolves.toBe('written');
+    expect(withFreshTenantWrite).toHaveBeenLastCalledWith({}, 'tenant-a', work);
   });
 });

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -77,10 +77,7 @@ import {
   ExecutorHeartbeatCallbackRunner,
 } from '../utils/executor-heartbeat-callback.js';
 import { ensureRepoOriginAlignedById } from '../utils/realign-repo-origin';
-import {
-  createFreshTenantWriteDatabaseRunner,
-  deferWithTenantContext,
-} from '../utils/tenant-db-scope.js';
+import { deferWithTenantContext, withFreshTenantWrite } from '../utils/tenant-db-scope.js';
 import type { SessionsService } from './sessions';
 
 export interface TaskExecutorCredentialRevoker {
@@ -1405,10 +1402,8 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
     params?: TaskParams
   ): Promise<Task> {
     const terminationTenantId = getCurrentTenantId() ?? params?.tenant?.tenant_id;
-    const runInFreshTerminationTenantWriteDatabase = createFreshTenantWriteDatabaseRunner(
-      this.db,
-      terminationTenantId
-    );
+    const runInFreshTerminationTenantWriteDatabase = <T>(work: () => Promise<T>) =>
+      withFreshTenantWrite(this.db, terminationTenantId, work);
     const task = await runInFreshTerminationTenantWriteDatabase(() =>
       this.taskRepo.recordExecutorQuiescence(data)
     );
@@ -1552,10 +1547,9 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
       throw new BadRequest('sdk_version must be a bounded identifier');
     }
 
-    const runInFreshTerminationTenantWriteDatabase = createFreshTenantWriteDatabaseRunner(
-      this.db,
-      getCurrentTenantId() ?? params?.tenant?.tenant_id
-    );
+    const terminationTenantId = getCurrentTenantId() ?? params?.tenant?.tenant_id;
+    const runInFreshTerminationTenantWriteDatabase = <T>(work: () => Promise<T>) =>
+      withFreshTenantWrite(this.db, terminationTenantId, work);
 
     const current = await this.get(data.task_id, params);
     const mode = current.sdk_watchdog_mode ?? 'observe';

--- a/apps/agor-daemon/src/utils/session-queue-tenant-scope.test.ts
+++ b/apps/agor-daemon/src/utils/session-queue-tenant-scope.test.ts
@@ -2,6 +2,7 @@ import {
   getCurrentTenantDatabaseScope,
   getCurrentTenantId,
   runWithTenantDatabaseScope,
+  TenantWriteGateActiveError,
 } from '@agor/core/db';
 import type { SessionID } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
@@ -265,6 +266,47 @@ describe('session queue tenant scope', () => {
 
     expect(work).not.toHaveBeenCalled();
     expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: expect.any(String) }));
+  });
+
+  it('blocks a deferred queue drain at short tenant write admission', async () => {
+    const tx = {
+      execute: vi
+        .fn()
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([
+          {
+            value_text: JSON.stringify({
+              generation: 'queue-gate-generation',
+              acquiredAt: '2026-08-24T00:00:00.000Z',
+            }),
+          },
+        ]),
+    };
+    const db = {
+      transaction: vi.fn(async (callback: (scoped: unknown) => Promise<unknown>) => callback(tx)),
+    };
+    const work = vi.fn(async () => undefined);
+
+    const error = await new Promise<unknown>((resolve) => {
+      deferWithSessionQueueTenantScope(
+        {
+          db: db as never,
+          config: {
+            database: { dialect: 'postgresql' },
+            multi_tenancy: { mode: 'required_from_auth', auth_claim: 'tenant_id' },
+          },
+          sessionId: 'session-1' as SessionID,
+          params: { tenant: { tenant_id: 'tenant-frozen', source: 'explicit' } },
+          label: 'frozen queue drain',
+        },
+        work,
+        resolve
+      );
+    });
+
+    expect(error).toBeInstanceOf(TenantWriteGateActiveError);
+    expect(work).not.toHaveBeenCalled();
+    expect(db.transaction).toHaveBeenCalledOnce();
   });
 
   it('defers request-less queue drains with a trusted tenant hint', async () => {

--- a/apps/agor-daemon/src/utils/session-queue-tenant-scope.test.ts
+++ b/apps/agor-daemon/src/utils/session-queue-tenant-scope.test.ts
@@ -212,9 +212,17 @@ describe('session queue tenant scope', () => {
     consoleError.mockRestore();
   });
 
-  it('defers promptable-session queue drains with active tenant params', async () => {
-    const { db } = makePgDb();
-    const seen: string[] = [];
+  it('waits for commit and defers queue work with tenant identity but no retained transaction', async () => {
+    const events: string[] = [];
+    const tx = { execute: vi.fn(async () => []) };
+    const db = {
+      transaction: vi.fn(async (callback: (transaction: unknown) => Promise<unknown>) => {
+        events.push('tx:start');
+        const result = await callback(tx);
+        events.push('tx:committed');
+        return result;
+      }),
+    };
 
     const drained = new Promise<void>((resolve, reject) => {
       void runWithTenantDatabaseScope(db as never, 'tenant-active', async () => {
@@ -231,17 +239,24 @@ describe('session queue tenant scope', () => {
           },
           async (params) => {
             expect(getCurrentTenantDatabaseScope()).toBeUndefined();
-            seen.push(`tenant:${getCurrentTenantId()}`);
-            seen.push(`params:${params.tenant?.tenant_id}`);
+            events.push(`work:${getCurrentTenantId()}:${params.tenant?.tenant_id}`);
             resolve();
           },
           reject
         );
+        events.push('scheduled');
       }).catch(reject);
     });
     await drained;
 
-    expect(seen).toEqual(['tenant:tenant-active', 'params:tenant-active']);
+    expect(events).toEqual([
+      'tx:start',
+      'scheduled',
+      'tx:committed',
+      'tx:start',
+      'tx:committed',
+      'work:tenant-active:tenant-active',
+    ]);
   });
 
   it('does not defer request-less queue drains in required tenant mode without params or ALS', async () => {

--- a/apps/agor-daemon/src/utils/session-queue-tenant-scope.ts
+++ b/apps/agor-daemon/src/utils/session-queue-tenant-scope.ts
@@ -1,12 +1,11 @@
 import { type AgorConfig, resolveMultiTenancyConfig } from '@agor/core/config';
-import {
-  assertTenantWritable,
-  runWithTenantContext,
-  runWithTenantDatabaseScope,
-  type TenantScopeAwareDatabase,
-} from '@agor/core/db';
+import { runWithTenantContext, type TenantScopeAwareDatabase } from '@agor/core/db';
 import type { Params, SessionID, TenantContext, TenantID } from '@agor/core/types';
-import { deferWithTenantContext, resolveTenantIdForDeferredScope } from './tenant-db-scope.js';
+import {
+  assertTenantWriteAdmission,
+  deferWithTenantContext,
+  resolveTenantIdForDeferredScope,
+} from './tenant-db-scope.js';
 
 type QueueTenantParams = Params & {
   tenant?: Pick<TenantContext, 'tenant_id' | 'source'>;
@@ -107,12 +106,10 @@ export function deferWithSessionQueueTenantScope(
     console.error(`❌ [Queue] ${options.label} failed:`, error);
   };
 
-  // A queue drain is a deferred tenant writer: fail closed at the write gate
-  // (see assertTenantWritable) before running; a held gate defers via handleError.
+  // A queue drain is a deferred tenant writer: fail closed through short
+  // tenant write admission before running; a held gate defers via handleError.
   const guarded = (tenantId: string, scopedParams: QueueTenantParams): Promise<void> =>
-    runWithTenantDatabaseScope(options.db, tenantId, (scoped) =>
-      assertTenantWritable(scoped, tenantId)
-    ).then(() => work(scopedParams));
+    assertTenantWriteAdmission(options.db, tenantId).then(() => work(scopedParams));
 
   const capturedTenantId = resolveTenantIdForDeferredScope(options.params);
   if (capturedTenantId) {

--- a/apps/agor-daemon/src/utils/tenant-db-scope.test.ts
+++ b/apps/agor-daemon/src/utils/tenant-db-scope.test.ts
@@ -12,11 +12,11 @@ import jwt from 'jsonwebtoken';
 import { describe, expect, it, vi } from 'vitest';
 import { RUNTIME_JWT_AUDIENCE, RUNTIME_JWT_ISSUER } from '../auth/runtime-tokens.js';
 import {
-  createFreshTenantWriteDatabaseRunner,
   createTenantDatabaseScopeAroundHook,
   createTenantWriteAdmissionAroundHook,
   deferWithTenantContext,
   deferWithTenantDatabaseScope,
+  withFreshTenantWrite,
 } from './tenant-db-scope.js';
 
 function makePgDb() {
@@ -39,7 +39,7 @@ function signRuntimeJwt(secret: string, payload: Record<string, unknown>) {
   });
 }
 
-describe('createFreshTenantWriteDatabaseRunner', () => {
+describe('withFreshTenantWrite', () => {
   it('remains a no-op write gate on the single-tenant SQLite path', async () => {
     const db = createDatabase({ url: ':memory:' });
     const work = vi.fn(async () => {
@@ -47,9 +47,7 @@ describe('createFreshTenantWriteDatabaseRunner', () => {
       return 'written';
     });
 
-    await expect(createFreshTenantWriteDatabaseRunner(db, 'default')(work)).resolves.toBe(
-      'written'
-    );
+    await expect(withFreshTenantWrite(db, 'default', work)).resolves.toBe('written');
     expect(work).toHaveBeenCalledOnce();
   });
 
@@ -64,11 +62,9 @@ describe('createFreshTenantWriteDatabaseRunner', () => {
         });
       }),
     };
-    const runMutation = createFreshTenantWriteDatabaseRunner(db as never, 'tenant-a');
-
     await runWithTenantDatabaseScope(db as never, 'tenant-a', async () => {
       expect(getCurrentTenantDatabaseScope()?.db).toMatchObject({ marker: 'tx-1' });
-      await runMutation(async () => {
+      await withFreshTenantWrite(db as never, 'tenant-a', async () => {
         expect(getCurrentTenantId()).toBe('tenant-a');
         expect(getCurrentTenantDatabaseScope()?.db).toMatchObject({ marker: 'tx-2' });
       });
@@ -96,14 +92,14 @@ describe('createFreshTenantWriteDatabaseRunner', () => {
     const db = {
       transaction: vi.fn(async (callback: (scoped: unknown) => Promise<unknown>) => callback(tx)),
     };
-    const runMutation = createFreshTenantWriteDatabaseRunner(db as never, 'tenant-frozen');
-
-    await expect(runMutation(work)).rejects.toBeInstanceOf(TenantWriteGateActiveError);
+    await expect(withFreshTenantWrite(db as never, 'tenant-frozen', work)).rejects.toBeInstanceOf(
+      TenantWriteGateActiveError
+    );
     expect(work).not.toHaveBeenCalled();
   });
 
   it('fails closed when no trusted tenant identity is available', () => {
-    expect(() => createFreshTenantWriteDatabaseRunner({} as never, undefined)).toThrow(
+    expect(() => withFreshTenantWrite({} as never, undefined, async () => undefined)).toThrow(
       'Missing tenant context'
     );
   });
@@ -476,6 +472,39 @@ describe('createTenantDatabaseScopeAroundHook', () => {
         message: 'Missing tenant context for deferred tenant-scoped work',
       })
     );
+  });
+
+  it('blocks deferred mutation work at the gate inside its fresh tenant transaction', async () => {
+    const work = vi.fn(async () => undefined);
+    const tx = {
+      execute: vi
+        .fn()
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([
+          {
+            value_text: JSON.stringify({
+              generation: 'deferred-gate-generation',
+              acquiredAt: '2026-08-24T00:00:00.000Z',
+            }),
+          },
+        ]),
+    };
+    const db = {
+      transaction: vi.fn(async (callback: (scoped: unknown) => Promise<unknown>) => callback(tx)),
+    };
+
+    const error = await new Promise<unknown>((resolve) => {
+      deferWithTenantDatabaseScope(
+        db as never,
+        { tenant: { tenant_id: 'tenant-frozen' } },
+        work,
+        resolve
+      );
+    });
+
+    expect(error).toBeInstanceOf(TenantWriteGateActiveError);
+    expect(work).not.toHaveBeenCalled();
+    expect(db.transaction).toHaveBeenCalledOnce();
   });
 
   it('documents the failed startup mode when deferred work only exits ALS', async () => {

--- a/apps/agor-daemon/src/utils/tenant-db-scope.test.ts
+++ b/apps/agor-daemon/src/utils/tenant-db-scope.test.ts
@@ -15,7 +15,6 @@ import {
   createTenantDatabaseScopeAroundHook,
   createTenantWriteAdmissionAroundHook,
   deferWithTenantContext,
-  deferWithTenantDatabaseScope,
   withFreshTenantWrite,
 } from './tenant-db-scope.js';
 
@@ -106,6 +105,41 @@ describe('withFreshTenantWrite', () => {
 });
 
 describe('createTenantWriteAdmissionAroundHook', () => {
+  it('fails closed before a recognized write when tenant identity is missing', async () => {
+    const { db } = makePgDb();
+    const hook = createTenantWriteAdmissionAroundHook(db as never);
+    const next = vi.fn(async () => undefined);
+
+    await expect(hook({ method: 'create', params: {} } as never, next)).rejects.toBeInstanceOf(
+      NotAuthenticated
+    );
+
+    expect(next).not.toHaveBeenCalled();
+    expect(db.transaction).not.toHaveBeenCalled();
+  });
+
+  it('composes with the installed identity-only scope without retaining its admission transaction', async () => {
+    const { db, tx } = makePgDb();
+    const identity = createTenantDatabaseScopeAroundHook({
+      db: db as never,
+      jwtSecret: 'secret',
+      config: { multi_tenancy: { mode: 'static', static_tenant_id: 'tenant-long' } },
+      transaction: false,
+    });
+    const admission = createTenantWriteAdmissionAroundHook(db as never);
+    const context = { method: 'create', params: {} } as never;
+    const next = vi.fn(async () => {
+      expect(getCurrentTenantId()).toBe('tenant-long');
+      expect(getCurrentTenantDatabaseScope()).toBeUndefined();
+    });
+
+    await identity(context, () => admission(context, next));
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(db.transaction).toHaveBeenCalledOnce();
+    expect(tx.execute).toHaveBeenCalledTimes(2);
+  });
+
   it('checks a mutation in one short unit without holding it across long work', async () => {
     const { db, tx } = makePgDb();
     const hook = createTenantWriteAdmissionAroundHook(db as never);
@@ -378,133 +412,6 @@ describe('createTenantDatabaseScopeAroundHook', () => {
       tenant_id: 'tenant-a',
       source: 'explicit',
     });
-  });
-
-  it('re-enters a fresh tenant scope for deferred executor session startup', async () => {
-    const { db } = makePgDb();
-    const hook = createTenantDatabaseScopeAroundHook({
-      db: db as never,
-      jwtSecret: 'secret',
-      config: {
-        database: { dialect: 'postgresql' },
-        multi_tenancy: { mode: 'required_from_auth', auth_claim: 'tenant_id' },
-      },
-    });
-    const context = {
-      params: { provider: 'rest', authentication: { payload: { tenant_id: 'tenant-a' } } },
-    } as never;
-    const sessionRepo = {
-      async findById(sessionId: string) {
-        return getCurrentTenantId() === 'tenant-a'
-          ? { session_id: sessionId, tenant_id: 'tenant-a' }
-          : null;
-      },
-    };
-
-    await new Promise<void>((resolve, reject) => {
-      hook(context, async () => {
-        deferWithTenantDatabaseScope(
-          db as never,
-          (context as { params: { tenant?: { tenant_id?: string } } }).params,
-          async () => {
-            const session = await sessionRepo.findById('session-1');
-            expect(session).toEqual({ session_id: 'session-1', tenant_id: 'tenant-a' });
-            resolve();
-          },
-          reject
-        );
-      }).catch(reject);
-    });
-  });
-
-  it('waits until the active tenant transaction commits before running deferred work', async () => {
-    const events: string[] = [];
-    const tx = { execute: vi.fn(async () => []) };
-    const db = {
-      transaction: vi.fn(async (callback: (tx: unknown) => Promise<unknown>) => {
-        events.push('tx:start');
-        const result = await callback(tx);
-        events.push('tx:committed');
-        return result;
-      }),
-    };
-
-    const done = new Promise<void>((resolve, reject) => {
-      runWithTenantDatabaseScope(db as never, 'tenant-a', async () => {
-        deferWithTenantDatabaseScope(
-          db as never,
-          {},
-          async () => {
-            events.push(`work:${getCurrentTenantId()}`);
-            resolve();
-          },
-          reject
-        );
-        events.push('scheduled');
-      }).catch(reject);
-    });
-
-    await done;
-    await new Promise((resolve) => setImmediate(resolve));
-
-    expect(events).toEqual([
-      'tx:start',
-      'scheduled',
-      'tx:committed',
-      'tx:start',
-      'tx:committed',
-      'tx:start',
-      'work:tenant-a',
-      'tx:committed',
-    ]);
-  });
-
-  it('fails deferred tenant-scoped work loudly when no tenant can be resolved', async () => {
-    const { db } = makePgDb();
-    const onError = vi.fn();
-    const work = vi.fn(async () => undefined);
-
-    deferWithTenantDatabaseScope(db as never, {}, work, onError);
-
-    expect(work).not.toHaveBeenCalled();
-    expect(onError).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: 'Missing tenant context for deferred tenant-scoped work',
-      })
-    );
-  });
-
-  it('blocks deferred mutation work at the gate inside its fresh tenant transaction', async () => {
-    const work = vi.fn(async () => undefined);
-    const tx = {
-      execute: vi
-        .fn()
-        .mockResolvedValueOnce([])
-        .mockResolvedValueOnce([
-          {
-            value_text: JSON.stringify({
-              generation: 'deferred-gate-generation',
-              acquiredAt: '2026-08-24T00:00:00.000Z',
-            }),
-          },
-        ]),
-    };
-    const db = {
-      transaction: vi.fn(async (callback: (scoped: unknown) => Promise<unknown>) => callback(tx)),
-    };
-
-    const error = await new Promise<unknown>((resolve) => {
-      deferWithTenantDatabaseScope(
-        db as never,
-        { tenant: { tenant_id: 'tenant-frozen' } },
-        work,
-        resolve
-      );
-    });
-
-    expect(error).toBeInstanceOf(TenantWriteGateActiveError);
-    expect(work).not.toHaveBeenCalled();
-    expect(db.transaction).toHaveBeenCalledOnce();
   });
 
   it('documents the failed startup mode when deferred work only exits ALS', async () => {

--- a/apps/agor-daemon/src/utils/tenant-db-scope.ts
+++ b/apps/agor-daemon/src/utils/tenant-db-scope.ts
@@ -7,7 +7,6 @@ import {
 import {
   assertTenantWritable,
   enqueueAfterTenantDatabaseCommit,
-  enqueueTenantDatabasePostCommitCallback,
   getCurrentTenantDatabaseScope,
   getCurrentTenantId,
   isTenantWriteMethodName,
@@ -92,15 +91,16 @@ export function createTenantWriteAdmissionAroundHook(db: TenantScopeAwareDatabas
   return async (context: HookContext, next: () => Promise<void>): Promise<void> => {
     if (isTenantWriteMethodName(context.method)) {
       const tenantId = context.params.tenant?.tenant_id ?? getCurrentTenantId();
-      if (tenantId) {
-        try {
-          await assertTenantWriteAdmission(db, tenantId);
-        } catch (error) {
-          if (error instanceof TenantWriteGateActiveError) {
-            throw new Unavailable(error.message);
-          }
-          throw error;
+      if (!tenantId) {
+        throw new NotAuthenticated('Missing tenant context for tenant write admission');
+      }
+      try {
+        await assertTenantWriteAdmission(db, tenantId);
+      } catch (error) {
+        if (error instanceof TenantWriteGateActiveError) {
+          throw new Unavailable(error.message);
         }
+        throw error;
       }
     }
     await next();
@@ -143,57 +143,6 @@ export function assertTenantWriteAdmission(
   tenantId: string | undefined
 ): Promise<void> {
   return withFreshTenantWrite(db, tenantId, async () => undefined);
-}
-
-/**
- * Schedule asynchronous work outside the current ALS store, then re-enter a
- * fresh tenant database scope for the captured tenant. Use this for delayed
- * executor/queue/gateway work: bare setImmediate inherits possibly-committed
- * transaction objects, but a bare runWithoutTenantDatabaseScope loses Postgres
- * RLS context entirely.
- */
-export function deferWithTenantDatabaseScope(
-  db: TenantScopeAwareDatabase,
-  params: unknown,
-  work: () => Promise<void>,
-  onError?: (error: unknown) => void
-): void {
-  const tenantId = resolveTenantIdForDeferredScope(params);
-  if (!tenantId) {
-    const error = new Error('Missing tenant context for deferred tenant-scoped work');
-    if (onError) {
-      onError(error);
-    } else {
-      console.error('[tenant-db-scope] Deferred tenant-scoped work skipped:', error);
-    }
-    return;
-  }
-
-  const schedule = () => {
-    runWithoutTenantDatabaseScope(() => {
-      setImmediate(() => {
-        // Deferred tenant writer: fail closed at the write gate (see
-        // assertTenantWritable) inside the fresh transaction before the work.
-        void withFreshTenantWrite(db, tenantId, work).catch((error) => {
-          if (onError) {
-            onError(error);
-            return;
-          }
-          console.error('[tenant-db-scope] Deferred tenant-scoped work failed:', error);
-        });
-      });
-    });
-  };
-
-  // If the caller is inside a tenant DB transaction, wait until the
-  // transaction commits before opening the fresh scope. Otherwise executor
-  // startup can race ahead and read rows (sessions/tasks/messages) that are
-  // still invisible on its new connection.
-  if (enqueueTenantDatabasePostCommitCallback(async () => schedule())) {
-    return;
-  }
-
-  schedule();
 }
 
 /** Defer long orchestration work after commit with tenant identity only. */

--- a/apps/agor-daemon/src/utils/tenant-db-scope.ts
+++ b/apps/agor-daemon/src/utils/tenant-db-scope.ts
@@ -46,8 +46,6 @@ function readHeaderValue(
 
 type TenantScopedParams = { tenant?: Pick<TenantContext, 'tenant_id'> } | undefined;
 
-export type TenantDatabaseRunner = <T>(work: () => Promise<T>) => Promise<T>;
-
 /**
  * Enforce the tenant freeze gate inside an already-open tenant transaction.
  * Shared by ordinary Feathers services and custom authenticated routes so a
@@ -96,7 +94,7 @@ export function createTenantWriteAdmissionAroundHook(db: TenantScopeAwareDatabas
       const tenantId = context.params.tenant?.tenant_id ?? getCurrentTenantId();
       if (tenantId) {
         try {
-          await createFreshTenantWriteDatabaseRunner(db, tenantId)(async () => undefined);
+          await assertTenantWriteAdmission(db, tenantId);
         } catch (error) {
           if (error instanceof TenantWriteGateActiveError) {
             throw new Unavailable(error.message);
@@ -115,7 +113,7 @@ export function resolveTenantIdForDeferredScope(params?: unknown): string | unde
 }
 
 /**
- * Build the mutation boundary used by long-lived tenant orchestration.
+ * Run one mutation boundary used by long-lived tenant orchestration.
  *
  * Executor callbacks and termination coordinators can outlive the request
  * transaction that created them. AsyncLocalStorage propagates that transaction
@@ -123,20 +121,28 @@ export function resolveTenantIdForDeferredScope(params?: unknown): string | unde
  * rejoin a possibly committed scope. Always leave any inherited DB scope, open
  * one new short tenant transaction, and enforce the write gate inside it.
  */
-export function createFreshTenantWriteDatabaseRunner(
+export function withFreshTenantWrite<T>(
   db: TenantScopeAwareDatabase,
-  tenantId: string | undefined
-): TenantDatabaseRunner {
+  tenantId: string | undefined,
+  work: () => Promise<T>
+): Promise<T> {
   if (!tenantId) {
     throw new Error('Missing tenant context for tenant-scoped mutation');
   }
-  return <T>(work: () => Promise<T>): Promise<T> =>
-    runWithoutTenantDatabaseScope(() =>
-      runWithTenantDatabaseScope(db, tenantId, async (scoped) => {
-        await assertTenantWritable(scoped, tenantId);
-        return work();
-      })
-    );
+  return runWithoutTenantDatabaseScope(() =>
+    runWithTenantDatabaseScope(db, tenantId, async (scoped) => {
+      await assertTenantWritable(scoped, tenantId);
+      return work();
+    })
+  );
+}
+
+/** Assert write admission in one fresh, short tenant database unit. */
+export function assertTenantWriteAdmission(
+  db: TenantScopeAwareDatabase,
+  tenantId: string | undefined
+): Promise<void> {
+  return withFreshTenantWrite(db, tenantId, async () => undefined);
 }
 
 /**
@@ -168,10 +174,7 @@ export function deferWithTenantDatabaseScope(
       setImmediate(() => {
         // Deferred tenant writer: fail closed at the write gate (see
         // assertTenantWritable) inside the fresh transaction before the work.
-        void runWithTenantDatabaseScope(db, tenantId, async (scoped) => {
-          await assertTenantWritable(scoped, tenantId);
-          await work();
-        }).catch((error) => {
+        void withFreshTenantWrite(db, tenantId, work).catch((error) => {
           if (onError) {
             onError(error);
             return;

--- a/scripts/check-multitenancy-boundaries.mjs
+++ b/scripts/check-multitenancy-boundaries.mjs
@@ -151,10 +151,9 @@ const checks = [
       'apps/agor-daemon/src/setup/socketio.ts': 1,
       // Event-loop flushes for the exact-token disconnect assertions above.
       'apps/agor-daemon/src/setup/socketio.test.ts': 2,
-      'apps/agor-daemon/src/utils/tenant-db-scope.test.ts': 1,
-      // The two tenant-aware deferral helpers deliberately leave the current
-      // ALS store before scheduling and then re-enter identity or DB scope.
-      'apps/agor-daemon/src/utils/tenant-db-scope.ts': 2,
+      // The tenant-aware deferral helper deliberately leaves the current ALS
+      // database store before scheduling and then re-enters tenant identity.
+      'apps/agor-daemon/src/utils/tenant-db-scope.ts': 1,
     },
   },
   {


### PR DESCRIPTION
## Summary

- replace the curried `createFreshTenantWriteDatabaseRunner(db, tenantId)(work)` API with the direct `withFreshTenantWrite(db, tenantId, work)` operation
- add `assertTenantWriteAdmission(db, tenantId)` for admission-only paths instead of running empty callbacks
- avoid duplicate prompt admission transactions while retaining the installed long-route admission boundary and fresh repository write gates
- fail closed when a recognized write reaches admission without trusted tenant context
- remove the unused generic deferred database-scope helper and preserve lifecycle coverage on the real tenant queue path
- route deferred work and queue admission through the smaller API while preserving the narrow runner adapters required by termination coordination
- strengthen installed-hook, custom-route, and behavioral composition coverage for frozen writes, recognized custom reads, and deferred tenant re-entry

## Preserved invariants

- tenant identity still comes only from authenticated or otherwise trusted authority
- PostgreSQL/RLS work still runs in short-lived tenant transactions
- tenant write freezes remain fail closed for registered and custom writes, while recognized reads are not over-gated
- deferred work captures tenant identity and explicitly opens a fresh scope rather than retaining a request transaction
- SQLite behavior and explicit scheduler/system-global paths are unchanged

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm check`
- focused daemon tenant-scope, installed-hook, custom-route, scheduler, queue, and deferred-work tests: **235 passed**
- focused core tenant scope, unit-of-work, write-gate, schema, and scheduler tests: **45 passed**, **10 PostgreSQL-gated skipped without a server**
- disposable PostgreSQL integration lane: **156 passed, 0 failed, 0 skipped** across 32 files
- PostgreSQL runner interruption cleanup test passed
