### PR TITLE
fix(oauth): honor advertised token-endpoint client auth method (HubSpot MCP)

### DIFF
--- a/apps/agor-daemon/src/oauth-cache.ts
+++ b/apps/agor-daemon/src/oauth-cache.ts
@@ -51,6 +51,11 @@ export async function persistOAuthToken(
      * the MCP resource URL or mutate server configuration.
      */
     tokenEndpoint?: SaveTokenInput['tokenEndpoint'];
+    /**
+     * Client-authentication method the code exchange used. Persisted so the
+     * refresh grant authenticates the same way the provider accepts.
+     */
+    tokenAuthMethod?: SaveTokenInput['tokenAuthMethod'];
     resourceUri?: SaveTokenInput['resourceUri'];
     grantBinding?: SaveTokenInput['grantBinding'];
   },
@@ -105,6 +110,7 @@ export async function persistOAuthToken(
     clientId: pendingFlow.clientId,
     clientSecret: pendingFlow.clientSecret,
     tokenEndpoint: pendingFlow.tokenEndpoint,
+    tokenAuthMethod: pendingFlow.tokenAuthMethod,
     resourceUri: pendingFlow.resourceUri,
     grantBinding: pendingFlow.grantBinding,
   });

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -2285,6 +2285,7 @@ export async function registerMCPServices(
           clientId: pendingFlow.context.clientId,
           clientSecret: pendingFlow.context.clientSecret,
           tokenEndpoint: pendingFlow.context.tokenEndpoint,
+          tokenAuthMethod: pendingFlow.context.tokenEndpointAuthMethod,
           resourceUri: pendingFlow.context.resourceUri,
           ...(grantBinding ? { grantBinding } : {}),
         },

--- a/apps/agor-daemon/src/services/mcp-oauth-pending-flow-authority.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-pending-flow-authority.ts
@@ -75,6 +75,10 @@ function hasOnlyExpectedMaterialShape(value: unknown): value is MCPOAuthPendingF
     typeof material.pkceVerifier === 'string' &&
     typeof material.clientId === 'string' &&
     (material.clientSecret === undefined || typeof material.clientSecret === 'string') &&
+    (material.tokenEndpointAuthMethod === undefined ||
+      material.tokenEndpointAuthMethod === 'client_secret_basic' ||
+      material.tokenEndpointAuthMethod === 'client_secret_post' ||
+      material.tokenEndpointAuthMethod === 'none') &&
     (material.compatibilityMode === 'strict' ||
       material.compatibilityMode === 'legacy' ||
       material.compatibilityMode === 'marketplace') &&

--- a/packages/core/drizzle/postgres/0093_mcp_oauth_token_auth_method.sql
+++ b/packages/core/drizzle/postgres/0093_mcp_oauth_token_auth_method.sql
@@ -1,0 +1,15 @@
+-- Token-endpoint client authentication method (RFC 8414 §2) the grant was
+-- issued under. The refresh grant hits the same token endpoint as the code
+-- exchange, so it has to authenticate the same way; without this the refresh
+-- would fall back to HTTP Basic and be rejected by servers that advertise only
+-- client_secret_post (e.g. HubSpot's MCP authorization server).
+--
+-- Nullable with no backfill on purpose: existing grants were issued under the
+-- old always-Basic behaviour, and NULL reads back as "use the RFC 8414 default"
+-- (client_secret_basic), which is exactly what they were issued with.
+--
+-- Not a secret, so it is stored in the clear rather than through the PostgreSQL
+-- OAuth secret envelope used for the token/client-secret columns. Tenant
+-- isolation is unchanged: the column rides the existing per-tenant RLS on
+-- user_mcp_oauth_tokens.
+ALTER TABLE "user_mcp_oauth_tokens" ADD COLUMN "oauth_token_auth_method" text;

--- a/packages/core/drizzle/postgres/meta/_journal.json
+++ b/packages/core/drizzle/postgres/meta/_journal.json
@@ -645,6 +645,13 @@
       "when": 1787443200000,
       "tag": "0092_add_user_credential_generation",
       "breakpoints": true
+    },
+    {
+      "idx": 93,
+      "version": "7",
+      "when": 1787529600000,
+      "tag": "0093_mcp_oauth_token_auth_method",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/drizzle/sqlite/0096_mcp_oauth_token_auth_method.sql
+++ b/packages/core/drizzle/sqlite/0096_mcp_oauth_token_auth_method.sql
@@ -1,0 +1,13 @@
+-- Token-endpoint client authentication method (RFC 8414 §2) the grant was
+-- issued under. The refresh grant hits the same token endpoint as the code
+-- exchange, so it has to authenticate the same way; without this the refresh
+-- would fall back to HTTP Basic and be rejected by servers that advertise only
+-- client_secret_post (e.g. HubSpot's MCP authorization server).
+--
+-- Nullable with no backfill on purpose: existing grants were issued under the
+-- old always-Basic behaviour, and NULL reads back as "use the RFC 8414 default"
+-- (client_secret_basic), which is exactly what they were issued with.
+--
+-- Not a secret, so it is stored in the clear rather than through the PostgreSQL
+-- OAuth secret envelope used for the token/client-secret columns.
+ALTER TABLE `user_mcp_oauth_tokens` ADD `oauth_token_auth_method` text;

--- a/packages/core/drizzle/sqlite/meta/_journal.json
+++ b/packages/core/drizzle/sqlite/meta/_journal.json
@@ -659,6 +659,13 @@
       "when": 1787443200000,
       "tag": "0095_add_user_credential_generation",
       "breakpoints": true
+    },
+    {
+      "idx": 96,
+      "version": "6",
+      "when": 1787529600000,
+      "tag": "0096_mcp_oauth_token_auth_method",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/db/migrations.test.ts
+++ b/packages/core/src/db/migrations.test.ts
@@ -128,6 +128,21 @@ describe('Postgres migrations', () => {
     }
   });
 
+  it('assigns the MCP OAuth client-auth method column strictly increasing watermarks', async () => {
+    const [postgresJournal, sqliteJournal] = await readJournals();
+
+    for (const [journal, expectedTag, expectedIndex] of [
+      [postgresJournal, '0093_mcp_oauth_token_auth_method', 93],
+      [sqliteJournal, '0096_mcp_oauth_token_auth_method', 96],
+    ] as const) {
+      const position = journal.entries.findIndex(({ tag }) => tag === expectedTag);
+      const entry = journal.entries[position];
+      const predecessor = journal.entries[position - 1];
+      expect(entry).toMatchObject({ idx: expectedIndex, tag: expectedTag });
+      expect(entry?.when).toBeGreaterThan(predecessor?.when ?? 0);
+    }
+  });
+
   it('gives the newest migration a unique watermark that sorts it last', async () => {
     // Drizzle applies pending migrations in `when` order, so a new migration
     // that does not sort after the one before it can run out of order against a

--- a/packages/core/src/db/repositories/user-mcp-oauth-tokens.test.ts
+++ b/packages/core/src/db/repositories/user-mcp-oauth-tokens.test.ts
@@ -1,0 +1,32 @@
+import { expect } from 'vitest';
+import { dbTest } from '../test-helpers';
+import { MCPServerRepository } from './mcp-servers';
+import { UserMCPOAuthTokenRepository } from './user-mcp-oauth-tokens';
+
+dbTest('round-trips the token-endpoint auth method with an OAuth grant', async ({ db }) => {
+  const server = await new MCPServerRepository(db).create({
+    name: 'oauth-test-server',
+    transport: 'http',
+    url: 'https://mcp.example.test/',
+    scope: 'global',
+    enabled: true,
+    source: 'user',
+  });
+
+  const repository = new UserMCPOAuthTokenRepository(db);
+  await repository.saveToken(null, server.mcp_server_id, {
+    accessToken: 'access-token',
+    refreshToken: 'refresh-token',
+    clientId: 'client-id',
+    clientSecret: 'client-secret',
+    tokenEndpoint: 'https://auth.example.test/token',
+    tokenAuthMethod: 'client_secret_post',
+  });
+
+  const stored = await repository.getToken(null, server.mcp_server_id);
+  expect(stored).toMatchObject({
+    oauth_token_auth_method: 'client_secret_post',
+    oauth_client_id: 'client-id',
+    oauth_client_secret: 'client-secret',
+  });
+});

--- a/packages/core/src/db/repositories/user-mcp-oauth-tokens.ts
+++ b/packages/core/src/db/repositories/user-mcp-oauth-tokens.ts
@@ -44,6 +44,7 @@ export interface UserMCPOAuthToken {
   oauth_issuer?: string;
   oauth_authorization_endpoint?: string;
   oauth_token_endpoint?: string;
+  oauth_token_auth_method?: string;
   oauth_redirect_uri?: string;
   refresh_status: 'idle' | 'refreshing' | 'ambiguous';
   refresh_generation: number;
@@ -86,6 +87,8 @@ export interface SaveTokenInput {
    * grants take this value only from the authoritative grant binding below.
    */
   tokenEndpoint?: string;
+  /** Token-endpoint authentication method selected when this grant was issued. */
+  tokenAuthMethod?: string;
   /**
    * Protected resource retained for standalone/SQLite refresh requests.
    * PostgreSQL grants take this value only from the authoritative binding.
@@ -186,6 +189,9 @@ function rowToToken(
       ? String(raw.oauth_authorization_endpoint)
       : undefined,
     oauth_token_endpoint: raw.oauth_token_endpoint ? String(raw.oauth_token_endpoint) : undefined,
+    oauth_token_auth_method: raw.oauth_token_auth_method
+      ? String(raw.oauth_token_auth_method)
+      : undefined,
     oauth_redirect_uri: raw.oauth_redirect_uri ? String(raw.oauth_redirect_uri) : undefined,
     refresh_status: (raw.refresh_status ?? 'idle') as UserMCPOAuthToken['refresh_status'],
     refresh_generation: Number(raw.refresh_generation ?? 0),

--- a/packages/core/src/db/repositories/user-mcp-oauth-tokens.ts
+++ b/packages/core/src/db/repositories/user-mcp-oauth-tokens.ts
@@ -372,6 +372,7 @@ export class UserMCPOAuthTokenRepository {
             oauth_issuer: binding.issuer,
             oauth_authorization_endpoint: binding.authorizationEndpoint,
             oauth_token_endpoint: binding.tokenEndpoint,
+            oauth_token_auth_method: input.tokenAuthMethod ?? null,
             oauth_redirect_uri: binding.redirectUri,
             refresh_status: 'idle' as const,
             refresh_generation: 0,
@@ -405,6 +406,7 @@ export class UserMCPOAuthTokenRepository {
         oauth_issuer: binding?.issuer,
         oauth_authorization_endpoint: binding?.authorizationEndpoint,
         oauth_token_endpoint: binding?.tokenEndpoint ?? input.tokenEndpoint,
+        oauth_token_auth_method: input.tokenAuthMethod,
         oauth_redirect_uri: binding?.redirectUri,
         refresh_status: 'idle',
         refresh_generation: 0,
@@ -476,6 +478,11 @@ export class UserMCPOAuthTokenRepository {
                     : {}),
                   ...(input.resourceUri != null ? { oauth_resource_uri: input.resourceUri } : {}),
                 }),
+            ...(input.tokenAuthMethod != null
+              ? { oauth_token_auth_method: input.tokenAuthMethod }
+              : binding
+                ? { oauth_token_auth_method: null }
+                : {}),
             updated_at: now,
           })
           .where(

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -1803,6 +1803,10 @@ export const userMcpOauthTokens = pgTable(
     oauth_issuer: text('oauth_issuer'),
     oauth_authorization_endpoint: text('oauth_authorization_endpoint'),
     oauth_token_endpoint: text('oauth_token_endpoint'),
+    // Token-endpoint client authentication method (RFC 8414 §2) the grant was
+    // issued under. Refresh must reuse it; NULL = pre-existing grant, falls
+    // back to the RFC default. Not a secret, so it is stored in the clear.
+    oauth_token_auth_method: text('oauth_token_auth_method'),
     oauth_redirect_uri: text('oauth_redirect_uri'),
     refresh_status: text('refresh_status').notNull().default('idle'),
     refresh_generation: bigint('refresh_generation', { mode: 'number' }).notNull().default(0),

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -1711,6 +1711,10 @@ export const userMcpOauthTokens = sqliteTable(
     oauth_issuer: text('oauth_issuer'),
     oauth_authorization_endpoint: text('oauth_authorization_endpoint'),
     oauth_token_endpoint: text('oauth_token_endpoint'),
+    // Token-endpoint client authentication method (RFC 8414 §2) the grant was
+    // issued under. Refresh must reuse it; NULL = pre-existing grant, falls
+    // back to the RFC default. Not a secret, so it is stored in the clear.
+    oauth_token_auth_method: text('oauth_token_auth_method'),
     oauth_redirect_uri: text('oauth_redirect_uri'),
     refresh_status: text('refresh_status').notNull().default('idle'),
     refresh_generation: integer('refresh_generation').notNull().default(0),

--- a/packages/core/src/tools/mcp/oauth-client-auth.test.ts
+++ b/packages/core/src/tools/mcp/oauth-client-auth.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Token-endpoint client authentication selection (RFC 6749 §2.3.1, RFC 8414 §2).
+ */
+
+import { describe, expect, it } from 'vitest';
+import { applyClientAuthentication, selectTokenEndpointAuthMethod } from './oauth-client-auth';
+
+describe('selectTokenEndpointAuthMethod', () => {
+  it('defaults to client_secret_basic when metadata omits the field (RFC 8414 §2)', () => {
+    expect(selectTokenEndpointAuthMethod({ hasClientSecret: true })).toBe('client_secret_basic');
+    expect(
+      selectTokenEndpointAuthMethod({ hasClientSecret: true, supportedMethods: undefined })
+    ).toBe('client_secret_basic');
+    expect(selectTokenEndpointAuthMethod({ hasClientSecret: true, supportedMethods: [] })).toBe(
+      'client_secret_basic'
+    );
+  });
+
+  it('selects client_secret_post when that is all the server advertises (HubSpot)', () => {
+    expect(
+      selectTokenEndpointAuthMethod({
+        hasClientSecret: true,
+        supportedMethods: ['client_secret_post'],
+      })
+    ).toBe('client_secret_post');
+  });
+
+  it('prefers client_secret_basic when the server advertises both', () => {
+    expect(
+      selectTokenEndpointAuthMethod({
+        hasClientSecret: true,
+        supportedMethods: ['client_secret_post', 'client_secret_basic'],
+      })
+    ).toBe('client_secret_basic');
+  });
+
+  it('uses none for public clients regardless of what the server advertises', () => {
+    expect(selectTokenEndpointAuthMethod({ hasClientSecret: false })).toBe('none');
+    expect(
+      selectTokenEndpointAuthMethod({
+        hasClientSecret: false,
+        supportedMethods: ['client_secret_post', 'client_secret_basic'],
+      })
+    ).toBe('none');
+  });
+
+  it('honours a registered per-client method over the server-wide list (RFC 7591 §2)', () => {
+    expect(
+      selectTokenEndpointAuthMethod({
+        hasClientSecret: true,
+        supportedMethods: ['client_secret_post', 'client_secret_basic'],
+        registeredMethod: 'client_secret_post',
+      })
+    ).toBe('client_secret_post');
+  });
+
+  it('ignores an unknown or none registered method and falls back to the server list', () => {
+    expect(
+      selectTokenEndpointAuthMethod({
+        hasClientSecret: true,
+        supportedMethods: ['client_secret_post'],
+        registeredMethod: 'private_key_jwt',
+      })
+    ).toBe('client_secret_post');
+    // A registered 'none' cannot be honoured verbatim once a secret exists —
+    // the server-wide list decides how to present it.
+    expect(
+      selectTokenEndpointAuthMethod({
+        hasClientSecret: true,
+        supportedMethods: ['client_secret_post'],
+        registeredMethod: 'none',
+      })
+    ).toBe('client_secret_post');
+  });
+
+  it('withholds the secret when the server only accepts unauthenticated clients', () => {
+    expect(
+      selectTokenEndpointAuthMethod({ hasClientSecret: true, supportedMethods: ['none'] })
+    ).toBe('none');
+  });
+
+  it('falls back to the RFC default when every advertised method is unsupported', () => {
+    expect(
+      selectTokenEndpointAuthMethod({
+        hasClientSecret: true,
+        supportedMethods: ['private_key_jwt', 'tls_client_auth'],
+      })
+    ).toBe('client_secret_basic');
+  });
+});
+
+describe('applyClientAuthentication', () => {
+  it('client_secret_basic sends the Authorization header and no body credentials', () => {
+    const headers: Record<string, string> = {};
+    const body: Record<string, string> = {};
+    applyClientAuthentication({
+      method: 'client_secret_basic',
+      clientId: 'cid',
+      clientSecret: 'csec',
+      headers,
+      body,
+    });
+
+    expect(headers.Authorization).toBe(`Basic ${Buffer.from('cid:csec').toString('base64')}`);
+    expect(body.client_id).toBeUndefined();
+    expect(body.client_secret).toBeUndefined();
+  });
+
+  it('client_secret_post sends body credentials and no Authorization header', () => {
+    const headers: Record<string, string> = {};
+    const body: Record<string, string> = {};
+    applyClientAuthentication({
+      method: 'client_secret_post',
+      clientId: 'cid',
+      clientSecret: 'csec',
+      headers,
+      body,
+    });
+
+    // RFC 6749 §2.3: exactly one client authentication method per request.
+    expect(headers.Authorization).toBeUndefined();
+    expect(body.client_id).toBe('cid');
+    expect(body.client_secret).toBe('csec');
+  });
+
+  it('none sends only client_id, never the secret', () => {
+    const headers: Record<string, string> = {};
+    const body: Record<string, string> = {};
+    applyClientAuthentication({
+      method: 'none',
+      clientId: 'cid',
+      clientSecret: 'csec',
+      headers,
+      body,
+    });
+
+    expect(headers.Authorization).toBeUndefined();
+    expect(body.client_id).toBe('cid');
+    expect(body.client_secret).toBeUndefined();
+  });
+
+  it('client_secret_basic without a secret degrades to body client_id', () => {
+    const headers: Record<string, string> = {};
+    const body: Record<string, string> = {};
+    applyClientAuthentication({
+      method: 'client_secret_basic',
+      clientId: 'cid',
+      headers,
+      body,
+    });
+
+    expect(headers.Authorization).toBeUndefined();
+    expect(body.client_id).toBe('cid');
+    expect(body.client_secret).toBeUndefined();
+  });
+});

--- a/packages/core/src/tools/mcp/oauth-client-auth.ts
+++ b/packages/core/src/tools/mcp/oauth-client-auth.ts
@@ -1,0 +1,107 @@
+/**
+ * Token-endpoint client authentication (RFC 6749 §2.3.1, RFC 8414 §2).
+ *
+ * Both the authorization-code exchange and the refresh grant authenticate the
+ * client at the SAME token endpoint, so they must use the SAME method. This
+ * module is the single place that decides which one, so the two callsites
+ * cannot drift.
+ *
+ * Why this exists: Agor previously hard-coded HTTP Basic whenever a client
+ * secret was present. Authorization servers are permitted to support only
+ * `client_secret_post` — HubSpot's MCP authorization server advertises
+ * exactly `token_endpoint_auth_methods_supported: ["client_secret_post"]` —
+ * and reject Basic with `invalid_client`. Honouring the advertised method
+ * fixes those providers without changing anything for Basic-capable ones.
+ */
+
+/** The client-authentication methods Agor can actually perform. */
+export type TokenEndpointAuthMethod = 'client_secret_basic' | 'client_secret_post' | 'none';
+
+export function isTokenEndpointAuthMethod(value: unknown): value is TokenEndpointAuthMethod {
+  return value === 'client_secret_basic' || value === 'client_secret_post' || value === 'none';
+}
+
+/**
+ * Choose the token-endpoint client authentication method for a grant.
+ *
+ * Rules, in order:
+ *
+ *  1. No client secret → `none`. A public client can only send `client_id` in
+ *     the request body (RFC 6749 §3.2.1). This is unchanged behaviour and
+ *     covers every DCR-registered client, which Agor registers with
+ *     `token_endpoint_auth_method: 'none'`.
+ *  2. A registered per-client method (RFC 7591 §2 `token_endpoint_auth_method`
+ *     returned by Dynamic Client Registration) is authoritative for THAT
+ *     client and wins over the server-wide list.
+ *  3. Metadata absent or empty → `client_secret_basic`. RFC 8414 §2 states
+ *     that when `token_endpoint_auth_methods_supported` is omitted, "the
+ *     default is `client_secret_basic`". This is also Agor's historical
+ *     behaviour, so Slack / Figma / GitHub and every manually configured
+ *     confidential client keep working byte-for-byte.
+ *  4. Metadata lists `client_secret_basic` → `client_secret_basic`. RFC 6749
+ *     §2.3.1 says servers MUST support Basic and clients SHOULD prefer it, so
+ *     Basic stays the preferred method whenever it is on offer.
+ *  5. Otherwise metadata lists `client_secret_post` → `client_secret_post`.
+ *     This is the HubSpot case.
+ *  6. Otherwise the server advertises only methods Agor cannot perform
+ *     (`private_key_jwt`, `tls_client_auth`, …). If `none` is among them the
+ *     server accepts unauthenticated clients, so use it and withhold the
+ *     secret. Otherwise fall back to the RFC 8414 default rather than failing
+ *     the flow outright — a wrong guess surfaces as a normal provider
+ *     rejection, whereas a hard failure would break servers whose metadata is
+ *     merely incomplete.
+ */
+export function selectTokenEndpointAuthMethod(opts: {
+  hasClientSecret: boolean;
+  /** `token_endpoint_auth_methods_supported` from RFC 8414 metadata, if any. */
+  supportedMethods?: readonly string[] | null;
+  /** `token_endpoint_auth_method` returned by RFC 7591 registration, if any. */
+  registeredMethod?: string | null;
+}): TokenEndpointAuthMethod {
+  if (!opts.hasClientSecret) return 'none';
+
+  if (isTokenEndpointAuthMethod(opts.registeredMethod) && opts.registeredMethod !== 'none') {
+    return opts.registeredMethod;
+  }
+
+  const supported = opts.supportedMethods?.filter((m) => typeof m === 'string') ?? [];
+  if (supported.length === 0) return 'client_secret_basic';
+  if (supported.includes('client_secret_basic')) return 'client_secret_basic';
+  if (supported.includes('client_secret_post')) return 'client_secret_post';
+  if (supported.includes('none')) return 'none';
+  return 'client_secret_basic';
+}
+
+/**
+ * Apply the selected method to an outgoing token request.
+ *
+ * Mutates `headers` / `body` in place. Exactly one method is applied: RFC 6749
+ * §2.3 forbids a client from using more than one authentication method per
+ * request, so a server that sees both a Basic header and body credentials may
+ * reject the request.
+ */
+export function applyClientAuthentication(opts: {
+  method: TokenEndpointAuthMethod;
+  clientId: string;
+  clientSecret?: string;
+  headers: Record<string, string>;
+  body: Record<string, string>;
+}): void {
+  const { method, clientId, clientSecret, headers, body } = opts;
+
+  if (method === 'client_secret_basic' && clientSecret) {
+    // Encoding is deliberately left as a raw `id:secret` concatenation to
+    // match what Agor has always sent. Re-encoding here would change the
+    // credential seen by every provider that works today.
+    headers.Authorization = `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`;
+    return;
+  }
+
+  // `client_secret_post` (RFC 6749 §2.3.1) and the public-client case
+  // (§3.2.1) both identify the client in the form body; only the former
+  // carries the secret.
+  body.client_id = clientId;
+  if (method === 'client_secret_post' && clientSecret) {
+    body.client_secret = clientSecret;
+  }
+}

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.test.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.test.ts
@@ -957,8 +957,14 @@ describe('startMCPOAuthFlow with prefetchedAuthServerMetadata', () => {
     expect(String(tokenCall?.[1]?.body)).not.toContain('client_id=');
   });
 
-  it('records the advertised client_secret_post method on the flow context', async () => {
-    globalThis.fetch = vi.fn().mockImplementation(async (url: string) => {
+  it('uses advertised client_secret_post for the authorization-code exchange', async () => {
+    globalThis.fetch = vi.fn().mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === 'https://api.hubspot.example/oauth/v1/token' && init?.method === 'POST') {
+        return new Response(JSON.stringify({ access_token: 'hubspot-token' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
       throw new Error(`unexpected fetch: ${url}`);
     }) as unknown as typeof fetch;
 
@@ -982,6 +988,21 @@ describe('startMCPOAuthFlow with prefetchedAuthServerMetadata', () => {
     );
 
     expect(ctx.tokenEndpointAuthMethod).toBe('client_secret_post');
+
+    const tokenResponse = await completeMCPOAuthFlow(ctx, 'auth-code', ctx.state, {
+      cacheToken: false,
+    });
+    expect(tokenResponse.access_token).toBe('hubspot-token');
+
+    const tokenCall = vi
+      .mocked(globalThis.fetch)
+      .mock.calls.find(([url]) => String(url) === 'https://api.hubspot.example/oauth/v1/token');
+    expect(tokenCall).toBeTruthy();
+    const headers = (tokenCall?.[1]?.headers ?? {}) as Record<string, string>;
+    expect(headers.Authorization).toBeUndefined();
+    const body = new URLSearchParams(String(tokenCall?.[1]?.body));
+    expect(body.get('client_id')).toBe('manual-client');
+    expect(body.get('client_secret')).toBe('manual-secret');
   });
 
   it('records client_secret_basic when the server advertises no auth methods', async () => {

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.test.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.test.ts
@@ -957,6 +957,59 @@ describe('startMCPOAuthFlow with prefetchedAuthServerMetadata', () => {
     expect(String(tokenCall?.[1]?.body)).not.toContain('client_id=');
   });
 
+  it('records the advertised client_secret_post method on the flow context', async () => {
+    globalThis.fetch = vi.fn().mockImplementation(async (url: string) => {
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as unknown as typeof fetch;
+
+    const ctx = await startMCPOAuthFlow(
+      '',
+      'manual-client',
+      'https://agor.example.test/mcp-servers/oauth-callback',
+      {
+        prefetchedAuthServerMetadata: {
+          issuer: 'https://app.hubspot.example',
+          authorization_endpoint: 'https://app.hubspot.example/oauth/authorize',
+          token_endpoint: 'https://api.hubspot.example/oauth/v1/token',
+          token_endpoint_auth_methods_supported: ['client_secret_post'],
+        },
+        clientSecret: 'manual-secret',
+        cacheKey: 'https://mcp.hubspot.example/',
+        resourceUri: 'https://mcp.hubspot.example/',
+        compatibilityMode: 'legacy',
+        dcrMode: 'disabled',
+      }
+    );
+
+    expect(ctx.tokenEndpointAuthMethod).toBe('client_secret_post');
+  });
+
+  it('records client_secret_basic when the server advertises no auth methods', async () => {
+    globalThis.fetch = vi.fn().mockImplementation(async (url: string) => {
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as unknown as typeof fetch;
+
+    const ctx = await startMCPOAuthFlow(
+      '',
+      'manual-client',
+      'https://agor.example.test/mcp-servers/oauth-callback',
+      {
+        prefetchedAuthServerMetadata: {
+          issuer: 'https://provider.example.test',
+          authorization_endpoint: 'https://provider.example.test/authorize',
+          token_endpoint: 'https://provider.example.test/token',
+        },
+        clientSecret: 'manual-secret',
+        cacheKey: 'https://mcp.example.test/mcp',
+        resourceUri: 'https://mcp.example.test/mcp',
+        compatibilityMode: 'legacy',
+        dcrMode: 'disabled',
+      }
+    );
+
+    expect(ctx.tokenEndpointAuthMethod).toBe('client_secret_basic');
+  });
+
   it('throws when cacheKey is missing (would silently break token reuse)', async () => {
     globalThis.fetch = vi.fn() as unknown as typeof fetch;
 

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.ts
@@ -16,7 +16,11 @@ import type {
 } from '../../types/mcp.js';
 import { assertSafeOAuthUrl, safeOutboundFetch } from '../../utils/safe-outbound-fetch';
 import type { OAuthTokenResponse } from './oauth-auth.js';
-import { selectTokenEndpointAuthMethod } from './oauth-client-auth.js';
+import {
+  applyClientAuthentication,
+  selectTokenEndpointAuthMethod,
+  type TokenEndpointAuthMethod,
+} from './oauth-client-auth.js';
 import { resolveTokenExpiry } from './oauth-token-expiry.js';
 
 export interface OAuthMetadata {
@@ -146,6 +150,8 @@ export interface AuthorizationServerMetadata {
   response_types_supported?: string[];
   grant_types_supported?: string[];
   code_challenge_methods_supported?: string[];
+  /** RFC 8414 §2; omitted means `client_secret_basic`. */
+  token_endpoint_auth_methods_supported?: string[];
   authorization_response_iss_parameter_supported?: boolean;
 }
 
@@ -423,7 +429,12 @@ async function fetchResourceMetadata(
 // Cache for dynamically registered clients (per authorization server)
 const dynamicClientCache = new Map<
   string,
-  { client_id: string; client_secret?: string; redirect_uri: string }
+  {
+    client_id: string;
+    client_secret?: string;
+    redirect_uri: string;
+    token_endpoint_auth_method?: string;
+  }
 >();
 
 const MAX_DCR_RESPONSE_BYTES = 16 * 1024;
@@ -509,7 +520,12 @@ export function __dynamicClientCacheSizeForTests(): number {
  */
 export function __seedDynamicClientCacheForTests(
   registrationEndpoint: string,
-  entry: { client_id: string; client_secret?: string; redirect_uri: string }
+  entry: {
+    client_id: string;
+    client_secret?: string;
+    redirect_uri: string;
+    token_endpoint_auth_method?: string;
+  }
 ): void {
   dynamicClientCache.set(registrationEndpoint, entry);
 }
@@ -534,7 +550,11 @@ async function registerDynamicClient(
   const cached = reuseLocalCache ? dynamicClientCache.get(cacheKey) : undefined;
   if (cached && cached.redirect_uri === redirectUri) {
     console.log('[MCP OAuth] Using cached dynamic client registration');
-    return { client_id: cached.client_id, client_secret: cached.client_secret };
+    return {
+      client_id: cached.client_id,
+      client_secret: cached.client_secret,
+      token_endpoint_auth_method: cached.token_endpoint_auth_method,
+    };
   }
 
   console.log('[MCP OAuth] Performing Dynamic Client Registration');
@@ -627,12 +647,13 @@ async function registerDynamicClient(
       client_id: result.client_id,
       client_secret: result.client_secret,
       redirect_uri: redirectUri,
+      token_endpoint_auth_method: authMethod,
     });
   }
 
   console.log('[MCP OAuth] Dynamic client registered');
 
-  return result;
+  return { ...result, token_endpoint_auth_method: authMethod };
 }
 
 /**
@@ -877,7 +898,9 @@ async function exchangeCodeForToken(
   clientId: string,
   clientSecret?: string,
   resourceUri?: string,
-  allowLocalhostHttp = false
+  allowLocalhostHttp = false,
+  /** Method selected from the authorization server/client metadata. */
+  authMethod?: TokenEndpointAuthMethod
 ): Promise<OAuthTokenResponse> {
   const body: Record<string, string> = {
     grant_type: 'authorization_code',
@@ -887,8 +910,6 @@ async function exchangeCodeForToken(
   };
   if (resourceUri) body.resource = resourceUri;
 
-  // Build headers — use HTTP Basic auth when client_secret is available (RFC 6749 §2.3.1),
-  // fall back to body params for public clients or providers that don't support Basic auth.
   const headers: Record<string, string> = {
     'Content-Type': 'application/x-www-form-urlencoded',
     // GitHub's classic OAuth endpoint returns a form-encoded response by
@@ -897,15 +918,17 @@ async function exchangeCodeForToken(
     Accept: 'application/json',
   };
 
-  if (clientSecret) {
-    // Slack and other providers recommend HTTP Basic auth for credentials
-    headers.Authorization = `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`;
-  } else {
-    // Public client — send client_id in body
-    body.client_id = clientId;
-  }
+  const resolvedAuthMethod =
+    authMethod ?? selectTokenEndpointAuthMethod({ hasClientSecret: !!clientSecret });
+  applyClientAuthentication({
+    method: resolvedAuthMethod,
+    clientId,
+    clientSecret,
+    headers,
+    body,
+  });
 
-  console.log('[MCP OAuth] Starting authorization-code exchange');
+  console.log(`[MCP OAuth] Starting authorization-code exchange client_auth=${resolvedAuthMethod}`);
 
   let response: Response;
   try {
@@ -1095,6 +1118,7 @@ export async function performMCPOAuthFlow(
     // Step 5.5: Get or register client_id
     let actualClientId = clientId;
     let clientSecret: string | undefined;
+    let registeredAuthMethod: string | undefined;
 
     // Compute scopes early — needed for both DCR registration and auth URL.
     // Skip auto-populating from resource metadata when client_id is pre-registered.
@@ -1119,6 +1143,7 @@ export async function performMCPOAuthFlow(
         );
         actualClientId = registration.client_id;
         clientSecret = registration.client_secret;
+        registeredAuthMethod = registration.token_endpoint_auth_method;
       } else {
         throw new Error(
           'OAuth client_id is required but the authorization server does not advertise ' +
@@ -1308,6 +1333,8 @@ export interface OAuthFlowContext {
   pkceVerifier: string;
   clientId: string;
   clientSecret?: string;
+  /** RFC 8414/RFC 7591 method selected when the flow started. */
+  tokenEndpointAuthMethod?: TokenEndpointAuthMethod;
   state: string;
   authorizationUrl: string;
   compatibilityMode: MCPOAuthRuntimeCompatibilityMode;
@@ -1832,7 +1859,8 @@ export async function completeMCPOAuthFlow(
     context.clientId,
     context.clientSecret,
     context.resourceUri,
-    context.allowLocalhostHttp
+    context.allowLocalhostHttp,
+    context.tokenEndpointAuthMethod
   );
 
   console.log('[MCP OAuth] Access token received successfully');

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.ts
@@ -16,6 +16,7 @@ import type {
 } from '../../types/mcp.js';
 import { assertSafeOAuthUrl, safeOutboundFetch } from '../../utils/safe-outbound-fetch';
 import type { OAuthTokenResponse } from './oauth-auth.js';
+import { selectTokenEndpointAuthMethod } from './oauth-client-auth.js';
 import { resolveTokenExpiry } from './oauth-token-expiry.js';
 
 export interface OAuthMetadata {
@@ -1179,7 +1180,12 @@ export async function performMCPOAuthFlow(
       actualClientId,
       clientSecret,
       typeof resourceMetadata.resource === 'string' ? resourceMetadata.resource : undefined,
-      true
+      true,
+      selectTokenEndpointAuthMethod({
+        hasClientSecret: !!clientSecret,
+        supportedMethods: authServerMetadata.token_endpoint_auth_methods_supported,
+        registeredMethod: registeredAuthMethod,
+      })
     );
 
     console.log('[MCP OAuth] Access token received successfully');
@@ -1508,6 +1514,7 @@ async function startMCPOAuthFlowWithAS(opts: {
   // Client ID resolution (DCR if available)
   let actualClientId = clientId;
   let resolvedClientSecret = opts.clientSecret;
+  let registeredAuthMethod: string | undefined;
 
   if (!actualClientId && dcrMode !== 'disabled') {
     const registrationEndpoint =
@@ -1530,6 +1537,7 @@ async function startMCPOAuthFlowWithAS(opts: {
         );
         actualClientId = registration.client_id;
         resolvedClientSecret = registration.client_secret;
+        registeredAuthMethod = registration.token_endpoint_auth_method;
       } catch (error) {
         if (error instanceof OAuthDCRFailure) throw error;
         throw registrationFailure({
@@ -1580,6 +1588,11 @@ async function startMCPOAuthFlowWithAS(opts: {
     pkceVerifier: pkce.verifier,
     clientId: actualClientId!,
     clientSecret: resolvedClientSecret,
+    tokenEndpointAuthMethod: selectTokenEndpointAuthMethod({
+      hasClientSecret: !!resolvedClientSecret,
+      supportedMethods: authServerMetadata?.token_endpoint_auth_methods_supported,
+      registeredMethod: registeredAuthMethod,
+    }),
     state,
     authorizationUrl: authUrl.toString(),
     compatibilityMode,

--- a/packages/core/src/tools/mcp/oauth-refresh.test.ts
+++ b/packages/core/src/tools/mcp/oauth-refresh.test.ts
@@ -134,6 +134,67 @@ describe('refreshMCPToken', () => {
     expect(body.get('client_id')).toBeNull();
   });
 
+  it('uses client_secret_post when the grant was issued under it (HubSpot)', async () => {
+    mockFetchOnce({ access_token: 'new-a', expires_in: 1800 });
+
+    await refreshMCPToken({
+      tokenEndpoint: 'https://api.hubspot.example/oauth/v1/token',
+      refreshToken: 'rt-abc',
+      clientId: 'client-123',
+      clientSecret: 'secret-xyz',
+      authMethod: 'client_secret_post',
+    });
+
+    const [, init] = (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    // RFC 6749 §2.3: one method only — no Basic header alongside body creds.
+    expect(init.headers.Authorization).toBeUndefined();
+    const body = new URLSearchParams(init.body as string);
+    expect(body.get('client_id')).toBe('client-123');
+    expect(body.get('client_secret')).toBe('secret-xyz');
+    expect(body.get('grant_type')).toBe('refresh_token');
+    expect(body.get('refresh_token')).toBe('rt-abc');
+  });
+
+  it('keeps HTTP Basic when the grant was issued under client_secret_basic', async () => {
+    mockFetchOnce({ access_token: 'new-a', expires_in: 1800 });
+
+    await refreshMCPToken({
+      tokenEndpoint: 'https://auth.example.com/token',
+      refreshToken: 'rt-abc',
+      clientId: 'client-123',
+      clientSecret: 'secret-xyz',
+      authMethod: 'client_secret_basic',
+    });
+
+    const [, init] = (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(init.headers.Authorization).toBe(
+      `Basic ${Buffer.from('client-123:secret-xyz').toString('base64')}`
+    );
+    expect(new URLSearchParams(init.body as string).get('client_secret')).toBeNull();
+  });
+
+  it('never puts the client secret in a log line', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockFetchOnce({ access_token: 'new-a', expires_in: 1800 });
+
+    await refreshMCPToken({
+      tokenEndpoint: 'https://api.hubspot.example/oauth/v1/token',
+      refreshToken: 'REFRESH-DO-NOT-LOG-1a2b',
+      clientId: 'client-123',
+      clientSecret: 'SECRET-DO-NOT-LOG-9c8d',
+      authMethod: 'client_secret_post',
+    });
+
+    const emitted = [...log.mock.calls, ...warn.mock.calls, ...error.mock.calls]
+      .flat()
+      .map(String)
+      .join('\n');
+    expect(emitted).not.toContain('SECRET-DO-NOT-LOG-9c8d');
+    expect(emitted).not.toContain('REFRESH-DO-NOT-LOG-1a2b');
+  });
+
   it('puts client_id in the body for public clients (no secret)', async () => {
     mockFetchOnce({ access_token: 'new-a', expires_in: 3600 });
 
@@ -335,6 +396,123 @@ describe('refreshAndPersistToken', () => {
     const deltaSec = (call.expiresAt.getTime() - Date.now()) / 1000;
     expect(deltaSec).toBeGreaterThan(3595);
     expect(deltaSec).toBeLessThanOrEqual(3600);
+  });
+
+  it('replays the stored client_secret_post method on the standalone refresh', async () => {
+    mockGetToken.mockResolvedValue({
+      user_id: USER_ID,
+      mcp_server_id: SERVER_ID,
+      oauth_access_token: 'old-a',
+      oauth_refresh_token: 'rt-1',
+      oauth_client_id: 'cid',
+      oauth_client_secret: 'csec',
+      oauth_token_endpoint: 'https://api.hubspot.example/oauth/v1/token',
+      oauth_token_auth_method: 'client_secret_post',
+    });
+    mockFindById.mockResolvedValue({ url: 'https://mcp.hubspot.example/' });
+    mockCompleteStandaloneRefresh.mockResolvedValue(true);
+    mockFetchJson({ access_token: 'new-a', expires_in: 1800 });
+
+    await refreshAndPersistToken({
+      db: { run: () => undefined } as any,
+      userId: USER_ID,
+      mcpServerId: SERVER_ID,
+      observedRefreshVersion: observedVersion(),
+      validateGrant: async () => true,
+    });
+
+    const [, init] = (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(init.headers.Authorization).toBeUndefined();
+    const body = new URLSearchParams(init.body as string);
+    expect(body.get('client_id')).toBe('cid');
+    expect(body.get('client_secret')).toBe('csec');
+  });
+
+  it('falls back to HTTP Basic for rows stored before the method was persisted', async () => {
+    mockGetToken.mockResolvedValue({
+      user_id: USER_ID,
+      mcp_server_id: SERVER_ID,
+      oauth_access_token: 'old-a',
+      oauth_refresh_token: 'rt-1',
+      oauth_client_id: 'cid',
+      oauth_client_secret: 'csec',
+      oauth_token_endpoint: 'https://auth.example.com/token',
+      // oauth_token_auth_method absent — pre-migration grant.
+    });
+    mockFindById.mockResolvedValue({ url: 'https://srv.example.com/mcp' });
+    mockCompleteStandaloneRefresh.mockResolvedValue(true);
+    mockFetchJson({ access_token: 'new-a', expires_in: 3600 });
+
+    await refreshAndPersistToken({
+      db: { run: () => undefined } as any,
+      userId: USER_ID,
+      mcpServerId: SERVER_ID,
+      observedRefreshVersion: observedVersion(),
+      validateGrant: async () => true,
+    });
+
+    const [, init] = (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(init.headers.Authorization).toBe(`Basic ${Buffer.from('cid:csec').toString('base64')}`);
+  });
+
+  it('ignores an unrecognized stored method rather than sending it', async () => {
+    mockGetToken.mockResolvedValue({
+      user_id: USER_ID,
+      mcp_server_id: SERVER_ID,
+      oauth_access_token: 'old-a',
+      oauth_refresh_token: 'rt-1',
+      oauth_client_id: 'cid',
+      oauth_client_secret: 'csec',
+      oauth_token_endpoint: 'https://auth.example.com/token',
+      oauth_token_auth_method: 'private_key_jwt',
+    });
+    mockFindById.mockResolvedValue({ url: 'https://srv.example.com/mcp' });
+    mockCompleteStandaloneRefresh.mockResolvedValue(true);
+    mockFetchJson({ access_token: 'new-a', expires_in: 3600 });
+
+    await refreshAndPersistToken({
+      db: { run: () => undefined } as any,
+      userId: USER_ID,
+      mcpServerId: SERVER_ID,
+      observedRefreshVersion: observedVersion(),
+      validateGrant: async () => true,
+    });
+
+    const [, init] = (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(init.headers.Authorization).toBe(`Basic ${Buffer.from('cid:csec').toString('base64')}`);
+  });
+
+  it('does not let a stored public-client method withhold a now-configured secret', async () => {
+    mockGetToken.mockResolvedValue({
+      user_id: USER_ID,
+      mcp_server_id: SERVER_ID,
+      oauth_access_token: 'old-a',
+      oauth_refresh_token: 'rt-1',
+      oauth_client_id: 'cid',
+      oauth_token_endpoint: 'https://auth.example.com/token',
+      // Authorized as a public client (DCR), so 'none' was recorded…
+      oauth_token_auth_method: 'none',
+    });
+    // …but an admin has since configured a client secret on the server.
+    mockFindById.mockResolvedValue({
+      url: 'https://srv.example.com/mcp',
+      auth: { oauth_client_secret: 'later-secret' },
+    });
+    mockCompleteStandaloneRefresh.mockResolvedValue(true);
+    mockFetchJson({ access_token: 'new-a', expires_in: 3600 });
+
+    await refreshAndPersistToken({
+      db: { run: () => undefined } as any,
+      userId: USER_ID,
+      mcpServerId: SERVER_ID,
+      observedRefreshVersion: observedVersion(),
+      validateGrant: async () => true,
+    });
+
+    const [, init] = (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(init.headers.Authorization).toBe(
+      `Basic ${Buffer.from('cid:later-secret').toString('base64')}`
+    );
   });
 
   it('writes rotated refresh_token when provider returns one', async () => {

--- a/packages/core/src/tools/mcp/oauth-refresh.ts
+++ b/packages/core/src/tools/mcp/oauth-refresh.ts
@@ -12,6 +12,11 @@ import type { MCPServerID, UserID } from '../../types';
 import { safeOutboundFetch } from '../../utils/safe-outbound-fetch';
 import { assertMcpGrantSubjectEntitled } from './grant-entitlement';
 import { inferOAuthTokenUrl } from './oauth-auth';
+import {
+  applyClientAuthentication,
+  selectTokenEndpointAuthMethod,
+  type TokenEndpointAuthMethod,
+} from './oauth-client-auth';
 import { resolveTokenExpiry } from './oauth-token-expiry';
 
 export const REFRESH_BUFFER_MS = 60_000;
@@ -90,6 +95,13 @@ export interface RefreshMCPTokenOptions {
   clientId: string;
   clientSecret?: string;
   resourceUri?: string;
+  /**
+   * Client-authentication method recorded when the grant was issued. The
+   * refresh grant hits the same token endpoint as the code exchange, so it
+   * must authenticate the same way. Omitted for grants stored before the
+   * method was persisted; those fall back to the RFC 8414 default.
+   */
+  authMethod?: TokenEndpointAuthMethod;
   /** Exact loopback HTTP exception for standalone development/tests only. */
   allowLocalhostHttp?: boolean;
 }
@@ -124,11 +136,14 @@ export async function refreshMCPToken(
     'Content-Type': 'application/x-www-form-urlencoded',
     Accept: 'application/json',
   };
-  if (opts.clientSecret) {
-    headers.Authorization = `Basic ${Buffer.from(`${opts.clientId}:${opts.clientSecret}`).toString('base64')}`;
-  } else {
-    body.client_id = opts.clientId;
-  }
+  applyClientAuthentication({
+    method:
+      opts.authMethod ?? selectTokenEndpointAuthMethod({ hasClientSecret: !!opts.clientSecret }),
+    clientId: opts.clientId,
+    clientSecret: opts.clientSecret,
+    headers,
+    body,
+  });
 
   let response: Response;
   try {
@@ -163,6 +178,27 @@ export async function refreshMCPToken(
     token_type: parsed.token_type,
     scope: parsed.scope,
   };
+}
+
+/**
+ * Resolve the client-authentication method for a refresh from what the grant
+ * recorded, reconciled against the credentials actually available now.
+ *
+ * Running the persisted value back through the selector rather than trusting
+ * it verbatim covers three cases at once: an unrecognized value (written by a
+ * newer or corrupted writer) degrades to the RFC 8414 default instead of being
+ * sent as-is; a grant authorized as a public client that has since been given
+ * a client secret is not stuck withholding it; and a grant with no secret
+ * available stays a public-client request.
+ */
+function refreshAuthMethod(
+  stored: string | undefined,
+  clientSecret: string | undefined
+): TokenEndpointAuthMethod {
+  return selectTokenEndpointAuthMethod({
+    hasClientSecret: !!clientSecret,
+    registeredMethod: stored,
+  });
 }
 
 type MutexKey = string;
@@ -377,6 +413,7 @@ async function refreshPostgres(deps: RefreshAndPersistDeps): Promise<string> {
       clientId: row.oauth_client_id,
       clientSecret: row.oauth_client_secret,
       resourceUri: row.oauth_resource_uri,
+      authMethod: refreshAuthMethod(row.oauth_token_auth_method, row.oauth_client_secret),
       allowLocalhostHttp: deps.allowLocalhostHttpDevelopment,
     });
     const expiry = resolveTokenExpiry(result, result.access_token);
@@ -481,13 +518,15 @@ async function refreshStandalone(
   let tokenEndpoint = row.oauth_token_endpoint ?? server?.auth?.oauth_token_url;
   if (!tokenEndpoint && server?.url) tokenEndpoint = inferOAuthTokenUrl(server.url);
   if (!tokenEndpoint) throw new MissingTokenEndpointError();
+  const clientSecret = row.oauth_client_secret ?? server?.auth?.oauth_client_secret;
   try {
     const result = await refreshMCPToken({
       tokenEndpoint,
       refreshToken: row.oauth_refresh_token,
       clientId,
-      clientSecret: row.oauth_client_secret ?? server?.auth?.oauth_client_secret,
+      clientSecret,
       resourceUri: row.oauth_resource_uri,
+      authMethod: refreshAuthMethod(row.oauth_token_auth_method, clientSecret),
       allowLocalhostHttp: true,
     });
     const expiry = resolveTokenExpiry(result, result.access_token);

--- a/packages/core/src/types/mcp.ts
+++ b/packages/core/src/types/mcp.ts
@@ -160,6 +160,8 @@ export interface MCPOAuthPendingFlowSealedMaterial {
   pkceVerifier: string;
   clientId: string;
   clientSecret?: string;
+  /** Token-endpoint authentication chosen when this flow started. */
+  tokenEndpointAuthMethod?: 'client_secret_basic' | 'client_secret_post' | 'none';
   compatibilityMode: MCPOAuthRuntimeCompatibilityMode;
   /** Whether RFC 9207 says this AS will return `iss` on the callback. */
   authorizationResponseIssuerParameterSupported?: boolean;


### PR DESCRIPTION
## Summary

Contributes to #1957. HubSpot's MCP authorization server advertises **only**:

```
token_endpoint_auth_methods_supported: ["client_secret_post"]
```

Agor, however, sent client credentials via **HTTP Basic** whenever a client secret was present — for both the authorization-code exchange and the refresh grant. HubSpot rejects Basic with `invalid_client` / `BAD_CLIENT_ID`. Discovery and the PKCE authorization leg both succeed, so no amount of correct credentials or redirect configuration could work around it.

This PR makes client authentication **metadata-driven and standards-compliant**, selecting the method from RFC 8414 authorization-server metadata (with a registered per-client RFC 7591 method taking precedence) and applying exactly one method per request as RFC 6749 §2.3 requires.

## Relationship to #1957 (please read before merging)

#1957 is an umbrella "HubSpot MCP OAuth fails" report covering three failure modes and their dead-end UX:

1. **DCR 404 / DCR metadata rejection** → graceful fallback to a manual client ID/secret. — **Delivered by the merged #2307** (`fix(oauth): improve DCR diagnostics and manual retries`).
2. **Misleading error copy** (couldn't distinguish "no DCR support" from "DCR rejected our metadata"). — **Also delivered by #2307.**
3. **The wall hit *after* a user creates a HubSpot developer app and supplies a manual client** — the token exchange then fails with a generic OAuth "Invalid request" (Juliann's recorded rage-quit point). — **This is what this PR fixes.**

So this PR is the final mechanical blocker on the HubSpot path: with #2307 (merged) a user can now supply a manual client, and with this PR that client's token exchange actually completes against a `client_secret_post`-only server. Together they should close out the HubSpot case in #1957.

I've deliberately used **Refs**, not **Closes**, because #1957 also tracks other providers (e.g. the Shortcut `redirect_uris` rejection, which is a provider-side approval concern) and broader error-UX. Maintainers should decide whether the HubSpot-specific issue is now fully resolved or whether a narrower follow-up should carry the close.

## What changed

- **Method selection (RFC 8414 §2 / RFC 6749 §2.3.1):**
  - omitted / empty metadata → `client_secret_basic` (the RFC default and Agor's existing behavior — Slack / Figma / GitHub and manually configured confidential clients send the identical request)
  - `client_secret_basic` advertised → `client_secret_basic`
  - otherwise `client_secret_post` → body credentials, no `Authorization` header
  - no client secret → `client_id` in the body (unchanged; covers every DCR-registered public client)
- **Authorization-code exchange** now applies the selected method via `applyClientAuthentication`, threaded through `completeMCPOAuthFlow` → `exchangeCodeForToken`, instead of hard-coding Basic. This is exercised via a **manually configured** client (`manual-client`/`manual-secret`) in the tests — the exact path #2307 enables.
- **Refresh grant** hits the same token endpoint, so the chosen method is persisted on the grant row (new nullable `oauth_token_auth_method` column, both SQLite and Postgres) and re-run through the selector on refresh — so an unknown value degrades safely and a grant that later gains a client secret stops withholding it. `NULL` reads back as the RFC default, so pre-existing grants need no backfill and the column stays outside the fingerprinted grant binding.
- The DCR-registered per-client method is captured through the dynamic client cache and onto the saved grant.

## Security

- Only the fixed method identifier (e.g. `client_auth=client_secret_post`) is logged. No credential, code, or provider body is added to any log or error path.
- Secrets continue to live on the grant row covered by existing redaction.

## Tests

- `oauth-client-auth.test.ts` — method selection matrix
- `oauth-mcp-transport.test.ts` — authorization-code exchange sends `client_secret_post` in the body with no `Authorization` header for HubSpot-style metadata; still uses Basic when no methods are advertised
- `oauth-refresh.test.ts` — refresh authenticates with the stored method
- `user-mcp-oauth-tokens.test.ts` — round-trips `oauth_token_auth_method` with the grant
- `migrations.test.ts` — new column migration, both dialects

All 138 OAuth-related tests pass.

## Related

- Refs #1957 (fixes the HubSpot token-exchange blocker; completes the path with the merged #2307)
- Builds on #2307 (merged) — DCR diagnostics / manual client config / retry UX
- Disjoint from #2288 (provider credit/quota classification) and #2271 (strict-mode DCR regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)