### PR TITLE
fix(runtime): prevent health and terminal-result false failures

### DIFF
--- a/apps/agor-daemon/src/services/branches.test.ts
+++ b/apps/agor-daemon/src/services/branches.test.ts
@@ -2339,6 +2339,81 @@ describe('BranchesService environment health requests', () => {
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
+  dbTest(
+    'treats repeated automatic and explicit startup network failures as unrecorded observations',
+    async ({ db }) => {
+      const user = await new UsersRepository(db).create({
+        email: `${generateId()}@example.com`,
+        name: 'Startup health no-op',
+      });
+      const repo = await new RepoRepository(db).create({
+        repo_id: generateId(),
+        slug: `startup-health-noop-${generateId()}`,
+        name: 'Startup health no-op',
+        repo_type: 'remote',
+        remote_url: 'https://example.invalid/startup-health-noop.git',
+        local_path: `/tmp/${generateId()}`,
+        default_branch: 'main',
+      });
+      const branchRepo = new BranchRepository(db);
+      const branch = await branchRepo.create({
+        branch_id: generateId() as BranchID,
+        repo_id: repo.repo_id,
+        name: `startup-health-noop-${generateId()}`,
+        ref: 'main',
+        branch_unique_id: 8_700_000,
+        path: `/tmp/${generateId()}`,
+        created_by: user.user_id,
+        health_check_url: 'https://example.invalid/health',
+        environment_instance: { status: 'starting' },
+      });
+      const branchesService = { emit: vi.fn() };
+      const app = {
+        get(name: string) {
+          return name === 'distributedWorkIdentity'
+            ? { instanceId: 'daemon-a', bootId: 'boot-a' }
+            : {};
+        },
+        service(path: string) {
+          if (path === 'repos') return { get: vi.fn(async () => repo) };
+          if (path === 'branches') return branchesService;
+          throw new Error(`Unknown service: ${path}`);
+        },
+      } as unknown as Application;
+      const service = new BranchesService(db as never, app);
+      const fetchMock = vi.fn(async () => {
+        throw new Error('Health endpoint unreachable');
+      });
+      const errorLog = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      const warnLog = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      globalThis.fetch = fetchMock;
+
+      try {
+        for (let cycle = 0; cycle < 3; cycle += 1) {
+          await expect(
+            service.checkHealth(branch.branch_id, undefined, { intent: 'automatic' })
+          ).resolves.toMatchObject({
+            environment_instance: { status: 'starting' },
+          });
+        }
+        await expect(service.checkHealth(branch.branch_id)).resolves.toMatchObject({
+          environment_instance: { status: 'starting' },
+        });
+
+        expect(fetchMock).toHaveBeenCalledTimes(4);
+        expect(
+          (await branchRepo.findById(branch.branch_id))?.environment_instance?.last_health_check
+        ).toBeUndefined();
+        expect(branchesService.emit).not.toHaveBeenCalled();
+        expect(errorLog).not.toHaveBeenCalled();
+        expect(warnLog).not.toHaveBeenCalled();
+      } finally {
+        errorLog.mockRestore();
+        warnLog.mockRestore();
+      }
+    }
+  );
+
   dbTest('fences late health success across stop and archive races', async ({ db }) => {
     const user = await new UsersRepository(db).create({
       email: `${generateId()}@example.com`,

--- a/apps/agor-daemon/src/services/distributed-health-monitor.postgres.test.ts
+++ b/apps/agor-daemon/src/services/distributed-health-monitor.postgres.test.ts
@@ -48,7 +48,11 @@ function monitorOptions(
   };
 }
 
-async function seedBranch(db: TenantScopeAwareDatabase, tenantId: TenantID) {
+async function seedBranch(
+  db: TenantScopeAwareDatabase,
+  tenantId: TenantID,
+  status: 'starting' | 'running' = 'running'
+) {
   return runWithTenantDatabaseScope(db, tenantId, async (scoped) => {
     const user = await new UsersRepository(scoped).create({
       email: `${tenantId}-${generateId()}@example.com`,
@@ -72,7 +76,7 @@ async function seedBranch(db: TenantScopeAwareDatabase, tenantId: TenantID) {
       path: `/tmp/${generateId()}`,
       created_by: user.user_id,
       health_check_url: 'https://example.invalid/health',
-      environment_instance: { status: 'running' },
+      environment_instance: { status },
     });
   });
 }
@@ -137,6 +141,62 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
       ).toMatchObject({
         environment_instance: { status: 'running', last_health_check: { status: 'healthy' } },
       });
+      await Promise.all([monitorA.cleanup(), monitorB.cleanup()]);
+    });
+
+    it('coordinates repeated unrecorded startup failures without errors or realtime events', async () => {
+      const tenantId = `worker-starting-${generateId()}` as TenantID;
+      const branch = await seedBranch(dbA, tenantId, 'starting');
+      const fetchHealth = vi.fn(async () => {
+        throw new Error('Health endpoint unreachable');
+      });
+      const appA = makeApp();
+      const appB = makeApp();
+      const emitA = vi.spyOn(appA.branches, 'emit');
+      const emitB = vi.spyOn(appB.branches, 'emit');
+      const monitorA = new DistributedHealthMonitor(
+        appA.app as never,
+        dbA,
+        monitorOptions(tenantId, branch.branch_id, { fetchHealth })
+      );
+      const monitorB = new DistributedHealthMonitor(
+        appB.app as never,
+        dbB,
+        monitorOptions(tenantId, branch.branch_id, { fetchHealth })
+      );
+
+      const first = await Promise.all([monitorA.checkOnce(), monitorB.checkOnce()]);
+      expect(first.reduce((sum, result) => sum + result.claimed, 0)).toBe(1);
+      expect(first.reduce((sum, result) => sum + result.committed, 0)).toBe(1);
+      expect(first.reduce((sum, result) => sum + result.failures, 0)).toBe(0);
+
+      // The durable cooldown prevents event hints or a second replica from
+      // turning one expected startup failure into a tight retry loop.
+      const duringCooldown = await Promise.all([monitorA.checkOnce(), monitorB.checkOnce()]);
+      expect(duringCooldown.reduce((sum, result) => sum + result.claimed, 0)).toBe(0);
+      expect(duringCooldown.reduce((sum, result) => sum + result.failures, 0)).toBe(0);
+      expect(fetchHealth).toHaveBeenCalledOnce();
+
+      await new Promise((resolve) => setTimeout(resolve, 75));
+      const nextInterval = await Promise.all([monitorA.checkOnce(), monitorB.checkOnce()]);
+      expect(nextInterval.reduce((sum, result) => sum + result.committed, 0)).toBe(1);
+      expect(nextInterval.reduce((sum, result) => sum + result.failures, 0)).toBe(0);
+      expect(fetchHealth).toHaveBeenCalledTimes(2);
+      expect(
+        await runWithTenantDatabaseScope(dbA, tenantId, (scoped) =>
+          new BranchRepository(scoped).findById(branch.branch_id)
+        )
+      ).toMatchObject({ environment_instance: { status: 'starting' } });
+      expect(
+        (
+          await runWithTenantDatabaseScope(dbA, tenantId, (scoped) =>
+            new BranchRepository(scoped).findById(branch.branch_id)
+          )
+        )?.environment_instance?.last_health_check
+      ).toBeUndefined();
+      expect(emitA).not.toHaveBeenCalled();
+      expect(emitB).not.toHaveBeenCalled();
+
       await Promise.all([monitorA.cleanup(), monitorB.cleanup()]);
     });
 

--- a/apps/agor-daemon/src/setup/socketio-executor-auth.integration.test.ts
+++ b/apps/agor-daemon/src/setup/socketio-executor-auth.integration.test.ts
@@ -437,10 +437,29 @@ describe('executor Socket.IO connection capability', () => {
     ).resolves.toBeNull();
   });
 
-  it('acknowledges a self-revoking task RPC before disconnecting its executor', async () => {
+  it('drains a self-revoking task RPC acknowledgement before disconnecting its executor', async () => {
     const harness = await startHarness();
     harnesses.push(harness);
     await waitForConnect(harness.client);
+    const serverSocket = harness.socketConfig
+      .getSocketServer()
+      ?.sockets.sockets.get(harness.client.io.id!);
+    if (!serverSocket) throw new Error('Expected connected executor socket');
+    const connection = (serverSocket as unknown as { feathers?: Record<string, unknown> }).feathers;
+    const transport = serverSocket.conn.transport;
+    const send = transport.send.bind(transport);
+    let releaseAcknowledgement: (() => void) | undefined;
+    transport.send = ((packets: Parameters<typeof send>[0]) => {
+      // Deterministically model production transport backpressure. The Task
+      // mutation and token revocation commit before Feathers queues its RPC
+      // acknowledgement; closing the namespace while this write is held makes
+      // the client report a false task failure even though terminality won.
+      transport.writable = false;
+      releaseAcknowledgement = () => {
+        transport.send = send;
+        send(packets);
+      };
+    }) as typeof transport.send;
     const disconnected = waitForDisconnect(harness.client);
 
     const tasks = harness.client.service('tasks') as unknown as {
@@ -448,7 +467,22 @@ describe('executor Socket.IO connection capability', () => {
       finish(data: { task_id: string }): Promise<unknown>;
     };
     tasks.methods?.('finish');
-    await expect(tasks.finish({ task_id: TASK_ID })).resolves.toEqual({
+    const finish = tasks.finish({ task_id: TASK_ID });
+    void finish.catch(() => undefined);
+    await waitFor(
+      () =>
+        releaseAcknowledgement !== undefined &&
+        getAuthenticatedConnectionAuthority(connection) === undefined
+    );
+    await new Promise<void>((resolve) => setTimeout(resolve, 50));
+
+    // Revocation is already authoritative and the Task room is already gone,
+    // but transport retirement must not overtake the terminal RPC response.
+    expect(serverSocket.connected).toBe(true);
+    expect(harness.client.io.connected).toBe(true);
+    expect(harness.app.channels).not.toContain(executorTaskChannelName(TENANT_ID, TASK_ID));
+    releaseAcknowledgement?.();
+    await expect(finish).resolves.toEqual({
       accepted: true,
       task_id: TASK_ID,
     });

--- a/apps/agor-daemon/src/setup/socketio-executor-auth.integration.test.ts
+++ b/apps/agor-daemon/src/setup/socketio-executor-auth.integration.test.ts
@@ -447,6 +447,8 @@ describe('executor Socket.IO connection capability', () => {
     if (!serverSocket) throw new Error('Expected connected executor socket');
     const connection = (serverSocket as unknown as { feathers?: Record<string, unknown> }).feathers;
     const transport = serverSocket.conn.transport;
+    const disconnectListenersBefore = serverSocket.listenerCount('disconnect');
+    const readyListenersBefore = transport.listenerCount('ready');
     const send = transport.send.bind(transport);
     let releaseAcknowledgement: (() => void) | undefined;
     transport.send = ((packets: Parameters<typeof send>[0]) => {
@@ -481,6 +483,8 @@ describe('executor Socket.IO connection capability', () => {
     expect(serverSocket.connected).toBe(true);
     expect(harness.client.io.connected).toBe(true);
     expect(harness.app.channels).not.toContain(executorTaskChannelName(TENANT_ID, TASK_ID));
+    expect(serverSocket.listenerCount('disconnect')).toBe(disconnectListenersBefore + 1);
+    expect(transport.listenerCount('ready')).toBe(readyListenersBefore + 1);
     releaseAcknowledgement?.();
     await expect(finish).resolves.toEqual({
       accepted: true,
@@ -488,6 +492,8 @@ describe('executor Socket.IO connection capability', () => {
     });
 
     await disconnected;
+    expect(serverSocket.listenerCount('disconnect')).toBe(disconnectListenersBefore);
+    expect(transport.listenerCount('ready')).toBeLessThanOrEqual(readyListenersBefore);
   });
 
   it('rejects login when revocation lands after authority validation starts', async () => {

--- a/apps/agor-daemon/src/setup/socketio.ts
+++ b/apps/agor-daemon/src/setup/socketio.ts
@@ -272,6 +272,79 @@ export interface SocketIOResult {
  * user stays on the same board.
  */
 const GLOBAL_PRESENCE_EMIT_INTERVAL_MS = 10_000;
+const EXECUTOR_REVOCATION_DRAIN_TIMEOUT_MS = 5_000;
+
+function deferExecutorTransportWork(work: () => void): void {
+  // Transport-only callback: it must never perform database or tenant-owned
+  // work while retaining the revoking request's async context.
+  setImmediate(work);
+}
+
+/**
+ * Retire a revoked executor transport without overtaking the RPC response that
+ * caused the revocation.
+ *
+ * Task terminality revokes the bearer inside the Feathers service call. Its
+ * Socket.IO acknowledgement is queued only after that call returns, so an
+ * unconditional next-turn disconnect can close a backpressured transport
+ * before the already-committed terminal result reaches the executor. Wait for
+ * the current transport write to become writable again; authority and Task
+ * room membership have already been removed synchronously, so this bounded
+ * drain window grants no residual service or realtime access.
+ */
+function disconnectRevokedExecutorAfterTransportDrain(socket: Socket): void {
+  // The lightweight Socket.IO unit harness has no Engine.IO transport. Keep
+  // its behavior representative without requiring transport internals there.
+  const connection = socket.conn;
+  if (!connection) {
+    deferExecutorTransportWork(() => socket.disconnect(true));
+    return;
+  }
+
+  let finished = false;
+  let pendingTransport: Socket['conn']['transport'] | undefined;
+  let onReady: (() => void) | undefined;
+  let deadline: ReturnType<typeof setTimeout>;
+
+  const cleanup = () => {
+    if (pendingTransport && onReady) pendingTransport.removeListener('ready', onReady);
+    clearTimeout(deadline);
+    pendingTransport = undefined;
+    onReady = undefined;
+  };
+  const disconnect = () => {
+    if (finished) return;
+    finished = true;
+    cleanup();
+    if (socket.connected) socket.disconnect(true);
+  };
+  const inspectTransport = () => {
+    if (finished) return;
+    if (!socket.connected) {
+      finished = true;
+      cleanup();
+      return;
+    }
+    if (connection.readyState !== 'open' || connection.transport.writable) {
+      disconnect();
+      return;
+    }
+
+    pendingTransport = connection.transport;
+    onReady = () => {
+      // Engine.IO's own ready listener flushes queued packets first. Inspect on
+      // the following turn so a newly-started write can finish before close.
+      deferExecutorTransportWork(inspectTransport);
+    };
+    pendingTransport.once('ready', onReady);
+  };
+
+  deadline = setTimeout(disconnect, EXECUTOR_REVOCATION_DRAIN_TIMEOUT_MS);
+  deadline.unref?.();
+  // Feathers queues the acknowledgement after the service promise resolves.
+  // Inspect on the next turn, after that queueing opportunity.
+  deferExecutorTransportWork(inspectTransport);
+}
 
 function bearerTokenFromHeader(value: string | string[] | undefined): string | undefined {
   if (typeof value !== 'string') return undefined;
@@ -682,10 +755,11 @@ export function createSocketIOConfig(
         if (tenantId && authority.tenant?.tenant_id !== tenantId) continue;
         if (authority.principal.tokenFingerprint === tokenFingerprint) {
           // Retire the Feathers projection synchronously so no subsequent RPC
-          // can reuse the lease. Disconnect on the next turn so the terminal
-          // lifecycle RPC that committed revocation can still deliver its ack.
+          // can reuse the lease. Drain the terminal lifecycle acknowledgement
+          // before closing so a successful durable write is not reported as a
+          // task failure by the executor.
           retireSocketConnectionAuthority(app, feathers);
-          setImmediate(() => socket.disconnect(true));
+          disconnectRevokedExecutorAfterTransportDrain(socket);
         }
       }
     };

--- a/apps/agor-daemon/src/setup/socketio.ts
+++ b/apps/agor-daemon/src/setup/socketio.ts
@@ -304,13 +304,22 @@ function disconnectRevokedExecutorAfterTransportDrain(socket: Socket): void {
   let finished = false;
   let pendingTransport: Socket['conn']['transport'] | undefined;
   let onReady: (() => void) | undefined;
-  let deadline: ReturnType<typeof setTimeout>;
+  let onSocketDisconnect: (() => void) | undefined;
+  let deadline: ReturnType<typeof setTimeout> | undefined;
 
   const cleanup = () => {
     if (pendingTransport && onReady) pendingTransport.removeListener('ready', onReady);
-    clearTimeout(deadline);
+    if (onSocketDisconnect) socket.removeListener('disconnect', onSocketDisconnect);
+    if (deadline) clearTimeout(deadline);
     pendingTransport = undefined;
     onReady = undefined;
+    onSocketDisconnect = undefined;
+    deadline = undefined;
+  };
+  onSocketDisconnect = () => {
+    if (finished) return;
+    finished = true;
+    cleanup();
   };
   const disconnect = () => {
     if (finished) return;
@@ -339,6 +348,7 @@ function disconnectRevokedExecutorAfterTransportDrain(socket: Socket): void {
     pendingTransport.once('ready', onReady);
   };
 
+  socket.once('disconnect', onSocketDisconnect);
   deadline = setTimeout(disconnect, EXECUTOR_REVOCATION_DRAIN_TIMEOUT_MS);
   deadline.unref?.();
   // Feathers queues the acknowledgement after the service promise resolves.

--- a/packages/core/src/db/environment-health-ha.postgres.test.ts
+++ b/packages/core/src/db/environment-health-ha.postgres.test.ts
@@ -229,6 +229,36 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
       const branch = await seedBranch(dbA, tenantId, 'starting');
       await runWithTenantDatabaseScope(dbA, tenantId, async (scoped) => {
         const health = new EnvironmentHealthRepository(scoped);
+        const unrecorded = await health.claim({
+          branchId: branch.branch_id,
+          claimToken: 'starting-network-failure',
+          leaseDurationMs: 30_000,
+          identity: { instanceId: 'daemon-a', bootId: 'boot-a' },
+        });
+        if (unrecorded.outcome !== 'claimed') throw new Error('Expected startup failure claim');
+        expect(
+          await health.commit({
+            branchId: branch.branch_id,
+            claimToken: unrecorded.claim.claim_token,
+            environmentGeneration: unrecorded.claim.environment_generation,
+            observation: {
+              status: 'unhealthy',
+              message: 'Health endpoint unreachable',
+              recordWhileStarting: false,
+            },
+          })
+        ).toEqual({
+          outcome: 'committed',
+          mutated: false,
+          stateChanged: false,
+          environmentStatus: 'starting',
+        });
+        expect(
+          (await new BranchRepository(scoped).findById(branch.branch_id))?.environment_instance
+            ?.last_health_check
+        ).toBeUndefined();
+        expect(await health.release(branch.branch_id, unrecorded.claim.claim_token)).toBe(true);
+
         const first = await health.claim({
           branchId: branch.branch_id,
           claimToken: 'starting-owner',

--- a/packages/core/src/db/repositories/environment-health.test.ts
+++ b/packages/core/src/db/repositories/environment-health.test.ts
@@ -112,7 +112,12 @@ describe('EnvironmentHealthRepository lifecycle fencing', () => {
         environmentGeneration: claim.claim.environment_generation,
         observation: { status: 'healthy', message: 'HTTP 200', recordWhileStarting: true },
       })
-    ).resolves.toMatchObject({ outcome: 'committed', environmentStatus: 'running' });
+    ).resolves.toEqual({
+      outcome: 'committed',
+      mutated: true,
+      stateChanged: true,
+      environmentStatus: 'running',
+    });
     await expect(
       health.commit({
         branchId: branch.branch_id,
@@ -126,6 +131,99 @@ describe('EnvironmentHealthRepository lifecycle fencing', () => {
       last_health_check: { status: 'unhealthy', message: 'Timeout' },
     });
   });
+
+  dbTest(
+    'accepts an unrecorded startup observation without mutating branch state',
+    async ({ db }) => {
+      const branch = await seedStartingBranch(db);
+      const branches = new BranchRepository(db);
+      const health = new EnvironmentHealthRepository(db);
+      const claim = await health.claim({
+        branchId: branch.branch_id,
+        claimToken: 'startup-network-failure',
+        leaseDurationMs: 30_000,
+        identity: { instanceId: 'daemon-a', bootId: 'boot-a' },
+      });
+      if (claim.outcome !== 'claimed') throw new Error('Expected claim');
+
+      await expect(
+        health.commit({
+          branchId: branch.branch_id,
+          claimToken: claim.claim.claim_token,
+          environmentGeneration: claim.claim.environment_generation,
+          observation: {
+            status: 'unhealthy',
+            message: 'Health endpoint unreachable',
+            recordWhileStarting: false,
+          },
+        })
+      ).resolves.toEqual({
+        outcome: 'committed',
+        mutated: false,
+        stateChanged: false,
+        environmentStatus: 'starting',
+      });
+      expect(await branches.findById(branch.branch_id)).toMatchObject({
+        updated_at: branch.updated_at,
+        environment_instance: { status: 'starting' },
+      });
+      expect(
+        (await branches.findById(branch.branch_id))?.environment_instance?.last_health_check
+      ).toBeUndefined();
+    }
+  );
+
+  dbTest(
+    'persists repeated healthy and unhealthy observation times without state churn',
+    async ({ db }) => {
+      const branches = new BranchRepository(db);
+      const health = new EnvironmentHealthRepository(db);
+
+      for (const observation of [
+        { status: 'healthy' as const, message: 'HTTP 200' },
+        { status: 'unhealthy' as const, message: 'HTTP 503 Service Unavailable' },
+      ]) {
+        const seeded = await seedStartingBranch(db, 'running');
+        await branches.update(seeded.branch_id, {
+          environment_instance: {
+            status: 'running',
+            last_health_check: {
+              timestamp: '2026-01-01T00:00:00.000Z',
+              ...observation,
+            },
+          },
+        });
+        const before = await branches.findById(seeded.branch_id);
+        const claim = await health.claim({
+          branchId: seeded.branch_id,
+          claimToken: `repeated-${observation.status}`,
+          leaseDurationMs: 30_000,
+          identity: { instanceId: 'daemon-a', bootId: 'boot-a' },
+        });
+        if (claim.outcome !== 'claimed') throw new Error('Expected claim');
+
+        await expect(
+          health.commit({
+            branchId: seeded.branch_id,
+            claimToken: claim.claim.claim_token,
+            environmentGeneration: claim.claim.environment_generation,
+            observation: { ...observation, recordWhileStarting: true },
+          })
+        ).resolves.toEqual({
+          outcome: 'committed',
+          mutated: true,
+          stateChanged: false,
+          environmentStatus: 'running',
+        });
+        const after = await branches.findById(seeded.branch_id);
+        expect(after?.updated_at).toBe(before?.updated_at);
+        expect(after?.environment_instance?.last_health_check).toMatchObject(observation);
+        expect(after?.environment_instance?.last_health_check?.timestamp).not.toBe(
+          '2026-01-01T00:00:00.000Z'
+        );
+      }
+    }
+  );
 
   dbTest('invalidates an in-flight result across stop and restart', async ({ db }) => {
     const branch = await seedStartingBranch(db);

--- a/packages/core/src/db/repositories/environment-health.ts
+++ b/packages/core/src/db/repositories/environment-health.ts
@@ -378,18 +378,27 @@ export class EnvironmentHealthRepository {
               },
             }
           : activeEnvironment;
-        await update(txDb, branches)
-          .set({
-            ...(shouldRecord ? { data: { ...data, environment_instance: nextEnvironment } } : {}),
-            ...(stateChanged ? { updated_at: now } : {}),
-          })
-          .where(
-            and(
-              eq(branches.branch_id, input.branchId),
-              eq(branches.environment_health_claim_token, input.claimToken)
+        // A network failure while an environment is still starting is a
+        // legitimate, deliberately unrecorded observation: startup grace
+        // keeps the prior durable state until a recordable result arrives.
+        // The row lock and fences above still authorize it as a completed
+        // observation, but there are no branch columns to mutate. Do not hand
+        // an empty update to Drizzle, whose dialect-independent set mapper
+        // rejects it with "No values to set".
+        if (shouldRecord) {
+          await update(txDb, branches)
+            .set({
+              data: { ...data, environment_instance: nextEnvironment },
+              ...(stateChanged ? { updated_at: now } : {}),
+            })
+            .where(
+              and(
+                eq(branches.branch_id, input.branchId),
+                eq(branches.environment_health_claim_token, input.claimToken)
+              )
             )
-          )
-          .run();
+            .run();
+        }
         return {
           outcome: 'committed',
           mutated: shouldRecord,

--- a/packages/executor/src/handlers/sdk/base-executor.test.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { isTaskFailurePersisted } from '../../terminal-task.js';
 import {
   createStreamingCallbacks,
   executeToolTask,
@@ -136,7 +137,8 @@ describe('settleTaskFailure', () => {
       },
     } as never;
 
-    await settleTaskFailure(client, 'session-1' as never, 'task-1' as never, new Error('failed'), {
+    const failure = new Error('failed');
+    await settleTaskFailure(client, 'session-1' as never, 'task-1' as never, failure, {
       status: 'failed',
       error_message: 'failed',
     });
@@ -150,6 +152,33 @@ describe('settleTaskFailure', () => {
       },
     });
     expect(messageCreate).toHaveBeenCalledWith(expect.objectContaining({ index: 3 }));
+    expect(isTaskFailurePersisted(failure)).toBe(true);
+  });
+
+  it('does not mark a failure persisted until the terminal patch is acknowledged', async () => {
+    const failure = new Error('failed');
+    const client = {
+      service(name: string) {
+        if (name === 'tasks') {
+          return { patch: vi.fn().mockRejectedValue(new Error('socket disconnected')) };
+        }
+        if (name === 'messages') {
+          return {
+            find: vi.fn().mockResolvedValue({ total: 0, data: [] }),
+            create: vi.fn().mockResolvedValue(undefined),
+          };
+        }
+        throw new Error(`unexpected service ${name}`);
+      },
+    } as never;
+
+    await expect(
+      settleTaskFailure(client, 'session-1' as never, 'task-1' as never, failure, {
+        status: 'failed',
+        error_message: 'failed',
+      })
+    ).rejects.toThrow('socket disconnected');
+    expect(isTaskFailurePersisted(failure)).toBe(false);
   });
 
   it('does not persist Drizzle query parameters in task or transcript diagnostics', async () => {

--- a/packages/executor/src/handlers/sdk/base-executor.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.ts
@@ -29,6 +29,7 @@ import { formatExecutorFailure } from '../../safe-executor-error.js';
 import type { StreamingCallbacks } from '../../sdk-handlers/base/types.js';
 import { normalizeRawSdkResponse } from '../../sdk-handlers/normalizer-factory.js';
 import type { AgorClient } from '../../services/feathers-client.js';
+import { markTaskFailurePersisted } from '../../terminal-task.js';
 import { isDaemonOwnedAbort } from '../../termination-state.js';
 import { configureSessionGitSafeDirectories } from './git-safe-directory.js';
 
@@ -100,6 +101,7 @@ export async function settleTaskFailure(
     ...patch,
     ...(patch.error_message ? { error_message: formatExecutorFailure(failure) } : {}),
   });
+  markTaskFailurePersisted(failure);
 }
 
 /**

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -32,7 +32,7 @@ import { globalPermissionManager } from './permissions/permission-manager.js';
 import { formatExecutorFailure } from './safe-executor-error.js';
 import { getSdkActivityVersion, markSdkHealthAbort, SdkWatchdog } from './sdk-watchdog.js';
 import { type AgorClient, createExecutorClient } from './services/feathers-client.js';
-import { tryMarkTaskTerminal } from './terminal-task.js';
+import { isTaskFailurePersisted, tryMarkTaskTerminal } from './terminal-task.js';
 import { reportExecutorQuiescence } from './termination-report.js';
 import { isDaemonOwnedAbort, markCoordinatorTerminationAbort } from './termination-state.js';
 
@@ -144,6 +144,14 @@ export class AgorExecutor {
       );
       process.exit(0);
     } catch (error) {
+      if (isTaskFailurePersisted(error)) {
+        console.log(
+          `[executor.lifecycle] event=exit_requested task_id=${shortId(this.config.taskId)} ` +
+            'code=1 reason=task_failure_persisted'
+        );
+        process.exit(1);
+        return;
+      }
       const terminationRecovered = await this.recoverTerminationAfterExecutionError();
       if (terminationRecovered) {
         console.log(

--- a/packages/executor/src/terminal-task.test.ts
+++ b/packages/executor/src/terminal-task.test.ts
@@ -16,7 +16,12 @@
 import { TaskStatus } from '@agor/core/types';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { AgorClient } from './services/feathers-client.js';
-import { TERMINAL_STATUSES, tryMarkTaskTerminal } from './terminal-task.js';
+import {
+  isTaskFailurePersisted,
+  markTaskFailurePersisted,
+  TERMINAL_STATUSES,
+  tryMarkTaskTerminal,
+} from './terminal-task.js';
 
 type TaskShape = { task_id: string; status: TaskStatus };
 
@@ -61,6 +66,19 @@ describe('TERMINAL_STATUSES', () => {
     expect(TERMINAL_STATUSES.has(TaskStatus.STOPPING)).toBe(false);
     expect(TERMINAL_STATUSES.has(TaskStatus.AWAITING_PERMISSION)).toBe(false);
     expect(TERMINAL_STATUSES.has(TaskStatus.AWAITING_INPUT)).toBe(false);
+  });
+});
+
+describe('persisted task failure marker', () => {
+  it('marks only the acknowledged Error instance', () => {
+    const failure = new Error('provider failed');
+    const unrelated = new Error('provider failed');
+
+    expect(isTaskFailurePersisted(failure)).toBe(false);
+    expect(markTaskFailurePersisted(failure)).toBe(failure);
+    expect(isTaskFailurePersisted(failure)).toBe(true);
+    expect(isTaskFailurePersisted(unrelated)).toBe(false);
+    expect(isTaskFailurePersisted('provider failed')).toBe(false);
   });
 });
 

--- a/packages/executor/src/terminal-task.ts
+++ b/packages/executor/src/terminal-task.ts
@@ -20,6 +20,23 @@ import type { Task } from '@agor/core/types';
 import { TaskStatus } from '@agor/core/types';
 import type { AgorClient } from './services/feathers-client.js';
 
+const persistedTaskFailures = new WeakSet<Error>();
+
+/**
+ * Remember that the authoritative SDK failure path received the daemon's
+ * acknowledgement for its terminal Task patch. The task-scoped credential is
+ * revoked by that patch, so the top-level fail-safe must not try to read and
+ * patch the same Task again after the failure is rethrown.
+ */
+export function markTaskFailurePersisted<T extends Error>(failure: T): T {
+  persistedTaskFailures.add(failure);
+  return failure;
+}
+
+export function isTaskFailurePersisted(failure: unknown): failure is Error {
+  return failure instanceof Error && persistedTaskFailures.has(failure);
+}
+
 /**
  * Statuses past which any subsequent terminal-write is a no-op.
  * Includes `TIMED_OUT` so a subsequent uncaught-rejection/SIGTERM

--- a/scripts/check-multitenancy-boundaries.mjs
+++ b/scripts/check-multitenancy-boundaries.mjs
@@ -145,9 +145,9 @@ const checks = [
     baseline: {
       // Test-only async flush helpers / event loop flushes.
       'apps/agor-daemon/src/services/branches.test.ts': 1,
-      // Executor-token revocation clears authority synchronously, then yields
-      // one event-loop turn before transport teardown so the terminal RPC ack
-      // can flush. The callback performs no database or tenant-owned work.
+      // Executor-token revocation clears authority synchronously, then uses a
+      // transport-only deferral helper to drain the terminal RPC ack before
+      // teardown. Its callbacks perform no database or tenant-owned work.
       'apps/agor-daemon/src/setup/socketio.ts': 1,
       // Event-loop flushes for the exact-token disconnect assertions above.
       'apps/agor-daemon/src/setup/socketio.test.ts': 2,


### PR DESCRIPTION
## Summary

- accept deliberately unrecorded startup health observations as fenced no-ops instead of passing an empty update to Drizzle
- drain terminal Task RPC acknowledgements before retiring revoked executor transports, without retaining service or realtime authority
- avoid redundant terminal fallback RPCs after an acknowledged provider failure
- preserve lifecycle/generation/lease/tenant fencing, HA cooldown, and truthful failure recording

## Root cause

PR #2518 routed standalone and manual active health checks through the fenced health repository. That exposed a latent conditional update from PR #2230: an unreachable endpoint while an environment is still `starting` intentionally does not persist an unhealthy result during startup grace, so both update fragments were empty. Drizzle rejects `.set({})` before SQLite or PostgreSQL SQL generation with `No values to set`.

Separately, PR #2520 began revoking the task credential inside a terminal Task patch. Authority and Task-room membership were correctly removed immediately, but the next-turn Socket.IO disconnect could overtake the Feathers RPC acknowledgement under transport backpressure. The durable terminal write had committed while the executor observed a disconnect/timeout, treated the completed task as failed, and retried with its now-revoked credential.

## Fix

The health repository now returns a committed, non-mutating result only after validating the row lock, claim token, lifecycle generation, lease, tenant scope, and active state. No database update or realtime patch event is emitted for that no-op; recordable observations still persist their timestamp and transitions.

Executor revocation still fences authority synchronously, then waits for the already-queued transport write to drain before a bounded disconnect. A deterministic backpressure regression test proves the terminal RPC resolves before disconnect. Acknowledged provider failures are marked in-process so the top-level fail-safe exits with the real failure instead of issuing a duplicate RPC with a revoked credential.

## Validation

- focused core health repository: 8 passed
- focused daemon health paths: 89 passed
- broader core/daemon health and lifecycle suites: 278 passed, 7 environment-gated skips
- Socket.IO executor authority/backpressure suites: 104 passed
- executor terminal/client suites: 31 passed
- task credential-revocation suites: 32 passed, 10 PostgreSQL environment-gated skips
- `pnpm check`: workspace typecheck, lint, short-ID/multitenancy/realtime/filesystem boundaries, and builds passed
- focused post-check suites: core health 8 passed; daemon health/socket/credential 268 passed; executor terminal/client 31 passed
- managed two-replica PostgreSQL/RLS HA health smoke: single-owner claim, tenant isolation, bounded cadence, no error/event loop, and cleanup verified

## Deployment

**Suitable for expedited deployment after review.** Both changes are targeted lifecycle guards with no schema, configuration, restart, or retry-policy changes. Revoked sockets retain no authority during the bounded acknowledgement drain.

