### PR TITLE
fix(executor): acknowledge terminal writes before revocation teardown

### DIFF
--- a/apps/agor-daemon/src/setup/socketio-ack.integration.test.ts
+++ b/apps/agor-daemon/src/setup/socketio-ack.integration.test.ts
@@ -115,7 +115,7 @@ describe('executor acknowledgement failure convergence', () => {
               if (typeof acknowledge === 'function') {
                 packet[packet.length - 1] = (...args: unknown[]) => {
                   acknowledge(...args);
-                  setTimeout(() => socket.disconnect(true), 0);
+                  socket.disconnect(true);
                 };
               }
             }

--- a/apps/agor-daemon/src/setup/socketio-ack.integration.test.ts
+++ b/apps/agor-daemon/src/setup/socketio-ack.integration.test.ts
@@ -89,6 +89,63 @@ describe('executor acknowledgement failure convergence', () => {
     expect(mutationCount).toBe(1);
   });
 
+  it('does not reconnect a credential revoked after its terminal Task acknowledgement', async () => {
+    const app = feathersExpress(feathers());
+    let handshakeAuthenticationCount = 0;
+    app.use('tasks', {
+      async patch(id: string, data: Partial<Task>) {
+        return { task_id: id, session_id: SESSION_ID, ...data };
+      },
+    });
+    app.configure(
+      socketio({}, (io) => {
+        io.use((socket, next) => {
+          if (socket.handshake.auth?.token !== SESSION_TOKEN) {
+            next(new Error('Invalid executor handshake token'));
+            return;
+          }
+          handshakeAuthenticationCount += 1;
+          next();
+        });
+        io.on('connection', (socket) => {
+          socket.use((packet, next) => {
+            const [event, path] = packet;
+            if (event === 'patch' && path === 'tasks') {
+              const acknowledge = packet[packet.length - 1];
+              if (typeof acknowledge === 'function') {
+                packet[packet.length - 1] = (...args: unknown[]) => {
+                  acknowledge(...args);
+                  setTimeout(() => socket.disconnect(true), 0);
+                };
+              }
+            }
+            next();
+          });
+        });
+      })
+    );
+
+    server = await new Promise<Server>((resolve) => {
+      const listening = app.listen(0, '127.0.0.1', () => resolve(listening));
+    });
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('Expected a TCP test server');
+
+    client = await createExecutorClient(`http://127.0.0.1:${address.port}`, SESSION_TOKEN);
+    const disconnected = new Promise<void>((resolve) => client?.io.once('disconnect', resolve));
+    await expect(
+      client.service('tasks').patch(TASK_ID, {
+        status: TaskStatus.COMPLETED,
+        completed_at: '2026-08-24T00:00:00.000Z',
+      })
+    ).resolves.toMatchObject({ status: TaskStatus.COMPLETED });
+    await disconnected;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(handshakeAuthenticationCount).toBe(1);
+    expect(client.io.connected).toBe(false);
+  });
+
   it('rejects a stranded mutation once and converges through the executor terminal boundary', async () => {
     const app = feathersExpress(feathers());
     let mutationCount = 0;

--- a/apps/agor-daemon/src/setup/socketio-executor-auth.integration.test.ts
+++ b/apps/agor-daemon/src/setup/socketio-executor-auth.integration.test.ts
@@ -217,9 +217,9 @@ async function startHarness(
           user_id: params.user?.user_id,
         };
       },
-      async finish(data: { task_id: string }) {
+      async finish(data: { task_id: string; status?: 'completed' | 'failed' }) {
         await sessionTokens.revokeTaskTokens(data.task_id);
-        return { accepted: true, task_id: data.task_id };
+        return { accepted: true, task_id: data.task_id, status: data.status ?? 'completed' };
       },
     },
     { events: ['termination_requested'], methods: ['get', 'connectExecutor', 'finish'] }
@@ -437,64 +437,69 @@ describe('executor Socket.IO connection capability', () => {
     ).resolves.toBeNull();
   });
 
-  it('drains a self-revoking task RPC acknowledgement before disconnecting its executor', async () => {
-    const harness = await startHarness();
-    harnesses.push(harness);
-    await waitForConnect(harness.client);
-    const serverSocket = harness.socketConfig
-      .getSocketServer()
-      ?.sockets.sockets.get(harness.client.io.id!);
-    if (!serverSocket) throw new Error('Expected connected executor socket');
-    const connection = (serverSocket as unknown as { feathers?: Record<string, unknown> }).feathers;
-    const transport = serverSocket.conn.transport;
-    const disconnectListenersBefore = serverSocket.listenerCount('disconnect');
-    const readyListenersBefore = transport.listenerCount('ready');
-    const send = transport.send.bind(transport);
-    let releaseAcknowledgement: (() => void) | undefined;
-    transport.send = ((packets: Parameters<typeof send>[0]) => {
-      // Deterministically model production transport backpressure. The Task
-      // mutation and token revocation commit before Feathers queues its RPC
-      // acknowledgement; closing the namespace while this write is held makes
-      // the client report a false task failure even though terminality won.
-      transport.writable = false;
-      releaseAcknowledgement = () => {
-        transport.send = send;
-        send(packets);
+  it.each(['completed', 'failed'] as const)(
+    'drains a self-revoking %s Task RPC acknowledgement before disconnecting its executor',
+    async (status) => {
+      const harness = await startHarness();
+      harnesses.push(harness);
+      await waitForConnect(harness.client);
+      const serverSocket = harness.socketConfig
+        .getSocketServer()
+        ?.sockets.sockets.get(harness.client.io.id!);
+      if (!serverSocket) throw new Error('Expected connected executor socket');
+      const connection = (serverSocket as unknown as { feathers?: Record<string, unknown> })
+        .feathers;
+      const transport = serverSocket.conn.transport;
+      const disconnectListenersBefore = serverSocket.listenerCount('disconnect');
+      const readyListenersBefore = transport.listenerCount('ready');
+      const send = transport.send.bind(transport);
+      let releaseAcknowledgement: (() => void) | undefined;
+      transport.send = ((packets: Parameters<typeof send>[0]) => {
+        // Deterministically model production transport backpressure. The Task
+        // mutation and token revocation commit before Feathers queues its RPC
+        // acknowledgement; closing the namespace while this write is held makes
+        // the client report a false task failure even though terminality won.
+        transport.writable = false;
+        releaseAcknowledgement = () => {
+          transport.send = send;
+          send(packets);
+        };
+      }) as typeof transport.send;
+      const disconnected = waitForDisconnect(harness.client);
+
+      const tasks = harness.client.service('tasks') as unknown as {
+        methods?: (...names: string[]) => unknown;
+        finish(data: { task_id: string; status: 'completed' | 'failed' }): Promise<unknown>;
       };
-    }) as typeof transport.send;
-    const disconnected = waitForDisconnect(harness.client);
+      tasks.methods?.('finish');
+      const finish = tasks.finish({ task_id: TASK_ID, status });
+      void finish.catch(() => undefined);
+      await waitFor(
+        () =>
+          releaseAcknowledgement !== undefined &&
+          getAuthenticatedConnectionAuthority(connection) === undefined
+      );
+      await new Promise<void>((resolve) => setTimeout(resolve, 50));
 
-    const tasks = harness.client.service('tasks') as unknown as {
-      methods?: (...names: string[]) => unknown;
-      finish(data: { task_id: string }): Promise<unknown>;
-    };
-    tasks.methods?.('finish');
-    const finish = tasks.finish({ task_id: TASK_ID });
-    void finish.catch(() => undefined);
-    await waitFor(
-      () =>
-        releaseAcknowledgement !== undefined &&
-        getAuthenticatedConnectionAuthority(connection) === undefined
-    );
-    await new Promise<void>((resolve) => setTimeout(resolve, 50));
+      // Revocation is already authoritative and the Task room is already gone,
+      // but transport retirement must not overtake the terminal RPC response.
+      expect(serverSocket.connected).toBe(true);
+      expect(harness.client.io.connected).toBe(true);
+      expect(harness.app.channels).not.toContain(executorTaskChannelName(TENANT_ID, TASK_ID));
+      expect(serverSocket.listenerCount('disconnect')).toBe(disconnectListenersBefore + 1);
+      expect(transport.listenerCount('ready')).toBe(readyListenersBefore + 1);
+      releaseAcknowledgement?.();
+      await expect(finish).resolves.toEqual({
+        accepted: true,
+        task_id: TASK_ID,
+        status,
+      });
 
-    // Revocation is already authoritative and the Task room is already gone,
-    // but transport retirement must not overtake the terminal RPC response.
-    expect(serverSocket.connected).toBe(true);
-    expect(harness.client.io.connected).toBe(true);
-    expect(harness.app.channels).not.toContain(executorTaskChannelName(TENANT_ID, TASK_ID));
-    expect(serverSocket.listenerCount('disconnect')).toBe(disconnectListenersBefore + 1);
-    expect(transport.listenerCount('ready')).toBe(readyListenersBefore + 1);
-    releaseAcknowledgement?.();
-    await expect(finish).resolves.toEqual({
-      accepted: true,
-      task_id: TASK_ID,
-    });
-
-    await disconnected;
-    expect(serverSocket.listenerCount('disconnect')).toBe(disconnectListenersBefore);
-    expect(transport.listenerCount('ready')).toBeLessThanOrEqual(readyListenersBefore);
-  });
+      await disconnected;
+      expect(serverSocket.listenerCount('disconnect')).toBe(disconnectListenersBefore);
+      expect(transport.listenerCount('ready')).toBeLessThanOrEqual(readyListenersBefore);
+    }
+  );
 
   it('rejects login when revocation lands after authority validation starts', async () => {
     const harness = await startHarness({ pauseValidation: true });

--- a/apps/agor-daemon/src/setup/socketio.ts
+++ b/apps/agor-daemon/src/setup/socketio.ts
@@ -13,6 +13,7 @@
  * agor.db, and the JWT secret). See `terminal:*` handlers below.
  */
 
+import { AsyncLocalStorage } from 'node:async_hooks';
 import {
   type ResolvedMultiTenancyConfig,
   SOCKET_IO_MAX_BUFFER_SIZE_BYTES,
@@ -272,7 +273,9 @@ export interface SocketIOResult {
  * user stays on the same board.
  */
 const GLOBAL_PRESENCE_EMIT_INTERVAL_MS = 10_000;
-const EXECUTOR_REVOCATION_DRAIN_TIMEOUT_MS = 5_000;
+// Longer than the executor's 60s Feathers acknowledgement deadline. The
+// authority is fenced synchronously; this timer bounds only transport cleanup.
+const EXECUTOR_REVOCATION_DRAIN_TIMEOUT_MS = 65_000;
 
 function deferExecutorTransportWork(work: () => void): void {
   // Transport-only callback: it must never perform database or tenant-owned
@@ -292,13 +295,24 @@ function deferExecutorTransportWork(work: () => void): void {
  * room membership have already been removed synchronously, so this bounded
  * drain window grants no residual service or realtime access.
  */
-function disconnectRevokedExecutorAfterTransportDrain(socket: Socket): void {
+interface ExecutorRpcAcknowledgement {
+  socket: Socket;
+  revoked: boolean;
+  acknowledgeRetirement?: () => void;
+}
+
+const executorRpcAcknowledgement = new AsyncLocalStorage<ExecutorRpcAcknowledgement>();
+
+function disconnectRevokedExecutorAfterTransportDrain(
+  socket: Socket,
+  waitForAcknowledgement: boolean
+): () => void {
   // The lightweight Socket.IO unit harness has no Engine.IO transport. Keep
   // its behavior representative without requiring transport internals there.
   const connection = socket.conn;
   if (!connection) {
     deferExecutorTransportWork(() => socket.disconnect(true));
-    return;
+    return () => undefined;
   }
 
   let finished = false;
@@ -351,9 +365,12 @@ function disconnectRevokedExecutorAfterTransportDrain(socket: Socket): void {
   socket.once('disconnect', onSocketDisconnect);
   deadline = setTimeout(disconnect, EXECUTOR_REVOCATION_DRAIN_TIMEOUT_MS);
   deadline.unref?.();
-  // Feathers queues the acknowledgement after the service promise resolves.
-  // Inspect on the next turn, after that queueing opportunity.
-  deferExecutorTransportWork(inspectTransport);
+  if (!waitForAcknowledgement) deferExecutorTransportWork(inspectTransport);
+  return () => {
+    // The wrapped Feathers callback has synchronously handed the response to
+    // Socket.IO's encoder. Only now is transport writability meaningful.
+    deferExecutorTransportWork(inspectTransport);
+  };
 }
 
 function bearerTokenFromHeader(value: string | string[] | undefined): string | undefined {
@@ -769,7 +786,16 @@ export function createSocketIOConfig(
           // before closing so a successful durable write is not reported as a
           // task failure by the executor.
           retireSocketConnectionAuthority(app, feathers);
-          disconnectRevokedExecutorAfterTransportDrain(socket);
+          const rpc = executorRpcAcknowledgement.getStore();
+          const waitsForThisRpc = rpc?.socket === socket;
+          const acknowledgeRetirement = disconnectRevokedExecutorAfterTransportDrain(
+            socket,
+            waitsForThisRpc
+          );
+          if (waitsForThisRpc) {
+            rpc.revoked = true;
+            rpc.acknowledgeRetirement = acknowledgeRetirement;
+          }
         }
       }
     };
@@ -795,6 +821,24 @@ export function createSocketIOConfig(
         return;
       }
       activeConnections++;
+      // Bind revocation to the exact Feathers acknowledgement whose service
+      // call caused it. A next-turn/idle-transport heuristic is insufficient:
+      // Feathers invokes this callback only after the service promise returns,
+      // and a disconnect may otherwise overtake the response encoder.
+      socket.use?.((packet, next) => {
+        const lastIndex = packet.length - 1;
+        const acknowledgement = packet[lastIndex];
+        if (typeof acknowledgement !== 'function') {
+          next();
+          return;
+        }
+        const rpc: ExecutorRpcAcknowledgement = { socket, revoked: false };
+        packet[lastIndex] = (...args: unknown[]) => {
+          acknowledgement(...args);
+          if (rpc.revoked) rpc.acknowledgeRetirement?.();
+        };
+        executorRpcAcknowledgement.run(rpc, next);
+      });
       bindTerminalRequestJoin(feathersSocket);
       console.debug(
         `🔌 Socket.io connection established: ${socket.id} (auth: handshake, principal: ${authority?.principal.kind ?? 'invalid'}, user: ${authority?.principal.kind === 'user' ? shortId(authority.principal.userId) : 'none'}, total: ${activeConnections})`

--- a/apps/agor-daemon/src/setup/socketio.ts
+++ b/apps/agor-daemon/src/setup/socketio.ts
@@ -15,6 +15,7 @@
 
 import { AsyncLocalStorage } from 'node:async_hooks';
 import {
+  EXECUTOR_REVOCATION_TRANSPORT_CLEANUP_TIMEOUT_MS,
   type ResolvedMultiTenancyConfig,
   SOCKET_IO_MAX_BUFFER_SIZE_BYTES,
 } from '@agor/core/config';
@@ -273,10 +274,6 @@ export interface SocketIOResult {
  * user stays on the same board.
  */
 const GLOBAL_PRESENCE_EMIT_INTERVAL_MS = 10_000;
-// Longer than the executor's 60s Feathers acknowledgement deadline. The
-// authority is fenced synchronously; this timer bounds only transport cleanup.
-const EXECUTOR_REVOCATION_DRAIN_TIMEOUT_MS = 65_000;
-
 function deferExecutorTransportWork(work: () => void): void {
   // Transport-only callback: it must never perform database or tenant-owned
   // work while retaining the revoking request's async context.
@@ -363,7 +360,7 @@ function disconnectRevokedExecutorAfterTransportDrain(
   };
 
   socket.once('disconnect', onSocketDisconnect);
-  deadline = setTimeout(disconnect, EXECUTOR_REVOCATION_DRAIN_TIMEOUT_MS);
+  deadline = setTimeout(disconnect, EXECUTOR_REVOCATION_TRANSPORT_CLEANUP_TIMEOUT_MS);
   deadline.unref?.();
   if (!waitForAcknowledgement) deferExecutorTransportWork(inspectTransport);
   return () => {
@@ -825,20 +822,21 @@ export function createSocketIOConfig(
       // call caused it. A next-turn/idle-transport heuristic is insufficient:
       // Feathers invokes this callback only after the service promise returns,
       // and a disconnect may otherwise overtake the response encoder.
-      socket.use?.((packet, next) => {
-        const lastIndex = packet.length - 1;
-        const acknowledgement = packet[lastIndex];
-        if (typeof acknowledgement !== 'function') {
-          next();
-          return;
-        }
-        const rpc: ExecutorRpcAcknowledgement = { socket, revoked: false };
-        packet[lastIndex] = (...args: unknown[]) => {
-          acknowledgement(...args);
-          if (rpc.revoked) rpc.acknowledgeRetirement?.();
-        };
-        executorRpcAcknowledgement.run(rpc, next);
-      });
+      if (authority?.principal.kind === 'executor')
+        socket.use?.((packet, next) => {
+          const lastIndex = packet.length - 1;
+          const acknowledgement = packet[lastIndex];
+          if (typeof acknowledgement !== 'function') {
+            next();
+            return;
+          }
+          const rpc: ExecutorRpcAcknowledgement = { socket, revoked: false };
+          packet[lastIndex] = (...args: unknown[]) => {
+            acknowledgement(...args);
+            if (rpc.revoked) rpc.acknowledgeRetirement?.();
+          };
+          executorRpcAcknowledgement.run(rpc, next);
+        });
       bindTerminalRequestJoin(feathersSocket);
       console.debug(
         `🔌 Socket.io connection established: ${socket.id} (auth: handshake, principal: ${authority?.principal.kind ?? 'invalid'}, user: ${authority?.principal.kind === 'user' ? shortId(authority.principal.userId) : 'none'}, total: ${activeConnections})`

--- a/packages/core/src/config/constants.ts
+++ b/packages/core/src/config/constants.ts
@@ -89,6 +89,15 @@ export const WEBSOCKET = {
 /** Shared Socket.IO packet ceiling used by the daemon transport. */
 export const SOCKET_IO_MAX_BUFFER_SIZE_BYTES = 1_000_000;
 
+/** Executor Feathers RPC acknowledgement deadline. */
+export const EXECUTOR_FEATHERS_ACK_TIMEOUT_MS = 60_000;
+
+/** Extra time for bounded transport cleanup after the executor RPC deadline. */
+export const EXECUTOR_REVOCATION_TRANSPORT_CLEANUP_MARGIN_MS = 5_000;
+
+export const EXECUTOR_REVOCATION_TRANSPORT_CLEANUP_TIMEOUT_MS =
+  EXECUTOR_FEATHERS_ACK_TIMEOUT_MS + EXECUTOR_REVOCATION_TRANSPORT_CLEANUP_MARGIN_MS;
+
 /**
  * Pagination Constants
  *

--- a/packages/executor/src/services/feathers-client.test.ts
+++ b/packages/executor/src/services/feathers-client.test.ts
@@ -3,7 +3,8 @@ import { SOCKET_IO_MAX_BUFFER_SIZE_BYTES } from '@agor/core/config';
 import { describe, expect, it } from 'vitest';
 import {
   EXECUTOR_REQUEST_DATA_BUDGET_BYTES,
-  registerExecutorClientHooks,
+  registerExecutorRequestSizeGuard,
+  registerTerminalTaskAcknowledgementHook,
 } from './feathers-client.js';
 
 describe('executor transport budget', () => {
@@ -13,7 +14,7 @@ describe('executor transport budget', () => {
   });
 });
 
-describe('registerExecutorClientHooks – size guard', () => {
+describe('executor client hooks', () => {
   type HookFn = (ctx: Record<string, unknown>) => Promise<Record<string, unknown>>;
 
   function captureHook(onTerminalTaskAcknowledged?: () => void): {
@@ -24,12 +25,13 @@ describe('registerExecutorClientHooks – size guard', () => {
     let hook: HookFn | undefined;
     let afterHook: HookFn | undefined;
     const client = {
-      hooks(config: { before: { all: HookFn[] }; after: { all: HookFn[] } }) {
-        hook = config.before.all[0];
-        afterHook = config.after.all[0];
+      hooks(config: { before?: { all: HookFn[] }; after?: { all: HookFn[] } }) {
+        hook ??= config.before?.all[0];
+        afterHook ??= config.after?.all[0];
       },
     } as unknown as AgorClient;
-    registerExecutorClientHooks(client, onTerminalTaskAcknowledged);
+    registerExecutorRequestSizeGuard(client);
+    registerTerminalTaskAcknowledgementHook(client, onTerminalTaskAcknowledged ?? (() => {}));
     if (!hook || !afterHook) throw new Error('hook was not registered');
     return { hook, afterHook, client };
   }

--- a/packages/executor/src/services/feathers-client.test.ts
+++ b/packages/executor/src/services/feathers-client.test.ts
@@ -16,16 +16,22 @@ describe('executor transport budget', () => {
 describe('registerExecutorClientHooks – size guard', () => {
   type HookFn = (ctx: Record<string, unknown>) => Promise<Record<string, unknown>>;
 
-  function captureHook(): { hook: HookFn; client: AgorClient } {
+  function captureHook(onTerminalTaskAcknowledged?: () => void): {
+    hook: HookFn;
+    afterHook: HookFn;
+    client: AgorClient;
+  } {
     let hook: HookFn | undefined;
+    let afterHook: HookFn | undefined;
     const client = {
-      hooks(config: { before: { all: HookFn[] } }) {
+      hooks(config: { before: { all: HookFn[] }; after: { all: HookFn[] } }) {
         hook = config.before.all[0];
+        afterHook = config.after.all[0];
       },
     } as unknown as AgorClient;
-    registerExecutorClientHooks(client);
-    if (!hook) throw new Error('hook was not registered');
-    return { hook, client };
+    registerExecutorClientHooks(client, onTerminalTaskAcknowledged);
+    if (!hook || !afterHook) throw new Error('hook was not registered');
+    return { hook, afterHook, client };
   }
 
   function makeContext(path: string, method: string, data: unknown) {
@@ -74,4 +80,24 @@ describe('registerExecutorClientHooks – size guard', () => {
     const ctx = makeContext('messages', 'create', { content: oversizedPayload() });
     await expect(hook(ctx)).rejects.toThrow('messages.create');
   });
+
+  it.each(['completed', 'failed'])(
+    'suppresses revoked-credential reconnect only after an acknowledged %s Task patch',
+    async (status) => {
+      let acknowledgements = 0;
+      const { afterHook } = captureHook(() => {
+        acknowledgements += 1;
+      });
+
+      await afterHook({ ...makeContext('tasks', 'patch', { status }), result: { status } });
+      expect(acknowledgements).toBe(1);
+
+      await afterHook({ ...makeContext('tasks', 'get', { status }), result: { status } });
+      await afterHook({
+        ...makeContext('tasks', 'patch', { status: 'running' }),
+        result: { status: 'running' },
+      });
+      expect(acknowledgements).toBe(1);
+    }
+  );
 });

--- a/packages/executor/src/services/feathers-client.ts
+++ b/packages/executor/src/services/feathers-client.ts
@@ -8,7 +8,10 @@
  */
 
 import { type AgorClient, createClient } from '@agor/core/api';
-import { SOCKET_IO_MAX_BUFFER_SIZE_BYTES } from '@agor/core/config';
+import {
+  EXECUTOR_FEATHERS_ACK_TIMEOUT_MS,
+  SOCKET_IO_MAX_BUFFER_SIZE_BYTES,
+} from '@agor/core/config';
 import { isTerminalTaskStatus } from '@agor/core/types';
 
 // Re-export AgorClient type for use in other executor files
@@ -20,7 +23,6 @@ const DEBUG_FEATHERS_CLIENT =
 const SERVER_DISCONNECT_RECONNECT_BASE_DELAY_MS = 1000;
 const SERVER_DISCONNECT_RECONNECT_MAX_DELAY_MS = 30_000;
 const SERVER_DISCONNECT_RECONNECT_MAX_ATTEMPTS = 8;
-const EXECUTOR_ACK_TIMEOUT_MS = 60_000;
 
 export const EXECUTOR_REQUEST_DATA_BUDGET_BYTES = SOCKET_IO_MAX_BUFFER_SIZE_BYTES - 200_000;
 
@@ -30,10 +32,7 @@ function feathersClientDebug(...args: unknown[]): void {
   }
 }
 
-export function registerExecutorClientHooks(
-  client: AgorClient,
-  onTerminalTaskAcknowledged?: () => void
-): void {
+export function registerExecutorRequestSizeGuard(client: AgorClient): void {
   client.hooks({
     before: {
       all: [
@@ -61,6 +60,14 @@ export function registerExecutorClientHooks(
         },
       ],
     },
+  });
+}
+
+export function registerTerminalTaskAcknowledgementHook(
+  client: AgorClient,
+  onTerminalTaskAcknowledged: () => void
+): void {
+  client.hooks({
     after: {
       all: [
         async (context) => {
@@ -69,7 +76,7 @@ export function registerExecutorClientHooks(
             context.method === 'patch' &&
             isTerminalTaskStatus(context.result?.status)
           ) {
-            onTerminalTaskAcknowledged?.();
+            onTerminalTaskAcknowledged();
           }
           return context;
         },
@@ -125,11 +132,12 @@ export async function createExecutorClient(
     // credential's lifetime. Every automatic reconnect performs a fresh
     // authenticated handshake with the same bearer.
     reconnectionAttempts: Number.POSITIVE_INFINITY,
-    ackTimeout: EXECUTOR_ACK_TIMEOUT_MS,
+    ackTimeout: EXECUTOR_FEATHERS_ACK_TIMEOUT_MS,
     socketAuthentication: { accessToken: sessionToken },
   });
   let terminalTaskAcknowledged = false;
-  registerExecutorClientHooks(client, () => {
+  registerExecutorRequestSizeGuard(client);
+  registerTerminalTaskAcknowledgementHook(client, () => {
     terminalTaskAcknowledged = true;
   });
 

--- a/packages/executor/src/services/feathers-client.ts
+++ b/packages/executor/src/services/feathers-client.ts
@@ -9,6 +9,7 @@
 
 import { type AgorClient, createClient } from '@agor/core/api';
 import { SOCKET_IO_MAX_BUFFER_SIZE_BYTES } from '@agor/core/config';
+import { isTerminalTaskStatus } from '@agor/core/types';
 
 // Re-export AgorClient type for use in other executor files
 export type { AgorClient } from '@agor/core/api';
@@ -29,7 +30,10 @@ function feathersClientDebug(...args: unknown[]): void {
   }
 }
 
-export function registerExecutorClientHooks(client: AgorClient): void {
+export function registerExecutorClientHooks(
+  client: AgorClient,
+  onTerminalTaskAcknowledged?: () => void
+): void {
   client.hooks({
     before: {
       all: [
@@ -52,6 +56,20 @@ export function registerExecutorClientHooks(client: AgorClient): void {
               `Executor transcript data is ${byteSize} bytes, exceeding the ${EXECUTOR_REQUEST_DATA_BUDGET_BYTES}-byte transport budget (${path}.${context.method}). ` +
                 `Reduce the tool result size at the source (e.g. pagination, filtering, or result limits).`
             );
+          }
+          return context;
+        },
+      ],
+    },
+    after: {
+      all: [
+        async (context) => {
+          if (
+            context.path === 'tasks' &&
+            context.method === 'patch' &&
+            isTerminalTaskStatus(context.result?.status)
+          ) {
+            onTerminalTaskAcknowledged?.();
           }
           return context;
         },
@@ -110,7 +128,10 @@ export async function createExecutorClient(
     ackTimeout: EXECUTOR_ACK_TIMEOUT_MS,
     socketAuthentication: { accessToken: sessionToken },
   });
-  registerExecutorClientHooks(client);
+  let terminalTaskAcknowledged = false;
+  registerExecutorClientHooks(client, () => {
+    terminalTaskAcknowledged = true;
+  });
 
   let serverDisconnectReconnectAttempts = 0;
   let serverDisconnectReconnectTimer: ReturnType<typeof setTimeout> | undefined;
@@ -173,6 +194,13 @@ export async function createExecutorClient(
 
     serverDisconnectReconnectTimer = setTimeout(() => {
       serverDisconnectReconnectTimer = undefined;
+      // Socket.IO may deliver an acknowledgement and the following namespace
+      // disconnect in one transport batch. Client after-hooks settle on the
+      // next microtask, so re-check before reopening the now-revoked bearer.
+      if (terminalTaskAcknowledged) {
+        resetServerDisconnectRecovery();
+        return;
+      }
       client.io.connect();
     }, delayMs);
   };
@@ -182,6 +210,10 @@ export async function createExecutorClient(
     logSocketEvent('disconnected', reason);
 
     if (reason === 'io server disconnect') {
+      if (terminalTaskAcknowledged) {
+        resetServerDisconnectRecovery();
+        return;
+      }
       // Socket.IO intentionally disables automatic reconnect after a server-
       // initiated namespace disconnect. In practice, long executor tasks can
       // see this at the same ~15-minute boundary as proxy transport rotation.


### PR DESCRIPTION
## Summary

- bind executor credential revocation teardown to the exact Feathers RPC acknowledgement that caused terminal Task persistence
- keep token authority and executor Task-room fencing synchronous while delaying only bounded transport cleanup
- suppress executor reconnect only after a terminal Task response has actually been acknowledged
- preserve reconnect and failure visibility for unacknowledged network, database, and provider failures

## Root cause

The post-#2543 drain path inspected Engine.IO `transport.writable` before Feathers had invoked the Socket.IO acknowledgement callback. A transport could be idle at that instant, causing the daemon to disconnect it before the already-committed terminal Task response was encoded. The executor then interpreted the lost acknowledgement as task execution failure and retried the intentionally revoked credential.

## Correctness

- terminal Task persistence remains authoritative and immutable
- token revocation, local authority retirement, Task-room removal, and HA invalidation remain synchronous
- transport retirement is tied to the originating RPC acknowledgement and bounded by cleanup timeout
- completed and failed terminal writes resolve before intentional disconnect
- acknowledged terminal writes do not reconnect revoked credentials, including acknowledgement/disconnect packets delivered in one transport batch
- non-terminal and unacknowledged disconnects retain bounded reconnect behavior
- teardown removes temporary listeners and timers

## Testing

- `pnpm i`
- `pnpm check`
- `pnpm --filter @agor/daemon exec vitest run src/setup/socketio.test.ts src/setup/socketio-ack.integration.test.ts src/setup/socketio-executor-auth.integration.test.ts src/services/tasks.callbacks.test.ts`
- `pnpm --filter @agor/executor exec vitest run src/services/feathers-client.test.ts src/handlers/sdk/base-executor.test.ts src/terminal-task.test.ts`

Focused result: 126 daemon tests and 33 executor tests passed.
