### PR TITLE
feat(mcp): make auth mutation and recovery safe

### DIFF
--- a/apps/agor-cli/src/commands/mcp/add.ts
+++ b/apps/agor-cli/src/commands/mcp/add.ts
@@ -3,6 +3,7 @@
  */
 
 import { normalizeMCPCustomHeaders } from '@agor/core/tools/mcp/http-headers';
+import type { CreateMCPServerInput, MCPScope, MCPTransport } from '@agor/core/types';
 import { shortId } from '@agor-live/client';
 import { Args, Flags } from '@oclif/core';
 import chalk from 'chalk';
@@ -97,14 +98,13 @@ export default class McpAdd extends BaseCommand {
       this.log(chalk.bold(`Adding MCP server ${chalk.cyan(args.name)}...`));
 
       // Build request data
-      const data: Record<string, unknown> = {
+      const data: CreateMCPServerInput & { session_id?: string } = {
         name: args.name,
         display_name: flags['display-name'],
         description: flags.description,
-        transport: flags.transport,
-        scope: flags.scope,
+        transport: flags.transport as MCPTransport,
+        scope: flags.scope as MCPScope,
         enabled: flags.enabled,
-        source: 'user',
       };
 
       // Add transport-specific config

--- a/apps/agor-daemon/src/hooks/classify-missing-credential.test.ts
+++ b/apps/agor-daemon/src/hooks/classify-missing-credential.test.ts
@@ -1,3 +1,4 @@
+import { SAFE_ZERO_TURN_PROVIDER_RESULT_MESSAGE } from '@agor/core';
 import { resolveApiKey } from '@agor/core/config';
 import type { SessionRepository, TaskRepository } from '@agor/core/db';
 import type { HookContext, Message, Session, Task } from '@agor/core/types';
@@ -167,7 +168,7 @@ describe('classifyMissingCredentialFailure', () => {
     expect(result.content).not.toContain('Credit balance is too low');
   });
 
-  it('classifies the verified Anthropic credit failure when a credential resolved', async () => {
+  it('uses fixed generic recovery instead of inferring credit state from provider prose', async () => {
     vi.mocked(resolveApiKey).mockResolvedValue({
       apiKey: 'sk-ant-user-key',
       connection: { ANTHROPIC_API_KEY: 'sk-ant-user-key' },
@@ -178,19 +179,14 @@ describe('classifyMissingCredentialFailure', () => {
     const ctx = await runHook()(makeContext({ ...zeroTurnBillingResult }));
     const result = ctx.data as Message;
 
-    expect(result.metadata).toMatchObject({
-      error_kind: 'provider_credit_exhausted',
-      tool: 'claude-code',
-    });
-    expect(result.type).toBe('system');
-    expect(result.content).toBe(
-      "This session's Claude Code account needs available credit or quota before it can respond."
-    );
+    expect(result.metadata?.error_kind).toBeUndefined();
+    expect(result.type).toBe('assistant');
+    expect(result.content).toBe(SAFE_ZERO_TURN_PROVIDER_RESULT_MESSAGE);
     expect(result.content).not.toContain('Credit balance is too low');
     expect(result.content_preview).not.toContain('Credit balance is too low');
   });
 
-  it('classifies the verified Anthropic credit failure from an SDK error result', async () => {
+  it('uses the same fixed recovery for a real SDK-shaped provider failure result', async () => {
     vi.mocked(resolveApiKey).mockResolvedValue({
       apiKey: 'sk-ant-user-key',
       connection: { ANTHROPIC_API_KEY: 'sk-ant-user-key' },
@@ -201,134 +197,39 @@ describe('classifyMissingCredentialFailure', () => {
     const ctx = await runHook()(makeContext({ ...sdkErrorBillingResult }));
     const result = ctx.data as Message;
 
-    expect(result.metadata).toMatchObject({
-      error_kind: 'provider_credit_exhausted',
-      tool: 'claude-code',
-    });
+    expect(result.metadata?.error_kind).toBeUndefined();
+    expect(result.content).toBe(SAFE_ZERO_TURN_PROVIDER_RESULT_MESSAGE);
     expect(result.content).not.toContain('Credit balance is too low');
   });
 
-  it('classifies a stable billing signal in a short zero-turn result', async () => {
+  it('never passes an unclassified executor provider failure body through persistence', async () => {
     vi.mocked(resolveApiKey).mockResolvedValue({
       apiKey: 'sk-ant-user-key',
       connection: { ANTHROPIC_API_KEY: 'sk-ant-user-key' },
       source: 'user',
       useNativeAuth: false,
     });
-
-    const ctx = await runHook()(
-      makeContext({
-        ...zeroTurnResult,
-        content: [{ type: 'text', text: 'provider error: payment_required' }],
-      })
-    );
-
-    expect((ctx.data as Message).metadata?.error_kind).toBe('provider_credit_exhausted');
-  });
-
-  it('classifies a billing signal within the bounded search window of a long error', async () => {
-    vi.mocked(resolveApiKey).mockResolvedValue({
-      apiKey: 'sk-ant-user-key',
-      connection: { ANTHROPIC_API_KEY: 'sk-ant-user-key' },
-      source: 'user',
-      useNativeAuth: false,
-    });
-
-    const ctx = await runHook()(
-      makeContext({
-        ...zeroTurnResult,
-        content: [{ type: 'text', text: `${'x'.repeat(480)} payment_required ${'x'.repeat(40)}` }],
-      })
-    );
-
-    expect((ctx.data as Message).metadata?.error_kind).toBe('provider_credit_exhausted');
-  });
-
-  it('does not classify a billing signal beyond the bounded search window', async () => {
-    vi.mocked(resolveApiKey).mockResolvedValue({
-      apiKey: 'sk-ant-user-key',
-      connection: { ANTHROPIC_API_KEY: 'sk-ant-user-key' },
-      source: 'user',
-      useNativeAuth: false,
-    });
-
-    const ctx = await runHook()(
-      makeContext({
-        ...zeroTurnResult,
-        content: [{ type: 'text', text: `${'x'.repeat(500)} payment_required` }],
-      })
-    );
-
-    expect((ctx.data as Message).metadata?.error_kind).toBeUndefined();
-    expect((ctx.data as Message).content).toEqual([
-      { type: 'text', text: `${'x'.repeat(500)} payment_required` },
-    ]);
-  });
-
-  it('does not classify a signal beyond the bound of one multiline error block', async () => {
-    vi.mocked(resolveApiKey).mockResolvedValue({
-      apiKey: 'sk-ant-user-key',
-      connection: { ANTHROPIC_API_KEY: 'sk-ant-user-key' },
-      source: 'user',
-      useNativeAuth: false,
-    });
+    const sentinel = 'SENTINEL_DAEMON_PROVIDER_FAILURE';
 
     const ctx = await runHook()(
       makeContext({
         ...sdkErrorBillingResult,
-        content: [
-          {
-            type: 'text',
-            text: `${'x'.repeat(500)}\ncredit balance is too low`,
-          },
-        ],
+        content: [{ type: 'text', text: `provider returned ${sentinel}` }],
       })
     );
 
-    expect((ctx.data as Message).metadata?.error_kind).toBeUndefined();
+    expect(JSON.stringify(ctx.data)).not.toContain(sentinel);
+    expect((ctx.data as Message).content).toBe(SAFE_ZERO_TURN_PROVIDER_RESULT_MESSAGE);
   });
 
-  it('classifies an early signal in a distinct error block after a long multiline error', async () => {
-    vi.mocked(resolveApiKey).mockResolvedValue({
-      apiKey: 'sk-ant-user-key',
-      connection: { ANTHROPIC_API_KEY: 'sk-ant-user-key' },
-      source: 'user',
-      useNativeAuth: false,
-    });
-
-    const ctx = await runHook()(
-      makeContext({
-        ...sdkErrorBillingResult,
-        content: [
-          { type: 'text', text: 'Agent SDK error (error_during_execution): ' },
-          { type: 'text', text: `${'x'.repeat(600)}\nordinary tail` },
-          { type: 'text', text: '\n' },
-          { type: 'text', text: 'payment_required' },
-        ],
-      })
-    );
-
-    expect((ctx.data as Message).metadata?.error_kind).toBe('provider_credit_exhausted');
-  });
-
-  it('does not classify ordinary rate-limit text or arbitrary quota prose', async () => {
-    vi.mocked(resolveApiKey).mockResolvedValue({
-      apiKey: 'sk-ant-user-key',
-      connection: { ANTHROPIC_API_KEY: 'sk-ant-user-key' },
-      source: 'user',
-      useNativeAuth: false,
-    });
-
-    for (const content of ['429 Too Many Requests', 'Your quota may be limited']) {
-      const ctx = await runHook()(
-        makeContext({ ...zeroTurnResult, content: [{ type: 'text', text: content }] })
-      );
-      expect((ctx.data as Message).metadata?.error_kind).toBeUndefined();
-      expect((ctx.data as Message).content).toEqual([{ type: 'text', text: content }]);
-    }
-  });
-
-  it('lets an explicit billing code win when a provider also reports HTTP 429', async () => {
+  it.each([
+    'payment_required',
+    'insufficient_quota',
+    'quota_exhausted',
+    'billing_hard_limit_reached',
+    'Credit balance is too low',
+    '429 Too Many Requests',
+  ])('does not derive recovery authority from provider text: %s', async (providerText) => {
     vi.mocked(resolveApiKey).mockResolvedValue({
       apiKey: 'sk-ant-user-key',
       connection: { ANTHROPIC_API_KEY: 'sk-ant-user-key' },
@@ -339,14 +240,16 @@ describe('classifyMissingCredentialFailure', () => {
     const ctx = await runHook()(
       makeContext({
         ...zeroTurnResult,
-        content: [{ type: 'text', text: '429 Too Many Requests: insufficient_quota' }],
+        content: [{ type: 'text', text: providerText }],
       })
     );
 
-    expect((ctx.data as Message).metadata?.error_kind).toBe('provider_credit_exhausted');
+    expect((ctx.data as Message).metadata?.error_kind).toBeUndefined();
+    expect((ctx.data as Message).content).toBe(SAFE_ZERO_TURN_PROVIDER_RESULT_MESSAGE);
+    expect(JSON.stringify(ctx.data)).not.toContain(providerText);
   });
 
-  it('preserves legitimate zero-turn output when an API key resolved', async () => {
+  it('sanitizes zero-turn output even when an API key resolved', async () => {
     vi.mocked(resolveApiKey).mockResolvedValue({
       apiKey: 'sk-ant-user-key',
       connection: { ANTHROPIC_API_KEY: 'sk-ant-user-key' },
@@ -358,6 +261,7 @@ describe('classifyMissingCredentialFailure', () => {
 
     expect((ctx.data as Message).metadata?.error_kind).toBeUndefined();
     expect((ctx.data as Message).type).toBe('assistant');
+    expect((ctx.data as Message).content).toBe(SAFE_ZERO_TURN_PROVIDER_RESULT_MESSAGE);
   });
 
   it('does not classify a normal assistant message without the zero-turn marker', async () => {
@@ -413,7 +317,7 @@ describe('classifyMissingCredentialFailure', () => {
     expect(taskRepository.findById).not.toHaveBeenCalled();
   });
 
-  it('preserves legitimate zero-turn output with a Claude subscription token', async () => {
+  it('sanitizes zero-turn output with a Claude subscription token', async () => {
     vi.mocked(resolveApiKey).mockResolvedValue({
       apiKey: undefined,
       connection: { CLAUDE_CODE_OAUTH_TOKEN: 'sk-ant-oat01-test' },
@@ -425,9 +329,10 @@ describe('classifyMissingCredentialFailure', () => {
 
     expect((ctx.data as Message).metadata?.error_kind).toBeUndefined();
     expect((ctx.data as Message).type).toBe('assistant');
+    expect((ctx.data as Message).content).toBe(SAFE_ZERO_TURN_PROVIDER_RESULT_MESSAGE);
   });
 
-  it('preserves zero-turn output when native auth is configured', async () => {
+  it('sanitizes zero-turn output when native auth is configured', async () => {
     vi.mocked(resolveApiKey).mockResolvedValue({
       apiKey: undefined,
       connection: {},
@@ -438,6 +343,7 @@ describe('classifyMissingCredentialFailure', () => {
     const ctx = await runHook()(makeContext({ ...zeroTurnResult }));
 
     expect((ctx.data as Message).metadata?.error_kind).toBeUndefined();
+    expect((ctx.data as Message).content).toBe(SAFE_ZERO_TURN_PROVIDER_RESULT_MESSAGE);
   });
 
   it('rejects mismatched task/session associations', async () => {
@@ -473,13 +379,29 @@ describe('classifyMissingCredentialFailure', () => {
     expect((ctx.data as Message).metadata?.error_kind).toBeUndefined();
   });
 
-  it('swallows resolution errors and leaves the zero-turn message untouched', async () => {
+  it('swallows resolution errors only after closing the zero-turn body', async () => {
     vi.mocked(resolveApiKey).mockRejectedValue(new Error('boom'));
 
     const ctx = await runHook()(makeContext({ ...zeroTurnResult }));
 
     expect((ctx.data as Message).metadata?.error_kind).toBeUndefined();
-    expect((ctx.data as Message).content).toEqual(zeroTurnResult.content);
+    expect((ctx.data as Message).content).toBe(SAFE_ZERO_TURN_PROVIDER_RESULT_MESSAGE);
+  });
+
+  it('does not log exception objects when classification fails', async () => {
+    const sentinel = 'SENTINEL_CLASSIFIER_EXCEPTION';
+    vi.mocked(resolveApiKey).mockRejectedValue(new Error(sentinel));
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    try {
+      await runHook()(makeContext({ ...sdkErrorBillingResult }));
+      expect(JSON.stringify(error.mock.calls)).not.toContain(sentinel);
+      expect(error).toHaveBeenCalledWith(
+        '[classifyMissingCredentialFailure] classification failed'
+      );
+    } finally {
+      error.mockRestore();
+    }
   });
 
   it('is a no-op without data or a classification marker', async () => {

--- a/apps/agor-daemon/src/hooks/classify-missing-credential.ts
+++ b/apps/agor-daemon/src/hooks/classify-missing-credential.ts
@@ -1,10 +1,12 @@
 /**
  * Before-create hook that reclassifies executor-scoped provider failures
  * without matching arbitrary provider stderr. It handles explicit credential
- * preflight failures and narrowly recognized zero-turn billing failures.
+ * preflight failures and provider-result messages whose credential state can
+ * be resolved authoritatively. Arbitrary provider prose is never classified.
  */
 
 import { TOOL_API_KEY_NAMES } from '@agor/agentic-tools';
+import { SAFE_ZERO_TURN_PROVIDER_RESULT_MESSAGE } from '@agor/core';
 import { resolveApiKey } from '@agor/core/config';
 import type { SessionRepository, TaskRepository, TenantScopeAwareDatabase } from '@agor/core/db';
 import { Forbidden } from '@agor/core/feathers';
@@ -33,11 +35,7 @@ function fallbackContent(toolDisplayName: string): string {
   return `This session needs to be connected to ${toolDisplayName} before it can run.`;
 }
 
-function providerCreditContent(toolDisplayName: string): string {
-  return `This session's ${toolDisplayName} account needs available credit or quota before it can respond.`;
-}
-
-type ProviderFailureKind = 'missing_credential' | 'provider_credit_exhausted';
+type ProviderFailureKind = 'missing_credential';
 
 export type ProviderFailureMessageLoader = (messageId: MessageID) => Promise<Message | null>;
 
@@ -102,10 +100,7 @@ function classifyProviderFailure(
   toolDisplayName: string,
   errorKind: ProviderFailureKind
 ): Partial<Message> {
-  const content =
-    errorKind === 'missing_credential'
-      ? fallbackContent(toolDisplayName)
-      : providerCreditContent(toolDisplayName);
+  const content = fallbackContent(toolDisplayName);
 
   return {
     ...data,
@@ -119,43 +114,6 @@ function classifyProviderFailure(
       tool,
     },
   };
-}
-
-const PROVIDER_CREDIT_SIGNALS = [
-  'insufficient_quota',
-  'quota_exhausted',
-  'billing_hard_limit_reached',
-  'payment_required',
-] as const;
-const PROVIDER_CREDIT_SIGNAL_PATTERN = new RegExp(`\\b(?:${PROVIDER_CREDIT_SIGNALS.join('|')})\\b`);
-const PROVIDER_ERROR_SEARCH_WINDOW = 500;
-
-function textBlocks(content: Message['content'] | undefined): string[] {
-  if (typeof content === 'string') return [content];
-  if (!Array.isArray(content)) return [];
-
-  return content
-    .filter((block) => block.type === 'text' && typeof block.text === 'string')
-    .map((block) => block.text as string);
-}
-
-function isProviderCreditFailure(
-  tool: AgenticToolName,
-  content: Message['content'] | undefined
-): boolean {
-  const blocks = textBlocks(content);
-  if (blocks.length === 0) return false;
-
-  // Claude's executor preserves each sdkResult.errors[] entry as its own text
-  // block. Bound each actual block without splitting internal newlines; a
-  // zero-turn string remains one bounded entry.
-  return blocks.some((block) => {
-    const searchWindow = block.slice(0, PROVIDER_ERROR_SEARCH_WINDOW).toLowerCase();
-    const isAnthropicCreditFailure =
-      tool === 'claude-code' && /\bcredit balance is too low\b/.test(searchWindow);
-    const hasStableCreditSignal = PROVIDER_CREDIT_SIGNAL_PATTERN.test(searchWindow);
-    return isAnthropicCreditFailure || hasStableCreditSignal;
-  });
 }
 
 function hasResolvedCredential(
@@ -176,8 +134,10 @@ export function classifyMissingCredentialFailure(
   toolDisplayNames: Record<string, string>
 ) {
   return async (context: HookContext): Promise<HookContext> => {
-    const data = context.data as Partial<Message> | undefined;
+    let data = context.data as Partial<Message> | undefined;
     if (!data?.task_id || !data.session_id) return context;
+    const taskId = data.task_id as TaskID;
+    const sessionId = data.session_id;
     const executorScope = authenticatedTaskExecutorRuntimeScope(context.params);
     if (!executorScope) return context;
 
@@ -192,13 +152,26 @@ export function classifyMissingCredentialFailure(
       throw new Forbidden('Provider failure classification requires this task executor');
     }
 
+    // Provider result bodies are untrusted and this hook runs immediately
+    // before persistence/realtime publication. Close the body before any DB or
+    // credential lookup which can fail. Missing-credential classification may
+    // replace this fixed fallback below; no other provider prose is retained.
+    if (isZeroTurnResult || isProviderFailureResult) {
+      data = {
+        ...data,
+        content: SAFE_ZERO_TURN_PROVIDER_RESULT_MESSAGE,
+        content_preview: SAFE_ZERO_TURN_PROVIDER_RESULT_MESSAGE.substring(0, 200),
+      };
+      context.data = data;
+    }
+
     try {
       const [task, session] = await Promise.all([
-        taskRepository.findById(data.task_id as TaskID),
-        sessionsRepository.findById(data.session_id),
+        taskRepository.findById(taskId),
+        sessionsRepository.findById(sessionId),
       ]);
       if (!task || !session) return context;
-      if (task.session_id !== data.session_id || session.session_id !== data.session_id) {
+      if (task.session_id !== sessionId || session.session_id !== sessionId) {
         return context;
       }
 
@@ -231,14 +204,10 @@ export function classifyMissingCredentialFailure(
           return context;
         }
 
-        if (!isProviderCreditFailure(tool, data.content)) return context;
-
-        context.data = classifyProviderFailure(
-          data,
-          tool,
-          toolDisplayNames[tool] ?? tool,
-          'provider_credit_exhausted'
-        );
+        // Claude/Codex provider result strings have no typed billing/auth
+        // discriminator. Parsing arbitrary prose here would both reintroduce a
+        // secret-reflection boundary and claim recovery state we cannot prove.
+        // Keep the fixed generic provider-result fallback.
         return context;
       }
 
@@ -249,8 +218,8 @@ export function classifyMissingCredentialFailure(
         toolDisplayNames[tool] ?? tool,
         'missing_credential'
       );
-    } catch (err) {
-      console.error('[classifyMissingCredentialFailure] classification failed:', err);
+    } catch {
+      console.error('[classifyMissingCredentialFailure] classification failed');
     }
 
     return context;

--- a/apps/agor-daemon/src/mcp/tools/mcp-servers.auth-status.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/mcp-servers.auth-status.test.ts
@@ -1,0 +1,35 @@
+import type { MCPServer } from '@agor/core/types';
+import { describe, expect, it } from 'vitest';
+import { summarizeMcpServer } from './mcp-servers.js';
+
+function server(auth: MCPServer['auth']): MCPServer {
+  return {
+    mcp_server_id: '01900000-0000-7000-8000-000000000001',
+    name: 'status-test',
+    transport: 'http',
+    url: 'https://mcp.example.test/mcp',
+    auth,
+    scope: 'global',
+    source: 'user',
+    enabled: true,
+    created_at: new Date(),
+    updated_at: new Date(),
+  };
+}
+
+describe('MCP server structured missing-auth status', () => {
+  it.each([
+    { type: 'bearer' as const },
+    { type: 'jwt' as const, api_url: 'https://auth.example.test/token' },
+  ])('reports an incomplete saved $type row as actionable needs-auth', async (auth) => {
+    const summary = await summarizeMcpServer({} as never, server(auth));
+    expect(summary.oauth_authenticated).toBe(false);
+    expect(summary.recovery).toEqual({
+      category: 'authentication_required',
+      action: 'save_and_retry',
+      message:
+        'Save the required authentication settings for this MCP server, then retry the task.',
+      mcp_server_id: '01900000-0000-7000-8000-000000000001',
+    });
+  });
+});

--- a/apps/agor-daemon/src/mcp/tools/mcp-servers.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/mcp-servers.test.ts
@@ -51,6 +51,69 @@ beforeEach(() => {
   mockGrantAuthority.mockReset().mockResolvedValue(true);
 });
 
+describe('safe MCP server config readback', () => {
+  it('redacts auth, header, and environment secrets even for an internal service result', async () => {
+    const { safeMcpServerConfigReadback } = await import('./mcp-servers.js');
+    const readback = safeMcpServerConfigReadback({
+      mcp_server_id: 'server-1',
+      name: 'private',
+      transport: 'http',
+      url: 'https://mcp.example.test',
+      scope: 'global',
+      source: 'user',
+      enabled: true,
+      headers: { 'X-Api-Key': 'header-secret' },
+      env: { API_KEY: 'env-secret' },
+      auth: { type: 'oauth', oauth_client_secret: 'client-secret' },
+      created_at: new Date(),
+      updated_at: new Date(),
+    } as never);
+
+    const serialized = JSON.stringify(readback);
+    expect(serialized).not.toContain('header-secret');
+    expect(serialized).not.toContain('env-secret');
+    expect(serialized).not.toContain('client-secret');
+    expect(readback.auth_secret_fields_configured).toEqual(['oauth_client_secret']);
+  });
+});
+
+describe('surface-neutral MCP authentication recovery', () => {
+  it.each(['<@U123> **urgent**', '[click me](https://evil.test) @channel'])(
+    'keeps markup-shaped server label %s out of recovery prose',
+    async (label) => {
+      const { summarizeMcpServer } = await import('./mcp-servers.js');
+      const summary = await summarizeMcpServer(
+        {
+          db: {} as never,
+          userId: '01900000-0000-7000-8000-000000000001' as never,
+          authenticatedUser: {} as never,
+          baseServiceParams: {} as never,
+          app: {} as never,
+        },
+        {
+          mcp_server_id: '01900000-0000-7000-8000-000000000002',
+          name: label,
+          display_name: label,
+          transport: 'http',
+          url: 'https://mcp.example.test',
+          scope: 'global',
+          source: 'user',
+          enabled: true,
+          auth: { type: 'oauth' },
+          created_at: new Date(),
+          updated_at: new Date(),
+        } as never
+      );
+
+      expect(summary.display_name).toBe(label);
+      expect(summary.recovery?.message).toBe(
+        'Sign in to this MCP server from an available authentication surface, then retry the task.'
+      );
+      expect(summary.recovery?.message).not.toContain(label);
+    }
+  );
+});
+
 type ServiceStub = Record<string, (...args: unknown[]) => unknown>;
 function makeFakeApp(services: Record<string, ServiceStub>) {
   return {
@@ -438,18 +501,18 @@ describe('agor_mcp_servers_create/update/attach', () => {
         transport: 'http',
         url: 'https://mcp.context7.com/mcp',
         scope: 'global',
-        source: 'user',
         enabled: true,
         auth: { type: 'oauth' },
       }),
     ]);
+    expect(createCalls[0]).not.toHaveProperty('source');
     expect(payload.mcp_server).toMatchObject({
       mcp_server_id: 'srv-new',
       name: 'context7',
       auth_type: 'oauth',
       oauth_authenticated: false,
     });
-    expect(payload.next_steps.join('\n')).toContain('Settings > MCP Servers');
+    expect(payload.next_steps.join('\n')).toContain('available MCP authentication surface');
   });
 
   it('does not create a server when attachToCurrentSession is requested without session context', async () => {

--- a/apps/agor-daemon/src/mcp/tools/mcp-servers.ts
+++ b/apps/agor-daemon/src/mcp/tools/mcp-servers.ts
@@ -1,12 +1,18 @@
 import { NotFound } from '@agor/core/feathers';
+import { MCP_AUTH_SECRET_FIELDS, redactMCPAuthSecrets } from '@agor/core/tools/mcp/auth-secrets';
+import { redactMCPEnvSecrets } from '@agor/core/tools/mcp/env-secrets';
 import {
   findDuplicateMCPCustomHeaderName,
   isReservedMCPCustomHeaderName,
   isValidMCPHeaderName,
+  MCP_HEADER_REDACTED_SENTINEL,
+  redactMCPCustomHeaders,
 } from '@agor/core/tools/mcp/http-headers';
 import type {
   CreateMCPServerInput,
   MCPAuth,
+  MCPAuthPatch,
+  MCPAuthRecovery,
   MCPServer,
   UpdateMCPServerInput,
 } from '@agor/core/types';
@@ -45,6 +51,7 @@ export interface McpServerSummary {
   oauth_authenticated: boolean;
   has_custom_headers: boolean;
   enabled: boolean;
+  recovery?: MCPAuthRecovery;
 }
 
 /** Resolve OAuth authentication status for an MCP server. */
@@ -55,6 +62,16 @@ async function getOAuthStatus(
   const authType = mcpServer.auth?.type || 'none';
 
   if (authType !== 'oauth') {
+    if (authType === 'bearer') return { authenticated: !!mcpServer.auth?.token?.trim() };
+    if (authType === 'jwt') {
+      return {
+        authenticated: !!(
+          mcpServer.auth?.api_url?.trim() &&
+          mcpServer.auth.api_token?.trim() &&
+          mcpServer.auth.api_secret?.trim()
+        ),
+      };
+    }
     return { authenticated: true };
   }
 
@@ -109,6 +126,21 @@ export async function summarizeMcpServer(
     oauth_authenticated: authenticated,
     has_custom_headers: !!mcpServer.headers && Object.keys(mcpServer.headers).length > 0,
     enabled: mcpServer.enabled,
+    ...(!authenticated
+      ? {
+          recovery: {
+            category: 'authentication_required' as const,
+            action: (authType === 'oauth' ? 'reauthenticate' : 'save_and_retry') as
+              | 'reauthenticate'
+              | 'save_and_retry',
+            message:
+              authType === 'oauth'
+                ? 'Sign in to this MCP server from an available authentication surface, then retry the task.'
+                : 'Save the required authentication settings for this MCP server, then retry the task.',
+            mcp_server_id: mcpServer.mcp_server_id,
+          },
+        }
+      : {}),
   };
 }
 
@@ -299,7 +331,7 @@ const mcpAuthInputSchema = z
       ),
     token: mcpOptionalString(
       'auth.token',
-      'Bearer token. Prefer {{ user.env.MCP_TOKEN }} templates; raw secrets will be stored redacted but are still visible in this MCP call transcript.'
+      'Bearer token. Prefer {{ user.env.MCP_TOKEN }} templates; raw secrets are stored in MCP server JSON, redacted on read, and remain visible in this MCP call transcript.'
     ),
     api_url: mcpOptionalString('auth.api_url', 'JWT auth API URL.'),
     api_token: mcpOptionalString(
@@ -402,6 +434,32 @@ const mcpAuthInputSchema = z
     "Auth config. Common OAuth path: { type: 'oauth' } plus url; leave OAuth URLs/client fields blank first so metadata discovery/DCR can do the work."
   );
 
+const nullableString = (description: string) =>
+  z.string().nullable().optional().describe(`${description} Pass null to clear.`);
+
+/** Same fields as create auth, but PATCH never requires resending the type or secrets. */
+const mcpAuthPatchSchema = z
+  .strictObject({
+    type: z.enum(['none', 'bearer', 'jwt', 'oauth']).optional(),
+    token: nullableString('Bearer token.'),
+    api_url: nullableString('JWT auth API URL.'),
+    api_token: nullableString('JWT API token.'),
+    api_secret: nullableString('JWT API secret.'),
+    oauth_authorization_url: nullableString('OAuth authorization endpoint override.'),
+    oauth_token_url: nullableString('OAuth token endpoint override.'),
+    oauth_client_id: nullableString('OAuth client ID.'),
+    oauth_client_secret: nullableString('OAuth client secret.'),
+    oauth_scope: nullableString('OAuth scopes, space-separated.'),
+    oauth_grant_type: z.enum(['client_credentials', 'authorization_code']).nullable().optional(),
+    oauth_mode: z.enum(['per_user', 'shared']).nullable().optional(),
+    oauth_compatibility_mode: z.enum(['strict', 'legacy']).nullable().optional(),
+    oauth_dcr_mode: z.enum(['disabled', 'advertised', 'fallback']).nullable().optional(),
+    insecure: z.boolean().nullable().optional(),
+  })
+  .describe(
+    'Partial auth patch. Omitted fields and redaction sentinels preserve stored values; null clears one field; changing type replaces the auth object.'
+  );
+
 const toolPermissionsSchema = z
   .record(z.string(), z.enum(['ask', 'allow', 'deny']))
   .describe("Optional per-tool permissions, e.g. { 'list_files': 'allow', 'write_file': 'ask' }.");
@@ -485,16 +543,40 @@ const mcpServerUpdateSchema = z
         'Replace custom HTTP headers. Redacted existing header values may be passed back unchanged by the UI; this tool should normally pass real template values or omit headers.'
       ),
     env: stringMapSchema.optional().describe('Replace environment variables.'),
-    auth: mcpAuthInputSchema
+    auth: mcpAuthPatchSchema
+      .nullable()
       .optional()
       .describe(
-        "Replace auth config. Existing redacted secrets are preserved if their redacted placeholders are passed back; prefer omitting auth unless changing it. Use { type: 'none' } to clear auth."
+        'Patch auth config. Omitted fields are preserved, null clears one field, auth:null clears all auth, and a type change replaces the old mode. Redacted secret placeholders mean unchanged.'
+      ),
+    expectedConfigVersion: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe(
+        'Compare-and-swap version from agor_mcp_servers_get. Stale edits return a conflict.'
+      ),
+    replaceAuth: z
+      .boolean()
+      .optional()
+      .describe(
+        'Explicitly replace the whole auth object, including for the same auth type. Omitted defaults to safe nested patch semantics.'
       ),
     scope: z.enum(['global', 'session']).optional().describe('Scope to set.'),
     enabled: z.boolean().optional().describe('Enabled flag.'),
     toolPermissions: toolPermissionsSchema.optional(),
   })
-  .superRefine((value, issue) => validateMcpServerConfig(value, issue, true));
+  .superRefine((value, issue) => {
+    validateMcpServerConfig(value, issue, true);
+    if (value.replaceAuth && value.auth === undefined) {
+      issue.addIssue({
+        code: 'custom',
+        path: ['replaceAuth'],
+        message: 'replaceAuth requires auth to be provided.',
+      });
+    }
+  });
 
 function validateHeaders(headers: Record<string, string> | undefined, issue: z.RefinementCtx) {
   if (!headers) return;
@@ -544,7 +626,7 @@ function validateMcpServerConfig(
     command?: string;
     args?: string[];
     headers?: Record<string, string>;
-    auth?: z.infer<typeof mcpAuthInputSchema>;
+    auth?: z.infer<typeof mcpAuthInputSchema> | z.infer<typeof mcpAuthPatchSchema> | null;
   },
   issue: z.RefinementCtx,
   partial: boolean
@@ -580,7 +662,7 @@ function validateMcpServerConfig(
           message: 'headers only apply to http/sse transports, not stdio.',
         });
       }
-      if (value.auth && value.auth.type !== 'none') {
+      if (value.auth && value.auth.type !== undefined && value.auth.type !== 'none') {
         issue.addIssue({
           code: 'custom',
           path: ['auth', 'type'],
@@ -619,6 +701,7 @@ function assertUpdateCompatibleWithCurrent(
   const transport = args.transport ?? current.transport;
   const url = args.url ?? current.url;
   const command = args.command ?? current.command;
+  const effectiveAuthType = args.auth === null ? 'none' : (args.auth?.type ?? current.auth?.type);
   const errors: string[] = [];
 
   if (transport === 'stdio') {
@@ -627,7 +710,7 @@ function assertUpdateCompatibleWithCurrent(
     if (args.headers && Object.keys(args.headers).length > 0) {
       errors.push('headers only apply to http/sse transports, not stdio.');
     }
-    if (args.auth && args.auth.type !== 'none') {
+    if (effectiveAuthType && effectiveAuthType !== 'none') {
       errors.push('auth only applies to http/sse transports, not stdio.');
     }
   } else {
@@ -651,7 +734,7 @@ function createOrUpdateNextSteps(
   const steps: string[] = [];
   if (authType === 'oauth') {
     steps.push(
-      `OAuth configured. If oauth_authenticated is false, authenticate in Settings > MCP Servers > ${server.display_name || server.name} > Test Authentication > Start OAuth Flow.`
+      `OAuth configured. If oauth_authenticated is false, sign in to ${server.display_name || server.name} from an available MCP authentication surface, then retry.`
     );
   }
   if (attach?.ok) {
@@ -670,6 +753,42 @@ function createOrUpdateNextSteps(
     );
   }
   return steps;
+}
+
+export function safeMcpServerConfigReadback(server: MCPServer) {
+  // Do this explicitly rather than depending on the Feathers dispatch hook:
+  // the built-in MCP transport may use trusted internal service params, while
+  // its tool result is still an external agent-visible response.
+  const auth = redactMCPAuthSecrets(server.auth);
+  const configuredSecretFields = auth
+    ? MCP_AUTH_SECRET_FIELDS.filter((field) => auth[field] === MCP_HEADER_REDACTED_SENTINEL)
+    : [];
+  return {
+    mcp_server_id: server.mcp_server_id,
+    name: server.name,
+    display_name: server.display_name,
+    description: server.description,
+    transport: server.transport,
+    command: server.command,
+    args: server.args,
+    url: server.url,
+    headers: redactMCPCustomHeaders(server.headers),
+    env: redactMCPEnvSecrets(server.env),
+    auth,
+    auth_secret_fields_configured: configuredSecretFields,
+    scope: server.scope,
+    owner_user_id: server.owner_user_id,
+    source: server.source,
+    catalog_entry_name: server.catalog_entry_name,
+    enabled: server.enabled,
+    tool_permissions: server.tool_permissions,
+    config_version: server.config_version,
+    capability_counts: {
+      tools: server.tools?.length ?? 0,
+      resources: server.resources?.length ?? 0,
+      prompts: server.prompts?.length ?? 0,
+    },
+  };
 }
 
 async function attachMcpServerToSession(ctx: McpContext, sessionId: string, mcpServerId: string) {
@@ -743,8 +862,7 @@ export function registerMcpServerTools(server: McpServer, ctx: McpContext): void
           total: servers.length,
           oauth_servers: servers.filter((s) => s.auth_type === 'oauth').length,
           authenticated: servers.filter((s) => s.oauth_authenticated).length,
-          needs_auth: servers.filter((s) => s.auth_type === 'oauth' && !s.oauth_authenticated)
-            .length,
+          needs_auth: servers.filter((s) => !s.oauth_authenticated).length,
         },
       });
     }
@@ -755,7 +873,7 @@ export function registerMcpServerTools(server: McpServer, ctx: McpContext): void
     'agor_mcp_servers_auth_status',
     {
       description:
-        'Check the OAuth authentication status for an MCP server. Returns whether the current user is authenticated. If NOT authenticated, returns instructions for the user to complete OAuth via Settings → MCP Servers. Use agor_mcp_servers_list to get server IDs.',
+        'Check the OAuth authentication status for an MCP server. Returns whether the current user is authenticated and a structured, surface-neutral recovery action when sign-in is required. Use agor_mcp_servers_list to get server IDs.',
       annotations: { readOnlyHint: true },
       inputSchema: z.strictObject({
         mcpServerId: mcpRequiredId(
@@ -785,9 +903,39 @@ export function registerMcpServerTools(server: McpServer, ctx: McpContext): void
         token_expires_at: tokenExpiresAt ? new Date(tokenExpiresAt).toISOString() : undefined,
         instructions:
           !authenticated && authType === 'oauth'
-            ? `To authenticate with "${mcpServer.display_name || mcpServer.name}", go to Settings > MCP Servers > ${mcpServer.display_name || mcpServer.name} > Click "Test Authentication" then "Start OAuth Flow". After completing the OAuth flow in your browser, the MCP tools will become available.`
+            ? 'Sign in to this MCP server from an available authentication surface, then retry the task.'
+            : undefined,
+        recovery:
+          !authenticated && authType === 'oauth'
+            ? {
+                category: 'authentication_required',
+                action: 'reauthenticate',
+                message:
+                  'Sign in to this MCP server from an available authentication surface, then retry the task.',
+                mcp_server_id: mcpServer.mcp_server_id,
+              }
             : undefined,
       });
+    }
+  );
+
+  server.registerTool(
+    'agor_mcp_servers_get',
+    {
+      description:
+        'Read one MCP server configuration before patching it. Secrets are never returned: configured secret fields contain a redaction sentinel and are also named in auth_secret_fields_configured. Pass config_version back as expectedConfigVersion to prevent a stale editor from overwriting a concurrent change.',
+      annotations: { readOnlyHint: true },
+      inputSchema: z.strictObject({
+        mcpServerId: mcpRequiredId('mcpServerId', 'MCP server', 'MCP server ID to read'),
+      }),
+    },
+    async (args) => {
+      const mcpServerId = await resolveMcpServerId(ctx, args.mcpServerId);
+      const mcpServer = (await ctx.app
+        .service('mcp-servers')
+        .get(mcpServerId, ctx.baseServiceParams)) as MCPServer;
+      assertMcpServerUsableByCaller(ctx, mcpServer);
+      return textResult({ mcp_server: safeMcpServerConfigReadback(mcpServer) });
     }
   );
 
@@ -827,7 +975,6 @@ export function registerMcpServerTools(server: McpServer, ctx: McpContext): void
             ? undefined
             : (args.auth as MCPAuth),
         scope: args.scope ?? 'global',
-        source: 'user',
         enabled: args.enabled ?? true,
       };
 
@@ -866,7 +1013,7 @@ export function registerMcpServerTools(server: McpServer, ctx: McpContext): void
     'agor_mcp_servers_update',
     {
       description:
-        'Update an existing MCP server definition. Permissions are service-enforced: admins always may, members only under the workspace `mcp_member_policy`, and nobody but an admin or the owner may touch a private server. Updating config does not create a session-specific link: enabled `global` servers are already effective for all sessions, while `session` scoped servers need `agor_sessions_add_mcp_server`. Provide only fields to change. Validation rejects incompatible combinations (e.g. stdio+url/auth/headers, remote+command/args, wrong auth fields). OAuth tip: keep only `auth:{type:"oauth"}` unless discovery fails or a provider requires endpoint/client overrides. Use `auth:{type:"none"}` to clear auth.',
+        'Safely patch an existing MCP server definition. Call agor_mcp_servers_get first and pass expectedConfigVersion for concurrent-edit protection. Auth is a nested patch: omitted fields preserve stored values, null clears one field, auth:null clears all auth, and changing auth.type replaces the old mode. Permissions remain service-enforced; new tasks resolve the saved configuration.',
       annotations: { destructiveHint: false, idempotentHint: false },
       inputSchema: mcpServerUpdateSchema,
     },
@@ -887,9 +1034,12 @@ export function registerMcpServerTools(server: McpServer, ctx: McpContext): void
       if (args.headers !== undefined) updates.headers = args.headers;
       if (args.env !== undefined) updates.env = args.env;
       if (args.auth !== undefined) {
-        updates.auth =
-          args.auth.type === 'none' ? ({ type: 'none' } as MCPAuth) : (args.auth as MCPAuth);
+        updates.auth = args.auth as MCPAuthPatch | null;
       }
+      if (args.expectedConfigVersion !== undefined) {
+        updates.expected_config_version = args.expectedConfigVersion;
+      }
+      if (args.replaceAuth !== undefined) updates.replace_auth = args.replaceAuth;
       if (args.scope !== undefined) updates.scope = args.scope;
       if (args.enabled !== undefined) updates.enabled = args.enabled;
       if (args.toolPermissions !== undefined) updates.tool_permissions = args.toolPermissions;
@@ -900,7 +1050,7 @@ export function registerMcpServerTools(server: McpServer, ctx: McpContext): void
       if (args.transport === 'stdio') {
         updates.url = undefined;
         updates.headers = undefined;
-        updates.auth = undefined;
+        updates.auth = null;
       } else if (args.transport === 'http' || args.transport === 'sse') {
         updates.command = undefined;
         updates.args = undefined;

--- a/apps/agor-daemon/src/oauth-auth-helpers.ts
+++ b/apps/agor-daemon/src/oauth-auth-helpers.ts
@@ -6,8 +6,13 @@
  * without spinning up the full daemon.
  */
 
-import type { TenantScopeAwareDatabase } from '@agor/core/db';
-import { assertTenantWritable, runWithTenantDatabaseScope } from '@agor/core/db';
+import type { TenantScopeAwareDatabase, TenantScopedDatabase } from '@agor/core/db';
+import {
+  assertTenantWritable,
+  getCurrentTenantId,
+  runWithTenantDatabaseScope,
+  runWithTenantDatabaseTransaction,
+} from '@agor/core/db';
 
 /**
  * Runs `work` inside a tenant database scope when `tenantId` is provided.
@@ -42,6 +47,26 @@ export async function runInOAuthTenantWriteScope<T>(
   return runWithTenantDatabaseScope(db, tenantId, async (scoped) => {
     await assertTenantWritable(scoped, tenantId);
     return work();
+  });
+}
+
+/**
+ * Native all-dialect OAuth metadata transaction.
+ *
+ * Unlike the identity-only SQLite branch of `runInOAuthTenantWriteScope`, this
+ * uses BEGIN IMMEDIATE on SQLite and a tenant/RLS transaction on PostgreSQL.
+ * Keep provider I/O out of this boundary; it is for the small set of database
+ * changes that must either all commit or all roll back.
+ */
+export async function runInOAuthTenantWriteTransaction<T>(
+  db: TenantScopeAwareDatabase,
+  tenantId: string | undefined,
+  work: (scoped: TenantScopedDatabase) => Promise<T>
+): Promise<T> {
+  const effectiveTenantId = tenantId ?? getCurrentTenantId();
+  return runWithTenantDatabaseTransaction(db, effectiveTenantId, async (scoped) => {
+    if (effectiveTenantId) await assertTenantWritable(scoped, effectiveTenantId);
+    return work(scoped);
   });
 }
 

--- a/apps/agor-daemon/src/register-hooks.mcp-headers-redaction.test.ts
+++ b/apps/agor-daemon/src/register-hooks.mcp-headers-redaction.test.ts
@@ -40,7 +40,7 @@ describe('register-hooks MCP server secret redaction', () => {
     // check: `authorizeMcpServerWriteHook` decides on `mcp_member_policy` plus
     // ownership, which is what lets a member hold a server of their own at all.
     expect(source).toMatch(
-      /update:\s*\[validateMcpServerOAuthCompatibility,\s*authorizeMcpServerWriteHook\]/
+      /update:\s*\[\s*authorizeMcpServerWriteHook,[\s\S]*?validateMcpServerOAuthCompatibility,?\s*\]/
     );
   });
 

--- a/apps/agor-daemon/src/register-hooks.test.ts
+++ b/apps/agor-daemon/src/register-hooks.test.ts
@@ -37,6 +37,7 @@ import {
   getTrustedSessionTenantId,
   isPromptFlowPatchOnly,
   PROMPT_FLOW_PATCH_FIELDS,
+  projectExecutorTaskSdkResponse,
   protectExternalTaskCreate,
   protectFilesystemHomeWrite,
   protectServerManagedTaskWrites,
@@ -476,6 +477,118 @@ describe('protectServerManagedTaskWrites', () => {
     context.params.provider = undefined;
 
     await expect(protectServerManagedTaskWrites(context)).resolves.toBe(context);
+  });
+});
+
+describe('projectExecutorTaskSdkResponse', () => {
+  it('closes a normalized-only executor patch without touching extension getters', async () => {
+    const sentinel = 'SENTINEL_NORMALIZED_ONLY_DAEMON_41a8';
+    const getter = vi.fn(() => {
+      throw new Error(sentinel);
+    });
+    const tokenUsage = Object.create({ provider_secret: sentinel }) as Record<string, unknown>;
+    Object.assign(tokenUsage, { inputTokens: 4, outputTokens: 2, totalTokens: 6 });
+    Object.defineProperty(tokenUsage, 'futureProviderField', { get: getter });
+    const context = {
+      path: 'tasks',
+      method: 'patch',
+      id: 'task-1',
+      data: {
+        normalized_sdk_response: {
+          tokenUsage,
+          contextWindowLimit: 100,
+          contextUsageSnapshot: {
+            totalTokens: 6,
+            maxTokens: 100,
+            percentage: 6,
+            memoryFiles: [{ path: sentinel }],
+          },
+          extension: { secret: sentinel },
+        },
+      },
+      params: { provider: 'socketio' },
+    } as unknown as HookContext;
+    const tasks = { findById: vi.fn() };
+    const sessions = { findById: vi.fn() };
+
+    await expect(projectExecutorTaskSdkResponse(tasks, sessions)(context)).resolves.toBe(context);
+
+    expect(context.data).toEqual({
+      normalized_sdk_response: {
+        tokenUsage: { inputTokens: 4, outputTokens: 2, totalTokens: 6 },
+        contextWindowLimit: 100,
+        contextUsageSnapshot: { totalTokens: 6, maxTokens: 100, percentage: 6 },
+      },
+    });
+    expect(getter).not.toHaveBeenCalled();
+    expect(JSON.stringify(context.data)).not.toContain(sentinel);
+    expect(tasks.findById).not.toHaveBeenCalled();
+    expect(sessions.findById).not.toHaveBeenCalled();
+  });
+
+  it('re-closes Claude result data before persistence and realtime publication', async () => {
+    const sentinel = 'SENTINEL_DAEMON_RAW_CLAUDE_RESULT_6d31';
+    const context = {
+      path: 'tasks',
+      method: 'patch',
+      id: 'task-1',
+      data: {
+        raw_sdk_response: {
+          type: 'result',
+          subtype: 'success',
+          result: sentinel,
+          errors: [sentinel],
+          duration_ms: 7,
+          duration_api_ms: Number.POSITIVE_INFINITY,
+          num_turns: 0,
+          is_error: false,
+          usage: { input_tokens: 3, provider_secret: sentinel },
+          modelUsage: { [sentinel]: { inputTokens: 3 } },
+        },
+      },
+      params: { provider: 'rest' },
+    } as unknown as HookContext;
+    const hook = projectExecutorTaskSdkResponse(
+      { findById: vi.fn().mockResolvedValue({ task_id: 'task-1', session_id: 'session-1' }) },
+      {
+        findById: vi
+          .fn()
+          .mockResolvedValue({ session_id: 'session-1', agentic_tool: 'claude-code' }),
+      }
+    );
+
+    await expect(hook(context)).resolves.toBe(context);
+    expect(context.data).toEqual({
+      raw_sdk_response: {
+        type: 'result',
+        subtype: 'success',
+        duration_ms: 7,
+        is_error: false,
+        num_turns: 0,
+        usage: {
+          input_tokens: 3,
+        },
+      },
+    });
+    expect(JSON.stringify(context.data)).not.toContain(sentinel);
+  });
+
+  it('does not alter another agentic tool raw response', async () => {
+    const raw = { type: 'turn.completed', usage: { input_tokens: 1 } };
+    const context = {
+      id: 'task-1',
+      data: { raw_sdk_response: raw },
+      params: { provider: 'socketio' },
+    } as unknown as HookContext;
+    const hook = projectExecutorTaskSdkResponse(
+      { findById: vi.fn().mockResolvedValue({ task_id: 'task-1', session_id: 'session-1' }) },
+      {
+        findById: vi.fn().mockResolvedValue({ session_id: 'session-1', agentic_tool: 'codex' }),
+      }
+    );
+
+    await hook(context);
+    expect((context.data as { raw_sdk_response: unknown }).raw_sdk_response).toBe(raw);
   });
 });
 

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -7,6 +7,7 @@
  */
 
 import { AGENTIC_TOOL_DISPLAY_NAMES } from '@agor/agentic-tools';
+import { projectClaudeResultResponse, projectNormalizedSdkResponse } from '@agor/core';
 import { analyticsLogger } from '@agor/core/analytics';
 import {
   type AgorConfig,
@@ -68,7 +69,7 @@ import {
   typedValidateQuery,
   userQueryValidator,
 } from '@agor/core/lib/feathers-validation';
-import { isMCPServerUsableBy } from '@agor/core/mcp';
+import { assertValidMCPServerWrite, isMCPServerUsableBy } from '@agor/core/mcp';
 import type {
   AuthenticatedParams,
   Board,
@@ -563,6 +564,44 @@ export const TENANT_IDENTITY_ONLY_SERVICE_PATHS = [
   'gateway-channels',
 ] as const;
 
+/**
+ * Closed MCP-server transport contract. Public REST/Socket.IO callers receive
+ * the narrow editor schema; trusted in-process catalog/import/discovery calls
+ * use the explicit internal schema that includes provenance/capabilities.
+ */
+export function validateMcpServerWriteInput(context: HookContext, create: boolean): HookContext {
+  const items = Array.isArray(context.data) ? context.data : [context.data];
+  const catalogEntryName = (
+    context.params as typeof context.params & {
+      mcpCatalogInstall?: { entry_name?: string };
+    }
+  ).mcpCatalogInstall?.entry_name;
+  try {
+    for (const item of items) {
+      // Marketplace connect is a public request that deliberately calls this
+      // service through a daemon-owned params capability. Validate the exact
+      // provenance stamp that the following authorization hook will inject;
+      // ordinary REST/Socket.IO callers cannot manufacture params fields.
+      const validatedItem =
+        catalogEntryName && item && typeof item === 'object' && !Array.isArray(item)
+          ? { ...item, catalog_entry_name: catalogEntryName }
+          : item;
+      assertValidMCPServerWrite(validatedItem, {
+        operation: create ? 'create' : 'mutation',
+        // Lack of a transport provider is not itself an authorization
+        // capability: built-in MCP tools and other in-process callers still
+        // operate on behalf of a user. The catalog's daemon-owned stamp is the
+        // only current path that may write protected provenance fields.
+        trusted: Boolean(catalogEntryName),
+        requireConfiguredCredentials: create && !catalogEntryName,
+      });
+    }
+  } catch (error) {
+    throw new BadRequest(error instanceof Error ? error.message : 'Invalid MCP server input');
+  }
+  return context;
+}
+
 /** Caller-specific Knowledge command responses must never become service events. */
 export function suppressKnowledgeCommandRealtimeEvent(context: HookContext): HookContext {
   context.event = null;
@@ -656,6 +695,51 @@ export async function protectServerManagedTaskWrites(context: HookContext): Prom
   }
 
   return context;
+}
+
+/**
+ * Defense in depth at the executor -> daemon persistence/realtime boundary.
+ * The executor projects Claude results first, but an old or compromised
+ * executor must not be able to reintroduce provider result/error prose or SDK
+ * extension objects into Task state.
+ */
+export function projectExecutorTaskSdkResponse(
+  tasks: Pick<TaskRepository, 'findById'>,
+  sessions: Pick<SessionRepository, 'findById'>
+) {
+  return async (context: HookContext): Promise<HookContext> => {
+    if (!context.params.provider || typeof context.id !== 'string') return context;
+    const write =
+      context.data && typeof context.data === 'object' && !Array.isArray(context.data)
+        ? (context.data as Record<string, unknown>)
+        : undefined;
+    if (!write) return context;
+
+    // Normalized responses are independently executor-owned input. An old or
+    // compromised executor can omit raw_sdk_response entirely, so close this
+    // object before any persistence/realtime path without conditioning it on
+    // agent type or a raw response being present.
+    if (Object.hasOwn(write, 'normalized_sdk_response')) {
+      const projected = projectNormalizedSdkResponse(write.normalized_sdk_response);
+      if (projected) write.normalized_sdk_response = projected;
+      else delete write.normalized_sdk_response;
+    }
+
+    if (!Object.hasOwn(write, 'raw_sdk_response')) return context;
+
+    const task = await tasks.findById(context.id as Task['task_id']);
+    if (!task) throw new NotFound('Task not found');
+    const session = await sessions.findById(task.session_id);
+    if (!session) throw new NotFound('Session not found');
+
+    if (session.agentic_tool === 'claude-code') {
+      write.raw_sdk_response = projectClaudeResultResponse(write.raw_sdk_response) ?? {
+        type: 'result',
+        subtype: 'unknown',
+      };
+    }
+    return context;
+  };
 }
 
 /** Run an identity-only service's database-reading before hooks in one short unit of work. */
@@ -2360,11 +2444,25 @@ export function registerHooks(ctx: RegisterHooksContext): void {
 
   safeService('mcp-servers')?.hooks({
     before: {
-      all: [typedValidateQuery(mcpServerQueryValidator), requireAuth],
+      // Authentication must run before query parsing so unauthenticated callers
+      // cannot use validation errors as a schema oracle.
+      all: [requireAuth, typedValidateQuery(mcpServerQueryValidator)],
       find: [scopeMcpServerFindToUsable],
-      create: [validateMcpServerOAuthCompatibility, authorizeMcpServerWriteHook],
-      update: [validateMcpServerOAuthCompatibility, authorizeMcpServerWriteHook],
-      patch: [validateMcpServerOAuthCompatibility, authorizeMcpServerWriteHook],
+      create: [
+        authorizeMcpServerWriteHook,
+        (context) => validateMcpServerWriteInput(context, true),
+        validateMcpServerOAuthCompatibility,
+      ],
+      update: [
+        authorizeMcpServerWriteHook,
+        (context) => validateMcpServerWriteInput(context, false),
+        validateMcpServerOAuthCompatibility,
+      ],
+      patch: [
+        authorizeMcpServerWriteHook,
+        (context) => validateMcpServerWriteInput(context, false),
+        validateMcpServerOAuthCompatibility,
+      ],
       remove: [authorizeMcpServerWriteHook],
     },
     after: {
@@ -3328,6 +3426,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       ],
       patch: [
         protectServerManagedTaskWrites,
+        projectExecutorTaskSdkResponse(taskRepository, sessionsRepository),
         ...(executionMode.appRbacEnabled
           ? [
               resolveSessionContext(),

--- a/apps/agor-daemon/src/register-services.oauth-sqlite.integration.test.ts
+++ b/apps/agor-daemon/src/register-services.oauth-sqlite.integration.test.ts
@@ -1,11 +1,15 @@
 import http, { type Server as HttpServer } from 'node:http';
 import {
   createDatabaseAsync,
+  eq,
   MCPServerRepository,
+  mcpServers,
   runMigrations,
+  shortId,
   type TenantScopeAwareDatabase,
   UserMCPOAuthTokenRepository,
   UsersRepository,
+  update,
 } from '@agor/core/db';
 import {
   type Application,
@@ -45,9 +49,12 @@ import {
 // The boundary under test is daemon discovery/OAuth authority, not the MCP
 // SDK's stream parser. Mock only the post-grant capability client so Vitest
 // does not try to type-strip eventsource-parser's published TypeScript file.
+const mcpClientTestState = vi.hoisted(() => ({ connectError: undefined as unknown }));
 vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
   Client: class {
-    async connect() {}
+    async connect() {
+      if (mcpClientTestState.connectError) throw mcpClientTestState.connectError;
+    }
     async close() {}
     async listTools() {
       return { tools: [] };
@@ -390,6 +397,7 @@ async function createHarness(
     durableAuthority?: NonNullable<RegisterServicesContext['mcpOAuthPendingFlowAuthority']>;
     lockGrantConfiguration?: NonNullable<RegisterServicesContext['lockMcpOAuthGrantConfiguration']>;
     outboundDnsLookup?: OutboundDnsLookup;
+    requireAuth?: RegisterServicesContext['requireAuth'];
   } = {}
 ) {
   const rawDb = await createDatabaseAsync({ dialect: 'sqlite', url: ':memory:' });
@@ -460,12 +468,33 @@ async function createHarness(
     UI_PORT: 5173,
     branchRbacEnabled: false,
     allowSuperadmin: false,
-    requireAuth: async (context) => context,
+    requireAuth: options.requireAuth ?? (async (context) => context),
     deployment: {} as RegisterServicesContext['deployment'],
     mcpOAuthPendingFlowAuthority: options.durableAuthority,
     lockMcpOAuthGrantConfiguration: options.lockGrantConfiguration,
     mcpOutboundDnsLookup: options.outboundDnsLookup,
   });
+  // The production registerHooks chain turns the catalog service's private
+  // params capability into the persisted provenance stamp. This service-only
+  // harness installs that narrow seam explicitly so the repository's trusted
+  // CREATE contract can reject incomplete catalog provenance.
+  app.service('mcp-servers').hooks({
+    before: {
+      create: [
+        (context) => {
+          const entryName = (
+            context.params as AuthenticatedParams & {
+              mcpCatalogInstall?: { entry_name?: string };
+            }
+          ).mcpCatalogInstall?.entry_name;
+          if (entryName && context.data && !Array.isArray(context.data)) {
+            context.data.catalog_entry_name = entryName;
+          }
+          return context;
+        },
+      ],
+    },
+  } as never);
 
   const invokeCallback = async (
     query: Record<string, string>
@@ -855,6 +884,7 @@ beforeEach(() => {
 });
 
 afterEach(async () => {
+  mcpClientTestState.connectError = undefined;
   await Promise.all(realSocketHarnesses.splice(0).map((harness) => harness.close()));
   await Promise.all(providers.splice(0).map((provider) => provider.close()));
   for (const db of databases.splice(0)) {
@@ -975,7 +1005,7 @@ describe('real Feathers Socket.IO request authority', () => {
       )
     ).resolves.toMatchObject({
       success: false,
-      error: expect.stringMatching(/invalid, expired, or already used/i),
+      error: expect.stringMatching(/authority|reservation|expired/i),
     });
     expect(provider.requests).toEqual([]);
   });
@@ -1006,6 +1036,49 @@ describe('real Feathers Socket.IO request authority', () => {
 
     await expect(request).rejects.toThrow(/authority/i);
     expect(provider.requests).toEqual([]);
+  });
+
+  it('sanitizes a secret-bearing DNS exception on a genuine test-jwt socket call', async () => {
+    const provider = await createTestProvider();
+    providers.push(provider);
+    const sentinel = 'SENTINEL_REAL_SOCKET_DNS_1b7e';
+    const getter = vi.fn(() => {
+      throw new Error(sentinel);
+    });
+    const hostileFailure = new TypeError(`DNS reflected https://${sentinel}.example.test`);
+    Object.defineProperties(hostileFailure, {
+      name: { get: getter },
+      code: { get: getter },
+    });
+    const harness = await createRealSocketHarness(provider, {
+      outboundDnsLookup: async () => {
+        throw hostileFailure;
+      },
+    });
+    realSocketHarnesses.push(harness);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const realtimeSpy = vi.fn();
+    for (const event of ['created', 'updated', 'patched', 'removed'] as const) {
+      harness.client.service('mcp-servers').on(event, realtimeSpy);
+    }
+    try {
+      const result = await harness.client.service('mcp-servers/test-jwt').create({
+        api_url: 'https://auth.example.test/token',
+        api_token: 'configured',
+        api_secret: sentinel,
+      });
+      expect(result).toMatchObject({ success: false, category: 'provider_unavailable' });
+      expect(JSON.stringify(result)).not.toContain(sentinel);
+      expect(JSON.stringify(errorSpy.mock.calls)).not.toContain(sentinel);
+      expect(getter).not.toHaveBeenCalled();
+      expect(JSON.stringify(await new MCPServerRepository(harness.rawDb).findAll())).not.toContain(
+        sentinel
+      );
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(realtimeSpy).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   it('fences oauth-start when A becomes B during the authoritative DB read', async () => {
@@ -1099,6 +1172,267 @@ describe('real Feathers Socket.IO request authority', () => {
 });
 
 describe('SQLite saved-row OAuth authority', () => {
+  it('authenticates REST mutations before the MCP OAuth around hook can read or write', async () => {
+    const provider = await createTestProvider();
+    providers.push(provider);
+    const harness = await createHarness(provider, 'per_user', {
+      requireAuth: async () => {
+        throw new Error('REST authentication rejected before MCP mutation');
+      },
+    });
+    databases.push(harness.rawDb);
+
+    await expect(
+      harness.app
+        .service('mcp-servers')
+        .patch(
+          harness.server.mcp_server_id,
+          { display_name: 'must-not-commit' },
+          { ...paramsFor(harness), provider: 'rest' }
+        )
+    ).rejects.toThrow('REST authentication rejected before MCP mutation');
+    await expect(
+      new MCPServerRepository(harness.rawDb).findById(harness.server.mcp_server_id)
+    ).resolves.not.toMatchObject({ display_name: 'must-not-commit' });
+  });
+
+  it('deletes incompatible durable grants when OAuth subject mode changes', async () => {
+    const provider = await createTestProvider();
+    providers.push(provider);
+    const harness = await createHarness(provider, 'per_user');
+    databases.push(harness.rawDb);
+    await authorizeSavedServer(harness);
+
+    const grants = new UserMCPOAuthTokenRepository(harness.rawDb);
+    await expect(
+      grants.getToken(harness.user.user_id as UserID, harness.server.mcp_server_id as MCPServerID)
+    ).resolves.toMatchObject({ oauth_access_token: 'sqlite-access-token' });
+
+    await harness.app
+      .service('mcp-servers')
+      .patch(harness.server.mcp_server_id, { auth: { oauth_mode: 'shared' } }, paramsFor(harness));
+
+    await expect(
+      grants.getToken(harness.user.user_id as UserID, harness.server.mcp_server_id as MCPServerID)
+    ).resolves.toBeNull();
+    await expect(
+      grants.getToken(null, harness.server.mcp_server_id as MCPServerID)
+    ).resolves.toBeNull();
+  });
+
+  it('rolls back the MCP server mutation when SQLite grant cleanup fails', async () => {
+    const provider = await createTestProvider();
+    providers.push(provider);
+    const harness = await createHarness(provider, 'per_user');
+    databases.push(harness.rawDb);
+    await authorizeSavedServer(harness);
+
+    const before = await new MCPServerRepository(harness.rawDb).findById(
+      harness.server.mcp_server_id
+    );
+    const cleanup = vi
+      .spyOn(UserMCPOAuthTokenRepository.prototype, 'deleteAllForServer')
+      .mockRejectedValueOnce(new Error('injected grant cleanup failure'));
+    try {
+      await expect(
+        harness.app
+          .service('mcp-servers')
+          .patch(
+            harness.server.mcp_server_id,
+            { auth: { oauth_mode: 'shared' } },
+            paramsFor(harness)
+          )
+      ).rejects.toThrow('injected grant cleanup failure');
+    } finally {
+      cleanup.mockRestore();
+    }
+
+    await expect(
+      new MCPServerRepository(harness.rawDb).findById(harness.server.mcp_server_id)
+    ).resolves.toMatchObject({
+      config_version: before?.config_version,
+      auth: { oauth_mode: 'per_user' },
+    });
+    await expect(
+      new UserMCPOAuthTokenRepository(harness.rawDb).getToken(
+        harness.user.user_id as UserID,
+        harness.server.mcp_server_id as MCPServerID
+      )
+    ).resolves.toMatchObject({ oauth_access_token: 'sqlite-access-token' });
+  });
+
+  it('keeps a local pending flow usable when the SQLite mutation rolls back', async () => {
+    const provider = await createTestProvider();
+    providers.push(provider);
+    const harness = await createHarness(provider, 'per_user');
+    databases.push(harness.rawDb);
+    const started = (await harness.app
+      .service('mcp-servers/oauth-start')
+      .create({ mcp_server_id: harness.server.mcp_server_id }, paramsFor(harness))) as {
+      success: boolean;
+      authorizationUrl: string;
+      attempt_id: string;
+    };
+    const state = new URL(started.authorizationUrl).searchParams.get('state');
+    expect(started.success).toBe(true);
+    expect(state).toBeTruthy();
+
+    const cleanup = vi
+      .spyOn(UserMCPOAuthTokenRepository.prototype, 'deleteAllForServer')
+      .mockRejectedValueOnce(new Error('injected local-flow rollback'));
+    try {
+      await expect(
+        harness.app
+          .service('mcp-servers')
+          .patch(
+            harness.server.mcp_server_id,
+            { auth: { oauth_mode: 'shared' } },
+            paramsFor(harness)
+          )
+      ).rejects.toThrow('injected local-flow rollback');
+    } finally {
+      cleanup.mockRestore();
+    }
+
+    await expect(
+      harness.app
+        .service('mcp-servers/oauth-attempt-status')
+        .get(started.attempt_id, paramsFor(harness))
+    ).resolves.toMatchObject({ status: 'pending' });
+    await expect(harness.callback(state!)).resolves.toMatchObject({ status: 200 });
+    await expect(
+      new MCPServerRepository(harness.rawDb).findById(harness.server.mcp_server_id)
+    ).resolves.toMatchObject({ auth: { oauth_mode: 'per_user' } });
+  });
+
+  it('uses the canonical ID for a short-ID mutation with a real grant and local pending flow', async () => {
+    const provider = await createTestProvider();
+    providers.push(provider);
+    const harness = await createHarness(provider, 'per_user');
+    databases.push(harness.rawDb);
+    await authorizeSavedServer(harness);
+    const started = (await harness.app
+      .service('mcp-servers/oauth-start')
+      .create({ mcp_server_id: harness.server.mcp_server_id }, paramsFor(harness))) as {
+      authorizationUrl: string;
+      attempt_id: string;
+    };
+    const state = new URL(started.authorizationUrl).searchParams.get('state');
+    expect(state).toBeTruthy();
+
+    const updated = await harness.app
+      .service('mcp-servers')
+      .patch(
+        shortId(harness.server.mcp_server_id),
+        { auth: { oauth_scope: 'canonical-short-id' } },
+        paramsFor(harness)
+      );
+    expect(updated).toMatchObject({
+      mcp_server_id: harness.server.mcp_server_id,
+      auth: { oauth_scope: 'canonical-short-id' },
+    });
+    await expect(
+      new UserMCPOAuthTokenRepository(harness.rawDb).getToken(
+        harness.user.user_id as UserID,
+        harness.server.mcp_server_id as MCPServerID
+      )
+    ).resolves.toBeNull();
+    await expect(
+      harness.app
+        .service('mcp-servers/oauth-attempt-status')
+        .get(started.attempt_id, paramsFor(harness))
+    ).resolves.toMatchObject({
+      status: 'failed',
+      failure_code: 'server_configuration_changed',
+      recovery: expect.objectContaining({ category: 'configuration_changed' }),
+    });
+    await expect(harness.callback(state!)).resolves.toMatchObject({ status: 400 });
+  });
+
+  it('rolls back the MCP server mutation when durable pending-flow cleanup fails', async () => {
+    const provider = await createTestProvider();
+    providers.push(provider);
+    const invalidateForServer = vi.fn(async () => {
+      throw new Error('injected pending-flow cleanup failure');
+    });
+    const harness = await createHarness(provider, 'per_user', {
+      durableAuthority: {
+        invalidateForServer,
+        maintain: vi.fn(),
+      } as unknown as NonNullable<RegisterServicesContext['mcpOAuthPendingFlowAuthority']>,
+      lockGrantConfiguration: vi.fn(async () => undefined),
+    });
+    databases.push(harness.rawDb);
+    const before = await new MCPServerRepository(harness.rawDb).findById(
+      harness.server.mcp_server_id
+    );
+
+    await expect(
+      harness.app
+        .service('mcp-servers')
+        .patch(harness.server.mcp_server_id, { auth: { oauth_mode: 'shared' } }, paramsFor(harness))
+    ).rejects.toThrow('injected pending-flow cleanup failure');
+
+    expect(invalidateForServer).toHaveBeenCalledWith('default', harness.server.mcp_server_id);
+    await expect(
+      new MCPServerRepository(harness.rawDb).findById(harness.server.mcp_server_id)
+    ).resolves.toMatchObject({
+      config_version: before?.config_version,
+      auth: { oauth_mode: 'per_user' },
+    });
+  });
+
+  it('serializes literal-memory readers across config and grant cleanup', async () => {
+    const provider = await createTestProvider();
+    providers.push(provider);
+    const harness = await createHarness(provider, 'per_user');
+    databases.push(harness.rawDb);
+    await authorizeSavedServer(harness);
+
+    const cleanupStarted = deferred<void>();
+    const releaseCleanup = deferred<void>();
+    const originalDeleteAllForServer = UserMCPOAuthTokenRepository.prototype.deleteAllForServer;
+    const cleanup = vi
+      .spyOn(UserMCPOAuthTokenRepository.prototype, 'deleteAllForServer')
+      .mockImplementationOnce(async function (...args) {
+        cleanupStarted.resolve();
+        await releaseCleanup.promise;
+        return originalDeleteAllForServer.apply(this, args);
+      });
+    try {
+      const mutation = harness.app
+        .service('mcp-servers')
+        .patch(
+          harness.server.mcp_server_id,
+          { auth: { oauth_mode: 'shared' } },
+          paramsFor(harness)
+        );
+      await cleanupStarted.promise;
+
+      let readerFinished = false;
+      const observation = Promise.all([
+        new MCPServerRepository(harness.rawDb).findById(harness.server.mcp_server_id),
+        new UserMCPOAuthTokenRepository(harness.rawDb).getToken(
+          harness.user.user_id as UserID,
+          harness.server.mcp_server_id as MCPServerID
+        ),
+      ]).finally(() => {
+        readerFinished = true;
+      });
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(readerFinished).toBe(false);
+
+      releaseCleanup.resolve();
+      await mutation;
+      const [server, grant] = await observation;
+      expect(server?.auth).toMatchObject({ oauth_mode: 'shared' });
+      expect(grant).toBeNull();
+    } finally {
+      releaseCleanup.resolve();
+      cleanup.mockRestore();
+    }
+  });
+
   it('does not dispatch test-jwt caller secrets when socket authority changes during DNS', async () => {
     const provider = await createTestProvider();
     providers.push(provider);
@@ -1186,6 +1520,55 @@ describe('SQLite saved-row OAuth authority', () => {
     await expect(request).rejects.toThrow(/authority/i);
     expect(provider.requests).toEqual([]);
     expect(harness.emittedBrowserEvents).toEqual([]);
+  });
+
+  it('returns only closed OAuth start/discovery recovery for hostile network proxies', async () => {
+    const provider = await createTestProvider();
+    providers.push(provider);
+    const sentinel = 'SENTINEL_OAUTH_HOSTILE_PROXY_219f';
+    const getter = vi.fn(() => {
+      throw new Error(sentinel);
+    });
+    const hostile = new Proxy(new Error(sentinel), {
+      getPrototypeOf() {
+        throw new Error(sentinel);
+      },
+      getOwnPropertyDescriptor(target, property) {
+        if (property === 'name' || property === 'code') {
+          return { configurable: true, get: getter };
+        }
+        return Reflect.getOwnPropertyDescriptor(target, property);
+      },
+    });
+    const harness = await createHarness(provider, undefined, {
+      outboundDnsLookup: async () => {
+        throw hostile;
+      },
+    });
+    databases.push(harness.rawDb);
+    await new MCPServerRepository(harness.rawDb).update(harness.server.mcp_server_id, {
+      url: provider.savedMcpUrl.replace('127.0.0.1', 'localhost'),
+    });
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    try {
+      const oauthStart = await harness.app
+        .service('mcp-servers/oauth-start')
+        .create({ mcp_server_id: harness.server.mcp_server_id }, paramsFor(harness));
+      mcpClientTestState.connectError = hostile;
+      const discovery = await harness.app
+        .service('mcp-servers/discover')
+        .create({ mcp_server_id: harness.server.mcp_server_id }, paramsFor(harness));
+
+      expect(oauthStart).toMatchObject({ success: false, recovery: { category: 'unknown' } });
+      expect(discovery).toMatchObject({ success: false, category: 'unknown' });
+      expect(JSON.stringify({ oauthStart, discovery, logs: errorSpy.mock.calls })).not.toContain(
+        sentinel
+      );
+      expect(getter).not.toHaveBeenCalled();
+      expect(provider.requests).toEqual([]);
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   it('abandons oauth-start when its authoritative saved-row read finishes under B', async () => {
@@ -1325,14 +1708,20 @@ describe('SQLite saved-row OAuth authority', () => {
         authorizationUrl?: string;
         attempt_id?: string;
         redirect_uri?: string;
-        diagnostic?: { stage?: string; http_status?: number };
+        diagnostic?: unknown;
+        recovery?: { category?: string; action?: string; redirect_uri?: string };
       };
 
       expect(result).toMatchObject({
         success: false,
         redirect_uri: 'https://agor.example.test/mcp-servers/oauth-callback',
-        diagnostic: { stage: 'dcr_registration', http_status: 418 },
+        recovery: {
+          category: 'client_registration_failed',
+          action: 'configure_client',
+          redirect_uri: 'https://agor.example.test/mcp-servers/oauth-callback',
+        },
       });
+      expect(result.diagnostic).toBeUndefined();
       expect(result.authorizationUrl).toBeUndefined();
       expect(result.attempt_id).toBeUndefined();
       expect(policyLog).toHaveBeenCalledWith(
@@ -1568,7 +1957,10 @@ describe('SQLite saved-row OAuth authority', () => {
         },
         paramsFor(harness)
       )
-    ).resolves.toMatchObject({ success: false, error: expect.stringMatching(/operation/i) });
+    ).resolves.toMatchObject({
+      success: false,
+      error: expect.stringMatching(/authority|reservation/i),
+    });
     expect(provider.requests).toHaveLength(before);
 
     // Mismatch consumed the nonce. Neither the original caller nor a replay on
@@ -2157,9 +2549,14 @@ describe('SQLite saved-row OAuth authority', () => {
     // credential-peer matching. Mutating it therefore isolates the assertion:
     // only hydration's current binding check can remove the credential that
     // would otherwise make connect reuse this row.
-    await new MCPServerRepository(harness.rawDb).update(harness.server.mcp_server_id, {
-      catalog_entry_name: 'drifted/catalog-stamp',
-    });
+    // Simulate historical/on-disk drift below the now-closed repository and
+    // import contracts. Public and trusted writes can no longer create this
+    // inconsistent provenance combination, but grant hydration must remain
+    // fail-closed if an older database already contains it.
+    await update(harness.rawDb, mcpServers)
+      .set({ catalog_entry_name: 'drifted/catalog-stamp' })
+      .where(eq(mcpServers.mcp_server_id, harness.server.mcp_server_id))
+      .run();
 
     const entry = {
       name: 'test/sqlite-current-binding',

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -14,7 +14,6 @@ import {
   type AgorConfig,
   isDeploymentAgenticToolAvailable,
   MESSAGE_PAGINATION,
-  PublicBaseUrlNotConfiguredError,
   type ResolvedDeploymentConfig,
   requirePublicBaseUrl,
   resolveDeploymentAgenticToolPolicy,
@@ -22,10 +21,13 @@ import {
   resolveMultiTenancyConfig,
 } from '@agor/core/config';
 import {
+  AmbiguousIdError,
   and,
   BoardRepository,
   BranchRepository,
   DiscordMessageDeliveryRepository,
+  EntityNotFoundError,
+  enqueueAfterTenantDatabaseCommit,
   eq,
   GatewayChannelRepository,
   generateId,
@@ -57,11 +59,16 @@ import {
 } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import { BadRequest, Conflict, Forbidden, NotAuthenticated } from '@agor/core/feathers';
+import {
+  hasTemplateMarker,
+  type MCPExternalErrorStage,
+  sanitizeMCPExternalError,
+} from '@agor/core/mcp';
 import type {
   OAuthFlowContext,
   OAuthTokenResponse,
 } from '@agor/core/tools/mcp/oauth-mcp-transport';
-import { OAuthDCRFailure } from '@agor/core/tools/mcp/oauth-mcp-transport';
+import { OAuthConfigurationError } from '@agor/core/tools/mcp/oauth-mcp-transport';
 import type { RefreshAndPersistDeps } from '@agor/core/tools/mcp/oauth-refresh';
 import type {
   AuthenticatedParams,
@@ -116,7 +123,11 @@ import {
   type OpenCodeNativeStateMutationFence,
 } from './integrations/opencode/native-state-coordinator.js';
 import { getDaemonMetrics } from './metrics/index.js';
-import { runInOAuthTenantScope, runInOAuthTenantWriteScope } from './oauth-auth-helpers.js';
+import {
+  runInOAuthTenantScope,
+  runInOAuthTenantWriteScope,
+  runInOAuthTenantWriteTransaction,
+} from './oauth-auth-helpers.js';
 import { persistOAuthToken } from './oauth-cache.js';
 import {
   emitHaNativeSocketEvent,
@@ -181,6 +192,10 @@ import { createKnowledgeSearchService } from './services/knowledge-search.js';
 import { createKnowledgeSettingsService } from './services/knowledge-settings.js';
 import { createKnowledgeVersionsService } from './services/knowledge-versions.js';
 import { createLeaderboardService } from './services/leaderboard.js';
+import {
+  classifyMCPAuthRecovery,
+  recoveryForOAuthAttemptFailure,
+} from './services/mcp-auth-recovery.js';
 import { createMCPCatalogService } from './services/mcp-catalog.js';
 import { MCPCatalogReadinessService } from './services/mcp-catalog-readiness.js';
 import { MCPMarketplaceService } from './services/mcp-marketplace.js';
@@ -210,7 +225,10 @@ import {
 } from './services/mcp-oauth-grant-binding.js';
 import { MCPOAuthPendingFlowAuthority } from './services/mcp-oauth-pending-flow-authority.js';
 import { resolveAuthenticatedServerIds } from './services/mcp-oauth-status.js';
-import { createMCPServersService } from './services/mcp-servers.js';
+import {
+  createMCPServersService,
+  runWithMCPServerMutationDatabase,
+} from './services/mcp-servers.js';
 import { createMessagesService, MESSAGES_SERVICE_TRANSPORT_METHODS } from './services/messages.js';
 import { performOAuthDisconnect } from './services/oauth-disconnect.js';
 import { createReposService } from './services/repos.js';
@@ -1492,6 +1510,14 @@ export async function registerMCPServices(
     (postgresOAuthDeployment ? new MCPOAuthPendingFlowAuthority(db) : null);
   const lockOAuthGrantConfiguration =
     ctx.lockMcpOAuthGrantConfiguration ?? lockMCPOAuthGrantConfiguration;
+  const externalFailure = (event: string, stage: MCPExternalErrorStage, error: unknown) => {
+    const safe = sanitizeMCPExternalError(error, { stage });
+    const { type, code } = safe.diagnostic;
+    console.error(
+      `[${event}] event=mcp_external_failure stage=${stage} category=${safe.category} type=${type}${code ? ` code=${code}` : ''}`
+    );
+    return safe;
+  };
   const oauthFetch = async (
     input: string | URL | Request,
     init: RequestInit = {},
@@ -3001,9 +3027,7 @@ export async function registerMCPServices(
         return;
       }
     } catch (err) {
-      console.error(
-        `[OAuth Callback] Failed category=${err instanceof Error ? err.name : 'unknown'}`
-      );
+      externalFailure('OAuth Callback', 'oauth_callback', err);
       sendOAuthResultPage(
         res,
         false,
@@ -3114,29 +3138,61 @@ export async function registerMCPServices(
   // `registerMCPServices` is also exercised without a realtime transport in
   // service-only harnesses; there is nothing to publish in that shape.
   app.service('mcp-servers/oauth-browser-reservations').publish?.(() => []);
-  const invalidateOAuthGrantsAfterServerChange = async (
-    context: HookContext,
-    next: () => Promise<void>
-  ) => {
+  const coordinateMCPServerMutation = async (context: HookContext, next: () => Promise<void>) => {
+    // Service-level around hooks wrap the normal before-hook chain. Over REST,
+    // params.user/tenant do not exist until requireAuth runs, while Socket.io
+    // often arrives pre-populated. Authenticate explicitly before this hook
+    // reads tenant identity or opens the grant/config transaction; the regular
+    // before hook remains defense in depth and is harmlessly idempotent.
+    if (context.params.provider) await ctx.requireAuth(context);
     const tenantId = tenantIdFromParams(context.params as AuthenticatedParams);
-    const serverId = String(context.id ?? '');
-    await runInOAuthTenantWriteScope(db, tenantId, async () => {
-      if (durableOAuthFlows && tenantId && serverId) {
-        await lockOAuthGrantConfiguration(db, tenantId, serverId as MCPServerID);
+    const requestedServerId = String(context.id ?? '');
+    await runInOAuthTenantWriteTransaction(db, tenantId, async (scopedDb) => {
+      const repository = new MCPServerRepository(scopedDb);
+      let serverId: MCPServerID;
+      try {
+        serverId = await repository.resolveCanonicalId(requestedServerId);
+      } catch (error) {
+        if (!(error instanceof EntityNotFoundError) && !(error instanceof AmbiguousIdError)) {
+          throw error;
+        }
+        // Preserve the service's normal not-found/ambiguous-ID error mapping.
+        await next();
+        return;
       }
-      const before = serverId ? await new MCPServerRepository(db).findById(serverId) : null;
-      await next();
-      const after = serverId ? await new MCPServerRepository(db).findById(serverId) : null;
-      if (!hasMCPOAuthRelevantServerConfigurationChanged(before, after)) return;
-      await new UserMCPOAuthTokenRepository(db).deleteAllForServer(serverId as MCPServerID);
+      // Around hooks run before the ordinary authorization hooks. Rewriting to
+      // the canonical ID makes authorization, the repository write, advisory
+      // locking, snapshots, grants, and pending-flow cleanup use one identity.
+      context.id = serverId;
       if (durableOAuthFlows && tenantId) {
-        await durableOAuthFlows.invalidateForServer(tenantId, serverId as MCPServerID);
+        await lockOAuthGrantConfiguration(scopedDb, tenantId, serverId);
+      }
+      const before = await repository.findById(serverId);
+      await runWithMCPServerMutationDatabase(scopedDb, next);
+      const after = await repository.findById(serverId);
+      if (!hasMCPOAuthRelevantServerConfigurationChanged(before, after)) return;
+      await new UserMCPOAuthTokenRepository(scopedDb).deleteAllForServer(serverId);
+      if (durableOAuthFlows && tenantId) {
+        await durableOAuthFlows.invalidateForServer(tenantId, serverId);
       } else {
-        for (const [state, flow] of pendingOAuthFlows) {
-          if (flow.mcpServerId !== serverId) continue;
-          pendingOAuthFlows.delete(state);
-          markLocalOAuthAttempt(flow, 'failed', 'server_configuration_changed');
-          flow.tokenReject?.(new Error('MCP OAuth server configuration changed'));
+        const affectedLocalFlows = [...pendingOAuthFlows].filter(
+          ([, flow]) => flow.mcpServerId === serverId
+        );
+        // SQLite pending flows live in memory and therefore cannot join the DB
+        // transaction. Stage their destructive notification after commit so a
+        // failed config/grant transaction leaves them intact. A callback that
+        // races the tiny commit-to-callback interval still revalidates its
+        // saved-server fingerprint before token exchange/persistence.
+        const queued = enqueueAfterTenantDatabaseCommit(() => {
+          for (const [state, flow] of affectedLocalFlows) {
+            if (pendingOAuthFlows.get(state) !== flow) continue;
+            pendingOAuthFlows.delete(state);
+            markLocalOAuthAttempt(flow, 'failed', 'server_configuration_changed');
+            flow.tokenReject?.(new Error('MCP OAuth server configuration changed'));
+          }
+        });
+        if (!queued) {
+          throw new Error('MCP OAuth mutation did not own an atomic database transaction');
         }
       }
       console.log('[MCP OAuth Grant] grants_invalidated category=server_configuration_changed');
@@ -3144,8 +3200,8 @@ export async function registerMCPServices(
   };
   app.service('mcp-servers').hooks({
     around: {
-      patch: [invalidateOAuthGrantsAfterServerChange],
-      update: [invalidateOAuthGrantsAfterServerChange],
+      patch: [coordinateMCPServerMutation],
+      update: [coordinateMCPServerMutation],
     },
   });
 
@@ -3238,7 +3294,8 @@ export async function registerMCPServices(
         // particular, never downgrade a stale A request to a normal failure
         // response that B's mounted UI could consume.
         assertRequestAuthority?.();
-        return { success: false, error: error instanceof Error ? error.message : String(error) };
+        const safe = externalFailure('MCP JWT Test', 'jwt', error);
+        return { success: false, error: safe.message, category: safe.category };
       }
     },
   });
@@ -3304,10 +3361,7 @@ export async function registerMCPServices(
       // Do not downgrade an authority/deadline failure into "no fallback
       // challenge" and continue the browser flow.
       assertCurrent?.();
-      console.log(
-        '[OAuth Probe] Read-only tool-call fallback probe failed:',
-        probeError instanceof Error ? probeError.message : String(probeError)
-      );
+      externalFailure('OAuth Probe', 'discovery', probeError);
       return null;
     }
   }
@@ -3437,10 +3491,8 @@ export async function registerMCPServices(
           );
         } catch (fetchError) {
           assertInitialRequestAuthority?.();
-          return {
-            success: false,
-            error: `Failed to connect to MCP server: ${fetchError instanceof Error ? fetchError.message : String(fetchError)}`,
-          };
+          const safe = externalFailure('OAuth Test', 'discovery', fetchError);
+          return { success: false, error: safe.message, category: safe.category };
         }
 
         if (probeResponse.status !== 401) {
@@ -3458,10 +3510,6 @@ export async function registerMCPServices(
         }
 
         const wwwAuthenticate = probeResponse.headers.get('www-authenticate');
-        const allHeaders: Record<string, string> = {};
-        probeResponse.headers.forEach((value, key) => {
-          allHeaders[key] = value;
-        });
         console.log(`[OAuth Test] Probe response status=${probeResponse.status}`);
 
         let metadataUrl: string | null = null;
@@ -3529,8 +3577,14 @@ export async function registerMCPServices(
                   dcrMode: effectiveDcrMode,
                 });
               } catch (err) {
-                if (err instanceof PublicBaseUrlNotConfiguredError) {
-                  return { success: false, error: err.message, oauthType: 'oauth2.1' };
+                const recovery = classifyMCPAuthRecovery(err);
+                if (recovery.category === 'redirect_configuration_required') {
+                  return {
+                    success: false,
+                    error: recovery.message,
+                    recovery,
+                    oauthType: 'oauth2.1',
+                  };
                 }
                 throw err;
               }
@@ -3568,17 +3622,18 @@ export async function registerMCPServices(
                 message: 'OAuth 2.1 authentication successful!',
                 tokenValid: true,
                 mcpStatus: testResponse.status,
-                mcpStatusText: testResponse.statusText,
               };
             } catch (flowError) {
-              console.error(
-                `[OAuth Test] Browser flow failed category=${
-                  flowError instanceof Error ? flowError.name : 'unknown'
-                }`
-              );
+              const recovery = classifyMCPAuthRecovery(flowError, {
+                mcpServerId: data.mcp_server_id,
+              });
+              // Recovery must be fully derived before the external sanitizer;
+              // no post-sanitization branch may inspect the original unknown.
+              externalFailure('OAuth Test', 'oauth', flowError);
               return {
                 success: false,
-                error: `OAuth 2.1 browser flow failed: ${flowError instanceof Error ? flowError.message : String(flowError)}`,
+                error: recovery.message,
+                recovery,
                 oauthType: 'oauth2.1',
               };
             }
@@ -3684,11 +3739,12 @@ export async function registerMCPServices(
               requiresBrowserFlow: true,
             };
           } catch (metadataError) {
+            const safe = externalFailure('OAuth Test', 'oauth_metadata', metadataError);
             return {
               success: false,
-              error: `Failed to fetch OAuth metadata: ${metadataError instanceof Error ? metadataError.message : String(metadataError)}`,
+              error: safe.message,
+              category: safe.category,
               oauthType: 'oauth2.1',
-              metadataUrl: metadataUrl ?? undefined,
             };
           }
         }
@@ -3703,13 +3759,6 @@ export async function registerMCPServices(
         }
 
         if (probeResponse.status === 401) {
-          let responseBody = '';
-          try {
-            responseBody = await probeResponse.text();
-          } catch {
-            /* Ignore */
-          }
-
           if (effectiveClientId && effectiveClientSecret) {
             console.log('[OAuth Test] Using Client Credentials flow');
             const { fetchOAuthToken, inferOAuthTokenUrl } = await import(
@@ -3727,7 +3776,7 @@ export async function registerMCPServices(
                   oauthType: 'client_credentials',
                 };
             }
-            const { token, debugInfo } = await fetchOAuthToken(
+            const { token } = await fetchOAuthToken(
               {
                 token_url: tokenUrl,
                 client_id: effectiveClientId,
@@ -3762,10 +3811,9 @@ export async function registerMCPServices(
                 assertInitialRequestAuthority
               );
               mcpStatus = mcpResponse.status;
-              mcpStatusText = mcpResponse.statusText;
             } catch (mcpError) {
               assertInitialRequestAuthority?.();
-              mcpStatusText = mcpError instanceof Error ? mcpError.message : 'Connection failed';
+              mcpStatusText = externalFailure('OAuth Test', 'runtime', mcpError).message;
             }
             return {
               success: true,
@@ -3774,7 +3822,6 @@ export async function registerMCPServices(
               tokenUrlSource,
               mcpStatus,
               mcpStatusText,
-              debugInfo,
             };
           }
 
@@ -3784,9 +3831,6 @@ export async function registerMCPServices(
               'Server requires authentication (401) but OAuth 2.1 auto-discovery failed at every step.',
             oauthType: 'unknown',
             mcpStatus: probeResponse.status,
-            wwwAuthenticate: wwwAuthenticate || '<not present>',
-            responseHeaders: allHeaders,
-            responseBody: responseBody.substring(0, 500),
             hint:
               `${DISCOVERY_CASCADE_TRIED} ` +
               'None returned valid metadata. Options: (a) provide Client Credentials with explicit token URL, ' +
@@ -3796,11 +3840,26 @@ export async function registerMCPServices(
 
         return {
           success: false,
-          error: `MCP server returned ${probeResponse.status} ${probeResponse.statusText}`,
+          error: `MCP server returned status ${probeResponse.status}.`,
           mcpStatus: probeResponse.status,
         };
       } catch (error) {
-        return { success: false, error: error instanceof Error ? error.message : String(error) };
+        const recovery = classifyMCPAuthRecovery(error, {
+          mcpServerId: data.mcp_server_id,
+        });
+        if (
+          recovery.category === 'authentication_required' ||
+          recovery.category === 'permission_changed' ||
+          recovery.category === 'configuration_changed'
+        ) {
+          return {
+            success: false,
+            error: recovery.message,
+            recovery,
+          };
+        }
+        const safe = externalFailure('OAuth Test', 'oauth', error);
+        return { success: false, error: safe.message, category: safe.category };
       }
     },
   });
@@ -3843,10 +3902,17 @@ export async function registerMCPServices(
           savedServerId &&
           (!savedServer?.enabled || !savedServer.url || savedServer.auth?.type !== 'oauth')
         ) {
+          const recovery = {
+            category: 'configuration_changed' as const,
+            action: 'save_and_retry' as const,
+            message:
+              'OAuth requires an enabled, saved MCP server in the current tenant. Save changes, then restart OAuth.',
+            ...(savedServerId ? { mcp_server_id: savedServerId as MCPServerID } : {}),
+          };
           return {
             success: false,
-            error:
-              'OAuth requires an enabled, saved MCP server in the current tenant. Save changes, then restart OAuth.',
+            error: recovery.message,
+            recovery,
           } satisfies MCPOAuthStartFailure;
         }
 
@@ -3855,9 +3921,14 @@ export async function registerMCPServices(
         // fields remain accepted only for older callers.
         const effectiveMcpUrl = savedServer?.url ?? data.mcp_url;
         if (!effectiveMcpUrl) {
+          const recovery = classifyMCPAuthRecovery(
+            new OAuthConfigurationError('metadata_unavailable'),
+            { mcpServerId: savedServerId }
+          );
           return {
             success: false,
-            error: 'OAuth requires a saved MCP server URL. Save changes, then restart OAuth.',
+            error: recovery.message,
+            recovery,
           } satisfies MCPOAuthStartFailure;
         }
 
@@ -3871,10 +3942,17 @@ export async function registerMCPServices(
             savedServer.url !== effectiveMcpUrl ||
             savedServer.auth?.type !== 'oauth')
         ) {
+          const recovery = {
+            category: 'configuration_changed' as const,
+            action: 'save_and_retry' as const,
+            message:
+              'The saved MCP server changed before OAuth could start. Reload it, save the intended configuration, then retry.',
+            ...(savedServerId ? { mcp_server_id: savedServerId as MCPServerID } : {}),
+          };
           return {
             success: false,
-            error:
-              'PostgreSQL OAuth requires an enabled, saved MCP server matching this request. Save changes, then restart OAuth.',
+            error: recovery.message,
+            recovery,
           } satisfies MCPOAuthStartFailure;
         }
 
@@ -3935,9 +4013,17 @@ export async function registerMCPServices(
         }
 
         if (probeResponse.status !== 401) {
+          const recovery = {
+            category: 'configuration_changed' as const,
+            action: 'save_and_retry' as const,
+            message:
+              'This MCP server did not request OAuth authentication. Verify the saved MCP URL and authentication type, then retry.',
+            ...(savedServerId ? { mcp_server_id: savedServerId as MCPServerID } : {}),
+          };
           return {
             success: false,
-            error: 'Server did not return 401 — OAuth 2.1 authentication may not be required',
+            error: recovery.message,
+            recovery,
           } satisfies MCPOAuthStartFailure;
         }
 
@@ -3954,9 +4040,16 @@ export async function registerMCPServices(
           })
         );
         if (!discovery) {
+          const recovery = classifyMCPAuthRecovery(
+            new OAuthConfigurationError('metadata_unavailable'),
+            {
+              mcpServerId: savedServerId,
+            }
+          );
           return {
             success: false,
-            error: `Server returned 401 but does not advertise OAuth metadata. ${DISCOVERY_CASCADE_TRIED} None succeeded.`,
+            error: recovery.message,
+            recovery,
           } satisfies MCPOAuthStartFailure;
         }
 
@@ -3986,11 +4079,15 @@ export async function registerMCPServices(
             requestAuthority: assertRequestAuthority,
           });
         } catch (err) {
-          if (err instanceof PublicBaseUrlNotConfiguredError) {
-            console.error('[OAuth Start]', err.message);
+          const recovery = classifyMCPAuthRecovery(err, {
+            mcpServerId: data.mcp_server_id,
+          });
+          if (recovery.category === 'redirect_configuration_required') {
+            console.error('[OAuth Start] Failed category=PublicBaseUrlNotConfiguredError');
             return {
               success: false,
-              error: err.message,
+              error: recovery.message,
+              recovery,
             } satisfies MCPOAuthStartFailure;
           }
           throw err;
@@ -4010,12 +4107,14 @@ export async function registerMCPServices(
         // provider diagnostic; callers may otherwise continue an obsolete
         // flow under the replacement identity on the same socket.
         assertRequestAuthority?.();
-        console.error(
-          `[OAuth Start] Failed category=${error instanceof Error ? error.name : 'unknown'}`
-        );
-        const diagnostic = error instanceof OAuthDCRFailure ? error.diagnostic : undefined;
+        const preliminaryRecovery = classifyMCPAuthRecovery(error, {
+          mcpServerId: data.mcp_server_id,
+        });
         let redirectUri: string | null = null;
-        if (diagnostic) {
+        if (
+          preliminaryRecovery.category === 'client_registration_required' ||
+          preliminaryRecovery.category === 'client_registration_failed'
+        ) {
           try {
             redirectUri = await runWithinOAuthAuthority(
               assertRequestAuthority,
@@ -4026,10 +4125,19 @@ export async function registerMCPServices(
           }
         }
         assertRequestAuthority?.();
+        const recovery = redirectUri
+          ? classifyMCPAuthRecovery(error, {
+              mcpServerId: data.mcp_server_id,
+              redirectUri,
+            })
+          : preliminaryRecovery;
+        // This is deliberately the final consumer of the original unknown.
+        // Response construction below uses only the closed recovery contract.
+        externalFailure('OAuth Start', 'oauth', error);
         return {
           success: false,
-          error: error instanceof Error ? error.message : String(error),
-          ...(diagnostic ? { diagnostic } : {}),
+          error: recovery.message,
+          recovery,
           ...(redirectUri ? { redirect_uri: redirectUri } : {}),
         } satisfies MCPOAuthStartFailure;
       }
@@ -4039,6 +4147,22 @@ export async function registerMCPServices(
   app.service('mcp-servers/oauth-start').hooks({ before: { create: [ctx.requireAuth] } });
 
   // OAuth complete endpoint
+  const oauthCompletionFailure = (
+    failureCode: string,
+    mcpServerId?: string,
+    messageOverride?: string
+  ) => {
+    const recovery = recoveryForOAuthAttemptFailure(failureCode, mcpServerId);
+    return {
+      success: false as const,
+      error:
+        messageOverride ??
+        recovery?.message ??
+        'OAuth completion could not be validated. Reconnect this MCP server and try again.',
+      tokenObtained: false,
+      ...(recovery ? { recovery } : {}),
+    };
+  };
   app.use('/mcp-servers/oauth-complete', {
     async create(
       data: { callback_url: string } | { code: string; state: string; iss?: string },
@@ -4046,6 +4170,7 @@ export async function registerMCPServices(
     ) {
       let pendingFlow: PendingOAuthFlow | undefined;
       let completionStatus: 'failed' | 'ambiguous' | undefined;
+      let completionFailureCode: string | undefined;
       try {
         const { completeMCPOAuthFlow, parseOAuthCallback } = await import(
           '@agor/core/tools/mcp/oauth-mcp-transport'
@@ -4072,45 +4197,40 @@ export async function registerMCPServices(
           }
           const claimed = await durableOAuthFlows.claimForUser(activeTenantId, activeUserId, state);
           if (claimed.outcome === 'not_claimed') {
-            return {
-              success: claimed.flow?.status === 'succeeded',
-              error:
-                claimed.flow?.status === 'succeeded'
-                  ? undefined
-                  : terminalMessageForStatus(claimed.flow?.status ?? 'expired'),
-              tokenObtained: claimed.flow?.status === 'succeeded',
-            };
+            if (claimed.flow?.status === 'succeeded') {
+              return { success: true, tokenObtained: true };
+            }
+            return oauthCompletionFailure(
+              claimed.flow?.failureCode ?? 'authorization_failed',
+              claimed.flow?.mcpServerId
+            );
           }
           pendingFlow = pendingFromDurableClaim(durableOAuthFlows.openClaim(claimed.flow, state));
         } else {
           pendingFlow = pendingOAuthFlows.get(state);
           if (!pendingFlow) {
-            return {
-              success: false,
-              error: 'OAuth flow expired or not found. Please start the flow again.',
-            };
+            return oauthCompletionFailure('authorization_timed_out');
           }
           if (pendingFlow.tenantId && activeTenantId && pendingFlow.tenantId !== activeTenantId) {
-            return {
-              success: false,
-              error: 'OAuth flow belongs to a different tenant. Please restart the OAuth flow.',
-            };
+            return oauthCompletionFailure(
+              'authorization_failed',
+              undefined,
+              'OAuth flow belongs to a different tenant. Please restart the OAuth flow.'
+            );
           }
           if (pendingFlow.userId && activeUserId && pendingFlow.userId !== activeUserId) {
-            return {
-              success: false,
-              error: 'OAuth flow belongs to a different user. Please restart the OAuth flow.',
-            };
+            return oauthCompletionFailure(
+              'permission_changed',
+              pendingFlow.mcpServerId,
+              'OAuth flow belongs to a different user. Please restart the OAuth flow.'
+            );
           }
           pendingOAuthFlows.delete(state);
           // Same age check the callback applies — see `isLocalOAuthFlowExpired`.
           if (isLocalOAuthFlowExpired(pendingFlow)) {
             markLocalOAuthAttempt(pendingFlow, 'expired', 'authorization_timed_out');
             pendingFlow.tokenReject?.(new Error('OAuth flow expired before callback was received'));
-            return {
-              success: false,
-              error: 'OAuth flow expired or not found. Please start the flow again.',
-            };
+            return oauthCompletionFailure('authorization_timed_out', pendingFlow.mcpServerId);
           }
           markLocalOAuthAttempt(pendingFlow, 'exchanging');
         }
@@ -4128,6 +4248,7 @@ export async function registerMCPServices(
         if (pendingFlow) {
           const classification = classifyMCPOAuthCompletionFailure(error);
           const { ambiguous, failureCode } = classification;
+          completionFailureCode = failureCode;
           completionStatus = classification.status;
           if (pendingFlow.durableRecord) {
             try {
@@ -4149,14 +4270,19 @@ export async function registerMCPServices(
             )
           );
         }
-        console.error(
-          `[OAuth Complete] Failed category=${error instanceof Error ? error.name : 'unknown'}`
+        externalFailure('OAuth Complete', 'oauth_callback', error);
+        const recovery = recoveryForOAuthAttemptFailure(
+          completionFailureCode ?? 'authorization_failed',
+          pendingFlow?.mcpServerId
         );
         return {
           success: false,
-          error: pendingFlow
-            ? terminalMessageForStatus(completionStatus ?? 'failed')
-            : 'OAuth completion could not be validated. Start a new OAuth flow.',
+          error:
+            recovery?.message ??
+            (pendingFlow
+              ? terminalMessageForStatus(completionStatus ?? 'failed')
+              : 'OAuth completion could not be validated. Start a new OAuth flow.'),
+          ...(recovery ? { recovery } : {}),
         };
       }
     },
@@ -4218,11 +4344,7 @@ export async function registerMCPServices(
         });
         return { authenticated_server_ids: authenticatedServerIds };
       } catch (error) {
-        console.error(
-          `[OAuth Status] Token lookup failed category=${
-            error instanceof Error ? error.name : 'unknown'
-          }`
-        );
+        externalFailure('OAuth Status', 'oauth', error);
         return { authenticated_server_ids: [] };
       }
     },
@@ -4243,12 +4365,18 @@ export async function registerMCPServices(
           userId,
           attemptId as MCPOAuthAttemptID
         );
-        if (!attempt) return { status: 'not_found' as const };
+        if (!attempt) {
+          return {
+            status: 'not_found' as const,
+            recovery: recoveryForOAuthAttemptFailure('authorization_failed'),
+          };
+        }
         return {
           status: attempt.status,
           mcp_server_id: attempt.mcpServerId,
           oauth_mode: attempt.oauthMode,
           failure_code: attempt.failureCode ?? undefined,
+          recovery: recoveryForOAuthAttemptFailure(attempt.failureCode, attempt.mcpServerId),
         };
       }
 
@@ -4258,13 +4386,17 @@ export async function registerMCPServices(
         attempt.userId !== userId ||
         (attempt.tenantId && attempt.tenantId !== tenantId)
       ) {
-        return { status: 'not_found' as const };
+        return {
+          status: 'not_found' as const,
+          recovery: recoveryForOAuthAttemptFailure('authorization_failed'),
+        };
       }
       return {
         status: attempt.status,
         mcp_server_id: attempt.mcpServerId,
         oauth_mode: attempt.oauthMode,
         failure_code: attempt.failureCode,
+        recovery: recoveryForOAuthAttemptFailure(attempt.failureCode, attempt.mcpServerId),
       };
     },
   };
@@ -4527,11 +4659,7 @@ export async function registerMCPServices(
 
             headers[serverId] = { authorization: `Bearer ${accessToken}` };
           } catch (err) {
-            console.error(
-              `[OAuth AuthHeaders] request_failed category=${
-                err instanceof Error ? err.name : 'unknown_error'
-              }`
-            );
+            externalFailure('OAuth AuthHeaders', 'oauth', err);
             headers[serverId] = { error: 'unknown_error' };
           }
         })
@@ -4646,31 +4774,32 @@ export async function registerMCPServices(
 
         return { success: true, expires_at: expiresAt };
       } catch (err) {
-        if (
-          err instanceof InvalidGrantError ||
-          err instanceof MissingRefreshTokenError ||
-          err instanceof AmbiguousRefreshError ||
-          err instanceof GrantConfigurationChangedError
-        ) {
-          return { success: false, error: 'needs_reauth' };
+        try {
+          if (
+            err instanceof InvalidGrantError ||
+            err instanceof MissingRefreshTokenError ||
+            err instanceof AmbiguousRefreshError ||
+            err instanceof GrantConfigurationChangedError
+          ) {
+            return { success: false, error: 'needs_reauth' };
+          }
+          // A peer observed a known, non-ambiguous owner failure. Match the
+          // owner's retryable response rather than forcing one daemon's caller
+          // to reconnect for the same refresh generation.
+          if (err instanceof FailedRefreshError) {
+            return { success: false, error: 'token_refresh_failed' };
+          }
+          if (err instanceof MissingTokenEndpointError) {
+            return { success: false, error: 'missing_token_endpoint' };
+          }
+          if (err instanceof MissingClientIdError) {
+            return { success: false, error: 'missing_client_id' };
+          }
+        } catch {
+          // Hostile proxies are not trusted local refresh errors. Continue to
+          // the closed external sanitizer without serializing the original.
         }
-        // A peer observed a known, non-ambiguous owner failure. Match the
-        // owner's retryable response rather than forcing one daemon's caller
-        // to reconnect for the same refresh generation.
-        if (err instanceof FailedRefreshError) {
-          return { success: false, error: 'token_refresh_failed' };
-        }
-        if (err instanceof MissingTokenEndpointError) {
-          return { success: false, error: 'missing_token_endpoint' };
-        }
-        if (err instanceof MissingClientIdError) {
-          return { success: false, error: 'missing_client_id' };
-        }
-        console.error(
-          `[OAuth Refresh] refresh_failed category=${
-            err instanceof Error ? err.name : 'unknown_error'
-          }`
-        );
+        externalFailure('OAuth Refresh', 'oauth', err);
         return {
           success: false,
           error: 'token_refresh_failed',
@@ -4792,7 +4921,7 @@ export async function registerMCPServices(
         // like `{{ user.env.MCP_URL }}` have no scheme yet), so validating
         // pre-resolution would block legitimate templates from ever reaching
         // the resolver. The resolved URL is re-validated below before use.
-        const isTemplated = (url: string): boolean => url.includes('{{');
+        const isTemplated = (url: string): boolean => hasTemplateMarker(url);
 
         const hasInlineConfig = !!data.url;
         // `auth` is typed as the canonical MCPAuth (rather than narrowing to
@@ -5101,13 +5230,15 @@ export async function registerMCPServices(
             // missing-token signal — re-throw so the discover endpoint can
             // surface it to the caller instead of silently falling through to
             // an unauthenticated MCP probe.
-            if (error instanceof PublicBaseUrlNotConfiguredError) throw error;
-            if (error instanceof Forbidden || error instanceof Conflict) throw error;
-            console.error(
-              `[MCP Discovery] OAuth token acquisition failed category=${
-                error instanceof Error ? error.name : 'unknown'
-              }`
-            );
+            const recovery = classifyMCPAuthRecovery(error);
+            if (
+              recovery.category === 'redirect_configuration_required' ||
+              recovery.category === 'permission_changed' ||
+              recovery.category === 'configuration_changed'
+            ) {
+              throw error;
+            }
+            externalFailure('MCP Discovery OAuth token acquisition', 'discovery', error);
             return undefined;
           }
         };
@@ -5229,7 +5360,9 @@ export async function registerMCPServices(
             await connectWithTimeout(client, httpTransport);
           } catch (connectError) {
             assertCurrentRequestAuthority();
-            if (connectError instanceof Forbidden) throw connectError;
+            if (classifyMCPAuthRecovery(connectError).category === 'permission_changed') {
+              throw connectError;
+            }
             if (hadCachedOAuthToken && serverConfig.url && serverConfig.auth?.type === 'oauth') {
               const freshToken = await probeAndAcquireOAuthToken(serverConfig.url);
               if (freshToken) {
@@ -5267,7 +5400,12 @@ export async function registerMCPServices(
             description?: string;
             inputSchema?: Record<string, unknown>;
           }>;
-          type ResourcesResult = MCPListResult<{ uri: string; name: string; mimeType?: string }>;
+          type ResourcesResult = MCPListResult<{
+            uri: string;
+            name: string;
+            description?: string;
+            mimeType?: string;
+          }>;
           type PromptsResult = MCPListResult<{
             name: string;
             description?: string;
@@ -5304,20 +5442,21 @@ export async function registerMCPServices(
                   {
                     tools: toolsResult.tools.map((t) => ({
                       name: t.name,
-                      description: t.description || '',
+                      description: t.description,
                       input_schema: t.inputSchema,
                     })),
                     resources: resourcesResult.resources.map((r) => ({
                       uri: r.uri,
                       name: r.name,
+                      description: r.description,
                       mimeType: r.mimeType,
                     })),
                     prompts: promptsResult.prompts.map((p) => ({
                       name: p.name,
-                      description: p.description || '',
+                      description: p.description,
                       arguments: p.arguments?.map((a) => ({
                         name: a.name,
-                        description: a.description || '',
+                        description: a.description,
                         required: a.required,
                       })),
                     })),
@@ -5368,14 +5507,20 @@ export async function registerMCPServices(
           }
         }
       } catch (error) {
-        if (error instanceof PublicBaseUrlNotConfiguredError) {
-          console.error('[MCP Discovery]', error.message);
-          return { success: false, error: error.message };
+        const recovery = classifyMCPAuthRecovery(error);
+        if (recovery.category === 'redirect_configuration_required') {
+          console.error('[MCP Discovery] category=redirect_configuration_required');
+          return { success: false, error: recovery.message, recovery };
         }
-        console.error(
-          `[MCP Discovery] Failed category=${error instanceof Error ? error.name : 'unknown'}`
-        );
-        return { success: false, error: error instanceof Error ? error.message : String(error) };
+        if (
+          recovery.category === 'authentication_required' ||
+          recovery.category === 'permission_changed' ||
+          recovery.category === 'configuration_changed'
+        ) {
+          return { success: false, error: recovery.message, recovery };
+        }
+        const safe = externalFailure('MCP Discovery', 'discovery', error);
+        return { success: false, error: safe.message, category: safe.category };
       }
     },
   });

--- a/apps/agor-daemon/src/services/mcp-auth-recovery.test.ts
+++ b/apps/agor-daemon/src/services/mcp-auth-recovery.test.ts
@@ -1,0 +1,93 @@
+import { asMCPExternalError } from '@agor/core/mcp';
+import { OAuthConfigurationError, OAuthDCRFailure } from '@agor/core/tools/mcp/oauth-mcp-transport';
+import { describe, expect, it, vi } from 'vitest';
+import { classifyMCPAuthRecovery, recoveryForOAuthAttemptFailure } from './mcp-auth-recovery';
+
+describe('MCP auth recovery contract', () => {
+  it('maps DCR diagnostics to actionable public state without provider text', () => {
+    const recovery = classifyMCPAuthRecovery(
+      new OAuthDCRFailure('provider leaked secret=abc', {
+        stage: 'dcr_registration',
+        http_status: 500,
+      }),
+      { mcpServerId: 'server-a', redirectUri: 'https://agor.example/oauth/callback' }
+    );
+    expect(recovery).toMatchObject({
+      category: 'client_registration_failed',
+      action: 'configure_client',
+      mcp_server_id: 'server-a',
+    });
+    expect(JSON.stringify(recovery)).not.toContain('secret=abc');
+    expect(JSON.stringify(recovery)).not.toContain('dcr_registration');
+  });
+
+  it('maps durable failures without exposing internal failure detail', () => {
+    expect(recoveryForOAuthAttemptFailure('authorization_denied', 'server-a')).toMatchObject({
+      category: 'authorization_denied',
+      action: 'reauthenticate',
+    });
+    const unknown = recoveryForOAuthAttemptFailure('provider_raw_secret', 'server-a');
+    expect(unknown).toMatchObject({
+      category: 'authentication_required',
+      action: 'reauthenticate',
+    });
+    expect(JSON.stringify(unknown)).not.toContain('provider_raw_secret');
+  });
+
+  it('prefers typed OAuth configuration codes and sanitizes unknown fallbacks', () => {
+    expect(
+      classifyMCPAuthRecovery(
+        new OAuthConfigurationError('issuer_mismatch', 'issuer=https://secret.internal')
+      )
+    ).toMatchObject({ category: 'metadata_incompatible', action: 'review_compatibility' });
+    expect(
+      classifyMCPAuthRecovery(new OAuthConfigurationError('client_registration_required'))
+    ).toMatchObject({ category: 'client_registration_required', action: 'configure_client' });
+
+    const unknown = classifyMCPAuthRecovery(new Error('provider secret=do-not-reflect'));
+    expect(unknown).toMatchObject({ category: 'unknown', action: 'retry' });
+    expect(JSON.stringify(unknown)).not.toContain('do-not-reflect');
+  });
+
+  it.each([
+    ['provider_rejected', 'reauthenticate'],
+    ['invalid_response', 'retry'],
+    ['configuration_required', 'review_configuration'],
+  ] as const)('preserves the shared closed %s recovery contract', (category, action) => {
+    const recovery = classifyMCPAuthRecovery(
+      asMCPExternalError(new Error('SENTINEL_PROVIDER_PROSE'), {
+        stage: 'oauth',
+        category,
+      })
+    );
+
+    expect(recovery).toMatchObject({ category, action });
+    expect(JSON.stringify(recovery)).not.toContain('SENTINEL');
+  });
+
+  it('fails closed for hostile proxies without invoking name/code accessors', () => {
+    const sentinel = 'SENTINEL_HOSTILE_RECOVERY_PROXY';
+    const getter = vi.fn(() => {
+      throw new Error(sentinel);
+    });
+    const getPrototypeOf = vi.fn(() => {
+      throw new Error(sentinel);
+    });
+    const hostile = new Proxy(new OAuthConfigurationError('issuer_mismatch'), {
+      getPrototypeOf,
+      getOwnPropertyDescriptor(target, property) {
+        if (property === 'name' || property === 'code' || property === 'failureCode') {
+          return { configurable: true, get: getter };
+        }
+        return Reflect.getOwnPropertyDescriptor(target, property);
+      },
+    });
+
+    const recovery = classifyMCPAuthRecovery(hostile);
+
+    expect(recovery).toMatchObject({ category: 'unknown', action: 'retry' });
+    expect(JSON.stringify(recovery)).not.toContain(sentinel);
+    expect(getter).not.toHaveBeenCalled();
+    expect(getPrototypeOf).toHaveBeenCalled();
+  });
+});

--- a/apps/agor-daemon/src/services/mcp-auth-recovery.ts
+++ b/apps/agor-daemon/src/services/mcp-auth-recovery.ts
@@ -1,0 +1,186 @@
+import { PublicBaseUrlNotConfiguredError } from '@agor/core/config';
+import { BadRequest, Conflict, Forbidden } from '@agor/core/feathers';
+import { sanitizeMCPExternalError } from '@agor/core/mcp';
+import { OAuthConfigurationError, OAuthDCRFailure } from '@agor/core/tools/mcp/oauth-mcp-transport';
+import type { MCPAuthRecovery, MCPServerID } from '@agor/core/types';
+
+function target(mcpServerId?: string) {
+  return {
+    ...(mcpServerId ? { mcp_server_id: mcpServerId as MCPServerID } : {}),
+  };
+}
+
+type TrustedRecoveryErrorConstructor =
+  | typeof Forbidden
+  | typeof Conflict
+  | typeof BadRequest
+  | typeof OAuthDCRFailure
+  | typeof OAuthConfigurationError
+  | typeof PublicBaseUrlNotConfiguredError;
+
+function safeInstanceOf(error: unknown, errorClass: TrustedRecoveryErrorConstructor) {
+  try {
+    return error instanceof errorClass;
+  } catch {
+    return false;
+  }
+}
+
+function safeOwnDataValue(value: unknown, field: string): unknown {
+  if (!value || (typeof value !== 'object' && typeof value !== 'function')) return undefined;
+  try {
+    const descriptor = Object.getOwnPropertyDescriptor(value, field);
+    return descriptor && 'value' in descriptor ? descriptor.value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Convert internal/provider failures into the closed public recovery contract.
+ * Provider exception text is deliberately not inspected: even local logs are
+ * not a safe destination for URLs, redirects, or reflected request values.
+ */
+export function classifyMCPAuthRecovery(
+  error: unknown,
+  options: { mcpServerId?: string; redirectUri?: string } = {}
+): MCPAuthRecovery {
+  const common = target(options.mcpServerId);
+
+  if (safeInstanceOf(error, Forbidden)) {
+    return {
+      ...common,
+      category: 'permission_changed',
+      action: 'retry',
+      message:
+        'The MCP request authority or OAuth browser reservation changed or expired. Retry from the current signed-in session.',
+    };
+  }
+  if (safeInstanceOf(error, Conflict)) {
+    return {
+      ...common,
+      category: 'configuration_changed',
+      action: 'save_and_retry',
+      message:
+        'The MCP configuration changed during this request. Reload the saved settings and retry.',
+    };
+  }
+  if (safeInstanceOf(error, BadRequest)) {
+    return {
+      ...common,
+      category: 'authentication_required',
+      action: 'reauthenticate',
+      message:
+        'The OAuth browser reservation is invalid, expired, or already used. Start authentication again from the current session.',
+    };
+  }
+
+  if (safeInstanceOf(error, OAuthDCRFailure)) {
+    const diagnostic = safeOwnDataValue(error, 'diagnostic');
+    const missingEndpoint = safeOwnDataValue(diagnostic, 'stage') === 'dcr_endpoint_discovery';
+    return {
+      ...common,
+      category: missingEndpoint ? 'client_registration_required' : 'client_registration_failed',
+      action: 'configure_client',
+      message: missingEndpoint
+        ? 'This provider requires a pre-registered OAuth client. Save a Client ID and Client Secret on this MCP server, then retry.'
+        : 'The provider could not register an OAuth client automatically. Save a pre-registered Client ID and Client Secret on this MCP server, verify the provider registration, then retry.',
+      ...(options.redirectUri ? { redirect_uri: options.redirectUri } : {}),
+    };
+  }
+
+  if (safeInstanceOf(error, OAuthConfigurationError)) {
+    const failureCode = safeOwnDataValue(error, 'failureCode');
+    if (failureCode === 'client_registration_required') {
+      return {
+        ...common,
+        category: 'client_registration_required',
+        action: 'configure_client',
+        message:
+          'This provider requires a pre-registered OAuth client. Save a Client ID and Client Secret on this MCP server, then retry.',
+        ...(options.redirectUri ? { redirect_uri: options.redirectUri } : {}),
+      };
+    }
+    const incompatible = [
+      'metadata_incompatible',
+      'endpoint_override_mismatch',
+      'issuer_mismatch',
+      'pkce_required',
+    ].includes(typeof failureCode === 'string' ? failureCode : '');
+    return incompatible
+      ? {
+          ...common,
+          category: 'metadata_incompatible',
+          action: 'review_compatibility',
+          message:
+            'The provider OAuth metadata does not match this MCP server configuration. Verify the saved server URL and OAuth endpoints; use legacy compatibility only for a provider that requires it.',
+        }
+      : {
+          ...common,
+          category: 'metadata_unavailable',
+          action: 'save_and_retry',
+          message:
+            'OAuth metadata could not be discovered. Verify the MCP URL or save explicit authorization and token endpoints on this MCP server, then retry.',
+        };
+  }
+
+  if (safeInstanceOf(error, PublicBaseUrlNotConfiguredError)) {
+    return {
+      ...common,
+      category: 'redirect_configuration_required',
+      action: 'configure_redirect',
+      message:
+        'OAuth needs a browser-reachable Agor callback URL. Configure the deployment public URL and register the callback with the provider, then retry.',
+      ...(options.redirectUri ? { redirect_uri: options.redirectUri } : {}),
+    };
+  }
+
+  const external = sanitizeMCPExternalError(error, { stage: 'oauth' });
+  return {
+    ...common,
+    category: external.category,
+    action: external.action,
+    message: external.message,
+  };
+}
+
+/** Recovery for durable callback/attempt failure codes (never provider text). */
+export function recoveryForOAuthAttemptFailure(
+  failureCode: string | null | undefined,
+  mcpServerId?: string
+): MCPAuthRecovery | undefined {
+  if (!failureCode) return undefined;
+  const common = target(mcpServerId);
+  if (failureCode === 'authorization_denied') {
+    return {
+      ...common,
+      category: 'authorization_denied',
+      action: 'reauthenticate',
+      message: 'Authorization was not completed. Reconnect and approve access with the provider.',
+    };
+  }
+  if (failureCode === 'server_configuration_changed' || failureCode === 'authorization_changed') {
+    return {
+      ...common,
+      category: 'configuration_changed',
+      action: 'save_and_retry',
+      message:
+        'The MCP configuration changed during authorization. Review the saved settings and reconnect.',
+    };
+  }
+  if (failureCode === 'permission_changed') {
+    return {
+      ...common,
+      category: 'permission_changed',
+      action: 'contact_admin',
+      message:
+        'Your MCP authorization permission changed. Ask an administrator to review access, then reconnect.',
+    };
+  }
+  return {
+    ...common,
+    category: 'authentication_required',
+    action: 'reauthenticate',
+    message: 'Authentication did not complete. Reconnect this MCP server and try again.',
+  };
+}

--- a/apps/agor-daemon/src/services/mcp-catalog-connect.install.test.ts
+++ b/apps/agor-daemon/src/services/mcp-catalog-connect.install.test.ts
@@ -80,7 +80,11 @@ const CONNECT_REQUEST = {
  * puts it there. That second claim is asserted separately at the bottom of
  * this file, against the production registration itself.
  */
-async function buildDaemon(policy: MCPMemberPolicy, role: UserRole = 'member') {
+async function buildDaemon(
+  policy: MCPMemberPolicy,
+  role: UserRole = 'member',
+  catalogEntry: MCPCatalogEntry = CURATED
+) {
   const rawDb = await createDatabaseAsync({ dialect: 'sqlite', url: ':memory:' });
   const db = rawDb as unknown as TenantScopeAwareDatabase;
   await runMigrations(rawDb);
@@ -98,7 +102,7 @@ async function buildDaemon(policy: MCPMemberPolicy, role: UserRole = 'member') {
   } as never);
   app.use('mcp-catalog', {
     async get() {
-      return CURATED;
+      return catalogEntry;
     },
   } as never);
   app.use('sessions', {
@@ -135,11 +139,14 @@ async function buildDaemon(policy: MCPMemberPolicy, role: UserRole = 'member') {
       paramsFor(caller, callerRole)
     );
   const connect = () => connectAs(user, role);
-  const installedServers = () => new MCPServerRepository(rawDb).findAll({});
+  const serverRepository = new MCPServerRepository(rawDb);
+  const installedServers = () => serverRepository.findAll({});
+  const seedServer = (server: Parameters<MCPServerRepository['create']>[0]) =>
+    serverRepository.create(server);
   const addUser = (email: string, addedRole: UserRole) =>
     users.create({ email, name: email, role: addedRole }) as Promise<User>;
 
-  return { user, connect, connectAs, addUser, installedServers };
+  return { user, connect, connectAs, addUser, installedServers, seedServer };
 }
 
 describe('marketplace install, as it lands in the database', () => {
@@ -240,6 +247,52 @@ describe('marketplace install, as it lands in the database', () => {
     const servers = await installedServers();
     expect(servers).toHaveLength(1);
     expect(servers[0]?.owner_user_id).toBe(user.user_id);
+  });
+
+  it('authoritatively replaces stale same-type OAuth fields on a reused catalog install', async () => {
+    const oauthEntry = { ...CURATED, auth_type: 'oauth' } as MCPCatalogEntry;
+    const { user, connect, installedServers, seedServer } = await buildDaemon(
+      'allow_crud',
+      'member',
+      oauthEntry
+    );
+    await seedServer({
+      name: 'deepwiki',
+      display_name: 'DeepWiki',
+      transport: 'http',
+      url: CURATED.remote_url,
+      auth: {
+        type: 'oauth',
+        oauth_mode: 'per_user',
+        oauth_authorization_url: 'https://stale.example/authorize',
+        oauth_token_url: 'https://stale.example/token',
+        oauth_client_secret: 'stale-client-secret',
+        oauth_scope: 'stale:read stale:write',
+        // This is the one catalog reconciliation override the operator chose
+        // explicitly and is allowed to retain.
+        oauth_compatibility_mode: 'legacy',
+      },
+      scope: 'session',
+      source: 'catalog',
+      catalog_entry_name: DEEPWIKI,
+      owner_user_id: user.user_id as UserID,
+      enabled: true,
+    });
+    probeRemoteAuthType.mockResolvedValueOnce('oauth');
+
+    const result = (await connect()) as {
+      reused_existing_server: boolean;
+      mcp_server: MCPServer;
+    };
+
+    expect(result.reused_existing_server).toBe(true);
+    const [stored] = await installedServers();
+    expect(stored?.auth).toEqual({
+      type: 'oauth',
+      oauth_mode: 'per_user',
+      oauth_compatibility_mode: 'legacy',
+    });
+    expect(JSON.stringify(stored)).not.toContain('stale-client-secret');
   });
 });
 

--- a/apps/agor-daemon/src/services/mcp-catalog-connect.install.test.ts
+++ b/apps/agor-daemon/src/services/mcp-catalog-connect.install.test.ts
@@ -31,6 +31,7 @@ import type {
   MCPMemberPolicy,
   MCPServer,
   User,
+  UserID,
   UserRole,
 } from '@agor/core/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -335,12 +336,27 @@ describe('the write hook this seam depends on', () => {
       name: 'Mallory',
       role: 'member',
     })) as User;
+    const patchTarget = await new MCPServerRepository(rawDb).create({
+      name: 'registered-hook-patch-target',
+      transport: 'http',
+      url: 'https://mcp.example.test',
+      scope: 'global',
+      owner_user_id: bob.user_id as UserID,
+      source: 'user',
+    });
 
     const registeredHooks = captureRegisteredMcpServerCreateHooks(db);
     const createAs = async (caller: User, data: Record<string, unknown>) => {
       const context = {
         method: 'create',
-        data,
+        data: {
+          name: 'registered-hook-test',
+          transport: 'http',
+          url: 'https://mcp.example.test',
+          scope: 'global',
+          enabled: true,
+          ...data,
+        },
         params: {
           provider: 'rest',
           user: { user_id: caller.user_id, role: 'member' },
@@ -353,7 +369,7 @@ describe('the write hook this seam depends on', () => {
     const patchAs = async (caller: User, data: Record<string, unknown>) => {
       const context = {
         method: 'patch',
-        id: '01900000-0000-7000-8000-000000000099',
+        id: patchTarget.mcp_server_id,
         data,
         params: {
           provider: 'rest',
@@ -388,7 +404,7 @@ describe('the write hook this seam depends on', () => {
   });
 
   it.each(['marketplace', 'future-mode'])(
-    'rejects public create and patch compatibility mode %s before authorization',
+    'rejects public create and patch compatibility mode %s at the authorized write boundary',
     async (mode) => {
       const { bob, createAs, patchAs } = await standUpDaemonHooks();
       const data = {

--- a/apps/agor-daemon/src/services/mcp-catalog-connect.test.ts
+++ b/apps/agor-daemon/src/services/mcp-catalog-connect.test.ts
@@ -1145,6 +1145,7 @@ describe('mcp-catalog/connect — endpoints that sign the user in', () => {
 
       expect(result.reuse_kind).toBe('catalog_install');
       expect((patched.at(-1)!.data.auth as MCPAuth).oauth_compatibility_mode).toBe(mode);
+      expect(patched.at(-1)!.data.replace_auth).toBe(true);
       expect(result.mcp_server.auth?.oauth_compatibility_mode).toBe(mode);
       expect(result.effective_oauth_policy).toEqual({
         effective_mode: mode,
@@ -1208,6 +1209,7 @@ describe('mcp-catalog/connect — endpoints that sign the user in', () => {
         type: 'oauth',
         oauth_mode: 'per_user',
       });
+      expect(patched.at(-1)!.data.replace_auth).toBe(true);
     }
   );
 
@@ -2091,7 +2093,10 @@ describe('mcp-catalog/connect — reusing a key-bearing install', () => {
     const result = await createMCPCatalogConnectService(app).create(keyRequest, params);
 
     expect(patched).toEqual([
-      { id: 'server-existing', data: { auth: { type: 'bearer', token: NEW_KEY } } },
+      {
+        id: 'server-existing',
+        data: { auth: { type: 'bearer', token: NEW_KEY }, replace_auth: true },
+      },
     ]);
     expect(generationClaims).toEqual([{ ownerUserId: ALICE, catalogEntryName: LINEAR, value: 1 }]);
     expect(generationFinalizations).toEqual([
@@ -2125,7 +2130,10 @@ describe('mcp-catalog/connect — reusing a key-bearing install', () => {
     ]);
     expect(patched.at(-1)).toEqual({
       id: 'server-1',
-      data: { auth: { type: 'bearer', token: 'fake-new-key-2222' } },
+      data: {
+        auth: { type: 'bearer', token: 'fake-new-key-2222' },
+        replace_auth: true,
+      },
     });
   });
 
@@ -2217,7 +2225,10 @@ describe('mcp-catalog/connect — reusing a key-bearing install', () => {
     // fence. The important boundary is that Alice's new row, not Bob's
     // existing credential row, is the target.
     expect(patched).toEqual([
-      { id: 'server-1', data: { auth: { type: 'bearer', token: NEW_KEY } } },
+      {
+        id: 'server-1',
+        data: { auth: { type: 'bearer', token: NEW_KEY }, replace_auth: true },
+      },
     ]);
     expect(generationFinalizations).toEqual([
       { id: 'server-1', ownerUserId: ALICE, catalogEntryName: LINEAR, value: 1 },

--- a/apps/agor-daemon/src/services/mcp-catalog-connect.test.ts
+++ b/apps/agor-daemon/src/services/mcp-catalog-connect.test.ts
@@ -2473,16 +2473,20 @@ describe('mcp-catalog/connect — what a failed connect leaves behind', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const { app, created } = buildApp(CURATED);
     attachOf(app).create.mockRejectedValue(new Error('forbidden'));
-    sessionsOf(app).remove.mockRejectedValue(new Error('cleanup exploded'));
+    sessionsOf(app).remove.mockRejectedValue(
+      new Error('cleanup exploded SENTINEL_CATALOG_CLEANUP')
+    );
 
     await expect(createMCPCatalogConnectService(app).create(request, params)).rejects.toThrow(
       /forbidden/
     );
 
     expect(warn).toHaveBeenCalledWith(
-      expect.stringContaining('Left session session-1 behind'),
-      expect.anything()
+      expect.stringContaining(
+        'compensation_failed resource=session session_id=session-1 category=unknown type=Error'
+      )
     );
+    expect(JSON.stringify(warn.mock.calls)).not.toContain('SENTINEL_CATALOG_CLEANUP');
     // Honest about the residual: the session really is still there.
     expect(created.sessions).toHaveLength(1);
     warn.mockRestore();

--- a/apps/agor-daemon/src/services/mcp-catalog-connect.ts
+++ b/apps/agor-daemon/src/services/mcp-catalog-connect.ts
@@ -848,6 +848,10 @@ export function createMCPCatalogConnectService(
     const reconciledAuth = reconcile
       ? preserveExplicitOAuthCompatibility(server, prescribed)
       : prescribed;
+    // Both arms carry a complete catalog-authored auth object, not a public
+    // partial edit. Make that authority explicit so same-mode fields omitted
+    // by today's prescription cannot survive from an older install. The only
+    // retained field is the validated compatibility override selected above.
     const updates = reconcile
       ? {
           enabled: true,
@@ -856,8 +860,9 @@ export function createMCPCatalogConnectService(
           url: createInput.url,
           headers: {},
           auth: reconciledAuth,
+          replace_auth: true,
         }
-      : { auth: prescribed };
+      : { auth: prescribed, replace_auth: true };
     if (!generation) {
       await service('mcp-servers').patch(server.mcp_server_id, updates, {
         ...params,

--- a/apps/agor-daemon/src/services/mcp-catalog-connect.ts
+++ b/apps/agor-daemon/src/services/mcp-catalog-connect.ts
@@ -32,6 +32,7 @@
 
 import { isDatabaseUniqueConstraintError } from '@agor/core/db';
 import { BadRequest, NotAuthenticated, NotFound } from '@agor/core/feathers';
+import { sanitizeMCPExternalError } from '@agor/core/mcp';
 import { probeRemoteAuthType, probeRemoteBearerToken } from '@agor/core/mcp-catalog';
 import { MCP_AUTH_SECRET_FIELDS, redactMCPAuthSecrets } from '@agor/core/tools/mcp/auth-secrets';
 import { MCP_HEADER_REDACTED_SENTINEL } from '@agor/core/tools/mcp/http-headers';
@@ -58,6 +59,30 @@ import {
   isCurrentCatalogInstall,
 } from './mcp-catalog-install-policy.js';
 import type { MCPServersService } from './mcp-servers.js';
+
+/**
+ * A closed, daemon-authored control-plane response. Unlike provider/library
+ * exceptions, this is safe to preserve across the public service boundary and
+ * its credential_requirement value drives the Marketplace retry form.
+ */
+class CatalogConnectControlError extends BadRequest {}
+
+class CatalogCredentialRequirementError extends CatalogConnectControlError {
+  constructor(
+    message: string,
+    credentialRequirement: MCPCatalogConnectErrorData['credential_requirement']
+  ) {
+    super(message, { credential_requirement: credentialRequirement });
+  }
+}
+
+function isCatalogConnectControlError(error: unknown): error is CatalogConnectControlError {
+  try {
+    return error instanceof CatalogConnectControlError;
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Auth fields that decide where an authorization code or a client credential is
@@ -320,7 +345,7 @@ async function resolveAuthRequirement(
 
   if (probed === 'none' || probed === 'oauth') {
     if (bearerToken !== undefined) {
-      throw new BadRequest(
+      throw new CatalogCredentialRequirementError(
         `${catalogDisplayName(entry)} is not asking for a bearer access token${
           probed === 'oauth' ? '; it signs you in with your own account' : ''
         }. Connect it again without one.`,
@@ -328,9 +353,7 @@ async function resolveAuthRequirement(
         // what the endpoint actually wants is what lets the form drop the
         // field and the user retry, rather than being held at a button that
         // submits something the daemon will refuse again.
-        {
-          credential_requirement: probed === 'oauth' ? 'oauth' : 'not_accepted',
-        } satisfies MCPCatalogConnectErrorData
+        probed === 'oauth' ? 'oauth' : 'not_accepted'
       );
     }
     return probed === 'none' ? { type: 'none' } : catalogOAuthConfig(entry);
@@ -338,15 +361,15 @@ async function resolveAuthRequirement(
 
   if (probed === 'credentials') {
     if (entry.credentials?.scheme !== 'bearer') {
-      throw new BadRequest(
+      throw new CatalogCredentialRequirementError(
         `${catalogDisplayName(entry)} requires credentials, but its reviewed credential scheme is not supported by Marketplace`,
-        { credential_requirement: 'unsupported' } satisfies MCPCatalogConnectErrorData
+        'unsupported'
       );
     }
     return resolveBearerTokenAuth(entry, bearerToken);
   }
 
-  throw new BadRequest(
+  throw new CatalogConnectControlError(
     `${catalogDisplayName(entry)} could not be reached, so it cannot be connected`
   );
 }
@@ -381,13 +404,13 @@ async function resolveBearerTokenAuth(
 ): Promise<MCPAuth> {
   const name = catalogDisplayName(entry);
   if (bearerToken === undefined) {
-    throw new BadRequest(
+    throw new CatalogCredentialRequirementError(
       `${name} needs a bearer access token; paste one to connect it`,
       // The mirror of the `not_accepted` case: the client asked without a key
       // because the entry said none was needed, and the endpoint disagreed.
       // Without this the drawer has no field to offer and the sentence above is
       // an instruction the user cannot follow.
-      { credential_requirement: 'required' } satisfies MCPCatalogConnectErrorData
+      'required'
     );
   }
 
@@ -397,14 +420,12 @@ async function resolveBearerTokenAuth(
     // Still `required` — the endpoint wants a key, this one was just wrong. A
     // client that has already revealed the field keeps it revealed, which is
     // what lets a typo be corrected in place.
-    throw new BadRequest(
+    throw new CatalogCredentialRequirementError(
       `${name} did not accept that bearer access token; check it and try again`,
-      {
-        credential_requirement: 'required',
-      } satisfies MCPCatalogConnectErrorData
+      'required'
     );
   }
-  throw new BadRequest(
+  throw new CatalogConnectControlError(
     `${name} did not answer as an MCP server when that bearer access token was tried, so it was not connected`
   );
 }
@@ -890,7 +911,17 @@ export function createMCPCatalogConnectService(
         ).claimCatalogConnectGeneration(userId, entry.name),
       };
       const connectGeneration = bearerToken === undefined ? undefined : operationGeneration;
-      const auth = await resolveAuthRequirement(entry, bearerToken);
+      let auth: MCPAuth;
+      try {
+        auth = await resolveAuthRequirement(entry, bearerToken);
+      } catch (error) {
+        if (isCatalogConnectControlError(error)) throw error;
+        const safe = sanitizeMCPExternalError(error, { stage: 'discovery' });
+        console.error(
+          `[mcp-catalog/connect] event=mcp_external_failure stage=discovery category=${safe.category} type=${safe.diagnostic.type}`
+        );
+        throw new BadRequest(safe.message, { category: safe.category });
+      }
 
       const existing = await findExistingInstall(entry, auth, userId, params);
 
@@ -1082,9 +1113,9 @@ export function createMCPCatalogConnectService(
               provider: undefined,
             });
           } catch (cleanupError) {
+            const safe = sanitizeMCPExternalError(cleanupError, { stage: 'runtime' });
             console.warn(
-              `[mcp-catalog/connect] Left session ${session.session_id} behind after a failed connect:`,
-              cleanupError instanceof Error ? cleanupError.message : cleanupError
+              `[mcp-catalog/connect] compensation_failed resource=session session_id=${session.session_id} category=${safe.category} type=${safe.diagnostic.type}`
             );
           }
         }
@@ -1098,9 +1129,9 @@ export function createMCPCatalogConnectService(
               operationGeneration
             );
           } catch (cleanupError) {
+            const safe = sanitizeMCPExternalError(cleanupError, { stage: 'runtime' });
             console.warn(
-              `[mcp-catalog/connect] Left ${mcpServer.mcp_server_id} behind after a failed connect:`,
-              cleanupError instanceof Error ? cleanupError.message : cleanupError
+              `[mcp-catalog/connect] compensation_failed resource=mcp_server server_id=${mcpServer.mcp_server_id} category=${safe.category} type=${safe.diagnostic.type}`
             );
           }
         }

--- a/apps/agor-daemon/src/services/mcp-marketplace-actions.postgres.test.ts
+++ b/apps/agor-daemon/src/services/mcp-marketplace-actions.postgres.test.ts
@@ -113,7 +113,10 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
           _tenantId: TenantID,
           serverId: MCPServerID
         ) => {
-          await new MCPServerRepository(scoped).update(serverId, { transport: 'stdio' });
+          await new MCPServerRepository(scoped).update(serverId, {
+            transport: 'stdio',
+            command: 'catalog-authority-replacement',
+          });
         },
       ],
     ] as const)('rejects stale request authority after %s', async (_name, change) => {

--- a/apps/agor-daemon/src/services/mcp-marketplace-actions.test.ts
+++ b/apps/agor-daemon/src/services/mcp-marketplace-actions.test.ts
@@ -193,7 +193,7 @@ dbTest('Marketplace tool action reloads transport under the mutation lock', asyn
   await setPolicy(db, 'allow_private_only');
   const repo = new MCPServerRepository(db);
   const server = await seed(repo);
-  await repo.update(server.mcp_server_id, { transport: 'stdio' });
+  await repo.update(server.mcp_server_id, { transport: 'stdio', command: 'node' });
 
   await expect(
     new MCPMarketplaceToolPermissionService(db).create(

--- a/apps/agor-daemon/src/services/mcp-oauth-pending-flow-authority.postgres.test.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-pending-flow-authority.postgres.test.ts
@@ -21,6 +21,8 @@ import {
   type RawDatabase,
   runWithSystemDatabaseScope,
   runWithTenantDatabaseScope,
+  runWithTenantDatabaseTransaction,
+  shortId,
   sql,
   type TenantScopeAwareDatabase,
   UserMCPOAuthTokenRepository,
@@ -666,6 +668,99 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
         outcome: 'not_claimed',
         flow: { status: 'ambiguous' },
       });
+    });
+
+    it('rolls config, grant deletion, and pending invalidation back as one tenant transaction', async () => {
+      const bound = await seed('atomic-config-grant-flow');
+      const context = flowContext(crypto.randomUUID());
+      const fingerprint = 'c'.repeat(64);
+      const attemptId = await authorityA.create({
+        context,
+        ...bound,
+        mcpServerId: bound.serverId,
+        oauthMode: 'per_user',
+        configFingerprint: fingerprint,
+      });
+      const pending = await authorityA.getForUser(bound.tenantId, bound.userId, attemptId);
+      if (!pending) throw new Error('Expected pending-flow fixture');
+      await runWithTenantDatabaseScope(dbA, bound.tenantId, async (scoped) => {
+        await new UserMCPOAuthTokenRepository(scoped, masterSecret).saveToken(
+          bound.userId,
+          bound.serverId,
+          {
+            accessToken: 'atomic-access-token',
+            refreshToken: 'atomic-refresh-token',
+            clientId: context.clientId,
+            clientSecret: context.clientSecret,
+            grantBinding: {
+              generation: pending.grantGeneration,
+              version: pending.configFingerprintVersion,
+              fingerprint,
+              metadataUri: context.metadataUrl,
+              resourceUri: context.resourceUri,
+              issuer: context.issuer,
+              authorizationEndpoint: context.authorizationEndpoint,
+              tokenEndpoint: context.tokenEndpoint,
+              redirectUri: context.redirectUri,
+            },
+          }
+        );
+      });
+
+      await expect(
+        runWithTenantDatabaseTransaction(dbA, bound.tenantId, async (scoped) => {
+          await new MCPServerRepository(scoped).update(bound.serverId, {
+            auth: { oauth_mode: 'shared' },
+          });
+          await new UserMCPOAuthTokenRepository(scoped, masterSecret).deleteAllForServer(
+            bound.serverId
+          );
+          await authorityA.invalidateForServer(bound.tenantId, bound.serverId);
+          throw new Error('injected transaction failure');
+        })
+      ).rejects.toThrow('injected transaction failure');
+
+      await runWithTenantDatabaseScope(dbB, bound.tenantId, async (scoped) => {
+        await expect(
+          new MCPServerRepository(scoped).findById(bound.serverId)
+        ).resolves.toMatchObject({ auth: { oauth_mode: 'per_user' } });
+        await expect(
+          new UserMCPOAuthTokenRepository(scoped, masterSecret).getToken(
+            bound.userId,
+            bound.serverId
+          )
+        ).resolves.toMatchObject({ oauth_access_token: 'atomic-access-token' });
+      });
+      await expect(
+        authorityB.getForUser(bound.tenantId, bound.userId, attemptId)
+      ).resolves.toMatchObject({ status: 'pending', isCurrent: true });
+    });
+
+    it('maps short and full MCP IDs to the same PostgreSQL grant-configuration lock key', async () => {
+      const bound = await seed('canonical-lock-key');
+      const locked = Promise.withResolvers<void>();
+      const release = Promise.withResolvers<void>();
+      const first = runWithTenantDatabaseTransaction(dbA, bound.tenantId, async (scoped) => {
+        const canonical = await new MCPServerRepository(scoped).resolveCanonicalId(
+          shortId(bound.serverId)
+        );
+        expect(canonical).toBe(bound.serverId);
+        await lockMCPOAuthGrantConfiguration(scoped, bound.tenantId, canonical);
+        locked.resolve();
+        await release.promise;
+      });
+      await locked.promise;
+
+      let secondAcquired = false;
+      const second = runWithTenantDatabaseTransaction(dbB, bound.tenantId, async (scoped) => {
+        await lockMCPOAuthGrantConfiguration(scoped, bound.tenantId, bound.serverId);
+        secondAcquired = true;
+      });
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      expect(secondAcquired).toBe(false);
+      release.resolve();
+      await Promise.all([first, second]);
+      expect(secondAcquired).toBe(true);
     });
 
     it('expires pending attempts and never makes an expired state replayable', async () => {

--- a/apps/agor-daemon/src/services/mcp-servers.binding.test.ts
+++ b/apps/agor-daemon/src/services/mcp-servers.binding.test.ts
@@ -1,0 +1,85 @@
+import type { TenantScopeAwareDatabase, TenantScopedDatabase } from '@agor/core/db';
+import { createDatabaseAsync, MCPServerRepository, runMigrations } from '@agor/core/db';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  createMCPServersService,
+  type MCPServerParams,
+  runWithMCPServerMutationDatabase,
+} from './mcp-servers.js';
+
+async function databaseWithServer(label: string) {
+  const db = await createDatabaseAsync({ dialect: 'sqlite', url: ':memory:' });
+  await runMigrations(db);
+  const server = await new MCPServerRepository(db).create({
+    name: 'binding-test',
+    display_name: label,
+    transport: 'http',
+    url: 'https://mcp.example.test/mcp',
+    auth: { type: 'none' },
+    scope: 'global',
+  });
+  return { db, server };
+}
+
+describe('MCP mutation transaction binding', () => {
+  const databases: Array<Awaited<ReturnType<typeof createDatabaseAsync>>> = [];
+  afterEach(() => {
+    while (databases.length) {
+      databases.pop()?.$client?.close();
+    }
+  });
+
+  it('keeps overlapping requests isolated even when they reuse one params object', async () => {
+    const base = await databaseWithServer('base');
+    const first = await databaseWithServer('first');
+    const second = await databaseWithServer('second');
+    databases.push(base.db, first.db, second.db);
+    const service = createMCPServersService(base.db as TenantScopeAwareDatabase);
+    const params = {} as MCPServerParams;
+
+    let releaseFirst!: () => void;
+    const held = new Promise<void>((resolve) => (releaseFirst = resolve));
+    const firstRequest = runWithMCPServerMutationDatabase(
+      first.db as unknown as TenantScopedDatabase,
+      async () => {
+        await held;
+        await service.patch(first.server.mcp_server_id, { display_name: 'first-updated' }, params);
+      }
+    );
+    await runWithMCPServerMutationDatabase(second.db as unknown as TenantScopedDatabase, () =>
+      service.patch(second.server.mcp_server_id, { display_name: 'second-updated' }, params)
+    );
+    releaseFirst();
+    await firstRequest;
+    expect(
+      (await new MCPServerRepository(first.db).findById(first.server.mcp_server_id))?.display_name
+    ).toBe('first-updated');
+    expect(
+      (await new MCPServerRepository(second.db).findById(second.server.mcp_server_id))?.display_name
+    ).toBe('second-updated');
+  });
+
+  it('restores the exact outer repository after a nested binding completes', async () => {
+    const base = await databaseWithServer('base');
+    const first = await databaseWithServer('first');
+    const second = await databaseWithServer('second');
+    databases.push(base.db, first.db, second.db);
+    const service = createMCPServersService(base.db as TenantScopeAwareDatabase);
+    const params = {} as MCPServerParams;
+    await runWithMCPServerMutationDatabase(
+      first.db as unknown as TenantScopedDatabase,
+      async () => {
+        await runWithMCPServerMutationDatabase(second.db as unknown as TenantScopedDatabase, () =>
+          service.patch(second.server.mcp_server_id, { display_name: 'second-updated' }, params)
+        );
+        await service.patch(first.server.mcp_server_id, { display_name: 'first-updated' }, params);
+      }
+    );
+    expect(
+      (await new MCPServerRepository(first.db).findById(first.server.mcp_server_id))?.display_name
+    ).toBe('first-updated');
+    expect(
+      (await new MCPServerRepository(second.db).findById(second.server.mcp_server_id))?.display_name
+    ).toBe('second-updated');
+  });
+});

--- a/apps/agor-daemon/src/services/mcp-servers.member-policy.test.ts
+++ b/apps/agor-daemon/src/services/mcp-servers.member-policy.test.ts
@@ -156,7 +156,10 @@ describe('member policy, as it lands in mcp_servers', () => {
     await expect(update(created.mcp_server_id, { scope: 'global' })).rejects.toThrow(
       /reach cannot be widened/
     );
-    await update(created.mcp_server_id, { display_name: 'DeepWiki' });
+    await update(created.mcp_server_id, {
+      display_name: 'DeepWiki',
+      url: 'https://example.com/mcp',
+    });
 
     const [server] = await storedServers();
     expect(server).toMatchObject({ scope: 'session', display_name: 'DeepWiki' });
@@ -271,7 +274,7 @@ describe('the MCP member policy endpoint, as it is registered', () => {
   it('registers the invalidation at the mcp-servers transport boundary', () => {
     const serviceRegistration = servicesSource.slice(
       servicesSource.indexOf("app.use('/mcp-servers', createMCPServersService(db)"),
-      servicesSource.indexOf('const invalidateOAuthGrantsAfterServerChange')
+      servicesSource.indexOf('const coordinateMCPServerMutation')
     );
     expect(serviceRegistration).toContain('events: [MCP_MEMBER_POLICY_CHANGED_EVENT]');
   });

--- a/apps/agor-daemon/src/services/mcp-servers.ts
+++ b/apps/agor-daemon/src/services/mcp-servers.ts
@@ -5,9 +5,16 @@
  * Uses DrizzleService adapter with MCPServerRepository.
  */
 
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { PAGINATION } from '@agor/core/config';
-import { MCPServerRepository, type TenantScopeAwareDatabase } from '@agor/core/db';
-import { Conflict } from '@agor/core/feathers';
+import {
+  MCPServerConfigConflictError,
+  MCPServerRepository,
+  type TenantScopeAwareDatabase,
+  type TenantScopedDatabase,
+} from '@agor/core/db';
+import { BadRequest, Conflict } from '@agor/core/feathers';
+import { MCPAuthValidationError, MCPServerWriteValidationError } from '@agor/core/mcp';
 import type {
   CreateMCPServerInput,
   MCPScope,
@@ -19,7 +26,7 @@ import type {
   QueryParams,
   UpdateMCPServerInput,
 } from '@agor/core/types';
-import { DrizzleService } from '../adapters/drizzle';
+import { DrizzleService, type Repository } from '../adapters/drizzle';
 
 /**
  * MCP Server service params
@@ -41,6 +48,27 @@ export type MCPServerParams = QueryParams<{
   };
 };
 
+// Transaction handles are server-internal request state, never part of the
+// public Feathers params contract. Async-local context makes them impossible
+// for a REST/Socket.IO caller to manufacture or serialize.
+const mutationDatabaseContext = new AsyncLocalStorage<TenantScopedDatabase>();
+
+/**
+ * Run a coordinated mutation with a transaction database that survives
+ * Feathers before hooks replacing/cloning `params`. AsyncLocalStorage is
+ * request-local and naturally supports overlapping and nested requests.
+ */
+export function runWithMCPServerMutationDatabase<T>(
+  db: TenantScopedDatabase,
+  operation: () => T
+): T {
+  return mutationDatabaseContext.run(db, operation);
+}
+
+function mutationDatabase(): TenantScopedDatabase | undefined {
+  return mutationDatabaseContext.getStore();
+}
+
 /**
  * Extended MCP servers service with custom methods
  */
@@ -53,7 +81,11 @@ export class MCPServersService extends DrizzleService<
 
   constructor(db: TenantScopeAwareDatabase) {
     const mcpServerRepo = new MCPServerRepository(db);
-    super(mcpServerRepo, {
+    // DrizzleService's legacy adapter contract accepts Partial<T>, while this
+    // repository deliberately exposes the narrower, validated CREATE DTO
+    // (including auth:null). Both the transport hook and repository validate
+    // that DTO before persistence.
+    super(mcpServerRepo as unknown as Repository<MCPServer>, {
       id: 'mcp_server_id',
       resourceType: 'McpServer',
       paginate: {
@@ -131,23 +163,86 @@ export class MCPServersService extends DrizzleService<
     return this.mcpServerRepo.findByScope(scope, scopeId);
   }
 
+  override async update(
+    id: string,
+    data: CreateMCPServerInput | UpdateMCPServerInput,
+    _params?: MCPServerParams
+  ): Promise<MCPServer> {
+    try {
+      // Preserve Feathers PUT replacement semantics while PATCH remains the
+      // safe nested merge. Callers may opt out explicitly for compatibility.
+      const replacement = data;
+      const transactionDb = mutationDatabase();
+      if (transactionDb) {
+        return await new MCPServerRepository(transactionDb).update(id, replacement, {
+          replace: true,
+        });
+      }
+      return await this.mcpServerRepo.update(id, replacement, { replace: true });
+    } catch (error) {
+      if (
+        error instanceof MCPAuthValidationError ||
+        error instanceof MCPServerWriteValidationError
+      ) {
+        throw new BadRequest(error.message);
+      }
+      if (error instanceof MCPServerConfigConflictError) {
+        throw new Conflict(error.message, {
+          mcp_server_id: error.mcpServerId,
+          expected_config_version: error.expectedVersion,
+          current_config_version: error.actualVersion,
+        });
+      }
+      throw error;
+    }
+  }
+
   override async patch(
     id: string | null,
     data: Partial<UpdateMCPServerInput>,
     params?: MCPServerParams
   ): Promise<MCPServer | MCPServer[]> {
-    const generation = params?.mcpCatalogConnectGeneration;
-    if (!generation || id === null) return super.patch(id, data, params);
-    await this.get(id, params);
-    const updated = await this.mcpServerRepo.updateIfCatalogConnectGeneration(
-      id,
-      generation.ownerUserId,
-      generation.catalogEntryName,
-      generation.value,
-      data
-    );
-    if (!updated) throw new Conflict('A newer marketplace connect superseded this request');
-    return updated;
+    try {
+      const transactionDb = mutationDatabase();
+      const repository = transactionDb
+        ? new MCPServerRepository(transactionDb)
+        : this.mcpServerRepo;
+      const generation = params?.mcpCatalogConnectGeneration;
+      if (!generation || id === null) {
+        if (id !== null && transactionDb) return repository.update(id, data);
+        return await super.patch(id, data, params);
+      }
+      if (transactionDb) {
+        const existing = await repository.findById(id);
+        if (!existing) throw new Error(`MCP server ${id} not found`);
+      } else {
+        await this.get(id, params);
+      }
+      const updated = await repository.updateIfCatalogConnectGeneration(
+        id,
+        generation.ownerUserId,
+        generation.catalogEntryName,
+        generation.value,
+        data
+      );
+      if (!updated) throw new Conflict('A newer marketplace connect superseded this request');
+      return updated;
+    } catch (error) {
+      if (
+        error instanceof MCPAuthValidationError ||
+        error instanceof MCPServerWriteValidationError
+      ) {
+        throw new BadRequest(error.message);
+      }
+      if (error instanceof MCPServerConfigConflictError) {
+        throw new Conflict(error.message, {
+          mcp_server_id: error.mcpServerId,
+          expected_config_version: error.expectedVersion,
+          current_config_version: error.actualVersion,
+        });
+      }
+      throw error;
+    }
   }
 
   /** Internal compensation primitive; deliberately not registered as a REST method. */

--- a/apps/agor-daemon/src/services/mcp-servers.write-contract.test.ts
+++ b/apps/agor-daemon/src/services/mcp-servers.write-contract.test.ts
@@ -1,0 +1,228 @@
+import type { TenantScopeAwareDatabase } from '@agor/core/db';
+import { createDatabaseAsync, MCPServerRepository, runMigrations } from '@agor/core/db';
+import { feathers } from '@agor/core/feathers';
+import { MCP_HEADER_REDACTED_SENTINEL } from '@agor/core/tools/mcp/http-headers';
+import type { AuthenticatedParams, MCPAuth, MCPServer } from '@agor/core/types';
+import { describe, expect, it } from 'vitest';
+import { redactMCPServerSecretFields, validateMcpServerWriteInput } from '../register-hooks.js';
+import { createMCPServersService } from './mcp-servers.js';
+
+const externalParams = (provider: 'rest' | 'socketio') =>
+  ({
+    provider,
+    authenticated: true,
+    user: { user_id: 'user-1', role: 'admin' },
+  }) as unknown as AuthenticatedParams;
+
+async function buildService() {
+  const rawDb = await createDatabaseAsync({ dialect: 'sqlite', url: ':memory:' });
+  await runMigrations(rawDb);
+  const repository = new MCPServerRepository(rawDb);
+  const app = feathers();
+  app.use('mcp-servers', createMCPServersService(rawDb as unknown as TenantScopeAwareDatabase));
+  app.service('mcp-servers').hooks({
+    before: {
+      create: [(context) => validateMcpServerWriteInput(context, true)],
+      patch: [(context) => validateMcpServerWriteInput(context, false)],
+      update: [(context) => validateMcpServerWriteInput(context, false)],
+    },
+    after: {
+      create: [redactMCPServerSecretFields],
+      patch: [redactMCPServerSecretFields],
+      update: [redactMCPServerSecretFields],
+    },
+  } as never);
+  return { app, repository };
+}
+
+const createInput = (auth: MCPAuth) => ({
+  name: `server-${auth.type}`,
+  transport: 'http' as const,
+  url: 'https://mcp.example.test/mcp',
+  auth,
+  scope: 'global' as const,
+  enabled: true,
+});
+
+describe('MCP server public write contract', () => {
+  it.each(['rest', 'socketio'] as const)(
+    'rejects server-owned and unknown top-level CREATE/PUT fields in %s provider-hook units',
+    async (provider) => {
+      const { app } = await buildService();
+      const params = externalParams(provider);
+
+      for (const field of [
+        'mcp_server_id',
+        'created_at',
+        'updated_at',
+        'config_version',
+        'runtime_generation',
+        'mcp_runtime',
+      ]) {
+        await expect(
+          app
+            .service('mcp-servers')
+            .create({ ...createInput({ type: 'none' }), [field]: Number.MAX_SAFE_INTEGER }, params)
+        ).rejects.toThrow(`Unknown MCP server field: ${field}`);
+      }
+
+      const stored = await app.service('mcp-servers').create(createInput({ type: 'none' }), params);
+      await expect(
+        app
+          .service('mcp-servers')
+          .update(
+            stored.mcp_server_id,
+            { display_name: 'forged', owner_user_id: 'user-2' } as never,
+            params
+          )
+      ).rejects.toThrow('Unknown MCP server field: owner_user_id');
+      for (const field of ['mcp_server_id', 'created_at', 'config_version', 'tools']) {
+        await expect(
+          app
+            .service('mcp-servers')
+            .update(stored.mcp_server_id, { display_name: 'forged', [field]: [] } as never, params)
+        ).rejects.toThrow(`Unknown MCP server field: ${field}`);
+      }
+    }
+  );
+
+  it.each(['rest', 'socketio'] as const)(
+    'rejects CREATE sentinels and unknown nested auth fields in %s provider-hook units',
+    async (provider) => {
+      const { app, repository } = await buildService();
+      const params = externalParams(provider);
+
+      await expect(
+        app
+          .service('mcp-servers')
+          .create(createInput({ type: 'bearer', token: MCP_HEADER_REDACTED_SENTINEL }), params)
+      ).rejects.toThrow(/redaction sentinel on create/);
+      await expect(
+        app
+          .service('mcp-servers')
+          .create(
+            createInput({ type: 'oauth', oauth_client_secret_typo: 'secret' } as never),
+            params
+          )
+      ).rejects.toThrow('Unknown auth field: oauth_client_secret_typo');
+      expect(await repository.findAll()).toHaveLength(0);
+    }
+  );
+
+  it('normalizes CREATE auth:null to an absent auth object', async () => {
+    const { app, repository } = await buildService();
+    const created = await app
+      .service('mcp-servers')
+      .create({ ...createInput({ type: 'none' }), auth: null } as never, externalParams('rest'));
+    expect(created.auth).toBeUndefined();
+    expect((await repository.findById(created.mcp_server_id))?.auth).toBeUndefined();
+  });
+
+  it.each([
+    {
+      label: 'bearer',
+      auth: { type: 'bearer', token: 'bearer-secret' } as MCPAuth,
+      replacement: { type: 'bearer', token: MCP_HEADER_REDACTED_SENTINEL },
+      secret: 'bearer-secret',
+      field: 'token',
+    },
+    {
+      label: 'JWT',
+      auth: {
+        type: 'jwt',
+        api_url: 'https://auth.example.test/token',
+        api_token: 'jwt-token',
+        api_secret: 'jwt-secret',
+      } as MCPAuth,
+      replacement: {
+        type: 'jwt',
+        api_url: 'https://auth.example.test/token',
+        api_token: MCP_HEADER_REDACTED_SENTINEL,
+        api_secret: MCP_HEADER_REDACTED_SENTINEL,
+      },
+      secret: 'jwt-secret',
+      field: 'api_secret',
+    },
+    {
+      label: 'OAuth',
+      auth: {
+        type: 'oauth',
+        oauth_scope: 'old-scope',
+        oauth_client_secret: 'oauth-secret',
+        oauth_access_token: 'oauth-access',
+        oauth_refresh_token: 'oauth-refresh',
+      } as MCPAuth,
+      replacement: {
+        type: 'oauth',
+        oauth_scope: 'new-scope',
+        oauth_client_secret: MCP_HEADER_REDACTED_SENTINEL,
+        oauth_access_token: MCP_HEADER_REDACTED_SENTINEL,
+        oauth_refresh_token: MCP_HEADER_REDACTED_SENTINEL,
+      },
+      secret: 'oauth-secret',
+      field: 'oauth_client_secret',
+    },
+  ])('round-trips redacted $label secrets through PUT without publishing them', async (entry) => {
+    const { app, repository } = await buildService();
+    const params = externalParams('socketio');
+    const created = await repository.create(createInput(entry.auth));
+    const events: MCPServer[] = [];
+    app
+      .service('mcp-servers')
+      .on('updated', (_server: MCPServer, hook: { dispatch?: MCPServer; result?: MCPServer }) =>
+        events.push((hook.dispatch ?? hook.result) as MCPServer)
+      );
+
+    const response = (await app.service('mcp-servers').update(
+      created.mcp_server_id,
+      {
+        display_name: 'PUT result',
+        transport: 'http',
+        url: 'https://mcp.example.test/mcp',
+        scope: 'global',
+        enabled: true,
+        auth: entry.replacement,
+      } as never,
+      params
+    )) as MCPServer;
+
+    const stored = await repository.findById(created.mcp_server_id);
+    expect(stored?.auth?.[entry.field as keyof MCPAuth]).toBe(entry.secret);
+    expect(response.auth?.[entry.field as keyof MCPAuth]).toBe(MCP_HEADER_REDACTED_SENTINEL);
+    expect(JSON.stringify(response)).not.toContain(entry.secret);
+    expect(JSON.stringify(events)).not.toContain(entry.secret);
+    if (entry.label === 'JWT') {
+      expect(stored?.auth).toMatchObject({ api_url: 'https://auth.example.test/token' });
+    }
+    if (entry.label === 'OAuth') expect(stored?.auth?.oauth_scope).toBe('new-scope');
+  });
+
+  it('preserves explicit field-clear and whole-auth-clear semantics on PATCH/PUT', async () => {
+    const { app, repository } = await buildService();
+    const params = externalParams('rest');
+    const created = await repository.create(
+      createInput({ type: 'oauth', oauth_client_id: 'client', oauth_client_secret: 'secret' })
+    );
+
+    await app
+      .service('mcp-servers')
+      .patch(created.mcp_server_id, { auth: { oauth_client_secret: null } }, params);
+    expect((await repository.findById(created.mcp_server_id))?.auth).toEqual({
+      type: 'oauth',
+      oauth_client_id: 'client',
+    });
+
+    await app.service('mcp-servers').update(
+      created.mcp_server_id,
+      {
+        transport: 'http',
+        url: 'https://mcp.example.test/mcp',
+        scope: 'global',
+        enabled: true,
+        auth: null,
+      } as never,
+      params
+    );
+    expect((await repository.findById(created.mcp_server_id))?.auth).toBeUndefined();
+  });
+});

--- a/apps/agor-daemon/src/services/mcp-servers.write-transport.integration.test.ts
+++ b/apps/agor-daemon/src/services/mcp-servers.write-transport.integration.test.ts
@@ -1,0 +1,934 @@
+import type { Server } from 'node:http';
+import type { TenantScopeAwareDatabase } from '@agor/core/db';
+import {
+  createDatabaseAsync,
+  MCPServerRepository,
+  runMigrations,
+  shortId,
+  UserMCPOAuthTokenRepository,
+} from '@agor/core/db';
+import {
+  errorHandler,
+  feathers,
+  feathersExpress,
+  NotAuthenticated,
+  rest,
+  socketio,
+  socketioClient,
+} from '@agor/core/feathers';
+import { mcpServerQueryValidator, typedValidateQuery } from '@agor/core/lib/feathers-validation';
+import { MCP_HEADER_REDACTED_SENTINEL } from '@agor/core/tools/mcp/http-headers';
+import type { HookContext, MCPAuth, MCPServer, MCPServerID } from '@agor/core/types';
+import { type Socket as ClientSocket, io as createSocketClient } from 'socket.io-client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { redactMCPServerSecretFields, validateMcpServerWriteInput } from '../register-hooks.js';
+import { type RegisterServicesContext, registerMCPServices } from '../register-services.js';
+import { createMCPServersService } from './mcp-servers.js';
+
+const USER_ID = '01900000-0000-7000-8000-000000000001';
+const AUTH_TOKEN = 'mcp-write-contract-token';
+
+type Client = ReturnType<typeof feathers> & { io?: ClientSocket };
+
+interface Harness {
+  baseUrl: string;
+  repository: MCPServerRepository;
+  client: Client;
+  socket: ClientSocket;
+  grants: UserMCPOAuthTokenRepository;
+  close(): Promise<void>;
+}
+
+interface CoordinatorProbe {
+  pendingServerIds: Set<string>;
+  invalidatedServerIds: string[];
+  lockServerIds: string[];
+}
+
+function waitForSocket(socket: ClientSocket): Promise<void> {
+  if (socket.connected) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    socket.once('connect', resolve);
+    socket.once('connect_error', reject);
+  });
+}
+
+async function createHarness(
+  token = AUTH_TOKEN,
+  coordinatorProbe?: CoordinatorProbe,
+  mcpOutboundDnsLookup?: RegisterServicesContext['mcpOutboundDnsLookup']
+): Promise<Harness> {
+  const rawDb = await createDatabaseAsync({ dialect: 'sqlite', url: ':memory:' });
+  await runMigrations(rawDb);
+  const repository = new MCPServerRepository(rawDb);
+  const app = feathersExpress(feathers());
+  app.use(feathersExpress.json());
+  app.configure(rest());
+  app.configure(
+    socketio({}, (io) => {
+      io.on('connection', (socket) => {
+        if (socket.handshake.auth.token === AUTH_TOKEN) {
+          socket.feathers.user = { user_id: USER_ID, role: 'admin' };
+          socket.feathers.tenant = { tenant_id: 'default', source: 'static' };
+          app.channel('authenticated').join(socket.feathers as never);
+        }
+      });
+    })
+  );
+  const requireAuth = (context: HookContext): HookContext => {
+    const bearer = context.params.headers?.authorization;
+    const restAuthenticated = bearer === `Bearer ${AUTH_TOKEN}`;
+    const socketUser = context.params.user ?? context.params.connection?.user;
+    if (context.params.provider && !restAuthenticated && !socketUser) {
+      throw new NotAuthenticated('Authentication required');
+    }
+    context.params.user = socketUser ?? ({ user_id: USER_ID, role: 'admin' } as never);
+    context.params.tenant =
+      context.params.tenant ?? ({ tenant_id: 'default', source: 'static' } as never);
+    return context;
+  };
+  if (coordinatorProbe || mcpOutboundDnsLookup) {
+    await registerMCPServices({
+      db: rawDb as unknown as TenantScopeAwareDatabase,
+      app: app as never,
+      config: {} as RegisterServicesContext['config'],
+      jwtSecret: 'transport-contract-jwt',
+      daemonUrl: 'http://127.0.0.1:3030',
+      bundledUiAvailable: false,
+      DAEMON_PORT: 3030,
+      UI_PORT: 5173,
+      branchRbacEnabled: false,
+      allowSuperadmin: false,
+      requireAuth: async (context) => requireAuth(context),
+      deployment: {} as RegisterServicesContext['deployment'],
+      ...(coordinatorProbe
+        ? {
+            mcpOAuthPendingFlowAuthority: {
+              invalidateForServer: async (_tenantId: string, serverId: MCPServerID) => {
+                if (!coordinatorProbe.pendingServerIds.delete(serverId)) return 0;
+                coordinatorProbe.invalidatedServerIds.push(serverId);
+                return 1;
+              },
+              maintain: async () => undefined,
+            } as unknown as NonNullable<RegisterServicesContext['mcpOAuthPendingFlowAuthority']>,
+            lockMcpOAuthGrantConfiguration: async (_db, _tenantId, serverId) => {
+              coordinatorProbe.lockServerIds.push(serverId);
+            },
+          }
+        : {}),
+      mcpOutboundDnsLookup,
+    });
+  } else {
+    app.use('mcp-servers', createMCPServersService(rawDb as unknown as TenantScopeAwareDatabase));
+  }
+  app.service('mcp-servers').hooks({
+    before: {
+      all: [requireAuth, typedValidateQuery(mcpServerQueryValidator)],
+      create: [(context) => validateMcpServerWriteInput(context, true)],
+      patch: [(context) => validateMcpServerWriteInput(context, false)],
+      update: [(context) => validateMcpServerWriteInput(context, false)],
+    },
+    after: {
+      create: [redactMCPServerSecretFields],
+      patch: [redactMCPServerSecretFields],
+      update: [redactMCPServerSecretFields],
+    },
+  } as never);
+  app.service('mcp-servers').publish(() => app.channel('authenticated'));
+  app.use(errorHandler());
+
+  const server = (await app.listen(0, '127.0.0.1')) as Server;
+  if (!server.listening) {
+    await new Promise<void>((resolve, reject) => {
+      server.once('listening', resolve);
+      server.once('error', reject);
+    });
+  }
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('Expected MCP test listener');
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+  const socket = createSocketClient(baseUrl, {
+    auth: { token },
+    transports: ['websocket'],
+    reconnection: false,
+  });
+  const client = feathers() as Client;
+  client.configure(socketioClient(socket));
+  await waitForSocket(socket);
+
+  return {
+    baseUrl,
+    repository,
+    grants: new UserMCPOAuthTokenRepository(rawDb),
+    client,
+    socket,
+    close: async () => {
+      socket.close();
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve()))
+      );
+      (rawDb as unknown as { $client?: { close(): void } }).$client?.close();
+    },
+  };
+}
+
+function createInput(auth: MCPAuth = { type: 'none' }) {
+  return {
+    name: 'transport-contract',
+    display_name: 'Transport Contract',
+    transport: 'http' as const,
+    url: 'https://mcp.example.test/mcp',
+    auth,
+    scope: 'global' as const,
+    enabled: true,
+  };
+}
+
+async function restWrite(
+  harness: Harness,
+  method: 'POST' | 'PUT' | 'PATCH',
+  data: unknown,
+  id?: string,
+  authenticated = true
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  const response = await fetch(`${harness.baseUrl}/mcp-servers${id ? `/${id}` : ''}`, {
+    method,
+    headers: {
+      'content-type': 'application/json',
+      ...(authenticated ? { authorization: `Bearer ${AUTH_TOKEN}` } : {}),
+    },
+    body: JSON.stringify(data),
+  });
+  return { status: response.status, body: (await response.json()) as Record<string, unknown> };
+}
+
+const invalidCreates: Array<{ label: string; value: Record<string, unknown>; error: RegExp }> = [
+  { label: 'caller ID', value: { mcp_server_id: USER_ID }, error: /mcp_server_id/ },
+  { label: 'timestamp', value: { created_at: new Date().toISOString() }, error: /created_at/ },
+  { label: 'runtime state', value: { mcp_runtime: {} }, error: /mcp_runtime/ },
+  { label: 'runtime revision', value: { config_version: 2 }, error: /config_version/ },
+  { label: 'source', value: { source: 'catalog' }, error: /source/ },
+  { label: 'import path', value: { import_path: '/tmp/secret' }, error: /import_path/ },
+  { label: 'catalog stamp', value: { catalog_entry_name: 'forged' }, error: /catalog_entry_name/ },
+  { label: 'transport enum', value: { transport: 'websocket' }, error: /transport must be/ },
+  { label: 'remote URL', value: { url: undefined }, error: /url is required/ },
+  {
+    label: 'stdio command',
+    value: { transport: 'stdio', url: undefined, command: undefined },
+    error: /command is required/,
+  },
+  { label: 'scope enum', value: { scope: 'tenant' }, error: /scope must be/ },
+  { label: 'enabled shape', value: { enabled: 'yes' }, error: /enabled must be boolean/ },
+  { label: 'args shape', value: { args: ['ok', 1] }, error: /args must contain/ },
+  { label: 'env shape', value: { env: { 'BAD-NAME': 'secret' } }, error: /environment variable/ },
+  {
+    label: 'headers shape',
+    value: { headers: { Authorization: 'secret' } },
+    error: /not an allowed/,
+  },
+  { label: 'name shape', value: { name: 7 }, error: /name must be a string/ },
+  { label: 'URL protocol', value: { url: 'javascript:alert(1)' }, error: /HTTP\(S\)/ },
+  {
+    label: 'unmatched opening header template',
+    value: { headers: { 'X-Secret': 'sentinel{{' } },
+    error: /unbalanced template delimiter/,
+  },
+  {
+    label: 'unmatched closing env template',
+    value: { env: { MCP_SECRET: 'sentinel}}' } },
+    error: /unbalanced template delimiter/,
+  },
+  {
+    label: 'unmatched bearer template',
+    value: { auth: { type: 'bearer', token: 'sentinel{{' } },
+    error: /unbalanced template delimiter/,
+  },
+  {
+    label: 'arbitrary URL template',
+    value: { url: 'https://mcp.example.test/{{ lookup user.env "TARGET" }}' },
+    error: /only user\.env templates/,
+  },
+  {
+    label: 'embedded URL credentials',
+    value: { url: 'https://user:pass@mcp.example.test' },
+    error: /embedded credentials/,
+  },
+  {
+    label: 'header sentinel',
+    value: { headers: { 'X-Secret': MCP_HEADER_REDACTED_SENTINEL } },
+    error: /redaction sentinel on create/,
+  },
+  {
+    label: 'env sentinel',
+    value: { env: { MCP_SECRET: MCP_HEADER_REDACTED_SENTINEL } },
+    error: /redaction sentinel on create/,
+  },
+  {
+    label: 'unknown auth key',
+    value: { auth: { type: 'oauth', oauth_client_secert: 'typo' } },
+    error: /oauth_client_secert/,
+  },
+  {
+    label: 'bearer sentinel',
+    value: { auth: { type: 'bearer', token: MCP_HEADER_REDACTED_SENTINEL } },
+    error: /redaction sentinel on create/,
+  },
+  {
+    label: 'missing bearer token',
+    value: { auth: { type: 'bearer' } },
+    error: /auth\.token is required/,
+  },
+  {
+    label: 'missing JWT fields',
+    value: { auth: { type: 'jwt' } },
+    error: /auth\.api_url is required/,
+  },
+  {
+    label: 'JWT sentinel',
+    value: { auth: { type: 'jwt', api_secret: MCP_HEADER_REDACTED_SENTINEL } },
+    error: /redaction sentinel on create/,
+  },
+  {
+    label: 'OAuth sentinel',
+    value: {
+      auth: { type: 'oauth', oauth_client_secret: MCP_HEADER_REDACTED_SENTINEL },
+    },
+    error: /redaction sentinel on create/,
+  },
+  {
+    label: 'wrong auth mode',
+    value: { auth: { type: 'none', token: 'must-not-persist' } },
+    error: /does not apply/,
+  },
+  {
+    label: 'OAuth enum',
+    value: { auth: { type: 'oauth', oauth_mode: 'workspace' } },
+    error: /oauth_mode/,
+  },
+  {
+    label: 'OAuth expiry range',
+    value: { auth: { type: 'oauth', oauth_token_expires_at: Number.MAX_SAFE_INTEGER + 1 } },
+    error: /safe integer/,
+  },
+  {
+    label: 'auth URL protocol',
+    value: { auth: { type: 'jwt', api_url: 'file:///tmp/token' } },
+    error: /HTTP\(S\)/,
+  },
+  {
+    label: 'arbitrary auth URL template',
+    value: { auth: { type: 'jwt', api_url: 'https://{{ lookup user.env "HOST" }}' } },
+    error: /only user\.env templates/,
+  },
+  {
+    label: 'stdio remote fields',
+    value: { transport: 'stdio', command: 'node', url: 'https://mcp.example.test' },
+    error: /does not apply to stdio/,
+  },
+];
+
+describe('MCP server real REST and Socket.IO write contract', () => {
+  it.each(['REST'] as const)(
+    'sanitizes secret-bearing JWT DNS/provider exceptions over %s',
+    async (transport) => {
+      const sentinel = `SENTINEL_${transport}_JWT_DNS_84a1`;
+      const harness = await createHarness(AUTH_TOKEN, undefined, async () => {
+        throw Object.assign(new Error(`lookup failed for https://${sentinel}.example.test`), {
+          code: 'ENOTFOUND',
+        });
+      });
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      const realtimeSpy = vi.fn();
+      for (const event of ['created', 'updated', 'patched', 'removed'] as const) {
+        harness.client.service('mcp-servers').on(event, realtimeSpy);
+      }
+      try {
+        const payload = {
+          api_url: 'https://auth.example.test/token',
+          api_token: 'configured-token',
+          api_secret: sentinel,
+        };
+        const result =
+          transport === 'REST'
+            ? await fetch(`${harness.baseUrl}/mcp-servers/test-jwt`, {
+                method: 'POST',
+                headers: {
+                  authorization: `Bearer ${AUTH_TOKEN}`,
+                  'content-type': 'application/json',
+                },
+                body: JSON.stringify(payload),
+              }).then((response) => response.json())
+            : await harness.client.service('mcp-servers/test-jwt').create(payload);
+
+        expect(result).toMatchObject({ success: false, category: 'provider_unavailable' });
+        expect(JSON.stringify(result)).not.toContain(sentinel);
+        expect(JSON.stringify(errorSpy.mock.calls)).not.toContain(sentinel);
+        expect(JSON.stringify(await harness.repository.findAll())).not.toContain(sentinel);
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        expect(JSON.stringify(realtimeSpy.mock.calls)).not.toContain(sentinel);
+        expect(realtimeSpy).not.toHaveBeenCalled();
+      } finally {
+        errorSpy.mockRestore();
+        await harness.close();
+      }
+    }
+  );
+  const harnesses: Harness[] = [];
+  afterEach(async () => {
+    while (harnesses.length) await harnesses.pop()!.close();
+  });
+
+  it.each(['REST', 'Socket.IO'] as const)(
+    'authenticates %s before parsing a deliberately invalid write',
+    async (transport) => {
+      const harness = await createHarness(transport === 'Socket.IO' ? 'wrong-token' : AUTH_TOKEN);
+      harnesses.push(harness);
+      const invalid = { ...createInput(), source: 'catalog' };
+      if (transport === 'REST') {
+        const response = await restWrite(harness, 'POST', invalid, undefined, false);
+        expect(response.status).toBe(401);
+        expect(JSON.stringify(response.body)).not.toContain('Unknown MCP server field');
+      } else {
+        await expect(harness.client.service('mcp-servers').create(invalid)).rejects.toThrow(
+          /Authentication required/
+        );
+      }
+      expect(await harness.repository.findAll()).toEqual([]);
+    }
+  );
+
+  it.each(['REST', 'Socket.IO'] as const)(
+    'authenticates %s before parsing an invalid query',
+    async (transport) => {
+      const harness = await createHarness(transport === 'Socket.IO' ? 'wrong-token' : AUTH_TOKEN);
+      harnesses.push(harness);
+      if (transport === 'REST') {
+        const response = await fetch(`${harness.baseUrl}/mcp-servers?transport=websocket`);
+        expect(response.status).toBe(401);
+        expect(await response.text()).not.toContain('validation');
+      } else {
+        await expect(
+          harness.client.service('mcp-servers').find({
+            query: { transport: 'websocket' },
+          } as never)
+        ).rejects.toThrow(/Authentication required/);
+      }
+    }
+  );
+
+  it.each(['REST', 'Socket.IO'] as const)(
+    'rejects every closed CREATE schema violation over real %s transport',
+    async (transport) => {
+      const harness = await createHarness();
+      harnesses.push(harness);
+      for (const invalid of invalidCreates) {
+        const payload = { ...createInput(), ...invalid.value };
+        if (transport === 'REST') {
+          const response = await restWrite(harness, 'POST', payload);
+          expect(response.status, invalid.label).toBe(400);
+          expect(String(response.body.message), invalid.label).toMatch(invalid.error);
+        } else {
+          await expect(
+            harness.client.service('mcp-servers').create(payload),
+            invalid.label
+          ).rejects.toThrow(invalid.error);
+        }
+      }
+      expect(await harness.repository.findAll()).toEqual([]);
+    }
+  );
+
+  it.each(['REST', 'Socket.IO'] as const)(
+    'rejects malformed PATCH and PUT fields over real %s transport',
+    async (transport) => {
+      const harness = await createHarness();
+      harnesses.push(harness);
+      const created = await harness.repository.create(
+        createInput({
+          type: 'oauth',
+          oauth_client_secret: 'stored-secret',
+        })
+      );
+      const invalidMutations = [
+        { data: { source: 'catalog' }, error: /source/ },
+        { data: { import_path: '/tmp/forged' }, error: /import_path/ },
+        { data: { catalog_entry_name: 'forged' }, error: /catalog_entry_name/ },
+        { data: { mcp_server_id: USER_ID }, error: /mcp_server_id/ },
+        { data: { created_at: new Date().toISOString() }, error: /created_at/ },
+        { data: { config_version: Number.MAX_SAFE_INTEGER }, error: /config_version/ },
+        { data: { mcp_runtime: {} }, error: /mcp_runtime/ },
+        { data: { runtime_generation: 9 }, error: /runtime_generation/ },
+        {
+          data: { headers: { 'X-Secret': 'sentinel}}' } },
+          error: /unbalanced template delimiter/,
+        },
+        {
+          data: { auth: { type: 'oauth', oauth_client_secret: 'sentinel{{' } },
+          error: /unbalanced template delimiter/,
+        },
+        { data: { expected_config_version: Number.MAX_SAFE_INTEGER + 1 }, error: /safe integer/ },
+        { data: { tool_permissions: { search: 'sometimes' } }, error: /tool_permissions/ },
+        { data: { replace_auth: true }, error: /replace_auth requires auth/ },
+        {
+          data: { auth: { token: 'wrong-mode' } },
+          error: /does not apply|auth\.type is required/,
+        },
+      ];
+      for (const entry of invalidMutations) {
+        for (const method of ['PATCH', 'PUT'] as const) {
+          if (transport === 'REST') {
+            const response = await restWrite(harness, method, entry.data, created.mcp_server_id);
+            expect(
+              response.status,
+              `${method} ${JSON.stringify(entry.data)}: ${JSON.stringify(response.body)}`
+            ).toBe(400);
+            expect(String(response.body.message)).toMatch(entry.error);
+          } else {
+            const service = harness.client.service('mcp-servers');
+            const request =
+              method === 'PATCH'
+                ? service.patch(created.mcp_server_id, entry.data)
+                : service.update(created.mcp_server_id, entry.data);
+            await expect(request).rejects.toThrow(entry.error);
+          }
+        }
+      }
+    }
+  );
+
+  it.each(['REST', 'Socket.IO'] as const)(
+    'persists CREATE auth:null as no auth over real %s transport',
+    async (transport) => {
+      const harness = await createHarness();
+      harnesses.push(harness);
+      const payload = { ...createInput(), auth: null };
+      const created =
+        transport === 'REST'
+          ? (await restWrite(harness, 'POST', payload)).body
+          : ((await harness.client.service('mcp-servers').create(payload)) as MCPServer);
+      expect(created.auth).toBeUndefined();
+      expect(
+        (await harness.repository.findById(String(created.mcp_server_id)))?.auth
+      ).toBeUndefined();
+    }
+  );
+
+  it.each(['REST', 'Socket.IO'] as const)(
+    'validates the effective row and cleans HTTP↔stdio transitions over real %s transport',
+    async (transport) => {
+      const harness = await createHarness();
+      harnesses.push(harness);
+      const remote = await harness.repository.create({
+        ...createInput({ type: 'bearer', token: 'remote-secret' }),
+        headers: { 'X-Remote': 'configured' },
+      });
+      const service = harness.client.service('mcp-servers');
+
+      const toStdio =
+        transport === 'REST'
+          ? await restWrite(
+              harness,
+              'PATCH',
+              { transport: 'stdio', command: 'node', args: ['server.js'] },
+              remote.mcp_server_id
+            )
+          : {
+              status: 200,
+              body: (await service.patch(remote.mcp_server_id, {
+                transport: 'stdio',
+                command: 'node',
+                args: ['server.js'],
+              })) as unknown as Record<string, unknown>,
+            };
+      expect(toStdio.status).toBe(200);
+      expect(await harness.repository.findById(remote.mcp_server_id)).toMatchObject({
+        transport: 'stdio',
+        command: 'node',
+        args: ['server.js'],
+      });
+      const storedStdio = await harness.repository.findById(remote.mcp_server_id);
+      expect(storedStdio?.url).toBeUndefined();
+      expect(storedStdio?.headers).toBeUndefined();
+      expect(storedStdio?.auth).toBeUndefined();
+
+      const toHttp =
+        transport === 'REST'
+          ? await restWrite(
+              harness,
+              'PATCH',
+              { transport: 'http', url: 'https://next.example.test/mcp' },
+              remote.mcp_server_id
+            )
+          : {
+              status: 200,
+              body: (await service.patch(remote.mcp_server_id, {
+                transport: 'http',
+                url: 'https://next.example.test/mcp',
+              })) as unknown as Record<string, unknown>,
+            };
+      expect(toHttp.status).toBe(200);
+      const storedHttp = await harness.repository.findById(remote.mcp_server_id);
+      expect(storedHttp).toMatchObject({
+        transport: 'http',
+        url: 'https://next.example.test/mcp',
+      });
+      expect(storedHttp?.command).toBeUndefined();
+      expect(storedHttp?.args).toBeUndefined();
+
+      const invalidRequests = [
+        { data: { command: 'must-not-append' }, error: /only apply to stdio/ },
+        { data: { transport: 'stdio' }, error: /command is required/ },
+      ];
+      for (const invalid of invalidRequests) {
+        if (transport === 'REST') {
+          const response = await restWrite(harness, 'PATCH', invalid.data, remote.mcp_server_id);
+          expect(response.status).toBe(400);
+          expect(String(response.body.message)).toMatch(invalid.error);
+        } else {
+          await expect(service.patch(remote.mcp_server_id, invalid.data)).rejects.toThrow(
+            invalid.error
+          );
+        }
+      }
+    }
+  );
+
+  it.each(['REST', 'Socket.IO'] as const)(
+    'applies PUT replacement to omitted non-secret configuration over real %s transport',
+    async (transport) => {
+      const harness = await createHarness();
+      harnesses.push(harness);
+      const created = await harness.repository.create({
+        ...createInput({ type: 'bearer', token: 'old-token' }),
+        description: 'remove me',
+        headers: { 'X-Old': 'header' },
+        env: { OLD_SECRET: 'value' },
+        tool_permissions: { search: 'allow' },
+      });
+      const replacement = {
+        display_name: 'PUT replacement',
+        transport: 'http',
+        url: 'https://replacement.example.test/mcp',
+        scope: 'global',
+        enabled: true,
+      };
+      const incomplete = { ...replacement, url: undefined };
+      if (transport === 'REST') {
+        const rejected = await restWrite(harness, 'PUT', incomplete, created.mcp_server_id);
+        expect(rejected.status).toBe(400);
+        expect(String(rejected.body.message)).toMatch(/url is required/);
+      } else {
+        await expect(
+          harness.client.service('mcp-servers').update(created.mcp_server_id, incomplete)
+        ).rejects.toThrow(/url is required/);
+      }
+      if (transport === 'REST') {
+        expect((await restWrite(harness, 'PUT', replacement, created.mcp_server_id)).status).toBe(
+          200
+        );
+      } else {
+        await harness.client.service('mcp-servers').update(created.mcp_server_id, replacement);
+      }
+      const stored = await harness.repository.findById(created.mcp_server_id);
+      expect(stored).toMatchObject({
+        display_name: 'PUT replacement',
+        transport: 'http',
+        url: 'https://replacement.example.test/mcp',
+      });
+      expect(stored?.description).toBeUndefined();
+      expect(stored?.headers).toBeUndefined();
+      expect(stored?.env).toBeUndefined();
+      expect(stored?.auth).toBeUndefined();
+      expect(stored?.tool_permissions).toBeUndefined();
+    }
+  );
+
+  it.each([
+    {
+      label: 'bearer',
+      auth: { type: 'bearer', token: 'bearer-secret' } as MCPAuth,
+      putAuth: { type: 'bearer', token: MCP_HEADER_REDACTED_SENTINEL },
+      secretField: 'token',
+      secret: 'bearer-secret',
+    },
+    {
+      label: 'JWT',
+      auth: {
+        type: 'jwt',
+        api_url: 'https://auth.example.test/token',
+        api_token: 'jwt-token',
+        api_secret: 'jwt-secret',
+      } as MCPAuth,
+      putAuth: {
+        type: 'jwt',
+        api_url: 'https://auth.example.test/token',
+        api_token: MCP_HEADER_REDACTED_SENTINEL,
+        api_secret: MCP_HEADER_REDACTED_SENTINEL,
+      },
+      secretField: 'api_secret',
+      secret: 'jwt-secret',
+    },
+    {
+      label: 'OAuth',
+      auth: {
+        type: 'oauth',
+        oauth_client_secret: 'oauth-secret',
+        oauth_access_token: 'oauth-access',
+        oauth_refresh_token: 'oauth-refresh',
+      } as MCPAuth,
+      putAuth: {
+        type: 'oauth',
+        oauth_client_secret: MCP_HEADER_REDACTED_SENTINEL,
+        oauth_access_token: MCP_HEADER_REDACTED_SENTINEL,
+        oauth_refresh_token: MCP_HEADER_REDACTED_SENTINEL,
+      },
+      secretField: 'oauth_client_secret',
+      secret: 'oauth-secret',
+    },
+  ])(
+    'redacts real responses/events and preserves $label plus header/env sentinels on PUT',
+    async (entry) => {
+      const harness = await createHarness();
+      harnesses.push(harness);
+      const createdEvent = new Promise<MCPServer>((resolve) => {
+        harness.client.service('mcp-servers').once('created', resolve);
+      });
+      const created = await restWrite(harness, 'POST', {
+        ...createInput(entry.auth),
+        headers: { 'X-Secret': 'header-secret' },
+        env: { MCP_SECRET: 'env-secret' },
+      });
+      expect(created.status).toBe(201);
+      expect(JSON.stringify(created.body)).not.toContain(entry.secret);
+      expect(JSON.stringify(created.body)).not.toContain('header-secret');
+      expect(JSON.stringify(created.body)).not.toContain('env-secret');
+      const createdEventJson = JSON.stringify(await createdEvent);
+      expect(createdEventJson).not.toContain(entry.secret);
+      expect(createdEventJson).not.toContain('header-secret');
+      expect(createdEventJson).not.toContain('env-secret');
+
+      const id = String(created.body.mcp_server_id);
+      const updatedEvent = new Promise<MCPServer>((resolve) => {
+        harness.client.service('mcp-servers').once('updated', resolve);
+      });
+      const put = (await harness.client.service('mcp-servers').update(id, {
+        display_name: 'Replacement label',
+        transport: 'http',
+        url: 'https://mcp.example.test/mcp',
+        scope: 'global',
+        enabled: true,
+        auth: entry.putAuth,
+        headers: { 'X-Secret': MCP_HEADER_REDACTED_SENTINEL },
+        env: { MCP_SECRET: MCP_HEADER_REDACTED_SENTINEL },
+      })) as MCPServer;
+      expect(JSON.stringify(put)).not.toContain(entry.secret);
+      const updatedEventJson = JSON.stringify(await updatedEvent);
+      expect(updatedEventJson).not.toContain(entry.secret);
+      expect(updatedEventJson).not.toContain('header-secret');
+      expect(updatedEventJson).not.toContain('env-secret');
+      const stored = await harness.repository.findById(id);
+      expect(stored?.auth?.[entry.secretField as keyof MCPAuth]).toBe(entry.secret);
+      expect(stored).toMatchObject({
+        display_name: 'Replacement label',
+        headers: { 'X-Secret': 'header-secret' },
+        env: { MCP_SECRET: 'env-secret' },
+      });
+
+      const cleared = await restWrite(harness, 'PATCH', { auth: null }, id);
+      expect(cleared.status).toBe(200);
+      expect((await harness.repository.findById(id))?.auth).toBeUndefined();
+    }
+  );
+
+  it.each(['REST', 'Socket.IO'] as const)(
+    'allows explicit bearer/JWT/OAuth secret clears and keeps the row editable over real %s',
+    async (transport) => {
+      const harness = await createHarness();
+      harnesses.push(harness);
+      const service = harness.client.service('mcp-servers');
+      const cases: Array<{ auth: MCPAuth; clear: Record<string, unknown>; expected: MCPAuth }> = [
+        {
+          auth: { type: 'bearer', token: 'saved-token' },
+          clear: { type: 'bearer', token: null },
+          expected: { type: 'bearer' },
+        },
+        {
+          auth: {
+            type: 'jwt',
+            api_url: 'https://auth.example.test/token',
+            api_token: 'saved-token',
+            api_secret: 'saved-secret',
+          },
+          clear: { type: 'jwt', api_token: null, api_secret: null },
+          expected: { type: 'jwt', api_url: 'https://auth.example.test/token' },
+        },
+        {
+          auth: {
+            type: 'oauth',
+            oauth_client_id: 'client',
+            oauth_client_secret: 'saved-secret',
+          },
+          clear: { type: 'oauth', oauth_client_secret: null },
+          expected: { type: 'oauth', oauth_client_id: 'client' },
+        },
+      ];
+
+      for (const [index, entry] of cases.entries()) {
+        const created = await harness.repository.create({
+          ...createInput(entry.auth),
+          name: `clear-${index}`,
+        });
+        if (transport === 'REST') {
+          const response = await restWrite(
+            harness,
+            'PATCH',
+            { auth: entry.clear },
+            created.mcp_server_id
+          );
+          expect(response.status).toBe(200);
+        } else {
+          await service.patch(created.mcp_server_id, { auth: entry.clear } as never);
+        }
+        expect((await harness.repository.findById(created.mcp_server_id))?.auth).toEqual(
+          entry.expected
+        );
+
+        const label = `still-editable-${index}`;
+        await service.patch(created.mcp_server_id, { display_name: label });
+        expect(await harness.repository.findById(created.mcp_server_id)).toMatchObject({
+          display_name: label,
+          auth: entry.expected,
+        });
+      }
+    }
+  );
+
+  it.each(['REST', 'Socket.IO'] as const)(
+    'honors PUT replace_auth:false merge compatibility over real %s',
+    async (transport) => {
+      const harness = await createHarness();
+      harnesses.push(harness);
+      const created = await harness.repository.create(
+        createInput({
+          type: 'oauth',
+          oauth_client_id: 'saved-client',
+          oauth_client_secret: 'saved-secret',
+          oauth_scope: 'before',
+        })
+      );
+      const put = {
+        display_name: 'Merged PUT',
+        transport: 'http' as const,
+        url: 'https://mcp.example.test/mcp',
+        scope: 'global' as const,
+        enabled: true,
+        replace_auth: false,
+        auth: { oauth_scope: 'after' },
+      };
+      if (transport === 'REST') {
+        expect((await restWrite(harness, 'PUT', put, created.mcp_server_id)).status).toBe(200);
+      } else {
+        await harness.client.service('mcp-servers').update(created.mcp_server_id, put as never);
+      }
+      expect((await harness.repository.findById(created.mcp_server_id))?.auth).toEqual({
+        type: 'oauth',
+        oauth_client_id: 'saved-client',
+        oauth_client_secret: 'saved-secret',
+        oauth_scope: 'after',
+      });
+    }
+  );
+
+  it('keeps trusted catalog provenance on the in-process contract only', async () => {
+    const harness = await createHarness();
+    harnesses.push(harness);
+    const external = await restWrite(harness, 'POST', {
+      ...createInput({ type: 'oauth' }),
+      source: 'catalog',
+      catalog_entry_name: 'io.example.mcp',
+    });
+    expect(external.status).toBe(400);
+
+    // Repository/catalog/import callers are explicit trusted in-process paths;
+    // they still pass the final effective-row contract before persistence.
+    await expect(
+      harness.repository.create({
+        ...createInput({ type: 'oauth' }),
+        source: 'catalog',
+      })
+    ).rejects.toThrow(/catalog_entry_name is required/);
+    const trusted = await harness.repository.create({
+      ...createInput({ type: 'oauth' }),
+      source: 'catalog',
+      catalog_entry_name: 'io.example.mcp',
+    });
+    expect(trusted).toMatchObject({ source: 'catalog', catalog_entry_name: 'io.example.mcp' });
+  });
+
+  it.each(['rest-patch', 'socket-put'] as const)(
+    'canonicalizes a short ID for configuration, grant, pending-flow, and lock work over %s',
+    async (transportCase) => {
+      const probe: CoordinatorProbe = {
+        pendingServerIds: new Set(),
+        invalidatedServerIds: [],
+        lockServerIds: [],
+      };
+      const harness = await createHarness(AUTH_TOKEN, probe);
+      harnesses.push(harness);
+      const created = await harness.repository.create({
+        ...createInput({
+          type: 'oauth',
+          oauth_mode: 'per_user',
+          oauth_client_id: 'client-id',
+          oauth_client_secret: 'client-secret',
+          oauth_scope: 'before',
+        }),
+        name: `short-${transportCase}`,
+      });
+      const fullId = created.mcp_server_id;
+      const abbreviatedId = shortId(fullId);
+      await harness.grants.saveToken(null, fullId, {
+        accessToken: 'historical-access-token',
+      });
+      probe.pendingServerIds.add(fullId);
+
+      if (transportCase === 'rest-patch') {
+        const response = await restWrite(
+          harness,
+          'PATCH',
+          { auth: { oauth_scope: 'after-rest' } },
+          abbreviatedId
+        );
+        expect(response.status).toBe(200);
+        expect(response.body).toMatchObject({ mcp_server_id: fullId });
+      } else {
+        const response = (await harness.client.service('mcp-servers').update(abbreviatedId, {
+          display_name: 'Short PUT',
+          transport: 'http',
+          url: 'https://mcp.example.test/mcp',
+          scope: 'global',
+          enabled: true,
+          auth: {
+            type: 'oauth',
+            oauth_mode: 'per_user',
+            oauth_client_id: 'client-id',
+            oauth_client_secret: MCP_HEADER_REDACTED_SENTINEL,
+            oauth_scope: 'after-socket',
+          },
+        })) as MCPServer;
+        expect(response).toMatchObject({ mcp_server_id: fullId, display_name: 'Short PUT' });
+        expect(response.auth?.oauth_client_secret).toBe(MCP_HEADER_REDACTED_SENTINEL);
+      }
+
+      const stored = await harness.repository.findById(fullId);
+      expect(stored?.auth?.oauth_scope).toBe(
+        transportCase === 'rest-patch' ? 'after-rest' : 'after-socket'
+      );
+      expect(stored?.auth?.oauth_client_secret).toBe('client-secret');
+      await expect(harness.grants.getToken(null, fullId)).resolves.toBeNull();
+      expect(probe.pendingServerIds.has(fullId)).toBe(false);
+      expect(probe.invalidatedServerIds).toEqual([fullId]);
+      expect(probe.lockServerIds).toEqual([fullId]);
+    }
+  );
+});

--- a/apps/agor-daemon/src/services/oauth-disconnect.test.ts
+++ b/apps/agor-daemon/src/services/oauth-disconnect.test.ts
@@ -124,4 +124,26 @@ describe('performOAuthDisconnect', () => {
     const result = await performOAuthDisconnect(deps);
     expect(result.success).toBe(true);
   });
+
+  it('returns and logs only the closed contract for hostile repository exceptions', async () => {
+    const sentinel = 'SENTINEL_OAUTH_DISCONNECT_EXCEPTION';
+    const failure = new Error(sentinel);
+    Object.defineProperty(failure, 'name', {
+      get() {
+        throw new Error(sentinel);
+      },
+    });
+    const log = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const deps = createMockDeps({
+      mcpServerRepo: { findById: vi.fn().mockRejectedValue(failure) },
+    });
+
+    const result = await performOAuthDisconnect(deps);
+
+    expect(result).toEqual({
+      success: false,
+      error: 'OAuth connection could not be removed',
+    });
+    expect(JSON.stringify(log.mock.calls)).not.toContain(sentinel);
+  });
 });

--- a/apps/agor-daemon/src/services/oauth-disconnect.ts
+++ b/apps/agor-daemon/src/services/oauth-disconnect.ts
@@ -5,6 +5,7 @@
  */
 
 import { shortId } from '@agor/core/db';
+import { sanitizeMCPExternalError } from '@agor/core/mcp';
 import type { MCPAuth } from '@agor/core/types';
 
 export interface OAuthDisconnectDeps {
@@ -71,8 +72,9 @@ export async function performOAuthDisconnect(
       oauthMode: server?.auth?.oauth_mode ?? 'per_user',
     };
   } catch (error) {
+    const safe = sanitizeMCPExternalError(error, { stage: 'oauth' });
     console.error(
-      `[OAuth Disconnect] Failed category=${error instanceof Error ? error.name : 'unknown'}`
+      `[OAuth Disconnect] event=mcp_external_failure category=${safe.category} type=${safe.diagnostic.type}`
     );
     return {
       success: false,

--- a/apps/agor-daemon/src/utils/mcp-discovered-capabilities.test.ts
+++ b/apps/agor-daemon/src/utils/mcp-discovered-capabilities.test.ts
@@ -116,6 +116,64 @@ describe('discovery authority/configuration CAS (SQLite)', () => {
     );
   });
 
+  it('accepts protocol-legal capabilities with optional descriptions and schemas', async () => {
+    const snapshot = await captureSnapshot();
+    const legal = {
+      tools: [{ name: 'no-description' }],
+      resources: [
+        { uri: 'file:///a', name: 'a' },
+        { uri: 'file:///b', name: 'b', description: 'optional' },
+      ],
+      prompts: [{ name: 'prompt', arguments: [{ name: 'subject' }] }],
+    };
+    await runWithTenantDatabaseTransaction(db, undefined, (scopedDb) =>
+      persistDiscoveredMCPCapabilities(scopedDb, undefined, snapshot, legal, masterSecret)
+    );
+
+    await expect(new MCPServerRepository(db).findById(server.mcp_server_id)).resolves.toMatchObject(
+      legal
+    );
+    await expect(
+      new MCPServerRepository(db).update(server.mcp_server_id, { display_name: 'Still editable' })
+    ).resolves.toMatchObject({ display_name: 'Still editable', ...legal });
+  });
+
+  it('fails closed on oversized or malicious provider discovery before persistence', async () => {
+    for (const malicious of [
+      {
+        tools: Array.from({ length: 257 }, (_, index) => ({ name: `tool-${index}` })),
+        resources: [],
+        prompts: [],
+      },
+      {
+        tools: [{ name: 'escape', provider_secret: 'must-not-persist' }],
+        resources: [],
+        prompts: [],
+      },
+      {
+        tools: [{ name: 'shape', input_schema: { value: () => 'not-json' } }],
+        resources: [],
+        prompts: [],
+      },
+    ]) {
+      const snapshot = await captureSnapshot();
+      await expect(
+        runWithTenantDatabaseTransaction(db, undefined, (scopedDb) =>
+          persistDiscoveredMCPCapabilities(
+            scopedDb,
+            undefined,
+            snapshot,
+            malicious as never,
+            masterSecret
+          )
+        )
+      ).rejects.toThrow(/at most 256|Unknown tools\[0\] field|must be an object/);
+      expect(
+        (await new MCPServerRepository(db).findById(server.mcp_server_id))?.tools
+      ).toBeUndefined();
+    }
+  });
+
   it('rejects endpoint A to B while provider I/O is held and writes no stale capabilities', async () => {
     const snapshot = await captureSnapshot();
     let releaseNetwork!: () => void;

--- a/apps/agor-daemon/src/utils/mcp-discovered-capabilities.ts
+++ b/apps/agor-daemon/src/utils/mcp-discovered-capabilities.ts
@@ -12,6 +12,7 @@ import {
   UsersRepository,
 } from '@agor/core/db';
 import { Conflict, Forbidden, NotAuthenticated, NotFound } from '@agor/core/feathers';
+import { assertValidDiscoveredMCPCapabilities } from '@agor/core/mcp';
 import { isAtLeastMemberRole, mayMemberUseMCPTransport } from '@agor/core/mcp/member-policy';
 import type {
   MCPAuth,
@@ -233,6 +234,10 @@ export async function persistDiscoveredMCPCapabilities(
   capabilities: DiscoveredMCPCapabilities,
   masterSecret: string
 ): Promise<void> {
+  // Provider discovery output is untrusted input. Bound and close it before
+  // any durable work so an oversized or extension-bearing response cannot be
+  // persisted and later bypass API redaction/export assumptions.
+  assertValidDiscoveredMCPCapabilities(capabilities);
   assertTenantDiscoveryScope(db, true);
   if (tenantId) await assertTenantWritable(db, tenantId);
 

--- a/apps/agor-daemon/src/utils/mcp-probe-templates.test.ts
+++ b/apps/agor-daemon/src/utils/mcp-probe-templates.test.ts
@@ -228,4 +228,39 @@ describe('resolveProbeServerTemplates', () => {
       expect(result.error).toContain('auth.oauth_client_secret');
     }
   });
+
+  it.each([
+    ['opening', 'SENTINEL_INLINE_OPEN_{{'],
+    ['closing', 'SENTINEL_INLINE_CLOSE_}}'],
+  ])('rejects a directly supplied unmatched %s delimiter', (_kind, marker) => {
+    const result = resolveProbeServerTemplates(
+      {
+        url: 'https://api.example.com/mcp',
+        transport: 'http',
+        headers: { 'X-Private': marker },
+        auth: { type: 'bearer', token: marker },
+      },
+      {}
+    );
+
+    expect(result.ok).toBe(false);
+    expect(JSON.stringify(result)).not.toContain(marker);
+  });
+
+  it.each([
+    ['opening', 'SENTINEL_INLINE_ENV_OPEN_{{'],
+    ['closing', 'SENTINEL_INLINE_ENV_CLOSE_}}'],
+  ])('rejects an unmatched %s delimiter introduced by user.env', (_kind, marker) => {
+    const result = resolveProbeServerTemplates(
+      {
+        url: '{{ user.env.MCP_URL }}',
+        transport: 'http',
+        auth: { type: 'oauth', oauth_client_secret: '{{ user.env.SECRET }}' },
+      },
+      { MCP_URL: `https://api.example.com/${marker}`, SECRET: marker }
+    );
+
+    expect(result.ok).toBe(false);
+    expect(JSON.stringify(result)).not.toContain(marker);
+  });
 });

--- a/apps/agor-daemon/src/utils/mcp-probe-templates.ts
+++ b/apps/agor-daemon/src/utils/mcp-probe-templates.ts
@@ -16,7 +16,11 @@
  */
 
 import { AGOR_USER_ENV_KEYS_VAR } from '@agor/core/config';
-import { buildMCPTemplateContextFromEnv, resolveMcpServerTemplates } from '@agor/core/mcp';
+import {
+  buildMCPTemplateContextFromEnv,
+  hasTemplateMarker,
+  resolveMcpServerTemplates,
+} from '@agor/core/mcp';
 import type { MCPAuth, MCPServer, MCPServerID, MCPTransport } from '@agor/core/types';
 
 export interface ProbeServerConfig {
@@ -99,7 +103,7 @@ export function resolveProbeServerTemplates(
     ] as const;
     for (const field of oauthTemplatedFields) {
       const original = serverConfig.auth[field];
-      if (original?.includes('{{') && !result.server.auth?.[field]) {
+      if (hasTemplateMarker(original) && !result.server.auth?.[field]) {
         unresolvedAuth.push(`auth.${field}`);
       }
     }

--- a/apps/agor-docs/content/guide/mcp-servers.mdx
+++ b/apps/agor-docs/content/guide/mcp-servers.mdx
@@ -13,11 +13,15 @@ Marketplace checks the live endpoint before installing it. An entry may be:
 
 For unsupported schemes, configure the server in **Settings → MCP Servers**. Custom headers support services such as Datadog API/application-key pairs; Marketplace's Datadog entry instead asks for the bearer PAT/SAT described in Datadog's MCP setup guide.
 
-## Storage, reconnecting, and removal
+## Safe edits, storage, and removal
 
-Bearer tokens are stored in the installed MCP server's auth configuration. Catalog installs are private to their owner, access controls restrict the row, and API and UI reads redact the token. Do not assume application-level encryption from those protections; encryption at rest applies only when the deployment's documented database or storage configuration guarantees it. OAuth access and refresh tokens use Agor's per-user OAuth token store.
+Bearer tokens and other MCP auth/header/env secrets are stored in MCP server JSON according to the deployment's storage security. Catalog installs are private to their owner, access controls restrict the row, and API, realtime, and UI projections redact secrets. Redaction is an output-boundary control, not application-level encryption; encryption at rest applies only when the deployment's documented database or storage configuration guarantees it. OAuth access and refresh tokens use Agor's per-user OAuth token store.
 
-Connecting an entry again opens a new session but reuses the same owner-specific install. Supplying a new bearer token verifies and atomically rotates that install; the previous token is not retained in another catalog row. Remove the MCP server in **Settings → MCP Servers** to delete Agor's stored configuration and token. Also revoke the token or OAuth grant at the provider when access should end immediately.
+Editing authentication is patch-safe: leaving a saved secret blank preserves it, while **Clear saved secret** explicitly removes it. Other omitted authentication fields are preserved; switching authentication type replaces the old mode. The edit form uses a configuration revision to detect another device's concurrent save. If that happens, **Reload latest** fetches the authoritative row and deliberately discards the local unsaved form before another save. OAuth shared/per-user mode changes remove credentials and grants that belong to the previous subject mode.
+
+Connecting an entry again opens a new session but reuses the same owner-specific install. Supplying a new bearer token verifies and atomically rotates that stored install; the previous token is not retained in another catalog row. Remove the MCP server in **Settings → MCP Servers** to delete Agor's stored configuration and token.
+
+> **Active-turn limitation:** Configuration changes are resolved for subsequent Task dispatches, but Agor does not yet mediate every request made by an MCP client that an already-running provider SDK owns. Editing, detaching, or removing a server is therefore not a synchronous revocation boundary for an active turn. Stop the active Task and revoke the token or OAuth grant at the provider when access must end immediately. Strong active revocation requires the planned daemon-mediated MCP egress gateway.
 
 ## Catalog curation for operators
 

--- a/apps/agor-ui/src/components/MCPServer/MCPOAuthRecoveryAlert.test.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPOAuthRecoveryAlert.test.tsx
@@ -1,26 +1,33 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { MCPOAuthRecoveryAlert } from './MCPOAuthRecoveryAlert';
 
 describe('MCPOAuthRecoveryAlert', () => {
-  it('shows DCR recovery, safe diagnostics, and the exact redirect URL', () => {
+  it('shows structured DCR recovery and the exact redirect URL without internal stages', () => {
+    const onConfigure = vi.fn();
+    const onRetry = vi.fn();
     render(
       <MCPOAuthRecoveryAlert
         failure={{
-          message: 'Dynamic Client Registration failed',
-          diagnostic: {
-            stage: 'dcr_registration',
-            http_status: 400,
+          message: 'The provider could not register an OAuth client automatically.',
+          recovery: {
+            category: 'client_registration_failed',
+            action: 'configure_client',
+            message: 'Configure a client.',
           },
           redirectUri: 'https://agor.example.com/mcp-servers/oauth-callback',
         }}
+        onConfigure={onConfigure}
+        onRetry={onRetry}
       />
     );
 
     expect(screen.getByText('OAuth setup needs attention')).toBeVisible();
-    expect(screen.getByText(/HTTP 400/)).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Configure OAuth client' })).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeVisible();
     expect(screen.getByText('https://agor.example.com/mcp-servers/oauth-callback')).toBeVisible();
     expect(screen.queryByRole('button', { name: 'Open OAuth settings' })).not.toBeInTheDocument();
+    expect(screen.queryByText(/dcr_registration|HTTP 400/)).not.toBeInTheDocument();
   });
 
   it('does not recommend manual client settings for unrelated failures', () => {
@@ -30,5 +37,54 @@ describe('MCPOAuthRecoveryAlert', () => {
     expect(
       screen.queryByText('https://agor.example.com/mcp-servers/oauth-callback')
     ).not.toBeInTheDocument();
+  });
+
+  it('turns compatibility and reauthentication recovery into surface actions', () => {
+    const { rerender } = render(
+      <MCPOAuthRecoveryAlert
+        failure={{
+          message: 'Review settings.',
+          recovery: {
+            category: 'metadata_incompatible',
+            action: 'review_compatibility',
+            message: 'Review settings.',
+          },
+        }}
+        onConfigure={vi.fn()}
+        onRetry={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('button', { name: 'Review OAuth settings' })).toBeVisible();
+
+    rerender(
+      <MCPOAuthRecoveryAlert
+        failure={{
+          message: 'Configuration is incomplete.',
+          recovery: {
+            category: 'configuration_required',
+            action: 'review_configuration',
+            message: 'Configuration is incomplete.',
+          },
+        }}
+        onConfigure={vi.fn()}
+        onRetry={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('button', { name: 'Review OAuth settings' })).toBeVisible();
+
+    rerender(
+      <MCPOAuthRecoveryAlert
+        failure={{
+          message: 'Sign in.',
+          recovery: {
+            category: 'authentication_required',
+            action: 'reauthenticate',
+            message: 'Sign in.',
+          },
+        }}
+        onRetry={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('button', { name: 'Sign in again' })).toBeVisible();
   });
 });

--- a/apps/agor-ui/src/components/MCPServer/MCPOAuthRecoveryAlert.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPOAuthRecoveryAlert.tsx
@@ -1,29 +1,48 @@
-import { Alert, Space, Typography } from 'antd';
+import { Alert, Button, Space, Typography } from 'antd';
 import type { MCPServerOAuthFailure } from './useMCPServerOAuthStart';
 
 interface MCPOAuthRecoveryAlertProps {
   failure: MCPServerOAuthFailure;
+  onRetry?: () => void;
+  onConfigure?: () => void;
 }
 
-export const MCPOAuthRecoveryAlert: React.FC<MCPOAuthRecoveryAlertProps> = ({ failure }) => {
-  const isDcrFailure = failure.diagnostic !== undefined;
+export const MCPOAuthRecoveryAlert: React.FC<MCPOAuthRecoveryAlertProps> = ({
+  failure,
+  onRetry,
+  onConfigure,
+}) => {
+  const action = failure.recovery?.action;
+  const configureLabel =
+    action === 'configure_client'
+      ? 'Configure OAuth client'
+      : action === 'review_compatibility' ||
+          action === 'review_configuration' ||
+          action === 'save_and_retry'
+        ? 'Review OAuth settings'
+        : undefined;
+  const retryLabel = action === 'reauthenticate' ? 'Sign in again' : 'Try again';
 
   return (
     <Alert
       type="error"
-      title={isDcrFailure ? 'OAuth setup needs attention' : 'OAuth flow could not start'}
+      title={failure.recovery ? 'OAuth setup needs attention' : 'OAuth flow could not start'}
       description={
         <Space orientation="vertical" size={4}>
           <Typography.Text>{failure.message}</Typography.Text>
-          {failure.diagnostic && (
-            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
-              Stage: {failure.diagnostic.stage.replaceAll('_', ' ')}
-              {failure.diagnostic.http_status !== undefined
-                ? ` · HTTP ${failure.diagnostic.http_status}`
-                : ''}
-            </Typography.Text>
-          )}
-          {isDcrFailure && failure.redirectUri && (
+          <Space>
+            {configureLabel && onConfigure && (
+              <Button size="small" onClick={onConfigure}>
+                {configureLabel}
+              </Button>
+            )}
+            {onRetry && (
+              <Button size="small" type={configureLabel ? 'default' : 'primary'} onClick={onRetry}>
+                {retryLabel}
+              </Button>
+            )}
+          </Space>
+          {action === 'configure_client' && failure.redirectUri && (
             <Typography.Text type="secondary" style={{ fontSize: 12 }}>
               Register this redirect URL with the provider:{' '}
               <Typography.Text code copyable>

--- a/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.test.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.test.tsx
@@ -469,6 +469,76 @@ describe('MCPServerEditModal legacy DCR compatibility', () => {
     open.mockRestore();
   });
 
+  it('reloads fresh catalog policy after a CAS conflict without overwriting it on retry', async () => {
+    const conflict = Object.assign(new Error('conflict'), {
+      code: 409,
+      data: { current_config_version: 9 },
+    });
+    const patch = vi
+      .fn()
+      .mockRejectedValueOnce(conflict)
+      .mockResolvedValueOnce({ config_version: 10 });
+    const latest = {
+      mcp_server_id: '01900000-0000-7000-8000-000000000088',
+      name: 'managed-after-conflict',
+      description: 'edited elsewhere',
+      transport: 'http',
+      url: 'https://managed.example/mcp',
+      scope: 'global',
+      source: 'catalog',
+      catalog_entry_name: 'com.example/managed',
+      enabled: true,
+      config_version: 9,
+      auth: { type: 'oauth' },
+      oauth_compatibility_policy: {
+        effective_mode: 'marketplace',
+        managed_by_catalog: true,
+      },
+    } as MCPServer;
+    const get = vi.fn().mockResolvedValue(latest);
+    const client = {
+      service: vi.fn(() => ({ patch, get })),
+      io: { on: vi.fn(), off: vi.fn() },
+    } as unknown as AgorClient;
+    const stale = {
+      ...latest,
+      description: 'stale local copy',
+      config_version: 8,
+      source: 'user',
+      catalog_entry_name: undefined,
+      oauth_compatibility_policy: undefined,
+      auth: { type: 'oauth', oauth_compatibility_mode: 'strict' },
+    } as MCPServer;
+
+    render(
+      <MCPServerEditModal
+        server={stale}
+        open
+        client={client}
+        identityKey="user-a"
+        authorityKey="user-a:admin:1"
+        authGeneration={1}
+        mutationAllowed
+        onClose={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await screen.findByText('Newer MCP settings are available');
+    fireEvent.click(screen.getByRole('button', { name: 'Reload latest' }));
+    await waitFor(() =>
+      expect(screen.getByLabelText('Description')).toHaveValue('edited elsewhere')
+    );
+    expect(screen.getByLabelText('OAuth Compatibility')).toHaveValue('marketplace');
+
+    fireEvent.change(screen.getByLabelText('Description'), { target: { value: 'retry edit' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(patch).toHaveBeenCalledTimes(2));
+    const retry = patch.mock.calls[1]?.[1] as { expected_config_version: number; auth: object };
+    expect(retry.expected_config_version).toBe(9);
+    expect(retry.auth).not.toHaveProperty('oauth_compatibility_mode');
+  });
+
   it.each(['Save', 'Start OAuth Flow'])(
     'blocks %s after authority is lost while the edit dialog remains open',
     async (action) => {

--- a/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.tsx
@@ -54,9 +54,9 @@ interface TestResult {
   resourceCount: number;
   promptCount: number;
   error?: string;
-  tools?: Array<{ name: string; description: string }>;
+  tools?: Array<{ name: string; description?: string }>;
   resources?: Array<{ name: string; uri: string; mimeType?: string }>;
-  prompts?: Array<{ name: string; description: string }>;
+  prompts?: Array<{ name: string; description?: string }>;
 }
 
 /**
@@ -95,6 +95,11 @@ const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
   // render. Gating on this keeps Save from flashing disabled while the modal
   // animates in.
   const [formHydrated, setFormHydrated] = useState(false);
+  const [configConflict, setConfigConflict] = useState(false);
+  const [reloadingLatest, setReloadingLatest] = useState(false);
+  const [managedOAuthCompatibilityMode, setManagedOAuthCompatibilityMode] = useState<
+    'strict' | 'marketplace' | undefined
+  >();
   const [formRevision, bumpFormRevision] = useFormRevision();
   const operationGuard = useAuthorityOperationGuard(
     authorityKey && mutationAllowed ? [authorityKey, client, mutationAllowed] : null
@@ -114,6 +119,7 @@ const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
       : [];
   const saveBlocked = !mutationAllowed || missingRequiredFields.length > 0;
   const mutationStateRef = useRef({ allowed: mutationAllowed, reason: mutationBlockedReason });
+  const configVersionRef = useRef(1);
   mutationStateRef.current = { allowed: mutationAllowed, reason: mutationBlockedReason };
 
   // Hydrate the form when the modal opens or the user swaps to a different
@@ -125,9 +131,12 @@ const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
     if (!open || !server) return;
 
     setTestResult(null);
+    setConfigConflict(false);
+    configVersionRef.current = server.config_version ?? 1;
     setPreserveAbsentDcrMode(false);
     setPreserveAbsentCompatibilityMode(false);
     setPreserveAbsentGrantType(false);
+    setManagedOAuthCompatibilityMode(undefined);
     const serverAuthType = (server.auth?.type as 'none' | 'bearer' | 'jwt' | 'oauth') || 'none';
     setAuthType(serverAuthType);
     setTransport(server.transport || (server.url ? 'http' : 'stdio'));
@@ -161,6 +170,11 @@ const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
       const managedCompatibilityMode = server.oauth_compatibility_policy?.managed_by_catalog
         ? server.oauth_compatibility_policy.effective_mode
         : undefined;
+      setManagedOAuthCompatibilityMode(
+        managedCompatibilityMode === 'strict' || managedCompatibilityMode === 'marketplace'
+          ? managedCompatibilityMode
+          : undefined
+      );
       setPreserveAbsentDcrMode(server.auth?.oauth_dcr_mode === undefined);
       setPreserveAbsentCompatibilityMode(server.auth?.oauth_compatibility_mode === undefined);
       setPreserveAbsentGrantType(server.auth?.oauth_grant_type === undefined);
@@ -196,6 +210,9 @@ const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
     setPreserveAbsentCompatibilityMode(false);
     setPreserveAbsentGrantType(false);
     setFormHydrated(false);
+    setConfigConflict(false);
+    setReloadingLatest(false);
+    setManagedOAuthCompatibilityMode(undefined);
     onClose();
   };
 
@@ -253,14 +270,17 @@ const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
         success: boolean;
         error?: string;
         capabilities?: { tools: number; resources: number; prompts: number };
-        tools?: Array<{ name: string; description: string }>;
+        tools?: Array<{ name: string; description?: string }>;
         resources?: Array<{ name: string; uri: string; mimeType?: string }>;
-        prompts?: Array<{ name: string; description: string }>;
+        prompts?: Array<{ name: string; description?: string }>;
       };
 
       if (!operation.isCurrent()) return;
 
       if (data.success && data.capabilities) {
+        const refreshed = await client.service('mcp-servers').get(server.mcp_server_id);
+        if (!operation.isCurrent()) return;
+        configVersionRef.current = refreshed.config_version ?? configVersionRef.current;
         setTestResult({
           success: true,
           toolCount: data.capabilities.tools,
@@ -279,15 +299,14 @@ const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
           error: data.error || 'Connection test failed',
         });
       }
-    } catch (error) {
+    } catch {
       if (!operation.isCurrent()) return;
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       setTestResult({
         success: false,
         toolCount: 0,
         resourceCount: 0,
         promptCount: 0,
-        error: errorMessage,
+        error: 'Connection test failed. Check the saved configuration and try again.',
       });
     } finally {
       browserAttempt?.cleanup();
@@ -319,6 +338,7 @@ const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
         scope: values.scope,
         enabled: values.enabled,
         transport: values.transport,
+        expected_config_version: configVersionRef.current,
       };
 
       if (values.transport === 'stdio') {
@@ -336,6 +356,7 @@ const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
         preserveAbsentDcrMode,
         preserveAbsentCompatibilityMode,
         preserveAbsentGrantType,
+        forPatch: true,
       });
 
       if (!operation.isCurrent()) return false;
@@ -343,10 +364,20 @@ const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
         showError(mutationStateRef.current.reason);
         return false;
       }
-      await client.service('mcp-servers').patch(server.mcp_server_id, updates);
+      const updated = await client.service('mcp-servers').patch(server.mcp_server_id, updates);
+      configVersionRef.current = updated.config_version ?? configVersionRef.current + 1;
       return operation.isCurrent();
     } catch (error) {
       if (!operation.isCurrent()) return false;
+      const conflictData = (error as { code?: number; data?: { current_config_version?: number } })
+        ?.data;
+      if ((error as { code?: number })?.code === 409 || conflictData?.current_config_version) {
+        setConfigConflict(true);
+        showError(
+          'This MCP server changed on another device. Reload the latest version before saving again.'
+        );
+        return false;
+      }
       // Name the field, rather than letting a rejected validation surface as
       // the generic message its non-Error shape would produce.
       const errorMessage =
@@ -363,6 +394,66 @@ const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
       if (!operation.isCurrent()) return;
       showSuccess('MCP server updated successfully');
       closeAndReset();
+    }
+  };
+
+  const reloadLatest = async () => {
+    if (!client || !server) return;
+    setReloadingLatest(true);
+    try {
+      const latest = await client.service('mcp-servers').get(server.mcp_server_id);
+      configVersionRef.current = latest.config_version ?? 1;
+      const latestAuthType = latest.auth?.type || 'none';
+      const latestManagedMode = latest.oauth_compatibility_policy?.managed_by_catalog
+        ? latest.oauth_compatibility_policy.effective_mode
+        : undefined;
+      setManagedOAuthCompatibilityMode(
+        latestManagedMode === 'strict' || latestManagedMode === 'marketplace'
+          ? latestManagedMode
+          : undefined
+      );
+      setPreserveAbsentDcrMode(latest.auth?.oauth_dcr_mode === undefined);
+      setPreserveAbsentCompatibilityMode(latest.auth?.oauth_compatibility_mode === undefined);
+      setPreserveAbsentGrantType(latest.auth?.oauth_grant_type === undefined);
+      setTransport(latest.transport);
+      setAuthType(latestAuthType);
+      // Deliberately discard dirty fields. The conflict alert names this
+      // behavior so an editor never mistakes Reload for a rebase operation.
+      form.resetFields();
+      form.setFieldsValue({
+        name: latest.name,
+        display_name: latest.display_name,
+        description: latest.description,
+        transport: latest.transport,
+        command: latest.command,
+        args: latest.args?.join(', '),
+        url: latest.url,
+        scope: latest.scope,
+        enabled: latest.enabled,
+        env: latest.env ? JSON.stringify(latest.env, null, 2) : undefined,
+        headers: latest.headers ? JSON.stringify(latest.headers, null, 2) : undefined,
+        auth_type: latestAuthType,
+        auth_token: latest.auth?.token,
+        jwt_api_url: latest.auth?.api_url,
+        jwt_api_token: latest.auth?.api_token,
+        jwt_api_secret: latest.auth?.api_secret,
+        oauth_authorization_url: latest.auth?.oauth_authorization_url,
+        oauth_token_url: latest.auth?.oauth_token_url,
+        oauth_client_id: latest.auth?.oauth_client_id,
+        oauth_client_secret: latest.auth?.oauth_client_secret,
+        oauth_scope: latest.auth?.oauth_scope,
+        oauth_grant_type: latest.auth?.oauth_grant_type || 'client_credentials',
+        oauth_mode: latest.auth?.oauth_mode || 'per_user',
+        oauth_compatibility_mode:
+          latestManagedMode ?? latest.auth?.oauth_compatibility_mode ?? 'strict',
+        oauth_dcr_mode: latest.auth?.oauth_dcr_mode || 'advertised',
+      });
+      setConfigConflict(false);
+      bumpFormRevision();
+    } catch (error) {
+      showError(error instanceof Error ? error.message : 'Failed to reload the latest MCP server');
+    } finally {
+      setReloadingLatest(false);
     }
   };
 
@@ -412,6 +503,20 @@ const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
           style={{ marginTop: 16 }}
         />
       )}
+      {configConflict && (
+        <Alert
+          type="warning"
+          showIcon
+          title="Newer MCP settings are available"
+          description="Reloading fetches the current server and discards your unsaved edits."
+          action={
+            <Button loading={reloadingLatest} onClick={() => void reloadLatest()}>
+              Reload latest
+            </Button>
+          }
+          style={{ marginTop: 16 }}
+        />
+      )}
       <Form
         form={form}
         layout="vertical"
@@ -444,13 +549,7 @@ const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
           mutationAllowed={mutationAllowed}
           mutationBlockedReason={mutationBlockedReason}
           formRevision={formRevision}
-          managedOAuthCompatibilityMode={
-            server?.oauth_compatibility_policy?.managed_by_catalog &&
-            (server.oauth_compatibility_policy.effective_mode === 'strict' ||
-              server.oauth_compatibility_policy.effective_mode === 'marketplace')
-              ? server.oauth_compatibility_policy.effective_mode
-              : undefined
-          }
+          managedOAuthCompatibilityMode={managedOAuthCompatibilityMode}
         />
       </Form>
     </Modal>

--- a/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.test.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.test.tsx
@@ -1,6 +1,6 @@
 import type { AgorClient } from '@agor-live/client';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { Form } from 'antd';
+import { Form, type FormInstance } from 'antd';
 import { useEffect } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MCPServerFormFields } from './MCPServerFormFields';
@@ -32,6 +32,36 @@ const oauthButton = (name = 'Start OAuth Flow') => buttonLabeled(name);
 
 describe('MCPServerFormFields OAuth start', () => {
   beforeEach(() => vi.clearAllMocks());
+
+  it('uses an explicit visible control to clear a saved bearer secret', async () => {
+    let capturedForm: FormInstance | undefined;
+    const Harness = () => {
+      const [form] = Form.useForm();
+      capturedForm = form;
+      useEffect(() => {
+        form.setFieldsValue({ auth_type: 'bearer', auth_token: '••••••••' });
+      }, [form]);
+      return (
+        <Form form={form}>
+          <MCPServerFormFields
+            mode="edit"
+            transport="http"
+            authType="bearer"
+            form={form}
+            client={null}
+            authorityKey="user-a:admin:1"
+            onPrepareOAuthStart={vi.fn().mockResolvedValue('saved-server')}
+          />
+        </Form>
+      );
+    };
+
+    render(<Harness />);
+    expect(await screen.findByText('Leaving this blank preserves the saved secret.')).toBeVisible();
+    fireEvent.click(buttonLabeled('Clear saved secret'));
+    expect(capturedForm?.getFieldValue('auth_token')).toBe('');
+    expect(capturedForm?.getFieldValue('auth_token_clear')).toBe(true);
+  });
 
   // #2332: every attempt — including the manual retry offered after a failed
   // start — must persist the current form and authorize against the ID that

--- a/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.tsx
@@ -75,9 +75,9 @@ export interface MCPServerFormFieldsProps {
     resourceCount: number;
     promptCount: number;
     error?: string;
-    tools?: Array<{ name: string; description: string }>;
+    tools?: Array<{ name: string; description?: string }>;
     resources?: Array<{ name: string; uri: string; mimeType?: string }>;
-    prompts?: Array<{ name: string; description: string }>;
+    prompts?: Array<{ name: string; description?: string }>;
   } | null;
   /** Persist current settings and return the authoritative server ID before every OAuth start. */
   onPrepareOAuthStart: () => Promise<string | null>;
@@ -225,9 +225,9 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
       } else {
         showError(data.error || 'Failed to disconnect OAuth');
       }
-    } catch (error) {
+    } catch {
       if (!operation.isCurrent()) return;
-      showError(`Disconnect error: ${error instanceof Error ? error.message : String(error)}`);
+      showError('OAuth disconnect failed. Check the connection and try again.');
     } finally {
       if (operation.isCurrent()) setDisconnectingOAuth(false);
     }
@@ -335,10 +335,9 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
       } else {
         showInfo('No authentication required - ready to use');
       }
-    } catch (error) {
+    } catch {
       if (!operation.isCurrent()) return;
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      showError(`Connection test failed: ${errorMessage}`);
+      showError('Connection test failed. Check the saved configuration and try again.');
     } finally {
       if (operation.isCurrent()) setTestingAuth(false);
     }
@@ -346,7 +345,7 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
 
   // One label for both the live and the blocked button, so a retry still reads
   // as a retry while it waits on a field.
-  const oauthStartLabel = oauthFailure?.diagnostic
+  const oauthStartLabel = oauthFailure?.recovery
     ? 'Save OAuth settings & retry'
     : oauthFailure
       ? 'Retry OAuth Flow'
@@ -354,6 +353,24 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
 
   const isRemoteTransport = isRemoteTransportValue(transport);
   const showAdvancedSection = isRemoteTransport && authType === 'oauth';
+  const savedSecretExtra = (formField: string) =>
+    mode === 'edit' ? (
+      <Space size={8} wrap>
+        <Typography.Text type="secondary">
+          Leaving this blank preserves the saved secret.
+        </Typography.Text>
+        <Button
+          size="small"
+          danger
+          onClick={() => {
+            form.setFieldValue(formField, '');
+            form.setFieldValue(`${formField}_clear`, true);
+          }}
+        >
+          Clear saved secret
+        </Button>
+      </Space>
+    ) : undefined;
 
   // ── Basic Information section ──────────────────────────────────────
   const isCreate = mode === 'create';
@@ -532,10 +549,18 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
             <Form.Item
               label="Token"
               name="auth_token"
-              rules={[{ required: true, message: 'Please enter a bearer token' }]}
+              rules={
+                mode === 'create'
+                  ? [{ required: true, message: 'Please enter a bearer token' }]
+                  : []
+              }
               tooltip="Bearer token. Supports templates like {{ user.env.API_TOKEN }}"
+              extra={savedSecretExtra('auth_token')}
             >
-              <Input.Password placeholder="{{ user.env.API_TOKEN }} or raw token" />
+              <Input.Password
+                placeholder="{{ user.env.API_TOKEN }} or raw token"
+                onChange={() => form.setFieldValue('auth_token_clear', false)}
+              />
             </Form.Item>
           )}
 
@@ -552,18 +577,34 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
               <Form.Item
                 label="API Token"
                 name="jwt_api_token"
-                rules={[{ required: true, message: 'Please enter the API token' }]}
+                rules={
+                  mode === 'create'
+                    ? [{ required: true, message: 'Please enter the API token' }]
+                    : []
+                }
                 tooltip="JWT API token. Supports templates like {{ user.env.JWT_TOKEN }}"
+                extra={savedSecretExtra('jwt_api_token')}
               >
-                <Input.Password placeholder="{{ user.env.JWT_TOKEN }} or raw token" />
+                <Input.Password
+                  placeholder="{{ user.env.JWT_TOKEN }} or raw token"
+                  onChange={() => form.setFieldValue('jwt_api_token_clear', false)}
+                />
               </Form.Item>
               <Form.Item
                 label="API Secret"
                 name="jwt_api_secret"
-                rules={[{ required: true, message: 'Please enter the API secret' }]}
+                rules={
+                  mode === 'create'
+                    ? [{ required: true, message: 'Please enter the API secret' }]
+                    : []
+                }
                 tooltip="JWT API secret. Supports templates like {{ user.env.JWT_SECRET }}"
+                extra={savedSecretExtra('jwt_api_secret')}
               >
-                <Input.Password placeholder="{{ user.env.JWT_SECRET }} or raw secret" />
+                <Input.Password
+                  placeholder="{{ user.env.JWT_SECRET }} or raw secret"
+                  onChange={() => form.setFieldValue('jwt_api_secret_clear', false)}
+                />
               </Form.Item>
             </>
           )}
@@ -846,10 +887,12 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
                     label="Client Secret"
                     name="oauth_client_secret"
                     tooltip="Required for servers that use confidential clients. The secret is sent via HTTP Basic Auth during token exchange."
+                    extra={savedSecretExtra('oauth_client_secret')}
                   >
                     <Input.Password
                       placeholder="Enter client secret or {{ user.env.OAUTH_CLIENT_SECRET }}"
                       allowClear
+                      onChange={() => form.setFieldValue('oauth_client_secret_clear', false)}
                     />
                   </Form.Item>
                   <Form.Item

--- a/apps/agor-ui/src/components/MCPServer/MCPServerPill.test.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerPill.test.tsx
@@ -3,16 +3,11 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MCPServerPill } from './MCPServerPill';
 
-const permissionState = vi.hoisted(() => ({ isAdmin: false }));
 const refreshAndRefetchMCPOAuthGrant = vi.hoisted(() => vi.fn());
 const showError = vi.fn();
 const showInfo = vi.fn();
 const showSuccess = vi.fn();
 const showWarning = vi.fn();
-
-vi.mock('@/hooks/usePermissions', () => ({
-  usePermissions: () => permissionState,
-}));
 
 vi.mock('@/utils/message', () => ({
   useThemedMessage: () => ({ showError, showInfo, showSuccess, showWarning }),
@@ -27,19 +22,23 @@ vi.mock('@/utils/mcpOAuthAttempt', () => ({
 describe('MCPServerPill OAuth recovery', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    permissionState.isAdmin = false;
   });
 
-  it('uses the shared OAuth start path and exposes DCR diagnostics', async () => {
+  it('uses the shared OAuth start path and exposes sanitized DCR recovery', async () => {
     const startOAuth = vi.fn().mockResolvedValue({
       success: false,
-      error: 'Dynamic Client Registration failed',
-      diagnostic: { stage: 'dcr_registration', http_status: 404 },
-      redirect_uri: 'https://agor.example.com/mcp-servers/oauth-callback',
+      error: 'The provider could not register an OAuth client automatically.',
+      recovery: {
+        category: 'client_registration_failed',
+        action: 'configure_client',
+        message: 'The provider could not register an OAuth client automatically.',
+        redirect_uri: 'https://agor.example.com/mcp-servers/oauth-callback',
+      },
     });
     const client = {
       service: vi.fn(() => ({ create: startOAuth })),
     } as unknown as AgorClient;
+    const onEdit = vi.fn();
     const server = {
       mcp_server_id: '01900000-0000-7000-8000-000000000004',
       name: 'oauth-server',
@@ -58,6 +57,9 @@ describe('MCPServerPill OAuth recovery', () => {
         authorityKey="user-a:member:1"
         actionAllowed
         actionBlockedReason="OAuth unavailable"
+        configureAllowed
+        configureBlockedReason="Only an administrator can change saved credentials."
+        onEdit={onEdit}
       />
     );
 
@@ -72,12 +74,118 @@ describe('MCPServerPill OAuth recovery', () => {
       mcp_server_id: '01900000-0000-7000-8000-000000000004',
     });
     expect(await screen.findByText('OAuth setup needs attention')).toBeVisible();
-    expect(screen.getByText(/HTTP 404/)).toBeVisible();
+    const configure = screen.getByRole('button', { name: 'Configure OAuth client' });
+    expect(configure).toBeVisible();
+    fireEvent.click(configure);
+    expect(onEdit).toHaveBeenCalledWith(server);
     expect(screen.getByText(/mcp-servers\/oauth-callback/)).toBeVisible();
+    expect(screen.queryByText(/dcr_registration|HTTP 404/)).not.toBeInTheDocument();
   });
 
+  it.each([
+    ['bearer', { type: 'bearer' as const }],
+    ['JWT', { type: 'jwt' as const, api_url: 'https://auth.example.test/token' }],
+  ])(
+    'opens configuration, never OAuth, for a %s server with a cleared secret',
+    async (_label, auth) => {
+      const service = vi.fn();
+      const client = { service } as unknown as AgorClient;
+      const onEdit = vi.fn();
+      const server = {
+        mcp_server_id: '01900000-0000-7000-8000-000000000014',
+        name: 'static-auth-server',
+        display_name: 'Static Auth Server',
+        transport: 'http',
+        url: 'https://mcp.example.test/mcp',
+        scope: 'global',
+        enabled: true,
+        auth,
+      } as MCPServer;
+
+      const { container } = render(
+        <MCPServerPill
+          server={server}
+          needsAuth
+          client={client}
+          authorityKey="user-a:member:1"
+          actionAllowed
+          actionBlockedReason="OAuth unavailable"
+          configureAllowed
+          configureBlockedReason="Only an administrator can change saved credentials."
+          onEdit={onEdit}
+        />
+      );
+
+      const configure = screen.getByRole('button', {
+        name: 'Needs configuration: Static Auth Server',
+      });
+      expect(configure).toHaveAccessibleName('Needs configuration: Static Auth Server');
+      expect(container.querySelector('.anticon-setting')).toBeInTheDocument();
+
+      // A browser-generated keyboard click has detail=0. Exercising the
+      // native button path proves it is not pointer-only.
+      act(() => configure.focus());
+      expect(configure).toHaveFocus();
+      fireEvent.click(configure, { detail: 0 });
+
+      expect(onEdit).toHaveBeenCalledOnce();
+      expect(onEdit).toHaveBeenCalledWith(server);
+      expect(service).not.toHaveBeenCalled();
+
+      fireEvent.mouseEnter(configure);
+      expect(
+        await screen.findByText(/needs configuration.*activate to configure/i)
+      ).toBeInTheDocument();
+    }
+  );
+
+  it.each(['bearer', 'jwt'] as const)(
+    'does not offer %s configuration to a viewer without mutation authority',
+    (type) => {
+      const service = vi.fn();
+      const onEdit = vi.fn();
+      const server = {
+        mcp_server_id: '01900000-0000-7000-8000-000000000015',
+        name: 'restricted-static-auth',
+        display_name: 'Restricted Credentials',
+        transport: 'http',
+        url: 'https://mcp.example.test/mcp',
+        scope: 'global',
+        enabled: true,
+        auth:
+          type === 'bearer'
+            ? { type: 'bearer' as const }
+            : { type: 'jwt' as const, api_url: 'https://auth.example.test/token' },
+      } as MCPServer;
+
+      render(
+        <MCPServerPill
+          server={server}
+          needsAuth
+          client={{ service } as unknown as AgorClient}
+          authorityKey="viewer:1"
+          actionAllowed={false}
+          actionBlockedReason="OAuth unavailable"
+          configureAllowed={false}
+          configureBlockedReason="Only an administrator can change saved credentials."
+          onEdit={onEdit}
+        />
+      );
+
+      const status = screen.getByRole('button', {
+        name: /Restricted Credentials MCP server\. Needs configuration\. Only an administrator/i,
+      });
+      expect(status).toHaveAttribute('aria-disabled', 'true');
+      fireEvent.click(status);
+      expect(onEdit).not.toHaveBeenCalled();
+      expect(service).not.toHaveBeenCalled();
+      expect(
+        screen.queryByRole('button', { name: 'Edit Restricted Credentials MCP server' })
+      ).not.toBeInTheDocument();
+    }
+  );
+
   it('names the admin edit action for the server it edits', () => {
-    permissionState.isAdmin = true;
     const onEdit = vi.fn();
     const server = {
       mcp_server_id: '01900000-0000-7000-8000-000000000005',
@@ -97,6 +205,8 @@ describe('MCPServerPill OAuth recovery', () => {
         authorityKey={null}
         actionAllowed={false}
         actionBlockedReason="OAuth unavailable"
+        configureAllowed
+        configureBlockedReason="Only an administrator can change saved credentials."
         onEdit={onEdit}
       />
     );
@@ -128,6 +238,8 @@ describe('MCPServerPill OAuth recovery', () => {
         authorityKey="user-a:member:1"
         actionAllowed
         actionBlockedReason="OAuth unavailable"
+        configureAllowed
+        configureBlockedReason="Only an administrator can change saved credentials."
       />
     );
 
@@ -146,6 +258,49 @@ describe('MCPServerPill OAuth recovery', () => {
         expect.any(Function)
       )
     );
+  });
+
+  it('uses a real visually-hidden live region and announces transitions, not initial ready state', async () => {
+    const server = {
+      mcp_server_id: '01900000-0000-7000-8000-000000000009',
+      name: 'oauth-server',
+      display_name: 'OAuth Server',
+      transport: 'http',
+      scope: 'global',
+      enabled: true,
+      auth: { type: 'oauth' },
+    } as MCPServer;
+    const common = {
+      server,
+      client: {} as AgorClient,
+      authorityKey: 'user-a:member:1',
+      actionAllowed: true,
+      actionBlockedReason: 'OAuth unavailable',
+      configureAllowed: true,
+      configureBlockedReason: 'Only an administrator can change saved credentials.',
+    };
+    const { container, rerender } = render(<MCPServerPill {...common} needsAuth={false} />);
+
+    const liveRegion = container.querySelector('[aria-live="polite"]');
+    expect(liveRegion).toBeInTheDocument();
+    expect(liveRegion).toHaveTextContent('');
+    expect(liveRegion).not.toHaveClass('sr-only');
+    expect(liveRegion).toHaveStyle({
+      position: 'absolute',
+      width: '1px',
+      height: '1px',
+      overflow: 'hidden',
+      whiteSpace: 'nowrap',
+      clipPath: 'inset(50%)',
+    });
+
+    rerender(<MCPServerPill {...common} needsAuth />);
+    await waitFor(() =>
+      expect(liveRegion).toHaveTextContent('OAuth Server requires authentication.')
+    );
+
+    rerender(<MCPServerPill {...common} needsAuth={false} />);
+    await waitFor(() => expect(liveRegion).toHaveTextContent('OAuth Server is ready.'));
   });
 
   it.each([
@@ -182,6 +337,8 @@ describe('MCPServerPill OAuth recovery', () => {
           authorityKey="user-a:member:1"
           actionAllowed
           actionBlockedReason="OAuth unavailable"
+          configureAllowed
+          configureBlockedReason="Only an administrator can change saved credentials."
         />
       );
 
@@ -200,6 +357,8 @@ describe('MCPServerPill OAuth recovery', () => {
           authorityKey={authorityKey}
           actionAllowed={actionAllowed}
           actionBlockedReason="OAuth unavailable"
+          configureAllowed
+          configureBlockedReason="Only an administrator can change saved credentials."
         />
       );
       expect(shouldApply()).toBe(false);
@@ -245,6 +404,8 @@ describe('MCPServerPill OAuth recovery', () => {
         authorityKey="user-a:member:1"
         actionAllowed
         actionBlockedReason="OAuth unavailable"
+        configureAllowed
+        configureBlockedReason="Only an administrator can change saved credentials."
       />
     );
 

--- a/apps/agor-ui/src/components/MCPServer/MCPServerPill.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerPill.tsx
@@ -1,9 +1,15 @@
 import type { AgorClient, MCPServer } from '@agor-live/client';
-import { ApiOutlined, EditOutlined, LoginOutlined, ReloadOutlined } from '@ant-design/icons';
+import {
+  ApiOutlined,
+  EditOutlined,
+  LoginOutlined,
+  ReloadOutlined,
+  SettingOutlined,
+} from '@ant-design/icons';
 import { Tooltip } from 'antd';
-import { useLayoutEffect, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useAuthorityOperationGuard } from '@/hooks/useAuthorityOperationGuard';
-import { usePermissions } from '@/hooks/usePermissions';
+import { VISUALLY_HIDDEN_STYLE } from '@/utils/accessibility';
 import { refreshAndRefetchMCPOAuthGrant } from '../../utils/mcpOAuthAttempt';
 import { useThemedMessage } from '../../utils/message';
 import { formatAbsoluteTime } from '../../utils/time';
@@ -21,6 +27,9 @@ interface MCPServerPillProps {
   /** Current server-side role/connection floor for OAuth mutations. */
   actionAllowed: boolean;
   actionBlockedReason: string;
+  /** Same authoritative gate used by the owning editor's mutation service. */
+  configureAllowed: boolean;
+  configureBlockedReason: string;
   onOAuthAttemptStarted?: (attemptId: string, serverId: string) => void;
   /** Lets an overlay owner open an editor without nesting its lifecycle in this pill. */
   onEdit?: (server: MCPServer) => void;
@@ -65,14 +74,15 @@ function formatRefreshError(error?: string): string {
     case 'token_refresh_failed':
       return 'provider token refresh failed — try again, or sign in again if it keeps failing';
     default:
-      return error || 'unknown error';
+      return 'credential refresh failed — retry, or sign in again if it keeps failing';
   }
 }
 
 /**
  * Clickable MCP server pill.
  *
- *   - Unauthenticated: warning + login icon, activation starts OAuth.
+ *   - OAuth unauthenticated: warning + login icon, activation starts OAuth.
+ *   - Bearer/JWT incomplete: warning + settings icon, activation opens config.
  *   - Authenticated:   purple + API icon, tooltip shows human-readable expiry,
  *                      activation force-refreshes the token (even before it's due)
  *                      so operators can probe per-provider refresh policy.
@@ -87,11 +97,12 @@ export const MCPServerPill: React.FC<MCPServerPillProps> = ({
   authorityKey,
   actionAllowed,
   actionBlockedReason,
+  configureAllowed,
+  configureBlockedReason,
   onOAuthAttemptStarted,
   onEdit,
 }) => {
   const { showSuccess, showInfo, showWarning, showError } = useThemedMessage();
-  const { isAdmin } = usePermissions();
   const [refreshing, setRefreshing] = useState(false);
   // Local override so the tooltip reflects a just-refreshed expiry without
   // waiting for a full MCPServer re-fetch from the parent.
@@ -109,6 +120,7 @@ export const MCPServerPill: React.FC<MCPServerPillProps> = ({
   }, [actionAllowed, authorityKey]);
 
   const isOAuthServer = server.auth?.type === 'oauth';
+  const needsConfiguration = needsAuth && !isOAuthServer;
   const expiresAt = expiresAtOverride ?? server.auth?.oauth_token_expires_at;
 
   const { handleStartOAuthFlow, oauthFailure, startingOAuthFlow } = useMCPServerOAuthStart({
@@ -152,9 +164,9 @@ export const MCPServerPill: React.FC<MCPServerPillProps> = ({
       } else {
         showError(`Refresh failed: ${formatRefreshError(result.error)}`);
       }
-    } catch (err) {
+    } catch {
       if (!shouldApply()) return;
-      showError(`Refresh error: ${err instanceof Error ? err.message : String(err)}`);
+      showError('Credential refresh failed. Check the connection and try again.');
     } finally {
       if (shouldApply()) setRefreshing(false);
     }
@@ -197,42 +209,73 @@ export const MCPServerPill: React.FC<MCPServerPillProps> = ({
     );
   }
 
-  const needsAuthTooltip = actionAllowed
-    ? `${server.display_name || server.name} isn’t connected. Activate to sign in.`
-    : actionBlockedReason;
-
   const label = server.display_name || server.name;
-  // The pill's own action, or nothing for a non-OAuth server. Named here
-  // because both the Tag's pointer target and the label button need to agree on
-  // whether there is one.
-  const primaryAction = actionAllowed
-    ? needsAuth
-      ? () => void handleStartOAuthFlow()
-      : isOAuthServer
-        ? handleRefreshClick
-        : undefined
-    : undefined;
+  const needsAuthTooltip = isOAuthServer
+    ? actionAllowed
+      ? `${label} isn’t connected. Activate to sign in.`
+      : actionBlockedReason
+    : configureAllowed && onEdit
+      ? `${label} needs configuration. Activate to configure saved credentials.`
+      : `${label} needs configuration. ${configureBlockedReason}`;
+
+  // OAuth and static credential recovery are deliberately separate actions:
+  // only OAuth may enter the browser-flow hook; bearer/JWT opens the editor.
+  const primaryAction = needsConfiguration
+    ? configureAllowed && onEdit
+      ? () => onEdit(server)
+      : undefined
+    : actionAllowed && isOAuthServer
+      ? needsAuth
+        ? () => void handleStartOAuthFlow()
+        : handleRefreshClick
+      : undefined;
+  const [announcedState, setAnnouncedState] = useState('');
+  const previousStatus = useRef({ needsAuth, startingOAuthFlow, refreshing });
+  useEffect(() => {
+    const previous = previousStatus.current;
+    let announcement = '';
+    if (!previous.startingOAuthFlow && startingOAuthFlow) {
+      announcement = `${label} sign-in is starting.`;
+    } else if (!previous.refreshing && refreshing) {
+      announcement = `${label} credentials are refreshing.`;
+    } else if (previous.needsAuth !== needsAuth) {
+      announcement = needsAuth
+        ? isOAuthServer
+          ? `${label} requires authentication.`
+          : `${label} needs configuration.`
+        : `${label} is ready.`;
+    }
+    previousStatus.current = { needsAuth, startingOAuthFlow, refreshing };
+    if (announcement) setAnnouncedState(announcement);
+  }, [isOAuthServer, label, needsAuth, refreshing, startingOAuthFlow]);
 
   return (
     <>
+      <span aria-live="polite" aria-atomic="true" style={VISUALLY_HIDDEN_STYLE}>
+        {announcedState}
+      </span>
       <Tooltip
         // The label is a button for actionable pills, so the same explanation
         // keyboard users receive on focus is available to pointer users on hover.
         trigger={['hover', 'focus']}
         title={
-          !actionAllowed && isOAuthServer
-            ? actionBlockedReason
-            : needsAuth
-              ? startingOAuthFlow
-                ? 'Starting OAuth authentication'
-                : needsAuthTooltip
-              : authedTooltip
+          needsConfiguration && !configureAllowed
+            ? configureBlockedReason
+            : !actionAllowed && isOAuthServer
+              ? actionBlockedReason
+              : needsAuth
+                ? startingOAuthFlow
+                  ? 'Starting OAuth authentication'
+                  : needsAuthTooltip
+                : authedTooltip
         }
       >
         <Tag
           color={needsAuth ? 'warning' : ENTITY_PILL_COLORS.mcp}
           icon={
-            needsAuth ? (
+            needsConfiguration ? (
+              <SettingOutlined aria-hidden />
+            ) : needsAuth ? (
               <LoginOutlined aria-hidden />
             ) : refreshing ? (
               <ReloadOutlined spin aria-hidden />
@@ -254,7 +297,11 @@ export const MCPServerPill: React.FC<MCPServerPillProps> = ({
             <button
               type="button"
               aria-label={
-                needsAuth ? `Sign in to ${label}` : `Refresh OAuth credentials for ${label}`
+                needsConfiguration
+                  ? `Needs configuration: ${label}`
+                  : needsAuth
+                    ? `Sign in to ${label}`
+                    : `Refresh OAuth credentials for ${label}`
               }
               aria-busy={startingOAuthFlow || refreshing}
               onClick={(event) => {
@@ -274,9 +321,23 @@ export const MCPServerPill: React.FC<MCPServerPillProps> = ({
               {label}
             </button>
           ) : (
-            label
+            <button
+              type="button"
+              aria-disabled="true"
+              aria-label={`${label} MCP server. ${needsConfiguration ? `Needs configuration. ${configureBlockedReason}` : needsAuth ? 'Authentication required.' : 'Ready.'}`}
+              style={{
+                margin: 0,
+                padding: 0,
+                background: 'transparent',
+                border: 'none',
+                color: 'inherit',
+                font: 'inherit',
+              }}
+            >
+              {label}
+            </button>
           )}
-          {isAdmin && onEdit && (
+          {configureAllowed && onEdit && (
             // Real <button> for keyboard focus + screen-reader semantics.
             // Native `title` (not <Tooltip>) so we don't stack a second
             // AntD tooltip on top of the parent expiry/auth tooltip.
@@ -319,7 +380,13 @@ export const MCPServerPill: React.FC<MCPServerPillProps> = ({
           )}
         </Tag>
       </Tooltip>
-      {oauthFailure && <MCPOAuthRecoveryAlert failure={oauthFailure} />}
+      {oauthFailure && (
+        <MCPOAuthRecoveryAlert
+          failure={oauthFailure}
+          onRetry={() => void handleStartOAuthFlow()}
+          onConfigure={configureAllowed && onEdit ? () => onEdit(server) : undefined}
+        />
+      )}
     </>
   );
 };

--- a/apps/agor-ui/src/components/MCPServer/mcp-form-requirements.test.ts
+++ b/apps/agor-ui/src/components/MCPServer/mcp-form-requirements.test.ts
@@ -27,12 +27,21 @@ describe('requiredMCPFields', () => {
     ]);
   });
 
-  it('adds the fields each remote auth type cannot work without', () => {
+  it('requires credentials on CREATE but leaves an explicitly cleared saved row editable', () => {
     expect(requiredMCPFields({ mode: 'edit', transport: 'http', authType: 'bearer' })).toEqual([
+      'url',
+    ]);
+    expect(requiredMCPFields({ mode: 'edit', transport: 'http', authType: 'jwt' })).toEqual([
+      'url',
+      'jwt_api_url',
+    ]);
+    expect(requiredMCPFields({ mode: 'create', transport: 'http', authType: 'bearer' })).toEqual([
+      'name',
       'url',
       'auth_token',
     ]);
-    expect(requiredMCPFields({ mode: 'edit', transport: 'http', authType: 'jwt' })).toEqual([
+    expect(requiredMCPFields({ mode: 'create', transport: 'http', authType: 'jwt' })).toEqual([
+      'name',
       'url',
       'jwt_api_url',
       'jwt_api_token',

--- a/apps/agor-ui/src/components/MCPServer/mcp-form-requirements.ts
+++ b/apps/agor-ui/src/components/MCPServer/mcp-form-requirements.ts
@@ -52,8 +52,14 @@ export function requiredMCPFields({
   }
 
   fields.push('url');
-  if (authType === 'bearer') fields.push('auth_token');
-  if (authType === 'jwt') fields.push('jwt_api_url', 'jwt_api_token', 'jwt_api_secret');
+  // CREATE must be immediately configured. EDIT deliberately permits an
+  // explicit secret clear: the saved row remains editable and the session/UI
+  // status moves to needs-auth until replacement credentials are supplied.
+  if (authType === 'bearer' && mode === 'create') fields.push('auth_token');
+  if (authType === 'jwt') {
+    fields.push('jwt_api_url');
+    if (mode === 'create') fields.push('jwt_api_token', 'jwt_api_secret');
+  }
   return fields;
 }
 

--- a/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.test.ts
+++ b/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.test.ts
@@ -366,3 +366,61 @@ describe('validateHeadersJSON', () => {
     );
   });
 });
+
+describe('buildAuthFromValues PATCH semantics', () => {
+  it('uses null to clear auth explicitly', () => {
+    expect(buildAuthFromValues({ auth_type: 'none' }, { forPatch: true })).toBeNull();
+  });
+
+  it('preserves redacted secrets and treats a blank secret as non-destructive', () => {
+    const auth = buildAuthFromValues(
+      {
+        auth_type: 'oauth',
+        oauth_client_id: '••••••••',
+        oauth_client_secret: '',
+        oauth_scope: 'calendar.events',
+      },
+      { forPatch: true }
+    );
+    expect(auth).toMatchObject({
+      type: 'oauth',
+      oauth_client_id: '••••••••',
+      oauth_scope: 'calendar.events',
+    });
+    expect(auth).not.toHaveProperty('oauth_client_secret');
+  });
+
+  it('clears a saved secret only through the explicit clear affordance', () => {
+    expect(
+      buildAuthFromValues(
+        {
+          auth_type: 'oauth',
+          oauth_client_secret: '',
+          oauth_client_secret_clear: true,
+        },
+        { forPatch: true }
+      )
+    ).toMatchObject({ type: 'oauth', oauth_client_secret: null });
+  });
+
+  it('supports explicit clear for bearer and JWT secrets', () => {
+    expect(
+      buildAuthFromValues(
+        { auth_type: 'bearer', auth_token: '', auth_token_clear: true },
+        { forPatch: true }
+      )
+    ).toEqual({ type: 'bearer', token: null });
+    expect(
+      buildAuthFromValues(
+        {
+          auth_type: 'jwt',
+          jwt_api_token: '',
+          jwt_api_token_clear: true,
+          jwt_api_secret: '',
+          jwt_api_secret_clear: true,
+        },
+        { forPatch: true }
+      )
+    ).toMatchObject({ type: 'jwt', api_token: null, api_secret: null });
+  });
+});

--- a/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.ts
+++ b/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.ts
@@ -3,7 +3,7 @@ import {
   isReservedMCPCustomHeaderName,
   isValidMCPHeaderName,
 } from '@agor/core/tools/mcp/http-headers';
-import type { MCPOAuthDCRMode } from '@agor-live/client';
+import type { MCPAuthPatch, MCPOAuthDCRMode } from '@agor-live/client';
 
 /**
  * OAuth utility functions extracted from MCPServersTable for testability.
@@ -191,10 +191,31 @@ export function buildAuthFromValues(
     preserveAbsentDcrMode?: boolean;
     preserveAbsentCompatibilityMode?: boolean;
     preserveAbsentGrantType?: boolean;
+    forPatch: true;
+  }
+): MCPAuthPatch | null;
+export function buildAuthFromValues(
+  values: Record<string, unknown>,
+  options?: {
+    preserveAbsentDcrMode?: boolean;
+    preserveAbsentCompatibilityMode?: boolean;
+    preserveAbsentGrantType?: boolean;
+    forPatch?: false;
+  }
+): BuiltAuth | undefined;
+export function buildAuthFromValues(
+  values: Record<string, unknown>,
+  options: {
+    preserveAbsentDcrMode?: boolean;
+    preserveAbsentCompatibilityMode?: boolean;
+    preserveAbsentGrantType?: boolean;
+    forPatch?: boolean;
   } = {}
-): BuiltAuth | undefined {
+): BuiltAuth | MCPAuthPatch | null | undefined {
   const authType = values.auth_type;
-  if (authType !== 'bearer' && authType !== 'jwt' && authType !== 'oauth') return undefined;
+  if (authType !== 'bearer' && authType !== 'jwt' && authType !== 'oauth') {
+    return options.forPatch ? null : undefined;
+  }
 
   const auth: BuiltAuth = { type: authType };
   if (authType === 'bearer') {
@@ -217,6 +238,41 @@ export function buildAuthFromValues(
     }
     if (options.preserveAbsentGrantType && values.oauth_grant_type === 'client_credentials') {
       delete auth.oauth_grant_type;
+    }
+  }
+  if (options.forPatch) {
+    const formToAuthField: Record<string, string> = {
+      auth_token: 'token',
+      jwt_api_url: 'api_url',
+      jwt_api_token: 'api_token',
+      jwt_api_secret: 'api_secret',
+      oauth_authorization_url: 'oauth_authorization_url',
+      oauth_token_url: 'oauth_token_url',
+      oauth_client_id: 'oauth_client_id',
+      oauth_client_secret: 'oauth_client_secret',
+      oauth_scope: 'oauth_scope',
+      oauth_grant_type: 'oauth_grant_type',
+    };
+    for (const [formField, authField] of Object.entries(formToAuthField)) {
+      const isSecret = [
+        'auth_token',
+        'jwt_api_token',
+        'jwt_api_secret',
+        'oauth_client_secret',
+      ].includes(formField);
+      if (values[`${formField}_clear`] === true) {
+        (auth as unknown as Record<string, unknown>)[authField] = null;
+      } else if (Object.hasOwn(values, formField) && values[formField] === '' && !isSecret) {
+        (auth as unknown as Record<string, unknown>)[authField] = null;
+      }
+    }
+    for (const [field, value] of Object.entries(auth)) {
+      const isSecret = ['token', 'api_token', 'api_secret', 'oauth_client_secret'].includes(field);
+      if (field !== 'type' && typeof value === 'string' && value.trim() === '' && !isSecret) {
+        (auth as unknown as Record<string, unknown>)[field] = null;
+      } else if (isSecret && value === '') {
+        delete (auth as unknown as Record<string, unknown>)[field];
+      }
     }
   }
   return auth;

--- a/apps/agor-ui/src/components/MCPServer/useMCPServerOAuthStart.test.tsx
+++ b/apps/agor-ui/src/components/MCPServer/useMCPServerOAuthStart.test.tsx
@@ -150,8 +150,13 @@ describe('useMCPServerOAuthStart', () => {
   it('classifies DCR recovery and accepts the authoritative redirect URL', async () => {
     const startOAuth = vi.fn().mockResolvedValue({
       success: false,
-      error: 'Dynamic Client Registration failed',
-      diagnostic: { stage: 'dcr_registration', http_status: 404 },
+      error: 'The provider could not register an OAuth client automatically.',
+      recovery: {
+        category: 'client_registration_failed',
+        action: 'configure_client',
+        message: 'Configure an OAuth client.',
+        redirect_uri: 'https://agor.example.com/mcp-servers/oauth-callback',
+      },
       redirect_uri: 'https://agor.example.com/mcp-servers/oauth-callback',
     });
     const { result } = renderHook(() =>
@@ -168,7 +173,10 @@ describe('useMCPServerOAuthStart', () => {
     await act(async () => result.current.handleStartOAuthFlow());
 
     expect(result.current.oauthFailure).toMatchObject({
-      diagnostic: { stage: 'dcr_registration', http_status: 404 },
+      recovery: expect.objectContaining({
+        category: 'client_registration_failed',
+        action: 'configure_client',
+      }),
       redirectUri: 'https://agor.example.com/mcp-servers/oauth-callback',
     });
   });
@@ -192,9 +200,49 @@ describe('useMCPServerOAuthStart', () => {
     await act(async () => result.current.handleStartOAuthFlow());
     expect(result.current.oauthFailure).toEqual({
       message: 'No public base URL configured',
-      diagnostic: undefined,
+      recovery: undefined,
       redirectUri: undefined,
     });
+  });
+
+  it('renders daemon-authored recovery from durable attempt polling', async () => {
+    oauthAttempt.wait.mockResolvedValue({
+      status: 'failed',
+      mcp_server_id: 'server-1',
+      recovery: {
+        category: 'permission_changed',
+        action: 'contact_admin',
+        message:
+          'Your MCP authorization permission changed. Ask an administrator to review access.',
+        mcp_server_id: 'server-1',
+      },
+    });
+    const startOAuth = vi.fn().mockResolvedValue({
+      success: true,
+      authorizationUrl: 'https://provider.example/authorize',
+      attempt_id: 'attempt-1',
+    });
+    const windowOpen = vi.spyOn(window, 'open').mockImplementation(() => null);
+    const { result } = renderHook(() =>
+      useMCPServerOAuthStart({
+        client: oauthClient(startOAuth),
+        authorityKey: 'user-a:admin:1',
+        onPrepareOAuthStart: vi.fn().mockResolvedValue('server-1'),
+        showError,
+        showInfo,
+        showSuccess,
+      })
+    );
+
+    await act(async () => result.current.handleStartOAuthFlow());
+    await waitFor(() =>
+      expect(result.current.oauthFailure?.recovery?.category).toBe('permission_changed')
+    );
+    expect(result.current.oauthFailure?.message).toMatch(/authorization permission changed/);
+    expect(showError).toHaveBeenCalledWith(
+      expect.stringMatching(/authorization permission changed/)
+    );
+    windowOpen.mockRestore();
   });
 
   it.each([

--- a/apps/agor-ui/src/components/MCPServer/useMCPServerOAuthStart.ts
+++ b/apps/agor-ui/src/components/MCPServer/useMCPServerOAuthStart.ts
@@ -1,4 +1,4 @@
-import type { MCPOAuthDCRDiagnostic, MCPOAuthStartFailure } from '@agor/core/types';
+import type { MCPAuthRecovery, MCPOAuthStartFailure } from '@agor/core/types';
 import type { AgorClient } from '@agor-live/client';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useAuthorityOperationGuard } from '@/hooks/useAuthorityOperationGuard';
@@ -10,7 +10,7 @@ import {
 
 export interface MCPServerOAuthFailure {
   message: string;
-  diagnostic?: MCPOAuthDCRDiagnostic;
+  recovery?: MCPAuthRecovery;
   redirectUri?: string;
 }
 
@@ -175,7 +175,14 @@ export function useMCPServerOAuthStart({
               onOAuthSucceeded?.();
             } else {
               if (!isCurrentStart()) return;
-              showError(oauthAttemptFailureMessage(attempt.status));
+              const message =
+                attempt.recovery?.message ?? oauthAttemptFailureMessage(attempt.status);
+              showError(message);
+              setOauthFailure({
+                message,
+                recovery: attempt.recovery,
+                redirectUri: attempt.recovery?.redirect_uri,
+              });
               setOauthCallbackModalVisible(false);
             }
           })
@@ -191,17 +198,18 @@ export function useMCPServerOAuthStart({
         if (!isCurrentStart()) return;
         setOauthFailure({
           message: data.error || 'Failed to start OAuth flow',
-          diagnostic: data.diagnostic,
-          redirectUri: data.redirect_uri,
+          recovery: data.recovery,
+          redirectUri: data.recovery?.redirect_uri ?? data.redirect_uri,
         });
       } else {
         if (!isCurrentStart()) return;
         setOauthFailure({ message: 'Failed to start OAuth flow' });
       }
-    } catch (error) {
+    } catch {
       if (isCurrentStart()) {
         setOauthFailure({
-          message: `OAuth flow error: ${error instanceof Error ? error.message : String(error)}`,
+          message:
+            'OAuth could not start. Check the connection and retry; ask an administrator to review the secure daemon logs if it continues.',
         });
       }
     } finally {

--- a/apps/agor-ui/src/components/MarkdownRenderer/VegaLiteRendererGate.tsx
+++ b/apps/agor-ui/src/components/MarkdownRenderer/VegaLiteRendererGate.tsx
@@ -5,6 +5,7 @@ import {
   type CustomRendererProps,
   StreamdownContext,
 } from 'streamdown';
+import { VISUALLY_HIDDEN_STYLE } from '@/utils/accessibility';
 import { isCodeCopyEnabled } from './streamdownControls';
 import { VegaLiteActivationBudgetContext } from './vegaLiteActivationBudget';
 import { loadVegaRenderer } from './vegaRendererLoader';
@@ -129,7 +130,7 @@ function VegaLiteCodeFallback({
     <CodeBlock code={code} isIncomplete={isIncomplete} language={language} lineNumbers={false}>
       {showCopy ? <CodeBlockCopyButton code={code} /> : null}
       {status ? (
-        <span aria-live="polite" className="sr-only">
+        <span aria-live="polite" style={VISUALLY_HIDDEN_STYLE}>
           {status}
         </span>
       ) : null}

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -27,7 +27,8 @@ import {
   LoadingOutlined,
 } from '@ant-design/icons';
 import { Alert, Button, Input, Modal, Spin, Tag, Tooltip, Typography, theme } from 'antd';
-import { type CSSProperties, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { VISUALLY_HIDDEN_STYLE } from '@/utils/accessibility';
 import { useAuthenticatedAuthorityScope } from '../../hooks/useAuthorityOperationGuard';
 import { useAgorStore } from '../../store/agorStore';
 import {
@@ -153,20 +154,6 @@ const LLM_OPTIONS: LlmOption[] = [
 // an AntD Tooltip (hover/focus) and as visually-hidden text inside the card, so
 // the reason isn't a hover-only affordance (see frontend.md a11y guidance).
 const GOAL_CAP_HINT = 'Deselect one to swap it for this.';
-
-// Visually hidden but exposed to assistive tech — carries the cap hint text
-// rendered inside disabled cards so it joins their accessible name.
-const SR_ONLY_STYLE: CSSProperties = {
-  position: 'absolute',
-  width: 1,
-  height: 1,
-  padding: 0,
-  margin: -1,
-  overflow: 'hidden',
-  clip: 'rect(0, 0, 0, 0)',
-  whiteSpace: 'nowrap',
-  border: 0,
-};
 
 function validateLlmKeyPattern(agent: AgenticToolName, key: string): string | null {
   const k = key.trim();
@@ -1074,7 +1061,7 @@ export function OnboardingWizard({
               aria-current={isCurrent ? 'step' : undefined}
               style={{ display: 'flex', alignItems: 'center' }}
             >
-              <span style={SR_ONLY_STYLE}>
+              <span style={VISUALLY_HIDDEN_STYLE}>
                 Step {index + 1} of {STEPS.length}: {STEP_META[step].label}.{' '}
                 {isCompleted ? 'Completed' : isCurrent ? 'Current step' : 'Not started'}.
               </span>
@@ -1259,7 +1246,7 @@ export function OnboardingWizard({
                   </div>
                   {/* Screen-reader-only cap reason — joins the disabled card's
                       accessible name so it isn't a hover-only affordance. */}
-                  {isDisabled && <span style={SR_ONLY_STYLE}>{GOAL_CAP_HINT}</span>}
+                  {isDisabled && <span style={VISUALLY_HIDDEN_STYLE}>{GOAL_CAP_HINT}</span>}
                 </button>
               </Tooltip>
             );

--- a/apps/agor-ui/src/components/SessionPanel/SessionMcpFooterControl.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionMcpFooterControl.tsx
@@ -220,8 +220,14 @@ const SessionMcpFooterControlForIdentity: React.FC<SessionMcpFooterControlProps>
                     ? 'Reconnect to the Agor daemon before changing OAuth credentials.'
                     : 'Your account can no longer change OAuth credentials.'
                 }
+                configureAllowed={editMutationAllowed}
+                configureBlockedReason={
+                  !connectionReady
+                    ? 'Reconnect to the Agor daemon before changing saved credentials.'
+                    : 'Only an administrator can change saved credentials.'
+                }
                 onOAuthAttemptStarted={markNewOAuthAttempt}
-                onEdit={handleEditServer}
+                onEdit={editMutationAllowed ? handleEditServer : undefined}
               />
             ))}
           </Space>

--- a/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
@@ -271,7 +271,6 @@ const MCPServersTableForIdentity: React.FC<MCPServersTableProps> = ({
       transport: values.transport as 'stdio' | 'http' | 'sse',
       scope: (values.scope as MCPScope | undefined) ?? offeredScopes[0],
       enabled: (values.enabled as boolean | undefined) ?? true,
-      source: 'user',
     };
 
     if (values.transport === 'stdio') {
@@ -319,7 +318,7 @@ const MCPServersTableForIdentity: React.FC<MCPServersTableProps> = ({
         return newServerId;
       }
 
-      const { name: _name, source: _source, ...updates } = data;
+      const { name: _name, ...updates } = data;
       if (!operation.isCurrent() || !addIsCurrentlyAllowed()) return null;
       await client.service('mcp-servers').patch(createdServerId, updates as UpdateMCPServerInput);
       if (!operation.isCurrent()) return null;

--- a/apps/agor-ui/src/utils/accessibility.ts
+++ b/apps/agor-ui/src/utils/accessibility.ts
@@ -1,0 +1,15 @@
+import type { CSSProperties } from 'react';
+
+/** Token-neutral visually-hidden content that remains available to assistive technology. */
+export const VISUALLY_HIDDEN_STYLE: CSSProperties = {
+  position: 'absolute',
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  overflow: 'hidden',
+  clip: 'rect(0, 0, 0, 0)',
+  clipPath: 'inset(50%)',
+  whiteSpace: 'nowrap',
+  border: 0,
+};

--- a/apps/agor-ui/src/utils/mcpAuth.test.ts
+++ b/apps/agor-ui/src/utils/mcpAuth.test.ts
@@ -29,10 +29,24 @@ describe('mcpServerNeedsAuth', () => {
     expect(mcpServerNeedsAuth(undefined, new Set())).toBe(false);
   });
 
-  it('returns false for non-OAuth server', () => {
+  it('returns false for a configured bearer server', () => {
     const server = makeOAuthServer();
     (server.auth as { type: string }).type = 'bearer';
+    server.auth!.token = 'saved-token';
     expect(mcpServerNeedsAuth(server, new Set())).toBe(false);
+  });
+
+  it('reports explicitly cleared bearer and JWT credentials as needs-auth', () => {
+    const bearer = makeOAuthServer();
+    bearer.auth = { type: 'bearer' };
+    expect(mcpServerNeedsAuth(bearer, new Set())).toBe(true);
+
+    const jwt = makeOAuthServer();
+    jwt.auth = { type: 'jwt', api_url: 'https://auth.example.test/token' };
+    expect(mcpServerNeedsAuth(jwt, new Set())).toBe(true);
+    jwt.auth.api_token = 'saved-token';
+    jwt.auth.api_secret = 'saved-secret';
+    expect(mcpServerNeedsAuth(jwt, new Set())).toBe(false);
   });
 
   it('returns false when token present and no expiry', () => {

--- a/apps/agor-ui/src/utils/mcpAuth.ts
+++ b/apps/agor-ui/src/utils/mcpAuth.ts
@@ -24,13 +24,24 @@ import type { MCPServer } from '@agor-live/client';
  * surfaces a "happy" purple chip and suppresses the above-prompt-box auth
  * banner — leaving users to send doomed prompts.
  *
- * Non-OAuth servers always return false (no auth needed).
+ * Bearer/JWT rows can intentionally remain saved after an explicit secret
+ * clear. Their redacted sentinel counts as a configured saved value; absence
+ * means the server needs configuration before it can be dispatched.
  */
 export function mcpServerNeedsAuth(
   server: MCPServer | undefined,
   userAuthenticatedMcpServerIds: Set<string>
 ): boolean {
-  if (server?.auth?.type !== 'oauth') return false;
+  if (!server?.auth || server.auth.type === 'none') return false;
+  if (server.auth.type === 'bearer') return !server.auth.token?.trim();
+  if (server.auth.type === 'jwt') {
+    return !(
+      server.auth.api_url?.trim() &&
+      server.auth.api_token?.trim() &&
+      server.auth.api_secret?.trim()
+    );
+  }
+  if (server.auth.type !== 'oauth') return false;
 
   const expiresAt = server.auth.oauth_token_expires_at;
   // Use `<=` to match the daemon-side boundary: `oauth-status` treats

--- a/context/README.md
+++ b/context/README.md
@@ -67,6 +67,7 @@ Designs that are referenced from code or in flight. Anything here is either stil
 - [`parent-session-callbacks.md`](explorations/parent-session-callbacks.md) — child-session completion notifications (referenced from `docs/never-lose-prompt-design.md`).
 - [`frontend-hardcoded-colors.md`](explorations/frontend-hardcoded-colors.md) — Biome/GritQL color audit, classification, and enforcement rollout.
 - [`web-terminal-ownership-ha.md`](explorations/web-terminal-ownership-ha.md) — process-affine terminal ownership, HA support, and failure semantics.
+- [`mcp-authoritative-egress-gateway.md`](explorations/mcp-authoritative-egress-gateway.md) — issue-ready design for strong MCP credential/request revocation at a daemon-owned egress boundary.
 
 ### Messaging & positioning (now in the Knowledge base)
 

--- a/context/explorations/mcp-authoritative-egress-gateway.md
+++ b/context/explorations/mcp-authoritative-egress-gateway.md
@@ -1,0 +1,227 @@
+# Authoritative MCP egress gateway
+
+Status: issue-ready design; not implemented by the #2500 auth-mutation slice.
+
+## Why lifecycle invalidation is insufficient
+
+Today an executor gives a provider SDK an MCP configuration containing an
+endpoint or process command and, for some transports, credential material. Once
+that SDK owns the client, a daemon-side generation check cannot close the gap
+between “checked” and “sent.” Stopping a Task after a configuration write is an
+availability optimization, not a revocation boundary:
+
+- PostgreSQL does not expose an uncommitted “mutation pending” row to another
+  transaction.
+- A remote executor acknowledgement proves only that it sent an acknowledgement,
+  not that a third-party SDK or subprocess stopped.
+- an HTTP request or provider side effect already accepted before revocation
+  cannot be recalled;
+- credential-bearing environment and stdio process startup happen outside the
+  daemon's request checks; and
+- crash recovery cannot safely infer that an unobserved provider is quiescent.
+
+The strong invariant therefore requires one owner for both credential use and
+MCP egress. No executor or provider SDK may receive a reusable raw credential or
+open a provider transport directly.
+
+## Target invariant and linearization point
+
+For each `(tenant, credential principal, MCP server)` authority:
+
+1. Every tool request obtains a gateway read lease before credentials are
+   resolved and retains it until the response, cancellation, or bounded timeout.
+2. An authority mutation obtains the corresponding write lease. New read leases
+   stop immediately. The mutation becomes authoritative only after admitted
+   reads have completed or the gateway has closed their owned transports.
+3. The write transaction increments a durable authority epoch, changes config or
+   grants, records an outbox event, and commits. A request may dispatch only when
+   its read lease and observed epoch are still current at the gateway's final
+   send boundary.
+4. Raw bearer, JWT, OAuth, header, and environment secrets remain inside the
+   gateway/credential store. Executors carry an opaque, short-lived capability
+   naming the tenant, Task, Session, prompter principal, server, and authority
+   epoch.
+
+“No old request after revocation” means no provider request is _admitted or
+dispatched after the write lease linearization point_. A provider side effect
+completed by a request admitted before that point is historical and cannot be
+undone. The mutation API must either wait for those admitted operations or fail
+closed with a bounded, actionable `egress_drain_failed` result; it must not claim
+to revoke already-completed provider effects.
+
+## Components
+
+### Gateway-facing MCP transport
+
+Expose an Agor-controlled MCP endpoint per effective server (or one endpoint
+with a server capability). Claude, Codex, Gemini, Cursor, OpenCode, and delegated
+executors connect only to that endpoint. The gateway validates the opaque Task
+capability, resolves the current effective server through the canonical branch,
+Session, Task, role/policy, attachment, and principal owners, and forwards
+JSON-RPC under a read lease.
+
+The Task capability is not a credential cache. It is audience-bound to the
+gateway, short lived, non-transferable across tenant/Task/server, and checked
+against durable Task activity and authority epoch on every call.
+
+### HTTP, SSE, and long-lived transports
+
+- The gateway owns DNS pinning, connection establishment, request bodies, and
+  response streaming.
+- Authorization is injected only after the final authority check. Redirects are
+  either refused or followed by the gateway under the existing safe-outbound
+  policy, with a new lease/epoch check at every hop. Authorization is never
+  forwarded to a different origin.
+- SSE, WebSocket, and streamable-HTTP connections are registered under the read
+  lease. A write lease closes them and waits for gateway-observed closure; an
+  executor acknowledgement is not part of the proof.
+- Each JSON-RPC tool invocation has its own admission record even when it shares
+  a pooled connection, so revocation can stop new calls without treating a TCP
+  socket as authority.
+
+### OAuth, JWT, and refresh
+
+- OAuth access/refresh tokens and registered client secrets stay in the daemon's
+  credential store. Refresh runs inside the gateway immediately before a call
+  that needs it and rechecks the grant binding before returning an internal
+  header value to the sender component.
+- Routine access-token rotation retains the grant identity/authorization epoch
+  and does not acquire an authority write lease. Reauthentication, disconnect,
+  grant revocation, OAuth mode changes, client/binding changes, and subject
+  changes do.
+- JWT client-credential exchanges are performed inside the gateway. The minted
+  bearer is request-local or bounded to the current read lease and is never
+  returned to a remote executor.
+- OAuth start, callback, polling, disconnect, and runtime failures use the same
+  closed recovery categories already exposed by the daemon; provider details
+  remain in redacted secure telemetry.
+
+### stdio
+
+Stdio cannot be made strong by proxying only HTTP. The gateway (or a co-located
+trusted egress worker) must own the subprocess, its credential-bearing
+environment, stdin/stdout JSON-RPC, and process group. Executors talk to the
+gateway, never spawn the configured command. Acquiring a write lease stops
+admission, closes pipes, terminates the gateway-owned process group, verifies
+process absence, and only then commits the mutation. Delegated platforms need a
+reviewed worker with the same contract; until then strong revocation is
+unsupported for delegated stdio and must fail closed rather than silently fall
+back to direct execution.
+
+### PostgreSQL, SQLite, and multiple daemons
+
+Database state is authority; Redis is only a wake-up hint.
+
+- PostgreSQL uses short transactions, not an HTTP-long outer transaction. A
+  per-authority row contains the epoch and mutation state. A write operation
+  claims it with a row/advisory lock, sets durable `draining`, and coordinates
+  with gateway-owned active leases before committing the new epoch.
+- Active distributed leases need a bounded TTL plus gateway heartbeat and an
+  ownership token. Expiry is not proof of third-party teardown, so an expired
+  gateway owner leaves the authority quarantined until that owner is fenced by
+  infrastructure or an operator-approved recovery verifies it cannot send.
+- SQLite uses `BEGIN IMMEDIATE` and the same state machine without pretending it
+  supplies cross-host coordination.
+- Outbox delivery accelerates connection closure and UI refresh. Every gateway
+  admission reads the durable epoch, so missed Redis events and daemon restarts
+  converge lazily.
+
+## Durable mutation state machine
+
+Use an idempotent operation keyed by `(tenant, authority, requested mutation
+fingerprint)`:
+
+1. `requested`: mutation payload is validated and durably staged under the
+   deployment's documented storage controls, but is not authoritative.
+2. `draining`: new gateway reads are refused; current owned reads are cancelled
+   or allowed to finish within policy.
+3. `ready_to_commit`: all registered gateway transports are observably closed.
+4. `committed`: config/grant change and epoch increment committed atomically;
+   an outbox row announces the new epoch.
+5. `failed` or `quarantined`: mutation did not become authoritative. Access stays
+   disabled only when absence of an old gateway owner cannot be proven. The API
+   returns an operational recovery code and an admin can retry the same operation.
+
+Startup reconciliation resumes idempotent operations from durable state. It
+never waits forever for an acknowledgement from a process that may not exist.
+Quarantine has an explicit owner, reason, timestamp, and operator recovery path.
+
+## Migration and compatibility
+
+1. **Observe:** inventory every direct MCP configuration/credential handoff and
+   emit secret-free telemetry for transports and SDKs in use.
+2. **HTTP opt-in:** introduce the gateway behind a per-tenant feature flag. Keep
+   direct mode behavior unchanged and label it as non-strong; do not mix direct
+   and gateway clients for one authority.
+3. **SDK adapters:** configure every provider SDK with the gateway endpoint and
+   opaque capability. Preserve `sdk_session_id` and conversation resume handles;
+   a transport refresh must not erase conversation state.
+4. **Remote executors:** require gateway reachability and capability audience
+   validation. Never export raw config as a compatibility fallback.
+5. **stdio worker:** move process ownership and env injection into the trusted
+   egress worker before enabling strong mode for stdio.
+6. **Enforce:** once a tenant has no observed direct clients, make direct
+   credential/config endpoints unavailable to executor tokens and enable the
+   write-lease mutation contract.
+
+Archives and existing MCP rows require no data-shape migration before rollout.
+Today MCP auth/header/env secrets are stored in MCP JSON and OAuth grants in the
+token tables according to the deployment's storage security; API, realtime,
+and UI projections redact them, but the JSON is not application-encrypted by
+this design. The gateway migration changes who may resolve and exercise those
+values. Older executors remain supported only in explicitly non-strong mode
+during rollout.
+
+The existing owner/admin raw session-config route remains a compatibility path
+for local executors. It must not be widened to collaborators or delegated
+executors: a repeated Task check immediately before returning a raw secret does
+not mediate the later provider send. Collaborator/delegated execution becomes
+supported only when its SDK receives a gateway capability rather than raw MCP
+configuration.
+
+## Latency and availability budgets
+
+These are rollout gates, not aspirations to measure after enforcement:
+
+- capability validation and lease admission add at most 5 ms p95 and 25 ms p99
+  within one region, excluding provider latency;
+- gateway forwarding adds at most 20 ms p95 to ordinary HTTP JSON-RPC calls and
+  must not buffer streaming responses beyond protocol framing;
+- routine access-token refresh may consume the provider's latency but must add
+  no authority write/drain cycle;
+- mutation drain defaults to 10 seconds and has a 30-second hard ceiling, after
+  which it returns `egress_drain_failed` or leaves the authority explicitly
+  quarantined rather than waiting indefinitely;
+- the gateway targets 99.99% monthly admission availability. Loss of the
+  authoritative database/lease owner fails closed for new MCP calls; control
+  plane and non-MCP conversation work remain available;
+- capability/epoch lookups require bounded caches with a maximum 1-second TTL,
+  invalidated eagerly by outbox hints but always checked at the final gateway
+  send boundary for write-draining authorities.
+
+## Acceptance tests for the gateway phase
+
+- Held HTTP body send, redirect, pooled connection, SSE, and WebSocket tests
+  prove no send occurs after write-lease admission.
+- OAuth/JWT refresh tests hold credential resolution across revocation and prove
+  no old or newly minted bearer leaves the gateway.
+- Stdio tests hold a JSON-RPC request and credential-bearing environment while
+  mutation terminates and verifies the process group.
+- Collaborator, role/policy, branch grant/group/visibility, attachment,
+  Marketplace permission/removal, OAuth disconnect/reauth, and deletion tests
+  exercise the canonical effective-authority resolver.
+- PostgreSQL tests use two real connections/daemons and cover transaction
+  visibility, lock loss, crash between each state, outbox replay, and restart.
+- Remote-executor tests kill the gateway owner and prove quarantine rather than
+  accepting an unverifiable acknowledgement.
+- Provider-side-effect tests document the admitted-before-linearization case and
+  prove mutations either wait for it or return the bounded drain failure.
+
+## Explicitly deferred from the current #2500 slice
+
+The current delivery does not add runtime generations, authority watermarks,
+remote quiescence acknowledgements, or strict hot reload. It provides safe
+configuration mutation and actionable recovery. Existing Tasks may retain the
+MCP clients with which their turn started; subsequent Task dispatch resolves the
+saved configuration again. Strong active revocation and authoritative live
+reload belong to this gateway phase.

--- a/packages/core/src/api/index.ts
+++ b/packages/core/src/api/index.ts
@@ -22,6 +22,7 @@ import type {
   CardWithType,
   CloneRepositoryResult,
   CreateAgenticToolPreset,
+  CreateMCPServerInput,
   CreateSessionInput,
   GatewayChannel,
   GatewayChannelCreateData,
@@ -73,6 +74,7 @@ import type {
   TemplateRenderResponse,
   TenantAgenticToolSettings,
   TenantAgenticToolSettingsPatch,
+  UpdateMCPServerInput,
   User,
   UserAvatarSettings,
   UserAvatarSyncRequest,
@@ -327,6 +329,14 @@ export interface GatewayChannelsService
     never,
     ClientInput<GatewayChannelPatchData> | null
   > {}
+
+/** MCP servers expose redacted entities but accept purpose-built auth patch DTOs. */
+export type MCPServersService = AgorService<
+  MCPServer,
+  ClientInput<CreateMCPServerInput>,
+  ClientInput<UpdateMCPServerInput>,
+  ClientInput<UpdateMCPServerInput> | null
+>;
 
 export type AgenticToolSettingsService = AgorService<
   TenantAgenticToolSettings,
@@ -800,7 +810,7 @@ export interface AgorClient
   service(path: 'cards'): AgorService<CardWithType>;
   service(path: 'card-types'): AgorService<CardType>;
   service(path: 'users'): UsersService;
-  service(path: 'mcp-servers'): AgorService<MCPServer>;
+  service(path: 'mcp-servers'): MCPServersService;
   service(path: 'mcp-catalog'): AgorService<MCPCatalogEntry>;
   service(path: 'mcp-catalog/readiness'): AgorService<MCPCatalogReadiness>;
   service(path: 'mcp-catalog/connect'): MCPCatalogConnectService;
@@ -1558,7 +1568,7 @@ export function createClient(
     let attemptCount = 0;
     const maxAttempts = options?.reconnectionAttempts ?? (isBrowser ? Infinity : 2);
 
-    socket.on('connect_error', (error: Error) => {
+    socket.on('connect_error', () => {
       attemptCount++;
       if (attemptCount === 1) {
         console.error(`✗ Daemon not running at ${url}`);

--- a/packages/core/src/db/repositories/mcp-server-ownership.test.ts
+++ b/packages/core/src/db/repositories/mcp-server-ownership.test.ts
@@ -219,7 +219,7 @@ describe('private MCP server ownership', () => {
       transport: 'http',
       url: 'https://mcp.linear.app/mcp',
       scope: 'session',
-      source: 'user',
+      source: 'catalog',
       owner_user_id: BOB,
       catalog_entry_name: 'com.linear/linear',
     });

--- a/packages/core/src/db/repositories/mcp-servers.test.ts
+++ b/packages/core/src/db/repositories/mcp-servers.test.ts
@@ -6,9 +6,12 @@
  */
 
 import type { MCPServer, MCPServerID, UpdateMCPServerInput, UserID } from '@agor/core/types';
-import { describe, expect } from 'vitest';
+import { eq } from 'drizzle-orm';
+import { describe, expect, vi } from 'vitest';
 import { generateId } from '../../lib/ids';
 import { MCP_HEADER_REDACTED_SENTINEL } from '../../tools/mcp/http-headers';
+import { select, update } from '../database-wrapper';
+import { mcpServers } from '../schema';
 import { dbTest } from '../test-helpers';
 import { EntityNotFoundError } from './base';
 import { MCPServerRepository } from './mcp-servers';
@@ -17,15 +20,19 @@ import { MCPServerRepository } from './mcp-servers';
  * Create test MCP server data with required fields
  */
 function createMCPServerData(overrides?: Partial<MCPServer>) {
+  const transport = overrides?.transport ?? (overrides?.auth || overrides?.url ? 'http' : 'stdio');
   return {
     mcp_server_id: overrides?.mcp_server_id ?? (generateId() as MCPServerID),
     name: overrides?.name ?? 'test-server',
-    transport: overrides?.transport ?? ('stdio' as const),
+    transport,
     scope: overrides?.scope ?? ('global' as const),
     enabled: overrides?.enabled ?? true,
     source: overrides?.source ?? ('user' as const),
     created_at: overrides?.created_at ?? new Date(),
     updated_at: overrides?.updated_at ?? new Date(),
+    ...(transport === 'stdio'
+      ? { command: overrides?.command ?? 'npx' }
+      : { url: overrides?.url ?? 'https://mcp.example.test/mcp' }),
     ...overrides,
   };
 }
@@ -227,6 +234,104 @@ describe('MCPServerRepository.findAll', () => {
 // ============================================================================
 
 describe('MCPServerRepository.update', () => {
+  dbTest('keeps daemon-owned config revisions monotonic', async ({ db }) => {
+    const repo = new MCPServerRepository(db);
+    const created = await repo.create({
+      ...createMCPServerData({
+        display_name: 'Before',
+        transport: 'http',
+        url: 'https://before.example.test/mcp',
+      }),
+      config_version: Number.MAX_SAFE_INTEGER,
+    } as never);
+    expect(created).toMatchObject({ config_version: 1 });
+
+    const metadataOnly = await repo.update(created.mcp_server_id, {
+      display_name: 'After',
+      expected_config_version: 1,
+    });
+    expect(metadataOnly).toMatchObject({ config_version: 2 });
+
+    const endpointEdit = await repo.update(created.mcp_server_id, {
+      url: 'https://changed.example.test/mcp',
+      expected_config_version: 2,
+    });
+    expect(endpointEdit).toMatchObject({ config_version: 3 });
+  });
+
+  dbTest(
+    'fails closed at revision exhaustion without making revision 1 valid again',
+    async ({ db }) => {
+      const repo = new MCPServerRepository(db);
+      const created = await repo.create(createMCPServerData({ display_name: 'Before' }));
+      const row = await select(db)
+        .from(mcpServers)
+        .where(eq(mcpServers.mcp_server_id, created.mcp_server_id))
+        .one();
+      for (const exhausted of [Number.MAX_SAFE_INTEGER - 1, Number.MAX_SAFE_INTEGER]) {
+        await update(db, mcpServers)
+          .set({ data: { ...row!.data, config_version: exhausted } })
+          .where(eq(mcpServers.mcp_server_id, created.mcp_server_id))
+          .run();
+
+        await expect(repo.findById(created.mcp_server_id)).resolves.toMatchObject({
+          display_name: 'Before',
+          config_version: exhausted,
+        });
+        await expect(
+          repo.update(created.mcp_server_id, {
+            display_name: 'Must not advance into an exhausted revision',
+            expected_config_version: exhausted,
+          })
+        ).rejects.toThrow('configuration revision is invalid or exhausted');
+
+        // A client which retained the initial revision must never regain CAS
+        // authority after exhaustion (ABA).
+        await expect(
+          repo.update(created.mcp_server_id, {
+            display_name: 'Ancient stale edit',
+            expected_config_version: 1,
+          })
+        ).rejects.toThrow('configuration revision is invalid or exhausted');
+      }
+
+      const stored = await select(db)
+        .from(mcpServers)
+        .where(eq(mcpServers.mcp_server_id, created.mcp_server_id))
+        .one();
+      expect(stored?.data.config_version).toBe(Number.MAX_SAFE_INTEGER);
+      expect(stored?.data.display_name).toBe('Before');
+    }
+  );
+
+  dbTest('projects a pre-existing invalid revision as baseline 1', async ({ db }) => {
+    const repo = new MCPServerRepository(db);
+    const created = await repo.create(createMCPServerData({ display_name: 'Invalid revision' }));
+    const row = await select(db)
+      .from(mcpServers)
+      .where(eq(mcpServers.mcp_server_id, created.mcp_server_id))
+      .one();
+    await update(db, mcpServers)
+      .set({ data: { ...row!.data, config_version: 0 } })
+      .where(eq(mcpServers.mcp_server_id, created.mcp_server_id))
+      .run();
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      await expect(repo.findById(created.mcp_server_id)).resolves.toMatchObject({
+        config_version: 1,
+      });
+      await expect(
+        repo.update(created.mcp_server_id, {
+          display_name: 'Recovered invalid revision',
+          expected_config_version: 1,
+        })
+      ).resolves.toMatchObject({ config_version: 2 });
+      expect(JSON.stringify(warning.mock.calls)).not.toContain('Invalid revision');
+    } finally {
+      warning.mockRestore();
+    }
+  });
+
   dbTest('should update MCP server', async ({ db }) => {
     const repo = new MCPServerRepository(db);
     const created = await repo.create(createMCPServerData({ name: 'original', enabled: true }));
@@ -260,6 +365,80 @@ describe('MCPServerRepository.update', () => {
         auth: { type: 'oauth', oauth_compatibility_mode: 'marketplace' } as never,
       })
     ).rejects.toThrow(/must be either strict or legacy/);
+  });
+
+  dbTest(
+    'merges a narrow auth patch without clobbering credentials or compatibility',
+    async ({ db }) => {
+      const repo = new MCPServerRepository(db);
+      const created = await repo.create(
+        createMCPServerData({
+          transport: 'http',
+          url: 'https://calendar.example.test/mcp',
+          auth: {
+            type: 'oauth',
+            oauth_scope: 'calendar.readonly',
+            oauth_client_id: 'registered-client',
+            oauth_client_secret: 'registered-secret',
+            oauth_compatibility_mode: 'legacy',
+          },
+        })
+      );
+
+      const updated = await repo.update(created.mcp_server_id, {
+        auth: { oauth_scope: 'calendar.events' },
+        expected_config_version: created.config_version,
+      });
+
+      expect(updated.config_version).toBe((created.config_version ?? 1) + 1);
+      expect(updated.auth).toEqual({
+        type: 'oauth',
+        oauth_scope: 'calendar.events',
+        oauth_client_id: 'registered-client',
+        oauth_client_secret: 'registered-secret',
+        oauth_compatibility_mode: 'legacy',
+      });
+    }
+  );
+
+  dbTest('clears one auth field with null and rejects a stale config version', async ({ db }) => {
+    const repo = new MCPServerRepository(db);
+    const created = await repo.create(
+      createMCPServerData({
+        auth: { type: 'oauth', oauth_scope: 'one', oauth_client_id: 'client' },
+      })
+    );
+    const updated = await repo.update(created.mcp_server_id, {
+      auth: { oauth_scope: null },
+      expected_config_version: created.config_version,
+    });
+    expect(updated.auth).toEqual({ type: 'oauth', oauth_client_id: 'client' });
+    await expect(
+      repo.update(created.mcp_server_id, {
+        auth: { oauth_scope: 'stale' },
+        expected_config_version: created.config_version,
+      })
+    ).rejects.toMatchObject({ name: 'MCPServerConfigConflictError' });
+  });
+
+  dbTest('supports an explicit same-mode whole-auth replacement', async ({ db }) => {
+    const repo = new MCPServerRepository(db);
+    const created = await repo.create(
+      createMCPServerData({
+        auth: {
+          type: 'oauth',
+          oauth_scope: 'old',
+          oauth_client_id: 'old-client',
+          oauth_client_secret: 'old-secret',
+        },
+      })
+    );
+    const updated = await repo.update(created.mcp_server_id, {
+      auth: { type: 'oauth', oauth_scope: 'new' },
+      replace_auth: true,
+      expected_config_version: created.config_version,
+    });
+    expect(updated.auth).toEqual({ type: 'oauth', oauth_scope: 'new' });
   });
 
   dbTest(

--- a/packages/core/src/db/repositories/mcp-servers.ts
+++ b/packages/core/src/db/repositories/mcp-servers.ts
@@ -6,6 +6,7 @@
 
 import type {
   CreateMCPServerInput,
+  MCPAuth,
   MCPScope,
   MCPServer,
   MCPServerFilters,
@@ -15,12 +16,21 @@ import type {
 } from '@agor/core/types';
 import { and, eq, isNull, like, or, sql } from 'drizzle-orm';
 import { generateId } from '../../lib/ids';
-import { restoreRedactedMCPAuthSecrets } from '../../tools/mcp/auth-secrets';
+import {
+  assertValidMCPAuthPatch,
+  MCPAuthValidationError,
+  mergeMCPAuth,
+  replaceMCPAuth,
+} from '../../tools/mcp/auth-patch';
 import { restoreRedactedMCPEnvSecrets } from '../../tools/mcp/env-secrets';
 import {
   normalizeMCPCustomHeaders,
   restoreRedactedMCPCustomHeaders,
 } from '../../tools/mcp/http-headers';
+import {
+  assertValidEffectiveMCPServer,
+  MCPServerWriteValidationError,
+} from '../../tools/mcp/server-validation';
 import { assertPublicMCPOAuthCompatibilityMode } from '../../types/mcp';
 import type { Database } from '../client';
 import {
@@ -40,6 +50,7 @@ import {
   mcpServers,
   sessionMcpServers,
 } from '../schema';
+import { runWithTenantDatabaseTransaction } from '../tenant-scope';
 import { AppVariableRepository } from './app-variables';
 import {
   AmbiguousIdError,
@@ -49,6 +60,186 @@ import {
   RepositoryError,
   resolveByShortIdPrefix,
 } from './base';
+
+/** Compare-and-swap failure for a stale MCP configuration editor. */
+export class MCPServerConfigConflictError extends Error {
+  constructor(
+    readonly mcpServerId: MCPServerID,
+    readonly expectedVersion: number,
+    readonly actualVersion: number
+  ) {
+    super(
+      `MCP server configuration changed (expected version ${expectedVersion}, current version ${actualVersion})`
+    );
+    this.name = 'MCPServerConfigConflictError';
+  }
+}
+
+export interface MCPServerUpdateOptions {
+  /** Feathers PUT: omitted mutable configuration is cleared instead of merged. */
+  replace?: boolean;
+}
+
+function mergeServerConfiguration(
+  current: MCPServer,
+  updates: UpdateMCPServerInput,
+  nextConfigVersion: number,
+  options: MCPServerUpdateOptions
+): MCPServer {
+  const {
+    expected_config_version: _expectedConfigVersion,
+    auth: authPatch,
+    replace_auth: replaceAuth,
+    ...persistedUpdates
+  } = updates;
+  const replacing = options.replace === true;
+  const merged: MCPServer = {
+    ...current,
+    ...persistedUpdates,
+    config_version: nextConfigVersion,
+  };
+
+  if (replacing) {
+    merged.display_name = persistedUpdates.display_name;
+    merged.description = persistedUpdates.description;
+    merged.command = persistedUpdates.command;
+    merged.args = persistedUpdates.args;
+    merged.url = persistedUpdates.url;
+    merged.tool_permissions = persistedUpdates.tool_permissions;
+  }
+
+  if ('headers' in updates || replacing) {
+    merged.headers =
+      'headers' in updates
+        ? restoreRedactedMCPCustomHeaders({ current: current.headers, next: updates.headers })
+        : undefined;
+  }
+  if ('env' in updates || replacing) {
+    merged.env =
+      'env' in updates
+        ? restoreRedactedMCPEnvSecrets({ current: current.env, next: updates.env })
+        : undefined;
+  }
+  if ('auth' in updates) {
+    const shouldReplaceAuth = replaceAuth ?? replacing;
+    merged.auth = shouldReplaceAuth
+      ? replaceMCPAuth(current.auth, authPatch)
+      : mergeMCPAuth(current.auth, authPatch);
+  } else if (replacing) {
+    merged.auth = undefined;
+  }
+
+  const transportChanged =
+    persistedUpdates.transport !== undefined && persistedUpdates.transport !== current.transport;
+  if (transportChanged) {
+    if (merged.transport === 'stdio') {
+      if (!Object.hasOwn(updates, 'command')) {
+        throw new MCPServerWriteValidationError(
+          'command is required when changing transport to stdio'
+        );
+      }
+      merged.url = undefined;
+      merged.headers = undefined;
+      merged.auth = undefined;
+    } else {
+      if (!Object.hasOwn(updates, 'url')) {
+        throw new MCPServerWriteValidationError(
+          `url is required when changing transport to ${merged.transport}`
+        );
+      }
+      merged.command = undefined;
+      merged.args = undefined;
+    }
+  } else if (merged.transport === 'stdio') {
+    if (
+      ('url' in updates && updates.url !== undefined) ||
+      ('headers' in updates && updates.headers !== undefined) ||
+      ('auth' in updates && updates.auth !== undefined && updates.auth !== null)
+    ) {
+      throw new MCPServerWriteValidationError(
+        'url, headers, and authentication do not apply to stdio transport'
+      );
+    }
+    // Deterministically repair historical inactive fields on the next edit.
+    merged.url = undefined;
+    merged.headers = undefined;
+    merged.auth = undefined;
+  } else {
+    if (
+      ('command' in updates && updates.command !== undefined) ||
+      ('args' in updates && updates.args !== undefined)
+    ) {
+      throw new MCPServerWriteValidationError('command and args only apply to stdio transport');
+    }
+    merged.command = undefined;
+    merged.args = undefined;
+  }
+
+  return merged;
+}
+
+async function waitForSQLiteBusyRetry(operation: string, attempt: number): Promise<void> {
+  const delayMs = Math.min(5 * 2 ** attempt, 100);
+  const retryNumber = attempt + 1;
+  const message = `[mcp-servers] SQLite busy; retrying ${operation} admission retry=${retryNumber} delay_ms=${delayMs}`;
+  if (retryNumber >= 4) console.warn(message);
+  else console.debug(message);
+  await new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+function nextMCPConfigVersion(
+  current: MCPServer,
+  expectedConfigVersion: number | undefined
+): number {
+  const revision = current.config_version ?? 1;
+  if (expectedConfigVersion !== undefined && expectedConfigVersion !== revision) {
+    throw new MCPServerConfigConflictError(current.mcp_server_id, expectedConfigVersion, revision);
+  }
+  if (revision >= Number.MAX_SAFE_INTEGER - 1) {
+    // MAX_SAFE_INTEGER is never issued. Once the last advanceable revision is
+    // reached, every mutation fails closed rather than wrapping/resetting and
+    // making an ancient CAS value authoritative again.
+    throw new RepositoryError('MCP server configuration revision is exhausted');
+  }
+  return revision + 1;
+}
+
+function assertStoredMCPConfigVersionCanAdvance(value: unknown): void {
+  // Missing/zero revisions are pre-CAS legacy shapes. Their public baseline 1
+  // remains recoverable. Positive unsafe or exhausted revisions may have
+  // previously issued lower values, so only an explicit administrative repair
+  // can change them without introducing ABA.
+  if (value === undefined || value === null || value === 0) return;
+  if (
+    typeof value !== 'number' ||
+    !Number.isSafeInteger(value) ||
+    value < 0 ||
+    value >= Number.MAX_SAFE_INTEGER - 1
+  ) {
+    throw new RepositoryError(
+      'MCP server configuration revision is invalid or exhausted; administrative repair is required'
+    );
+  }
+}
+
+function projectedMCPConfigVersion(value: unknown, serverId: string): number {
+  if (
+    value === undefined ||
+    (typeof value === 'number' &&
+      Number.isSafeInteger(value) &&
+      value >= 1 &&
+      value <= Number.MAX_SAFE_INTEGER)
+  ) {
+    return value === undefined ? 1 : Number(value);
+  }
+
+  // Normalize only the read projection for legacy/corrupt storage. Mutation
+  // independently rejects positive unsafe/exhausted storage, so this fallback
+  // can never make an ancient revision 1 authoritative again. Do not log row
+  // JSON, display metadata, URLs, or credentials.
+  console.warn(`[mcp-servers] Normalizing invalid configuration revision server_id=${serverId}`);
+  return 1;
+}
 
 /**
  * MCP Server repository implementation
@@ -101,6 +292,7 @@ export class MCPServerRepository
       headers: row.data.headers,
       env: row.data.env,
       auth: row.data.auth,
+      config_version: projectedMCPConfigVersion(row.data.config_version, row.mcp_server_id),
 
       // Scope foreign key (nullable UUID string - DB stores null, type expects undefined)
       owner_user_id: (row.owner_user_id as UserID | null) ?? undefined,
@@ -118,8 +310,15 @@ export class MCPServerRepository
   /**
    * Convert MCPServer to database insert format
    */
-  private mcpServerToInsert(data: CreateMCPServerInput | Partial<MCPServer>): MCPServerInsert {
-    assertPublicMCPOAuthCompatibilityMode('auth' in data ? data.auth : undefined);
+  private mcpServerToInsert(
+    data: CreateMCPServerInput | Partial<MCPServer>,
+    options: { preserveDaemonRevisions?: boolean } = {}
+  ): MCPServerInsert {
+    const submittedAuth = 'auth' in data ? (data.auth as unknown) : undefined;
+    if (submittedAuth !== undefined) {
+      assertValidMCPAuthPatch(submittedAuth, { create: true });
+    }
+    assertPublicMCPOAuthCompatibilityMode(submittedAuth);
     const now = Date.now();
     const serverId =
       'mcp_server_id' in data && data.mcp_server_id ? data.mcp_server_id : generateId();
@@ -127,6 +326,17 @@ export class MCPServerRepository
       data.transport === 'stdio'
         ? undefined
         : normalizeMCPCustomHeaders('headers' in data ? data.headers : undefined);
+    const normalizedAuth = (submittedAuth === null ? undefined : data.auth) as MCPAuth | undefined;
+    const effective = {
+      ...data,
+      headers,
+      auth: normalizedAuth,
+      source: data.source ?? 'user',
+      enabled: data.enabled ?? true,
+    } satisfies Partial<MCPServer>;
+    assertValidEffectiveMCPServer(effective, {
+      allowLegacyProvenance: options.preserveDaemonRevisions,
+    });
 
     return {
       mcp_server_id: serverId as string,
@@ -152,12 +362,20 @@ export class MCPServerRepository
         description: data.description,
         import_path: data.import_path,
         catalog_entry_name: data.catalog_entry_name,
+        // Revisions are daemon-owned. In particular, raw REST/socket callers
+        // cannot seed MAX_SAFE_INTEGER and permanently defeat monotonic CAS.
+        config_version:
+          options.preserveDaemonRevisions && 'config_version' in data
+            ? (data.config_version ?? 1)
+            : 1,
         command: data.command,
         args: data.args,
         url: data.url,
         headers,
         env: data.env,
-        auth: 'auth' in data ? data.auth : undefined,
+        // CREATE auth:null is the explicit unauthenticated form, never a JSON
+        // null masquerading as an MCPAuth object in later read paths.
+        auth: normalizedAuth,
         tools: 'tools' in data ? data.tools : undefined,
         resources: 'resources' in data ? data.resources : undefined,
         prompts: 'prompts' in data ? data.prompts : undefined,
@@ -178,6 +396,11 @@ export class MCPServerRepository
         .all();
       return rows.map((r: { mcp_server_id: string }) => r.mcp_server_id);
     });
+  }
+
+  /** Canonical identity for lock keys and multi-step mutation coordination. */
+  async resolveCanonicalId(id: string): Promise<MCPServerID> {
+    return (await this.resolveId(id)) as MCPServerID;
   }
 
   /**
@@ -271,7 +494,13 @@ export class MCPServerRepository
 
       return this.rowToMCPServer(row);
     } catch (error) {
-      if (error instanceof RepositoryError) throw error;
+      if (
+        error instanceof RepositoryError ||
+        error instanceof MCPAuthValidationError ||
+        error instanceof MCPServerWriteValidationError
+      ) {
+        throw error;
+      }
       throw new RepositoryError(
         `Failed to create MCP server: ${error instanceof Error ? error.message : String(error)}`,
         error
@@ -372,58 +601,49 @@ export class MCPServerRepository
   /**
    * Update MCP server by ID
    */
-  async update(id: string, updates: UpdateMCPServerInput): Promise<MCPServer> {
+  async update(
+    id: string,
+    updates: UpdateMCPServerInput,
+    options: MCPServerUpdateOptions = {}
+  ): Promise<MCPServer> {
     try {
       const fullId = await this.resolveId(id);
       const mutate = () =>
-        runDatabaseTransaction(
-          this.db,
-          async (tx) => {
-            const where = eq(mcpServers.mcp_server_id, fullId);
-            await lockRowForUpdate(tx, this.db, mcpServers, where);
-            const row = await select(tx).from(mcpServers).where(where).one();
-            if (!row) throw new EntityNotFoundError('MCPServer', id);
-            const current = this.rowToMCPServer(row as MCPServerRow);
+        runWithTenantDatabaseTransaction(this.db, undefined, async (tx) => {
+          const where = eq(mcpServers.mcp_server_id, fullId);
+          await lockRowForUpdate(tx, this.db, mcpServers, where);
+          const row = await select(tx).from(mcpServers).where(where).one();
+          if (!row) throw new EntityNotFoundError('MCPServer', id);
+          assertStoredMCPConfigVersionCanAdvance(row.data.config_version);
+          const current = this.rowToMCPServer(row as MCPServerRow);
 
-            const merged = { ...current, ...updates };
-            if ('headers' in updates) {
-              merged.headers = restoreRedactedMCPCustomHeaders({
-                current: current.headers,
-                next: updates.headers,
-              });
-            }
-            if ('auth' in updates) {
-              merged.auth = restoreRedactedMCPAuthSecrets({
-                current: current.auth,
-                next: updates.auth,
-              });
-            }
-            if ('env' in updates) {
-              merged.env = restoreRedactedMCPEnvSecrets({
-                current: current.env,
-                next: updates.env,
-              });
-            }
-            const insertData = this.mcpServerToInsert(merged);
+          const { expected_config_version: expectedConfigVersion, replace_auth: replaceAuth } =
+            updates;
+          if (replaceAuth && !('auth' in updates)) {
+            throw new Error('replace_auth requires an auth value');
+          }
+          const nextConfigVersion = nextMCPConfigVersion(current, expectedConfigVersion);
+          const merged = mergeServerConfiguration(current, updates, nextConfigVersion, options);
+          const insertData = this.mcpServerToInsert(merged, {
+            preserveDaemonRevisions: true,
+          });
 
-            await update(tx, mcpServers)
-              .set({
-                enabled: insertData.enabled,
-                scope: insertData.scope,
-                transport: insertData.transport,
-                catalog_entry_name: insertData.catalog_entry_name,
-                updated_at: new Date(),
-                data: insertData.data,
-              })
-              .where(where)
-              .run();
+          await update(tx, mcpServers)
+            .set({
+              enabled: insertData.enabled,
+              scope: insertData.scope,
+              transport: insertData.transport,
+              catalog_entry_name: insertData.catalog_entry_name,
+              updated_at: new Date(),
+              data: insertData.data,
+            })
+            .where(where)
+            .run();
 
-            const updated = await select(tx).from(mcpServers).where(where).one();
-            if (!updated) throw new RepositoryError('Failed to retrieve updated MCP server');
-            return this.rowToMCPServer(updated as MCPServerRow);
-          },
-          { sqliteImmediate: true }
-        );
+          const updated = await select(tx).from(mcpServers).where(where).one();
+          if (!updated) throw new RepositoryError('Failed to retrieve updated MCP server');
+          return this.rowToMCPServer(updated as MCPServerRow);
+        });
 
       // This method is the whole-row merge used by discovery and ordinary
       // patches. Retrying SQLite transaction admission lets it serialize with
@@ -441,12 +661,20 @@ export class MCPServerRepository
           ) {
             throw error;
           }
-          await new Promise((resolve) => setTimeout(resolve, Math.min(5 * 2 ** attempt, 100)));
+          await waitForSQLiteBusyRetry('configuration update', attempt);
         }
       }
     } catch (error) {
-      if (error instanceof RepositoryError) throw error;
-      if (error instanceof EntityNotFoundError) throw error;
+      if (
+        error instanceof RepositoryError ||
+        error instanceof MCPAuthValidationError ||
+        error instanceof MCPServerWriteValidationError
+      ) {
+        throw error;
+      }
+      if (error instanceof EntityNotFoundError || error instanceof MCPServerConfigConflictError) {
+        throw error;
+      }
       throw new RepositoryError(
         `Failed to update MCP server: ${error instanceof Error ? error.message : String(error)}`,
         error
@@ -470,68 +698,58 @@ export class MCPServerRepository
     const fullId = await this.resolveId(id);
     const key = MCPServerRepository.catalogConnectGenerationKey(ownerUserId, catalogEntryName);
     const mutate = () =>
-      runDatabaseTransaction(
-        this.db,
-        async (tx) => {
-          const generationWhere = and(
-            eq(appVariables.namespace, MCPServerRepository.CATALOG_CONNECT_GENERATION_NAMESPACE),
-            eq(appVariables.key, key)
-          );
-          await lockRowForUpdate(tx, this.db, appVariables, generationWhere!);
-          const generationRow = await select(tx).from(appVariables).where(generationWhere).one();
-          if (Number(generationRow?.value_text) !== expectedGeneration) return null;
+      runWithTenantDatabaseTransaction(this.db, undefined, async (tx) => {
+        const generationWhere = and(
+          eq(appVariables.namespace, MCPServerRepository.CATALOG_CONNECT_GENERATION_NAMESPACE),
+          eq(appVariables.key, key)
+        );
+        await lockRowForUpdate(tx, this.db, appVariables, generationWhere!);
+        const generationRow = await select(tx).from(appVariables).where(generationWhere).one();
+        if (Number(generationRow?.value_text) !== expectedGeneration) return null;
 
-          await lockRowForUpdate(tx, this.db, mcpServers, eq(mcpServers.mcp_server_id, fullId));
-          const row = await select(tx)
-            .from(mcpServers)
-            .where(eq(mcpServers.mcp_server_id, fullId))
-            .one();
-          if (!row) throw new EntityNotFoundError('MCPServer', id);
-          const current = this.rowToMCPServer(row as MCPServerRow);
-          if (
-            current.source !== 'catalog' ||
-            current.owner_user_id !== ownerUserId ||
-            current.catalog_entry_name !== catalogEntryName
-          ) {
-            throw new RepositoryError('Catalog connect generation does not match the install');
-          }
-          const merged = { ...current, ...updates };
-          if ('headers' in updates) {
-            merged.headers = restoreRedactedMCPCustomHeaders({
-              current: current.headers,
-              next: updates.headers,
-            });
-          }
-          if ('auth' in updates) {
-            merged.auth = restoreRedactedMCPAuthSecrets({
-              current: current.auth,
-              next: updates.auth,
-            });
-          }
-          if ('env' in updates) {
-            merged.env = restoreRedactedMCPEnvSecrets({ current: current.env, next: updates.env });
-          }
-          const insertData = this.mcpServerToInsert(merged);
-          await update(tx, mcpServers)
-            .set({
-              enabled: insertData.enabled,
-              scope: insertData.scope,
-              transport: insertData.transport,
-              catalog_entry_name: insertData.catalog_entry_name,
-              updated_at: new Date(),
-              data: insertData.data,
-            })
-            .where(eq(mcpServers.mcp_server_id, fullId))
-            .run();
-          const updated = await select(tx)
-            .from(mcpServers)
-            .where(eq(mcpServers.mcp_server_id, fullId))
-            .one();
-          if (!updated) throw new RepositoryError('Failed to retrieve updated MCP server');
-          return this.rowToMCPServer(updated as MCPServerRow);
-        },
-        { sqliteImmediate: true }
-      );
+        await lockRowForUpdate(tx, this.db, mcpServers, eq(mcpServers.mcp_server_id, fullId));
+        const row = await select(tx)
+          .from(mcpServers)
+          .where(eq(mcpServers.mcp_server_id, fullId))
+          .one();
+        if (!row) throw new EntityNotFoundError('MCPServer', id);
+        assertStoredMCPConfigVersionCanAdvance(row.data.config_version);
+        const current = this.rowToMCPServer(row as MCPServerRow);
+        if (
+          current.source !== 'catalog' ||
+          current.owner_user_id !== ownerUserId ||
+          current.catalog_entry_name !== catalogEntryName
+        ) {
+          throw new RepositoryError('Catalog connect generation does not match the install');
+        }
+        const { expected_config_version: expectedConfigVersion, replace_auth: replaceAuth } =
+          updates;
+        if (replaceAuth && !('auth' in updates)) {
+          throw new Error('replace_auth requires an auth value');
+        }
+        const nextConfigVersion = nextMCPConfigVersion(current, expectedConfigVersion);
+        const merged = mergeServerConfiguration(current, updates, nextConfigVersion, {});
+        const insertData = this.mcpServerToInsert(merged, {
+          preserveDaemonRevisions: true,
+        });
+        await update(tx, mcpServers)
+          .set({
+            enabled: insertData.enabled,
+            scope: insertData.scope,
+            transport: insertData.transport,
+            catalog_entry_name: insertData.catalog_entry_name,
+            updated_at: new Date(),
+            data: insertData.data,
+          })
+          .where(eq(mcpServers.mcp_server_id, fullId))
+          .run();
+        const updated = await select(tx)
+          .from(mcpServers)
+          .where(eq(mcpServers.mcp_server_id, fullId))
+          .one();
+        if (!updated) throw new RepositoryError('Failed to retrieve updated MCP server');
+        return this.rowToMCPServer(updated as MCPServerRow);
+      });
 
     // A pair of first-connects deliberately contend on this transaction. On
     // SQLite, BEGIN IMMEDIATE can report SQLITE_BUSY instead of honoring the
@@ -550,7 +768,7 @@ export class MCPServerRepository
         ) {
           throw error;
         }
-        await new Promise((resolve) => setTimeout(resolve, Math.min(5 * 2 ** attempt, 100)));
+        await waitForSQLiteBusyRetry('catalog credential update', attempt);
       }
     }
   }
@@ -692,8 +910,8 @@ export class MCPServerRepository
    *
    * Discovery and ordinary patches take the same row lock, so neither can
    * overwrite a concurrent per-tool decision with a stale whole JSON object.
-   * The SQL expression edits only `tool_permissions[toolName]`; undiscovered
-   * rules, explicit Ask rules, and another concurrent toggle remain intact.
+   * The row-locked update preserves undiscovered rules, explicit Ask rules,
+   * and another concurrent toggle while advancing the editor CAS revision.
    */
   async setToolEnabled(
     id: string,
@@ -754,17 +972,30 @@ export class MCPServerRepository
       ? and(eq(mcpServers.mcp_server_id, fullId), eq(mcpServers.owner_user_id, ownerUserId))!
       : eq(mcpServers.mcp_server_id, fullId);
     await lockRowForUpdate(this.db, this.db, mcpServers, target);
-
+    const row = await select(this.db).from(mcpServers).where(target).one();
+    if (!row) return false;
+    assertStoredMCPConfigVersionCanAdvance(row.data.config_version);
+    const current = this.rowToMCPServer(row as MCPServerRow);
+    const version = current.config_version ?? 1;
+    if (!Number.isSafeInteger(version) || version < 1 || version >= Number.MAX_SAFE_INTEGER - 1) {
+      throw new RepositoryError('MCP server configuration revision is invalid or exhausted');
+    }
     const sqlitePath = `$."tool_permissions"."${toolName
       .replace(/\\/g, '\\\\')
       .replace(/"/g, '\\"')}"`;
-    const nextData = isPostgresDatabase(this.db)
+    const nextPermissions = isPostgresDatabase(this.db)
       ? enabled
         ? sql`jsonb_set(${mcpServers.data}, '{tool_permissions}'::text[], coalesce(${mcpServers.data}->'tool_permissions', '{}'::jsonb) - ${toolName}::text, true)`
         : sql`jsonb_set(${mcpServers.data}, '{tool_permissions}'::text[], coalesce(${mcpServers.data}->'tool_permissions', '{}'::jsonb) || jsonb_build_object(${toolName}::text, 'deny'), true)`
       : enabled
         ? sql`json_remove(${mcpServers.data}, ${sqlitePath})`
         : sql`json_set(${mcpServers.data}, ${sqlitePath}, ${'deny'})`;
+    // Keep the repaired dialect-specific in-place JSON mutation so a tool
+    // permission edit cannot overwrite unrelated current configuration. The
+    // daemon-owned revision is advanced in that same statement.
+    const nextData = isPostgresDatabase(this.db)
+      ? sql`jsonb_set(${nextPermissions}, '{config_version}'::text[], to_jsonb(${version + 1}::bigint), true)`
+      : sql`json_set(${nextPermissions}, '$.config_version', ${version + 1})`;
     const result = await update(this.db, mcpServers)
       .set({ data: nextData, updated_at: new Date() })
       .where(target)

--- a/packages/core/src/db/repositories/session-mcp-servers.test.ts
+++ b/packages/core/src/db/repositories/session-mcp-servers.test.ts
@@ -195,8 +195,9 @@ describe('SessionMCPServerRepository.addServer', () => {
   dbTest('should reject a private server owned by another session creator', async ({ db }) => {
     const { session } = await setupTestData(db);
     const mcpServerRepo = new MCPServerRepository(db);
+    const anotherUserId = generateId() as UUID;
     const privateServer = await mcpServerRepo.create(
-      createMCPServerData({ owner_user_id: 'another-user' as UUID, scope: 'session' })
+      createMCPServerData({ owner_user_id: anotherUserId, scope: 'session' })
     );
     const repo = new SessionMCPServerRepository(db);
 
@@ -211,8 +212,9 @@ describe('SessionMCPServerRepository.addServer', () => {
     async ({ db }) => {
       const { session, server1 } = await setupTestData(db);
       const mcpServerRepo = new MCPServerRepository(db);
+      const anotherUserId = generateId() as UUID;
       const privateServer = await mcpServerRepo.create(
-        createMCPServerData({ owner_user_id: 'another-user' as UUID, scope: 'session' })
+        createMCPServerData({ owner_user_id: anotherUserId, scope: 'session' })
       );
       const repo = new SessionMCPServerRepository(db);
       await repo.addServer(session.session_id, server1.mcp_server_id);

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -1472,6 +1472,9 @@ export const mcpServers = pgTable(
         // that outlives the entry row.
         catalog_entry_name?: string;
 
+        // Daemon-owned optimistic-concurrency revision for public edits.
+        config_version?: number;
+
         // Transport config
         command?: string;
         args?: string[];
@@ -1507,20 +1510,21 @@ export const mcpServers = pgTable(
         // Discovered capabilities
         tools?: Array<{
           name: string;
-          description: string;
-          input_schema: Record<string, unknown>;
+          description?: string;
+          input_schema?: Record<string, unknown>;
         }>;
         resources?: Array<{
           uri: string;
           name: string;
+          description?: string;
           mimeType?: string;
         }>;
         prompts?: Array<{
           name: string;
-          description: string;
+          description?: string;
           arguments?: Array<{
             name: string;
-            description: string;
+            description?: string;
             required?: boolean;
           }>;
         }>;

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -1398,6 +1398,9 @@ export const mcpServers = sqliteTable(
         // that outlives the entry row.
         catalog_entry_name?: string;
 
+        // Daemon-owned optimistic-concurrency revision for public edits.
+        config_version?: number;
+
         // Transport config
         command?: string;
         args?: string[];
@@ -1433,20 +1436,21 @@ export const mcpServers = sqliteTable(
         // Discovered capabilities
         tools?: Array<{
           name: string;
-          description: string;
+          description?: string;
           input_schema?: Record<string, unknown>; // Optional - not all MCP servers provide schemas
         }>;
         resources?: Array<{
           uri: string;
           name: string;
+          description?: string;
           mimeType?: string;
         }>;
         prompts?: Array<{
           name: string;
-          description: string;
+          description?: string;
           arguments?: Array<{
             name: string;
-            description: string;
+            description?: string;
             required?: boolean;
           }>;
         }>;

--- a/packages/core/src/db/tenant-database-io.ts
+++ b/packages/core/src/db/tenant-database-io.ts
@@ -92,10 +92,20 @@ function rewrittenRowJsonb(elem: SQL, destinationTenantId: string, tableName: st
   // created a row. It cannot survive an archive crossing the import boundary:
   // the destination must treat the restored definition like any other imported
   // server and re-establish catalog trust only through Connect.
-  return sql`pg_catalog.jsonb_set(
-    (${tenantRewritten} #- '{data,catalog_entry_name}'::pg_catalog.text[]),
+  const imported = sql`pg_catalog.jsonb_set(
+    ((${tenantRewritten} #- '{data,catalog_entry_name}'::pg_catalog.text[])
+      #- '{catalog_entry_name}'::pg_catalog.text[]),
     '{source}'::pg_catalog.text[],
     '"imported"'::pg_catalog.jsonb
+  )`;
+  // Archive revisions are evidence about the source daemon, not authority in
+  // the destination. Validation rejects malformed/exhausted values before any
+  // write; every accepted row starts a fresh bounded editor-CAS sequence.
+  return sql`pg_catalog.jsonb_set(
+    ${imported},
+    '{data,config_version}'::pg_catalog.text[],
+    '1'::pg_catalog.jsonb,
+    true
   )`;
 }
 

--- a/packages/core/src/db/tenant-import.test.ts
+++ b/packages/core/src/db/tenant-import.test.ts
@@ -11,6 +11,7 @@ import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { MCP_HEADER_REDACTED_SENTINEL } from '../tools/mcp/http-headers';
 import type { Database } from './client';
 import {
   computeContentFingerprint,
@@ -122,11 +123,30 @@ describe('importTenant pre-mutation validation ordering', () => {
 describe('importTenant MCP OAuth public policy boundary', () => {
   async function archivedMcpManifest(
     mode: unknown,
-    headers?: Record<string, string>
+    headers?: Record<string, string>,
+    mutate?: (row: Record<string, unknown>) => void
   ): Promise<TenantArchiveManifest> {
-    const line = `${JSON.stringify({
-      data: { auth: { type: 'oauth', oauth_compatibility_mode: mode }, headers },
-    })}\n`;
+    const row: Record<string, unknown> = {
+      tenant_id: 'acme',
+      mcp_server_id: '01900000-0000-7000-8000-000000000001',
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+      name: 'archive-oauth',
+      transport: 'http',
+      scope: 'global',
+      enabled: true,
+      owner_user_id: null,
+      source: 'user',
+      catalog_entry_name: null,
+      data: {
+        config_version: 1,
+        url: 'https://mcp.example.test/mcp',
+        auth: { type: 'oauth', oauth_compatibility_mode: mode },
+        headers,
+      },
+    };
+    mutate?.(row);
+    const line = `${JSON.stringify(row)}\n`;
     await mkdir(databaseDir(scratch), { recursive: true });
     await writeFile(tableJsonlPath(scratch, 'mcp_servers'), line, 'utf8');
     return {
@@ -173,4 +193,107 @@ describe('importTenant MCP OAuth public policy boundary', () => {
       )
     ).rejects.toThrow(/Duplicate custom HTTP header names/);
   });
+
+  it.each([
+    {
+      label: 'unknown top-level secret',
+      mutate: (row: Record<string, unknown>) => Object.assign(row, { provider_secret: 'escape' }),
+      error: /Unknown archived mcp_servers field: provider_secret/,
+    },
+    {
+      label: 'unknown auth secret',
+      mutate: (row: Record<string, unknown>) => {
+        const data = row.data as Record<string, unknown>;
+        data.auth = { type: 'oauth', provider_secret: 'escape' };
+      },
+      error: /Unknown auth field: provider_secret/,
+    },
+    {
+      label: 'exhausted config revision',
+      mutate: (row: Record<string, unknown>) => {
+        (row.data as Record<string, unknown>).config_version = Number.MAX_SAFE_INTEGER;
+      },
+      error: /non-exhausted positive safe integer/,
+    },
+    {
+      label: 'redaction sentinel',
+      mutate: (row: Record<string, unknown>) => {
+        (row.data as Record<string, unknown>).auth = {
+          type: 'oauth',
+          oauth_client_secret: MCP_HEADER_REDACTED_SENTINEL,
+        };
+      },
+      error: /redaction sentinel/,
+    },
+    {
+      label: 'invalid transport combination',
+      mutate: (row: Record<string, unknown>) => {
+        row.transport = 'stdio';
+      },
+      error: /command is required|url does not apply/,
+    },
+    {
+      label: 'mode-mismatched auth',
+      mutate: (row: Record<string, unknown>) => {
+        (row.data as Record<string, unknown>).auth = { type: 'none', token: 'escape' };
+      },
+      error: /does not apply/,
+    },
+    {
+      label: 'forged catalog provenance',
+      mutate: (row: Record<string, unknown>) => {
+        row.source = 'catalog';
+      },
+      error: /requires catalog_entry_name evidence/,
+    },
+    {
+      label: 'catalog evidence on user provenance',
+      mutate: (row: Record<string, unknown>) => {
+        (row.data as Record<string, unknown>).catalog_entry_name = 'forged.catalog';
+      },
+      error: /catalog_entry_name only applies to catalog MCP servers|do not apply/,
+    },
+  ])('rejects archived MCP $label before import writes', async ({ mutate, error }) => {
+    await expect(
+      validateArchivedMCPCompatibilityModes(
+        scratch,
+        await archivedMcpManifest('strict', undefined, mutate)
+      )
+    ).rejects.toThrow(error);
+  });
+
+  it('accepts a bounded legacy imported row for revision reset during restore', async () => {
+    await expect(
+      validateArchivedMCPCompatibilityModes(
+        scratch,
+        await archivedMcpManifest('strict', undefined, (row) => {
+          row.source = 'imported';
+          (row.data as Record<string, unknown>).config_version = 42;
+        })
+      )
+    ).resolves.toBeUndefined();
+  });
+
+  it.each([
+    { type: 'bearer' as const },
+    { type: 'jwt' as const, api_url: 'https://auth.example.test/token' },
+  ])(
+    'accepts a legal 962f74fe-era incomplete $type row with optional capabilities',
+    async (auth) => {
+      await expect(
+        validateArchivedMCPCompatibilityModes(
+          scratch,
+          await archivedMcpManifest('strict', undefined, (row) => {
+            const data = row.data as Record<string, unknown>;
+            data.auth = auth;
+            data.tools = [{ name: 'legacy-tool' }];
+            data.resources = [{ uri: 'file:///legacy', name: 'legacy', description: 'optional' }];
+            data.prompts = [{ name: 'legacy-prompt', arguments: [{ name: 'subject' }] }];
+            // A legal base-version row may omit updated_at.
+            delete row.updated_at;
+          })
+        )
+      ).resolves.toBeUndefined();
+    }
+  );
 });

--- a/packages/core/src/db/tenant-import.ts
+++ b/packages/core/src/db/tenant-import.ts
@@ -34,9 +34,8 @@
 
 import { rm } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
-import { assertPublicMCPOAuthCompatibilityMode } from '@agor/core/types';
 import { sql } from 'drizzle-orm';
-import { findDuplicateMCPCustomHeaderName } from '../tools/mcp/http-headers';
+import { assertValidArchivedMCPServerRow } from '../tools/mcp/server-validation';
 import type { Database } from './client';
 import { executeRaw, isPostgresDatabase } from './database-wrapper';
 import { isDatabaseUniqueConstraintError } from './sanitize-error';
@@ -113,26 +112,12 @@ export async function validateArchivedMCPCompatibilityModes(
   if (!table || table.rowCount === 0) return;
   const lines = splitTenantJsonlLines(await readTableJsonl(archivePath, table.name));
   for (const line of lines) {
-    const row = JSON.parse(line) as { data?: unknown };
-    const data = row.data;
-    const publicData = data && typeof data === 'object' ? (data as Record<string, unknown>) : {};
-    const auth = publicData.auth;
     try {
-      assertPublicMCPOAuthCompatibilityMode(auth);
-      const headers = publicData.headers;
-      const duplicate =
-        headers && typeof headers === 'object' && !Array.isArray(headers)
-          ? findDuplicateMCPCustomHeaderName(headers as Record<string, unknown>)
-          : undefined;
-      if (duplicate) {
-        throw new Error(
-          `Duplicate custom HTTP header names are not allowed: ${duplicate.first} and ${duplicate.duplicate}`
-        );
-      }
+      assertValidArchivedMCPServerRow(JSON.parse(line));
     } catch (error) {
       throw new MalformedArchiveError(
         `Refusing to import mcp_servers: ${
-          error instanceof Error ? error.message : 'invalid OAuth compatibility policy'
+          error instanceof Error ? error.message : 'invalid MCP server row'
         }`
       );
     }

--- a/packages/core/src/db/tenant-portability.postgres.test.ts
+++ b/packages/core/src/db/tenant-portability.postgres.test.ts
@@ -162,9 +162,11 @@ async function seedNonPortableOAuthGrant(
         scope: 'global',
         enabled: true,
         source: 'catalog',
+        catalog_entry_name: 'com.example/portable-oauth',
         data: {
           url: 'https://mcp.example.test',
           catalog_entry_name: 'com.example/portable-oauth',
+          config_version: 42,
           auth: { type: 'oauth' },
         },
         created_at: new Date(),
@@ -787,9 +789,11 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)('tenant portability (Postgr
         .all();
       expect(servers).toHaveLength(1);
       expect(servers[0]?.source).toBe('imported');
+      expect(servers[0]?.catalog_entry_name).toBeNull();
       expect(
         (servers[0]?.data as { catalog_entry_name?: string } | undefined)?.catalog_entry_name
       ).toBeUndefined();
+      expect((servers[0]?.data as { config_version?: number } | undefined)?.config_version).toBe(1);
       await expect(
         new UserMCPOAuthTokenRepository(
           scoped,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,7 @@ export * from './design/board-backgrounds.js';
 export * from './environment/render-snapshot.js';
 export * from './knowledge/index.js';
 export * from './mcp/index.js';
+export * from './sdk-result-safety.js';
 export * from './search/index.js';
 export * from './sessions/index.js';
 export type { RepoCloneErrorCategory } from './types/index.js';

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -3,6 +3,28 @@
  */
 
 export {
+  assertValidMCPAuthPatch,
+  MCPAuthValidationError,
+  mergeMCPAuth,
+  replaceMCPAuth,
+} from '../tools/mcp/auth-patch';
+export {
+  asMCPExternalError,
+  isMCPAbortError,
+  MCPExternalError,
+  type MCPExternalErrorAction,
+  type MCPExternalErrorCategory,
+  type MCPExternalErrorStage,
+  type SanitizedMCPExternalError,
+  sanitizeMCPExternalError,
+} from '../tools/mcp/external-error';
+export {
+  assertValidDiscoveredMCPCapabilities,
+  assertValidEffectiveMCPServer,
+  assertValidMCPServerWrite,
+  MCPServerWriteValidationError,
+} from '../tools/mcp/server-validation';
+export {
   canConfigureMCPServers,
   isAtLeastMemberRole,
   isMcpGrantSubjectEntitled,
@@ -30,6 +52,7 @@ export {
 export {
   buildMCPTemplateContextFromEnv,
   containsTemplate,
+  hasTemplateMarker,
   isUserEnvPlaceholder,
   type MCPTemplateContext,
   type MCPTemplateResolutionResult,

--- a/packages/core/src/mcp/scoping.test.ts
+++ b/packages/core/src/mcp/scoping.test.ts
@@ -8,12 +8,13 @@ const makeServer = (id: string, scope: MCPServer['scope'], name = id): MCPServer
     mcp_server_id: id,
     name,
     transport: 'http',
+    url: `https://${id}.example.test/mcp`,
     scope,
     source: 'user',
     enabled: true,
     created_at: new Date(),
     updated_at: new Date(),
-    auth: { type: 'token', token: `value-${id}` },
+    auth: { type: 'bearer', token: `value-${id}` },
   }) as unknown as MCPServer;
 
 /** A handler that can drop individual tools — keeps these cases about scoping. */
@@ -235,6 +236,165 @@ describe('getMcpServersForSession', () => {
       oauth_access_token: 'real-oauth-token',
     });
   });
+
+  it.each([
+    ['file protocol', 'file:///tmp/mcp'],
+    ['embedded credentials', 'https://user:secret@mcp.example.test'],
+    ['malformed URL', 'not a url'],
+  ])('withholds a server whose resolved URL uses %s before SDK dispatch', async (_label, url) => {
+    const invalid = { ...makeServer('invalid', 'global'), url } as MCPServer;
+    const servers = await getMcpServersForSession(
+      'session-a' as SessionID,
+      {
+        mcpServerRepo: { findAll: vi.fn() } as never,
+        sessionMCPRepo: { listEffectiveServers: vi.fn().mockResolvedValue([invalid]) } as never,
+      },
+      ENFORCING
+    );
+
+    expect(servers).toEqual([]);
+  });
+
+  it('withholds malformed secret-bearing templates without leaking their values', async () => {
+    const sentinel = 'SENTINEL_NO_MCP_DISPATCH_19d2';
+    const malformed = `${sentinel}{{#if user.env.MISSING_SECRET}}`;
+    const invalid = {
+      ...makeServer('invalid-template', 'global'),
+      url: `https://mcp.example.test/${malformed}`,
+      headers: { Authorization: malformed },
+      env: { MCP_SECRET: malformed },
+      auth: {
+        type: 'jwt',
+        api_url: `https://auth.example.test/${malformed}`,
+        api_token: malformed,
+        api_secret: malformed,
+      },
+    } as MCPServer;
+    const spies = [
+      vi.spyOn(console, 'log').mockImplementation(() => undefined),
+      vi.spyOn(console, 'warn').mockImplementation(() => undefined),
+      vi.spyOn(console, 'error').mockImplementation(() => undefined),
+      vi.spyOn(console, 'debug').mockImplementation(() => undefined),
+    ];
+    try {
+      const servers = await getMcpServersForSession(
+        'session-a' as SessionID,
+        {
+          mcpServerRepo: { findAll: vi.fn() } as never,
+          sessionMCPRepo: {
+            listEffectiveServers: vi.fn().mockResolvedValue([invalid]),
+          } as never,
+        },
+        ENFORCING
+      );
+
+      expect(servers).toEqual([]);
+      expect(JSON.stringify(spies.flatMap((spy) => spy.mock.calls))).not.toContain(sentinel);
+    } finally {
+      for (const spy of spies) spy.mockRestore();
+    }
+  });
+
+  const markerFieldCases = [
+    {
+      family: 'url',
+      build: (value: string) => ({
+        ...makeServer('marker-url', 'global'),
+        url: `https://mcp.example.test/${value}`,
+      }),
+    },
+    {
+      family: 'headers',
+      build: (value: string) => ({
+        ...makeServer('marker-headers', 'global'),
+        headers: { 'X-Private': value },
+      }),
+    },
+    {
+      family: 'env',
+      build: (value: string) => ({
+        ...makeServer('marker-env', 'global'),
+        env: { PRIVATE_VALUE: value },
+      }),
+    },
+    {
+      family: 'bearer',
+      build: (value: string) => ({
+        ...makeServer('marker-bearer', 'global'),
+        auth: { type: 'bearer' as const, token: value },
+      }),
+    },
+    {
+      family: 'jwt',
+      build: (value: string) => ({
+        ...makeServer('marker-jwt', 'global'),
+        auth: {
+          type: 'jwt' as const,
+          api_url: 'https://auth.example.test/token',
+          api_token: 'configured',
+          api_secret: value,
+        },
+      }),
+    },
+    {
+      family: 'oauth',
+      build: (value: string) => ({
+        ...makeServer('marker-oauth', 'global'),
+        auth: { type: 'oauth' as const, oauth_client_secret: value },
+      }),
+    },
+  ];
+
+  it.each(
+    markerFieldCases.flatMap(({ family, build }) =>
+      (['{{', '}}'] as const).flatMap((delimiter) =>
+        (['stored', 'user.env'] as const).map((source) => ({
+          family,
+          build,
+          delimiter,
+          source,
+        }))
+      )
+    )
+  )(
+    'withholds a $source unmatched $delimiter marker in $family before executor dispatch',
+    async ({ build, delimiter, source, family }) => {
+      const sentinel = `SENTINEL_${source === 'stored' ? 'STORED' : 'ENV'}_${family}_${delimiter === '{{' ? 'OPEN' : 'CLOSE'}_${delimiter}`;
+      const storedValue = source === 'stored' ? sentinel : '{{ user.env.INJECTED_MARKER }}';
+      const userEnv = source === 'user.env' ? { INJECTED_MARKER: sentinel } : {};
+      const invalid = build(storedValue) as MCPServer;
+      const previousKeys = process.env.AGOR_USER_ENV_KEYS;
+      const previousValue = process.env.INJECTED_MARKER;
+      process.env.AGOR_USER_ENV_KEYS = Object.keys(userEnv).join(',');
+      Object.assign(process.env, userEnv);
+      const spies = [
+        vi.spyOn(console, 'log').mockImplementation(() => undefined),
+        vi.spyOn(console, 'warn').mockImplementation(() => undefined),
+        vi.spyOn(console, 'error').mockImplementation(() => undefined),
+        vi.spyOn(console, 'debug').mockImplementation(() => undefined),
+      ];
+      try {
+        const servers = await getMcpServersForSession(
+          'session-a' as SessionID,
+          {
+            mcpServerRepo: { findAll: vi.fn() } as never,
+            sessionMCPRepo: {
+              listEffectiveServers: vi.fn().mockResolvedValue([invalid]),
+            } as never,
+          },
+          ENFORCING
+        );
+        expect(servers).toEqual([]);
+        expect(JSON.stringify(spies.flatMap((spy) => spy.mock.calls))).not.toContain(sentinel);
+      } finally {
+        if (previousKeys === undefined) delete process.env.AGOR_USER_ENV_KEYS;
+        else process.env.AGOR_USER_ENV_KEYS = previousKeys;
+        if (previousValue === undefined) delete process.env.INJECTED_MARKER;
+        else process.env.INJECTED_MARKER = previousValue;
+        for (const spy of spies) spy.mockRestore();
+      }
+    }
+  );
 });
 
 describe('getMcpServersForSession - tool_permissions admission gate', () => {

--- a/packages/core/src/mcp/scoping.ts
+++ b/packages/core/src/mcp/scoping.ts
@@ -23,6 +23,7 @@ import type { MCPServer, MCPServerFilters, MCPServerID, SessionID } from '../typ
 import { isMCPServerUsableBy } from './ownership';
 import {
   buildMCPTemplateContextFromEnv,
+  hasTemplateMarker,
   resolveMcpServerTemplates,
   TEMPLATE_RESOLVABLE_MCP_AUTH_SECRET_FIELDS,
 } from './template-resolver';
@@ -229,14 +230,13 @@ export async function getMcpServersForSession(
     let templatesResolved = 0;
     let serversSkipped = 0;
 
-    const containsTemplate = (v: string | undefined) => v?.includes('{{') && v?.includes('}}');
-
     // Every auth field `resolveMcpServerTemplates` substitutes. Driven from the
     // canonical secret set plus the non-secret auth templates the resolver also
     // handles, so this trigger cannot drift from what resolution resolves.
     const AUTH_TEMPLATE_FIELDS = [
       ...TEMPLATE_RESOLVABLE_MCP_AUTH_SECRET_FIELDS,
       'api_url',
+      'oauth_authorization_url',
       'oauth_token_url',
       'oauth_client_id',
       'oauth_scope',
@@ -249,19 +249,26 @@ export async function getMcpServersForSession(
       // Check if any templatable field contains templates
       const envValues = Object.values(original.env ?? {}) as string[];
       const headerValues = Object.values(original.headers ?? {}) as string[];
-      const hasEnvTemplates = envValues.some(containsTemplate);
-      const hasHeaderTemplates = headerValues.some(containsTemplate);
-      const hasUrlTemplate = containsTemplate(original.url);
+      const hasEnvTemplates = envValues.some(hasTemplateMarker);
+      const hasHeaderTemplates = headerValues.some(hasTemplateMarker);
+      const hasUrlTemplate = hasTemplateMarker(original.url);
       const hasAuthTemplates = AUTH_TEMPLATE_FIELDS.some((field) =>
-        containsTemplate(original.auth?.[field] as string | undefined)
+        hasTemplateMarker(original.auth?.[field] as string | undefined)
       );
 
-      if (hasEnvTemplates || hasHeaderTemplates || hasUrlTemplate || hasAuthTemplates) {
+      // Resolve and validate every server, even when its stored row has no
+      // templates. This is the last common boundary before executor SDK config
+      // is built, and it prevents malformed legacy rows from being dispatched.
+      {
+        const hasTemplates =
+          hasEnvTemplates || hasHeaderTemplates || hasUrlTemplate || hasAuthTemplates;
         const result = resolveMcpServerTemplates(original, templateContext);
 
         if (!result.isValid) {
           // Remove server from list - required templates didn't resolve
-          console.warn(`   ⚠️  Skipping MCP server "${original.name}": ${result.errorMessage}`);
+          console.warn(
+            `[mcp-template] server_withheld server_id=${original.mcp_server_id} reason=invalid_configuration`
+          );
           servers.splice(i, 1);
           serversSkipped++;
         } else {
@@ -269,12 +276,12 @@ export async function getMcpServersForSession(
             ...servers[i],
             server: result.server,
           };
-          templatesResolved++;
+          if (hasTemplates) templatesResolved++;
 
           // Log warnings for non-critical unresolved fields
           if (result.unresolvedFields.length > 0) {
             console.warn(
-              `   ⚠️  MCP server "${original.name}" has unresolved optional templates: ${result.unresolvedFields.join(', ')}`
+              `[mcp-template] optional_fields_unresolved server_id=${original.mcp_server_id} fields=${result.unresolvedFields.join(',')}`
             );
           }
         }
@@ -352,12 +359,10 @@ export async function getMcpServersForSession(
             hydrated++;
           }
           mcpDebug(`   🔐 Hydrated OAuth auth headers for ${hydrated} MCP server(s)`);
-        } catch (error) {
-          console.warn(
-            `   ⚠️  Failed to hydrate OAuth MCP auth headers: ${
-              error instanceof Error ? error.message : String(error)
-            }`
-          );
+        } catch {
+          // Credential hydration failures may carry provider URLs or reflected
+          // headers. The caller receives structured recovery elsewhere.
+          console.warn('[mcp-auth] oauth_header_hydration_failed');
         }
       }
     }
@@ -375,10 +380,8 @@ export async function getMcpServersForSession(
         compareStrings(String(a.server.mcp_server_id), String(b.server.mcp_server_id))
       );
     });
-  } catch (error) {
-    console.warn(
-      `⚠️  Failed to resolve MCP servers: ${error instanceof Error ? error.message : String(error)}`
-    );
+  } catch {
+    console.warn('[mcp-runtime] server_resolution_failed');
     // Return empty array on error to avoid breaking session creation
     return [];
   }

--- a/packages/core/src/mcp/template-patterns.ts
+++ b/packages/core/src/mcp/template-patterns.ts
@@ -6,10 +6,18 @@
  */
 
 /**
- * Check if a string contains Handlebars template syntax.
+ * Check whether a value contains a balanced-looking Handlebars expression.
+ * This does not prove the expression is renderable; use `hasTemplateMarker`
+ * at security/admission boundaries so unmatched delimiters cannot pass as
+ * harmless literals.
  */
 export function containsTemplate(value: string): boolean {
   return value.includes('{{') && value.includes('}}');
+}
+
+/** Any opening OR closing Handlebars delimiter, balanced or otherwise. */
+export function hasTemplateMarker(value: string | undefined): boolean {
+  return typeof value === 'string' && (value.includes('{{') || value.includes('}}'));
 }
 
 /**
@@ -20,10 +28,31 @@ export function containsTemplate(value: string): boolean {
  * expressions, helper/fallback forms, partial values, and multiple expressions.
  */
 const USER_ENV_PLACEHOLDER_RE = /^\{\{\s*user\.env\.[A-Za-z_][A-Za-z0-9_]*\s*\}\}$/;
+const USER_ENV_REFERENCE_RE = /\{\{\s*user\.env\.[A-Za-z_][A-Za-z0-9_]*\s*\}\}/g;
 
 /**
  * Check if a string is a single bare `{{ user.env.NAME }}` placeholder.
  */
 export function isUserEnvPlaceholder(value: string): boolean {
   return USER_ENV_PLACEHOLDER_RE.test(value.trim());
+}
+
+/**
+ * Validate a persisted HTTP(S) URL template without resolving user secrets.
+ * Only direct `user.env` references are admitted. Runtime resolution still
+ * validates the final URL before egress; this check closes the stored shape.
+ */
+export function isValidMCPHttpUrlTemplate(value: string): boolean {
+  if (!hasTemplateMarker(value)) return false;
+  const substituted = value.replace(USER_ENV_REFERENCE_RE, 'template-value');
+  if (hasTemplateMarker(substituted)) return false;
+  const candidate = substituted.startsWith('template-value')
+    ? `https://template.invalid${substituted.slice('template-value'.length)}`
+    : substituted;
+  try {
+    const parsed = new URL(candidate);
+    return ['http:', 'https:'].includes(parsed.protocol) && !parsed.username && !parsed.password;
+  } catch {
+    return false;
+  }
 }

--- a/packages/core/src/mcp/template-resolver.test.ts
+++ b/packages/core/src/mcp/template-resolver.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { generateId } from '../lib/ids';
 import type { MCPServer, MCPServerID } from '../types';
+import { isValidMCPHttpUrlTemplate } from './template-patterns';
 import {
   buildMCPTemplateContextFromEnv,
   isUserEnvPlaceholder,
@@ -39,6 +40,17 @@ describe('isUserEnvPlaceholder', () => {
     expect(isUserEnvPlaceholder('{{user.env.A}}{{user.env.B}}')).toBe(false);
     expect(isUserEnvPlaceholder('{{ outer {{ user.env.X }} }}')).toBe(false);
     expect(isUserEnvPlaceholder('plain-secret')).toBe(false);
+  });
+});
+
+describe('isValidMCPHttpUrlTemplate', () => {
+  it('accepts supported user URL templates and rejects arbitrary expressions or protocols', () => {
+    expect(isValidMCPHttpUrlTemplate('{{ user.env.MCP_URL }}/mcp')).toBe(true);
+    expect(isValidMCPHttpUrlTemplate('https://{{ user.env.TENANT }}.example.test/mcp')).toBe(true);
+    expect(isValidMCPHttpUrlTemplate('https://example.test/{{user.env.PATH}}')).toBe(true);
+    expect(isValidMCPHttpUrlTemplate('{{ lookup user.env "MCP_URL" }}')).toBe(false);
+    expect(isValidMCPHttpUrlTemplate('file://{{ user.env.PATH }}')).toBe(false);
+    expect(isValidMCPHttpUrlTemplate('https://{{ user.env.BROKEN }')).toBe(false);
   });
 });
 
@@ -216,8 +228,154 @@ describe('resolveMcpServerTemplates', () => {
 
     expect(result.isValid).toBe(false);
     expect(result.unresolvedFields).toContain('url');
-    expect(result.errorMessage).toContain('broken-server');
-    expect(result.errorMessage).toContain('unresolved required templates');
+    expect(result.errorMessage).not.toContain('broken-server');
+    expect(result.errorMessage).toContain('invalid or unresolved url');
+  });
+
+  it('never exposes malformed secret-bearing URL/header/env/auth templates in logs or errors', () => {
+    const sentinel = 'SENTINEL_MCP_TEMPLATE_SECRET_f31ba6';
+    const malformed = `${sentinel}{{#if user.env.MISSING_SECRET}}`;
+    const spies = [
+      vi.spyOn(console, 'log').mockImplementation(() => undefined),
+      vi.spyOn(console, 'warn').mockImplementation(() => undefined),
+      vi.spyOn(console, 'error').mockImplementation(() => undefined),
+      vi.spyOn(console, 'debug').mockImplementation(() => undefined),
+    ];
+    try {
+      const result = resolveMcpServerTemplates(
+        createTestServer({
+          name: 'secret-safe-template-test',
+          transport: 'http',
+          url: `https://mcp.example.test/${malformed}`,
+          headers: { Authorization: malformed },
+          env: { MCP_PRIVATE_VALUE: malformed },
+          auth: {
+            type: 'jwt',
+            api_url: `https://auth.example.test/${malformed}`,
+            api_token: malformed,
+            api_secret: malformed,
+          },
+        }),
+        context
+      );
+
+      expect(result.isValid).toBe(false);
+      expect(result.unresolvedFields).toEqual(
+        expect.arrayContaining(['url', 'headers.*', 'env.*', 'auth.api_token', 'auth.api_secret'])
+      );
+      expect(JSON.stringify(result)).not.toContain(sentinel);
+      expect(JSON.stringify(spies.flatMap((spy) => spy.mock.calls))).not.toContain(sentinel);
+    } finally {
+      for (const spy of spies) spy.mockRestore();
+    }
+  });
+
+  const markerFamilyCases = [
+    {
+      family: 'url',
+      build: (value: string) =>
+        createTestServer({ transport: 'http', url: `https://mcp.example.test/${value}` }),
+    },
+    {
+      family: 'headers',
+      build: (value: string) =>
+        createTestServer({
+          transport: 'http',
+          url: 'https://mcp.example.test',
+          headers: { 'X-Private': value },
+        }),
+    },
+    {
+      family: 'env',
+      build: (value: string) =>
+        createTestServer({ transport: 'stdio', command: 'node', env: { PRIVATE: value } }),
+    },
+    {
+      family: 'bearer',
+      build: (value: string) =>
+        createTestServer({
+          transport: 'http',
+          url: 'https://mcp.example.test',
+          auth: { type: 'bearer', token: value },
+        }),
+    },
+    {
+      family: 'jwt',
+      build: (value: string) =>
+        createTestServer({
+          transport: 'http',
+          url: 'https://mcp.example.test',
+          auth: {
+            type: 'jwt',
+            api_url: 'https://auth.example.test/token',
+            api_token: 'configured',
+            api_secret: value,
+          },
+        }),
+    },
+    {
+      family: 'oauth',
+      build: (value: string) =>
+        createTestServer({
+          transport: 'http',
+          url: 'https://mcp.example.test',
+          auth: { type: 'oauth', oauth_client_secret: value },
+        }),
+    },
+  ] as const;
+
+  it.each(
+    markerFamilyCases.flatMap(({ family, build }) =>
+      (
+        [
+          ['unmatched opening marker', 'SENTINEL_DIRECT_OPEN_{{'],
+          ['unmatched closing marker', 'SENTINEL_DIRECT_CLOSE_}}'],
+        ] as const
+      ).map(([kind, value]) => ({ family, kind, value, build }))
+    )
+  )('rejects a directly stored $kind in $family without disclosure', ({ value, build }) => {
+    const spies = [
+      vi.spyOn(console, 'log').mockImplementation(() => undefined),
+      vi.spyOn(console, 'warn').mockImplementation(() => undefined),
+      vi.spyOn(console, 'error').mockImplementation(() => undefined),
+      vi.spyOn(console, 'debug').mockImplementation(() => undefined),
+    ];
+    try {
+      const result = resolveMcpServerTemplates(build(value), context);
+      expect(result.isValid).toBe(false);
+      expect(JSON.stringify(result)).not.toContain(value);
+      expect(JSON.stringify(spies.flatMap((spy) => spy.mock.calls))).not.toContain(value);
+    } finally {
+      for (const spy of spies) spy.mockRestore();
+    }
+  });
+
+  it.each(
+    markerFamilyCases.flatMap(({ family, build }) =>
+      (
+        [
+          ['unmatched opening marker', 'SENTINEL_ENV_OPEN_{{'],
+          ['unmatched closing marker', 'SENTINEL_ENV_CLOSE_}}'],
+        ] as const
+      ).map(([kind, value]) => ({ family, kind, value, build }))
+    )
+  )('rejects a $kind introduced through user.env in $family', ({ value, build }) => {
+    const spies = [
+      vi.spyOn(console, 'log').mockImplementation(() => undefined),
+      vi.spyOn(console, 'warn').mockImplementation(() => undefined),
+      vi.spyOn(console, 'error').mockImplementation(() => undefined),
+      vi.spyOn(console, 'debug').mockImplementation(() => undefined),
+    ];
+    try {
+      const result = resolveMcpServerTemplates(build('{{ user.env.INJECTED }}'), {
+        user: { env: { INJECTED: value } },
+      });
+      expect(result.isValid).toBe(false);
+      expect(JSON.stringify(result)).not.toContain(value);
+      expect(JSON.stringify(spies.flatMap((spy) => spy.mock.calls))).not.toContain(value);
+    } finally {
+      for (const spy of spies) spy.mockRestore();
+    }
   });
 
   it('should remain valid when optional env templates fail to resolve', () => {
@@ -236,7 +394,7 @@ describe('resolveMcpServerTemplates', () => {
 
     // stdio doesn't require url, so missing env vars don't make it invalid
     expect(result.isValid).toBe(true);
-    expect(result.unresolvedFields).toContain('env.OPTIONAL_VAR');
+    expect(result.unresolvedFields).toContain('env.*');
     expect(result.server.env).toEqual({
       GITHUB_TOKEN: 'gh_secret123',
     });
@@ -272,6 +430,36 @@ describe('resolveMcpServerTemplates', () => {
     const result = resolveMcpServerTemplates(server, context);
 
     expect(result.isValid).toBe(false);
-    expect(result.errorMessage).toContain('sse-server');
+    expect(result.errorMessage).not.toContain('sse-server');
+    expect(result.errorMessage).toContain('invalid or unresolved url');
+  });
+
+  it.each([
+    ['file protocol', 'file:///tmp/mcp'],
+    ['malformed value', 'not a URL'],
+    ['leftover template', 'https://{{still.secret}}/mcp'],
+    ['embedded credentials', 'https://user:password@example.test/mcp'],
+  ])('rejects a resolved URL with %s without echoing it', (_label, resolvedUrl) => {
+    const secret = 'password';
+    const result = resolveMcpServerTemplates(
+      createTestServer({ transport: 'http', url: resolvedUrl }),
+      context
+    );
+
+    expect(result.isValid).toBe(false);
+    expect(result.errorMessage).not.toContain(secret);
+    expect(result.errorMessage).not.toContain(resolvedUrl);
+  });
+
+  it('rejects a user-env URL that resolves to embedded credentials without logging the secret', () => {
+    const secretUrl = 'https://user:super-secret@example.test/mcp';
+    const result = resolveMcpServerTemplates(
+      createTestServer({ transport: 'http', url: '{{ user.env.MCP_URL }}' }),
+      { user: { env: { MCP_URL: secretUrl } } }
+    );
+
+    expect(result.isValid).toBe(false);
+    expect(result.errorMessage).not.toContain(secretUrl);
+    expect(result.errorMessage).not.toContain('super-secret');
   });
 });

--- a/packages/core/src/mcp/template-resolver.ts
+++ b/packages/core/src/mcp/template-resolver.ts
@@ -52,9 +52,14 @@
 import { AGOR_USER_ENV_KEYS_VAR } from '../config/env-resolver';
 import { renderTemplate } from '../templates/handlebars-helpers';
 import type { MCPAuth, MCPServer } from '../types';
-import { containsTemplate, isUserEnvPlaceholder } from './template-patterns';
+import {
+  containsTemplate,
+  hasTemplateMarker,
+  isUserEnvPlaceholder,
+  isValidMCPHttpUrlTemplate,
+} from './template-patterns';
 
-export { containsTemplate, isUserEnvPlaceholder };
+export { containsTemplate, hasTemplateMarker, isUserEnvPlaceholder };
 
 /**
  * Template context available for MCP configuration resolution.
@@ -127,33 +132,80 @@ export function buildMCPTemplateContextFromEnv(
 function resolveStringValue(
   fieldName: string,
   templateValue: string,
-  context: MCPTemplateContext
+  context: MCPTemplateContext,
+  malformedFields: string[]
 ): string | undefined {
-  if (!containsTemplate(templateValue)) {
+  if (!hasTemplateMarker(templateValue)) {
     // Not a template, pass through as-is
     return templateValue;
   }
 
+  if (!containsTemplate(templateValue)) {
+    addUnresolvedField(malformedFields, fieldName);
+    console.warn(
+      `[mcp-template] resolution_failed field_family=${templateFieldFamily(fieldName)} error_type=UnbalancedMarker`
+    );
+    return undefined;
+  }
+
   try {
     // Cast to satisfy renderTemplate's signature - MCPTemplateContext is compatible at runtime
-    const resolved = renderTemplate(templateValue, context as unknown as Record<string, unknown>);
+    let renderFailed = false;
+    const resolved = renderTemplate(templateValue, context as unknown as Record<string, unknown>, {
+      onFailure: () => {
+        renderFailed = true;
+      },
+    });
+
+    if (renderFailed) {
+      addUnresolvedField(malformedFields, fieldName);
+      return undefined;
+    }
 
     if (!resolved || resolved.trim() === '') {
       // Template resolved to empty - user probably hasn't set the var
-      // Log at debug level since this is expected during setup
-      console.log(`   ℹ️  MCP "${fieldName}" resolved to empty (user may need to set env var)`);
+      // Field names for env/header maps are caller-controlled and may
+      // themselves contain sensitive material. Report only the closed family.
+      console.log(`[mcp-template] resolution_empty field_family=${templateFieldFamily(fieldName)}`);
+      return undefined;
+    }
+
+    if (hasTemplateMarker(resolved)) {
+      addUnresolvedField(malformedFields, fieldName);
+      console.warn(
+        `[mcp-template] resolution_failed field_family=${templateFieldFamily(fieldName)} error_type=ResidualMarker`
+      );
       return undefined;
     }
 
     return resolved;
   } catch (error) {
-    // Template syntax error or other failure
+    // `renderTemplate` currently converts failures to an empty result, but
+    // keep this fail-closed boundary value-free if that contract ever changes.
+    const errorType = error instanceof Error ? 'Error' : 'UnknownError';
     console.warn(
-      `   ⚠️  Failed to resolve MCP template "${fieldName}":`,
-      error instanceof Error ? error.message : String(error)
+      `[mcp-template] resolution_failed field_family=${templateFieldFamily(fieldName)} error_type=${errorType}`
     );
+    addUnresolvedField(malformedFields, fieldName);
     return undefined;
   }
+}
+
+function templateFieldFamily(fieldName: string): 'url' | 'env' | 'headers' | 'auth' | 'unknown' {
+  if (fieldName === 'url') return 'url';
+  if (fieldName.startsWith('env.')) return 'env';
+  if (fieldName.startsWith('headers.')) return 'headers';
+  if (fieldName.startsWith('auth.')) return 'auth';
+  return 'unknown';
+}
+
+function addUnresolvedField(fields: string[], field: string): void {
+  const safeField = field.startsWith('env.')
+    ? 'env.*'
+    : field.startsWith('headers.')
+      ? 'headers.*'
+      : field;
+  if (!fields.includes(safeField)) fields.push(safeField);
 }
 
 /**
@@ -175,9 +227,10 @@ export function resolveMcpServerEnv(
   }
 
   const result: Record<string, string> = {};
+  const malformedFields: string[] = [];
 
   for (const [key, templateValue] of Object.entries(envTemplate)) {
-    const resolved = resolveStringValue(`env.${key}`, templateValue, context);
+    const resolved = resolveStringValue(`env.${key}`, templateValue, context, malformedFields);
     if (resolved !== undefined) {
       result[key] = resolved;
     }
@@ -226,21 +279,36 @@ export const TEMPLATE_RESOLVABLE_MCP_AUTH_SECRET_FIELDS = [
   'oauth_client_secret',
 ] as const;
 
+function isSafeResolvedHttpUrl(value: string | undefined): boolean {
+  if (!value || hasTemplateMarker(value)) return false;
+  try {
+    const parsed = new URL(value);
+    return (
+      (parsed.protocol === 'http:' || parsed.protocol === 'https:') &&
+      !parsed.username &&
+      !parsed.password
+    );
+  } catch {
+    return false;
+  }
+}
+
 export function resolveMcpServerTemplates(
   server: MCPServer,
   context: MCPTemplateContext
 ): MCPTemplateResolutionResult {
   const resolved: MCPServer = { ...server };
   const unresolvedFields: string[] = [];
+  const malformedFields: string[] = [];
 
   // Track original templated fields to detect unresolved templates
-  const hadUrlTemplate = server.url && containsTemplate(server.url);
+  const hadUrlTemplate = hasTemplateMarker(server.url);
 
   // Resolve URL (for HTTP/SSE transport)
   if (server.url) {
-    resolved.url = resolveStringValue('url', server.url, context);
+    resolved.url = resolveStringValue('url', server.url, context, malformedFields);
     if (hadUrlTemplate && !resolved.url) {
-      unresolvedFields.push('url');
+      addUnresolvedField(unresolvedFields, 'url');
     }
   }
 
@@ -248,12 +316,17 @@ export function resolveMcpServerTemplates(
   if (server.env) {
     const resolvedEnv: Record<string, string> = {};
     for (const [key, templateValue] of Object.entries(server.env)) {
-      const hadTemplate = containsTemplate(templateValue);
-      const resolvedValue = resolveStringValue(`env.${key}`, templateValue, context);
+      const hadTemplate = hasTemplateMarker(templateValue);
+      const resolvedValue = resolveStringValue(
+        `env.${key}`,
+        templateValue,
+        context,
+        malformedFields
+      );
       if (resolvedValue !== undefined) {
         resolvedEnv[key] = resolvedValue;
       } else if (hadTemplate) {
-        unresolvedFields.push(`env.${key}`);
+        addUnresolvedField(unresolvedFields, `env.${key}`);
       }
     }
     resolved.env = Object.keys(resolvedEnv).length > 0 ? resolvedEnv : undefined;
@@ -263,12 +336,17 @@ export function resolveMcpServerTemplates(
   if (server.headers) {
     const resolvedHeaders: Record<string, string> = {};
     for (const [key, templateValue] of Object.entries(server.headers)) {
-      const hadTemplate = containsTemplate(templateValue);
-      const resolvedValue = resolveStringValue(`headers.${key}`, templateValue, context);
+      const hadTemplate = hasTemplateMarker(templateValue);
+      const resolvedValue = resolveStringValue(
+        `headers.${key}`,
+        templateValue,
+        context,
+        malformedFields
+      );
       if (resolvedValue !== undefined) {
         resolvedHeaders[key] = resolvedValue;
       } else if (hadTemplate) {
-        unresolvedFields.push(`headers.${key}`);
+        addUnresolvedField(unresolvedFields, `headers.${key}`);
       }
     }
     resolved.headers = Object.keys(resolvedHeaders).length > 0 ? resolvedHeaders : undefined;
@@ -279,80 +357,104 @@ export function resolveMcpServerTemplates(
     const resolvedAuth: MCPAuth = { ...server.auth };
 
     if (server.auth.token) {
-      const hadTemplate = containsTemplate(server.auth.token);
-      resolvedAuth.token = resolveStringValue('auth.token', server.auth.token, context);
+      const hadTemplate = hasTemplateMarker(server.auth.token);
+      resolvedAuth.token = resolveStringValue(
+        'auth.token',
+        server.auth.token,
+        context,
+        malformedFields
+      );
       if (hadTemplate && !resolvedAuth.token) {
-        unresolvedFields.push('auth.token');
+        addUnresolvedField(unresolvedFields, 'auth.token');
       }
     }
     if (server.auth.api_url) {
-      const hadTemplate = containsTemplate(server.auth.api_url);
-      resolvedAuth.api_url = resolveStringValue('auth.api_url', server.auth.api_url, context);
+      const hadTemplate = hasTemplateMarker(server.auth.api_url);
+      resolvedAuth.api_url = resolveStringValue(
+        'auth.api_url',
+        server.auth.api_url,
+        context,
+        malformedFields
+      );
       if (hadTemplate && !resolvedAuth.api_url) {
-        unresolvedFields.push('auth.api_url');
+        addUnresolvedField(unresolvedFields, 'auth.api_url');
       }
     }
     if (server.auth.api_token) {
-      const hadTemplate = containsTemplate(server.auth.api_token);
-      resolvedAuth.api_token = resolveStringValue('auth.api_token', server.auth.api_token, context);
+      const hadTemplate = hasTemplateMarker(server.auth.api_token);
+      resolvedAuth.api_token = resolveStringValue(
+        'auth.api_token',
+        server.auth.api_token,
+        context,
+        malformedFields
+      );
       if (hadTemplate && !resolvedAuth.api_token) {
-        unresolvedFields.push('auth.api_token');
+        addUnresolvedField(unresolvedFields, 'auth.api_token');
       }
     }
     if (server.auth.api_secret) {
-      const hadTemplate = containsTemplate(server.auth.api_secret);
+      const hadTemplate = hasTemplateMarker(server.auth.api_secret);
       resolvedAuth.api_secret = resolveStringValue(
         'auth.api_secret',
         server.auth.api_secret,
-        context
+        context,
+        malformedFields
       );
       if (hadTemplate && !resolvedAuth.api_secret) {
-        unresolvedFields.push('auth.api_secret');
+        addUnresolvedField(unresolvedFields, 'auth.api_secret');
       }
     }
 
     // OAuth 2.0 fields (all optional - don't default to env vars, don't track as unresolved)
     if (server.auth.type === 'oauth') {
+      if (server.auth.oauth_authorization_url) {
+        resolvedAuth.oauth_authorization_url = resolveStringValue(
+          'auth.oauth_authorization_url',
+          server.auth.oauth_authorization_url,
+          context,
+          malformedFields
+        );
+      }
       // OAuth token URL (optional - can be auto-detected)
       if (server.auth.oauth_token_url) {
-        const _hadTemplate = containsTemplate(server.auth.oauth_token_url);
         resolvedAuth.oauth_token_url = resolveStringValue(
           'auth.oauth_token_url',
           server.auth.oauth_token_url,
-          context
+          context,
+          malformedFields
         );
         // Don't track as unresolved - it's optional
       }
 
       // OAuth client ID (optional - only resolve if provided)
       if (server.auth.oauth_client_id) {
-        const _hadTemplate = containsTemplate(server.auth.oauth_client_id);
         resolvedAuth.oauth_client_id = resolveStringValue(
           'auth.oauth_client_id',
           server.auth.oauth_client_id,
-          context
+          context,
+          malformedFields
         );
         // Don't track as unresolved - it's optional
       }
 
       // OAuth client secret (optional - only resolve if provided)
       if (server.auth.oauth_client_secret) {
-        const _hadTemplate = containsTemplate(server.auth.oauth_client_secret);
         resolvedAuth.oauth_client_secret = resolveStringValue(
           'auth.oauth_client_secret',
           server.auth.oauth_client_secret,
-          context
+          context,
+          malformedFields
         );
         // Don't track as unresolved - it's optional
       }
 
       // OAuth scope (optional)
       if (server.auth.oauth_scope) {
-        const _hadTemplate = containsTemplate(server.auth.oauth_scope);
         resolvedAuth.oauth_scope = resolveStringValue(
           'auth.oauth_scope',
           server.auth.oauth_scope,
-          context
+          context,
+          malformedFields
         );
         // Don't track as unresolved - it's optional
       }
@@ -364,39 +466,56 @@ export function resolveMcpServerTemplates(
     resolved.auth = resolvedAuth;
   }
 
-  // Determine validity - URL is critical for HTTP/SSE transports
+  // Validate after substitution at the common executor/probe boundary. A
+  // stored template is only a prescription; the resolved value can still be
+  // malformed, retain template syntax, switch protocol, or inject URL
+  // userinfo. Never include a resolved URL in the error or logs because it may
+  // contain user-provided path/query material.
   const isHttpTransport = server.transport === 'http' || server.transport === 'sse';
-  const urlRequired = isHttpTransport && hadUrlTemplate;
-  const urlMissing = urlRequired && !resolved.url;
+  const invalidFields = [...malformedFields];
+  if (
+    isHttpTransport &&
+    ((server.url && hasTemplateMarker(server.url) && !isValidMCPHttpUrlTemplate(server.url)) ||
+      !isSafeResolvedHttpUrl(resolved.url))
+  ) {
+    addUnresolvedField(invalidFields, 'url');
+  }
+  if (server.transport === 'stdio') {
+    if (!resolved.command?.trim()) addUnresolvedField(invalidFields, 'command');
+    if (resolved.url || resolved.headers || (resolved.auth && resolved.auth.type !== 'none')) {
+      addUnresolvedField(invalidFields, 'transport configuration');
+    }
+  }
+  for (const [field, value] of [
+    ['auth.api_url', resolved.auth?.api_url],
+    ['auth.oauth_authorization_url', resolved.auth?.oauth_authorization_url],
+    ['auth.oauth_token_url', resolved.auth?.oauth_token_url],
+  ] as const) {
+    const original =
+      field === 'auth.api_url'
+        ? server.auth?.api_url
+        : field === 'auth.oauth_authorization_url'
+          ? server.auth?.oauth_authorization_url
+          : server.auth?.oauth_token_url;
+    if (
+      value !== undefined &&
+      ((original && hasTemplateMarker(original) && !isValidMCPHttpUrlTemplate(original)) ||
+        !isSafeResolvedHttpUrl(value))
+    ) {
+      addUnresolvedField(invalidFields, field);
+    }
+  }
 
-  const isValid = !urlMissing;
+  const isValid = invalidFields.length === 0;
   let errorMessage: string | undefined;
 
   if (!isValid) {
-    const missingVars = unresolvedFields
-      .map((f) => {
-        // Extract the template variable name for better error messages
-        let originalValue: string | undefined;
-        if (f === 'url') {
-          originalValue = server.url;
-        } else if (f.startsWith('env.')) {
-          originalValue = server.env?.[f.slice(4)];
-        } else if (f.startsWith('headers.')) {
-          originalValue = server.headers?.[f.slice(8)];
-        } else if (f.startsWith('auth.') && server.auth) {
-          const authKey = f.slice(5) as keyof MCPAuth;
-          const authValue = server.auth[authKey];
-          originalValue = typeof authValue === 'string' ? authValue : undefined;
-        }
-        return originalValue || f;
-      })
-      .join(', ');
-    errorMessage = `MCP server "${server.name}" has unresolved required templates: ${missingVars}. Set the corresponding environment variables in your user settings.`;
+    errorMessage = `MCP server configuration has invalid or unresolved ${invalidFields.join(', ')}. Use renderable templates and HTTP(S) URLs without embedded credentials, then set any required user environment variables.`;
   }
 
   return {
     server: resolved,
-    unresolvedFields,
+    unresolvedFields: [...new Set([...unresolvedFields, ...malformedFields])],
     isValid,
     errorMessage,
   };

--- a/packages/core/src/sdk-result-safety.test.ts
+++ b/packages/core/src/sdk-result-safety.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  projectClaudeResultResponse,
+  projectContextUsageSnapshot,
+  projectNormalizedSdkResponse,
+} from './sdk-result-safety';
+
+describe('projectClaudeResultResponse', () => {
+  it('returns a runtime-validated closed projection without provider prose or extensions', () => {
+    const sentinel = 'SENTINEL_CLAUDE_RESULT_BODY_71e4';
+    const projected = projectClaudeResultResponse({
+      type: 'result',
+      subtype: 'success',
+      result: `provider result ${sentinel}`,
+      errors: [`provider error ${sentinel}`],
+      duration_ms: 12,
+      duration_api_ms: Number.POSITIVE_INFINITY,
+      is_error: false,
+      num_turns: 0,
+      total_cost_usd: 0.25,
+      usage: {
+        input_tokens: 10,
+        output_tokens: 2,
+        cache_read_input_tokens: Number.NaN,
+        provider_secret: sentinel,
+      },
+      modelUsage: { [sentinel]: { inputTokens: 10 } },
+      permission_denials: [{ message: sentinel }],
+      provider_extension: { secret: sentinel },
+    });
+
+    expect(projected).toEqual({
+      type: 'result',
+      subtype: 'success',
+      duration_ms: 12,
+      is_error: false,
+      num_turns: 0,
+      total_cost_usd: 0.25,
+      usage: {
+        input_tokens: 10,
+        output_tokens: 2,
+      },
+    });
+    expect(JSON.stringify(projected)).not.toContain(sentinel);
+  });
+
+  it('does not invoke hostile field getters', () => {
+    const getter = vi.fn(() => {
+      throw new Error('SENTINEL_GETTER');
+    });
+    const value = { type: 'result' };
+    Object.defineProperties(value, {
+      subtype: { get: getter },
+      result: { get: getter },
+      usage: { get: getter },
+      modelUsage: { get: getter },
+    });
+
+    expect(projectClaudeResultResponse(value)).toEqual({ type: 'result', subtype: 'unknown' });
+    expect(getter).not.toHaveBeenCalled();
+  });
+
+  it('rejects values which are not SDK result records', () => {
+    expect(projectClaudeResultResponse(undefined)).toBeUndefined();
+    expect(
+      projectClaudeResultResponse({ type: 'turn.completed', result: 'secret' })
+    ).toBeUndefined();
+  });
+});
+
+describe('normalized SDK response projection', () => {
+  it('rebuilds every nested object and excludes extensions', () => {
+    const sentinel = 'SENTINEL_NORMALIZED_EXTENSION_25d8';
+    const projected = projectNormalizedSdkResponse({
+      tokenUsage: {
+        inputTokens: 10,
+        outputTokens: 2,
+        totalTokens: 12,
+        cacheReadTokens: 3,
+        provider_secret: sentinel,
+      },
+      contextWindowLimit: 200_000,
+      costUsd: 0.2,
+      primaryModel: 'claude-sonnet-4-6',
+      durationMs: 12,
+      contextUsageSnapshot: {
+        totalTokens: 123,
+        maxTokens: 200_000,
+        percentage: 1,
+        memoryFiles: [{ path: sentinel }],
+      },
+      providerExtension: { secret: sentinel },
+    });
+
+    expect(projected).toEqual({
+      tokenUsage: {
+        inputTokens: 10,
+        outputTokens: 2,
+        totalTokens: 12,
+        cacheReadTokens: 3,
+      },
+      contextWindowLimit: 200_000,
+      costUsd: 0.2,
+      primaryModel: 'claude-sonnet-4-6',
+      durationMs: 12,
+      contextUsageSnapshot: { totalTokens: 123, maxTokens: 200_000, percentage: 1 },
+    });
+    expect(JSON.stringify(projected)).not.toContain(sentinel);
+  });
+
+  it('does not invoke prototype or own accessors', () => {
+    const getter = vi.fn(() => {
+      throw new Error('SENTINEL_NORMALIZED_GETTER');
+    });
+    const inherited = Object.create({ provider_secret: 'SENTINEL_PROTOTYPE' });
+    Object.defineProperty(inherited, 'tokenUsage', { get: getter });
+    expect(projectNormalizedSdkResponse(inherited)).toBeUndefined();
+    expect(getter).not.toHaveBeenCalled();
+  });
+
+  it('projects only the canonical context snapshot scalars', () => {
+    const sentinel = 'SENTINEL_CONTEXT_MEMORY_PATH';
+    expect(
+      projectContextUsageSnapshot({
+        totalTokens: 20,
+        maxTokens: 100,
+        percentage: 20,
+        rawMaxTokens: 110,
+        model: 'provider-model',
+        memoryFiles: [{ path: sentinel, type: sentinel, tokens: 2 }],
+        categories: [{ name: sentinel, tokens: 2, color: '#fff' }],
+      })
+    ).toEqual({ totalTokens: 20, maxTokens: 100, percentage: 20 });
+  });
+
+  it('rejects non-finite and incomplete normalized values', () => {
+    expect(
+      projectNormalizedSdkResponse({
+        tokenUsage: { inputTokens: 1, outputTokens: 1, totalTokens: Number.NaN },
+      })
+    ).toBeUndefined();
+    expect(
+      projectContextUsageSnapshot({ totalTokens: 1, maxTokens: Infinity, percentage: 1 })
+    ).toBeUndefined();
+  });
+});

--- a/packages/core/src/sdk-result-safety.ts
+++ b/packages/core/src/sdk-result-safety.ts
@@ -1,0 +1,188 @@
+/**
+ * Runtime projections for provider SDK results that cross the executor/daemon
+ * boundary. Provider SDK values are external input even when their TypeScript
+ * declarations are closed: extension properties, strings, and object keys can
+ * contain reflected credentials or response bodies.
+ */
+
+import type { ContextUsageSnapshot, Task } from './types/task.js';
+
+export const SAFE_ZERO_TURN_PROVIDER_RESULT_MESSAGE =
+  'The provider ended the request without returning a model response. Retry the prompt.';
+
+export type SafeNormalizedSdkResponse = NonNullable<Task['normalized_sdk_response']>;
+
+export type SafeClaudeResultSubtype =
+  | 'success'
+  | 'error_during_execution'
+  | 'error_max_turns'
+  | 'error_max_budget_usd'
+  | 'error_max_structured_output_retries'
+  | 'unknown';
+
+export interface SafeClaudeResultResponse {
+  type: 'result';
+  subtype: SafeClaudeResultSubtype;
+  duration_ms?: number;
+  duration_api_ms?: number;
+  is_error?: boolean;
+  num_turns?: number;
+  total_cost_usd?: number;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    cache_read_input_tokens?: number;
+    cache_creation_input_tokens?: number;
+  };
+}
+
+function ownDataValue(value: unknown, field: string): unknown {
+  if (!value || (typeof value !== 'object' && typeof value !== 'function')) return undefined;
+  try {
+    const descriptor = Object.getOwnPropertyDescriptor(value, field);
+    return descriptor && 'value' in descriptor ? descriptor.value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function finiteNonNegative(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function safeCount(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0 ? value : undefined;
+}
+
+function safePercentage(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= 100
+    ? value
+    : undefined;
+}
+
+function safeModel(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 && value.length <= 512 ? value : undefined;
+}
+
+function safeClaudeResultSubtype(value: unknown): SafeClaudeResultSubtype {
+  return value === 'success' ||
+    value === 'error_during_execution' ||
+    value === 'error_max_turns' ||
+    value === 'error_max_budget_usd' ||
+    value === 'error_max_structured_output_retries'
+    ? value
+    : 'unknown';
+}
+
+function projectClaudeUsage(value: unknown): SafeClaudeResultResponse['usage'] | undefined {
+  const inputTokens = safeCount(ownDataValue(value, 'input_tokens'));
+  const outputTokens = safeCount(ownDataValue(value, 'output_tokens'));
+  const cacheReadTokens = safeCount(ownDataValue(value, 'cache_read_input_tokens'));
+  const cacheCreationTokens = safeCount(ownDataValue(value, 'cache_creation_input_tokens'));
+  const projected = {
+    ...(inputTokens !== undefined ? { input_tokens: inputTokens } : {}),
+    ...(outputTokens !== undefined ? { output_tokens: outputTokens } : {}),
+    ...(cacheReadTokens !== undefined ? { cache_read_input_tokens: cacheReadTokens } : {}),
+    ...(cacheCreationTokens !== undefined
+      ? { cache_creation_input_tokens: cacheCreationTokens }
+      : {}),
+  };
+  return Object.keys(projected).length > 0 ? projected : undefined;
+}
+
+/**
+ * Produce the only Claude result shape allowed in Task persistence/realtime.
+ * Raw result/error prose, permission data, UUIDs, modelUsage keys, and unknown
+ * SDK extensions are deliberately excluded. The aggregate `usage` object is
+ * rebuilt field-by-field from finite counters; the provider object is never
+ * copied or spread.
+ */
+export function projectClaudeResultResponse(value: unknown): SafeClaudeResultResponse | undefined {
+  if (ownDataValue(value, 'type') !== 'result') return undefined;
+
+  const subtype = safeClaudeResultSubtype(ownDataValue(value, 'subtype'));
+  const durationMs = finiteNonNegative(ownDataValue(value, 'duration_ms'));
+  const durationApiMs = finiteNonNegative(ownDataValue(value, 'duration_api_ms'));
+  const isError = ownDataValue(value, 'is_error');
+  const numTurns = safeCount(ownDataValue(value, 'num_turns'));
+  const totalCostUsd = finiteNonNegative(ownDataValue(value, 'total_cost_usd'));
+  const usage = projectClaudeUsage(ownDataValue(value, 'usage'));
+
+  return {
+    type: 'result',
+    subtype,
+    ...(durationMs !== undefined ? { duration_ms: durationMs } : {}),
+    ...(durationApiMs !== undefined ? { duration_api_ms: durationApiMs } : {}),
+    ...(typeof isError === 'boolean' ? { is_error: isError } : {}),
+    ...(numTurns !== undefined ? { num_turns: numTurns } : {}),
+    ...(totalCostUsd !== undefined ? { total_cost_usd: totalCostUsd } : {}),
+    ...(usage ? { usage } : {}),
+  };
+}
+
+/**
+ * Close an SDK context response to the three canonical scalar fields used by
+ * Task/UI state. Claude's richer response includes memory paths, MCP tool
+ * names, prompt sections, and future extension objects; none cross this
+ * boundary. Accessors and inherited fields are never evaluated.
+ */
+export function projectContextUsageSnapshot(value: unknown): ContextUsageSnapshot | undefined {
+  const totalTokens = safeCount(ownDataValue(value, 'totalTokens'));
+  const maxTokens = safeCount(ownDataValue(value, 'maxTokens'));
+  const percentage = safePercentage(ownDataValue(value, 'percentage'));
+  if (totalTokens === undefined || maxTokens === undefined || percentage === undefined) {
+    return undefined;
+  }
+  return { totalTokens, maxTokens, percentage };
+}
+
+function projectNormalizedTokenUsage(
+  value: unknown
+): SafeNormalizedSdkResponse['tokenUsage'] | undefined {
+  const inputTokens = safeCount(ownDataValue(value, 'inputTokens'));
+  const outputTokens = safeCount(ownDataValue(value, 'outputTokens'));
+  const totalTokens = safeCount(ownDataValue(value, 'totalTokens'));
+  if (inputTokens === undefined || outputTokens === undefined || totalTokens === undefined) {
+    return undefined;
+  }
+  const cacheReadTokens = safeCount(ownDataValue(value, 'cacheReadTokens'));
+  const cacheCreationTokens = safeCount(ownDataValue(value, 'cacheCreationTokens'));
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens,
+    ...(cacheReadTokens !== undefined ? { cacheReadTokens } : {}),
+    ...(cacheCreationTokens !== undefined ? { cacheCreationTokens } : {}),
+  };
+}
+
+/**
+ * Runtime projection for the complete normalized SDK response persisted on a
+ * Task. This is a separate trust boundary from raw result projection: an old
+ * or compromised executor can patch normalized data without sending a raw
+ * response. Every nested object is rebuilt from allowlisted scalar fields;
+ * no provider/executor object is spread or retained by reference.
+ */
+export function projectNormalizedSdkResponse(
+  value: unknown
+): SafeNormalizedSdkResponse | undefined {
+  const tokenUsage = projectNormalizedTokenUsage(ownDataValue(value, 'tokenUsage'));
+  if (!tokenUsage) return undefined;
+
+  const contextWindowLimit = safeCount(ownDataValue(value, 'contextWindowLimit'));
+  const costUsd = finiteNonNegative(ownDataValue(value, 'costUsd'));
+  const primaryModel = safeModel(ownDataValue(value, 'primaryModel'));
+  const durationMs = finiteNonNegative(ownDataValue(value, 'durationMs'));
+  const contextUsageSnapshot = projectContextUsageSnapshot(
+    ownDataValue(value, 'contextUsageSnapshot')
+  );
+
+  return {
+    tokenUsage,
+    ...(contextWindowLimit !== undefined ? { contextWindowLimit } : {}),
+    ...(costUsd !== undefined ? { costUsd } : {}),
+    ...(primaryModel !== undefined ? { primaryModel } : {}),
+    ...(durationMs !== undefined ? { durationMs } : {}),
+    ...(contextUsageSnapshot ? { contextUsageSnapshot } : {}),
+  };
+}

--- a/packages/core/src/sdk/index.ts
+++ b/packages/core/src/sdk/index.ts
@@ -21,4 +21,4 @@ export type {
   SlashCommand,
 } from '@anthropic-ai/claude-agent-sdk';
 // Codex SDK - direct type exports for convenience
-export type { CodexOptions, Thread, ThreadItem } from '@openai/codex-sdk';
+export type { CodexOptions, Thread, ThreadItem, TurnCompletedEvent } from '@openai/codex-sdk';

--- a/packages/core/src/templates/handlebars-helpers.test.ts
+++ b/packages/core/src/templates/handlebars-helpers.test.ts
@@ -59,7 +59,7 @@ describe('handlebars-helpers', () => {
       const template = Handlebars.compile('{{add a b}}');
       expect(template({ a: 'foo', b: 5 })).toBe('0');
       expect(consoleWarnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('add helper received non-numeric values: foo, 5')
+        '[templates] helper_invalid_argument helper=add reason=non_numeric'
       );
     });
 
@@ -67,7 +67,7 @@ describe('handlebars-helpers', () => {
       const template = Handlebars.compile('{{add a b}}');
       expect(template({ a: 5, b: 'bar' })).toBe('0');
       expect(consoleWarnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('add helper received non-numeric values: 5, bar')
+        '[templates] helper_invalid_argument helper=add reason=non_numeric'
       );
     });
 
@@ -75,7 +75,7 @@ describe('handlebars-helpers', () => {
       const template = Handlebars.compile('{{add a b}}');
       expect(template({ a: 'foo', b: 'bar' })).toBe('0');
       expect(consoleWarnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('add helper received non-numeric values: foo, bar')
+        '[templates] helper_invalid_argument helper=add reason=non_numeric'
       );
     });
 
@@ -131,7 +131,7 @@ describe('handlebars-helpers', () => {
       const template = Handlebars.compile('{{sub a b}}');
       expect(template({ a: 'foo', b: 5 })).toBe('0');
       expect(consoleWarnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('sub helper received non-numeric values: foo, 5')
+        '[templates] helper_invalid_argument helper=sub reason=non_numeric'
       );
     });
 
@@ -182,7 +182,7 @@ describe('handlebars-helpers', () => {
       const template = Handlebars.compile('{{mul a b}}');
       expect(template({ a: 'foo', b: 5 })).toBe('0');
       expect(consoleWarnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('mul helper received non-numeric values: foo, 5')
+        '[templates] helper_invalid_argument helper=mul reason=non_numeric'
       );
     });
 
@@ -239,7 +239,7 @@ describe('handlebars-helpers', () => {
       const template = Handlebars.compile('{{div 10 0}}');
       expect(template({})).toBe('0');
       expect(consoleWarnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('div helper received zero divisor')
+        '[templates] helper_invalid_argument helper=div reason=zero_divisor'
       );
     });
 
@@ -247,7 +247,7 @@ describe('handlebars-helpers', () => {
       const template = Handlebars.compile('{{div a b}}');
       expect(template({ a: 'foo', b: 5 })).toBe('0');
       expect(consoleWarnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('div helper received non-numeric values: foo, 5')
+        '[templates] helper_invalid_argument helper=div reason=non_numeric'
       );
     });
 
@@ -266,7 +266,7 @@ describe('handlebars-helpers', () => {
       const template = Handlebars.compile('{{div 1 0}}');
       expect(template({})).toBe('0');
       expect(consoleWarnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('div helper received zero divisor')
+        '[templates] helper_invalid_argument helper=div reason=zero_divisor'
       );
     });
   });
@@ -306,7 +306,7 @@ describe('handlebars-helpers', () => {
       const template = Handlebars.compile('{{mod 10 0}}');
       expect(template({})).toBe('0');
       expect(consoleWarnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('mod helper received zero divisor')
+        '[templates] helper_invalid_argument helper=mod reason=zero_divisor'
       );
     });
 
@@ -314,7 +314,7 @@ describe('handlebars-helpers', () => {
       const template = Handlebars.compile('{{mod a b}}');
       expect(template({ a: 'foo', b: 5 })).toBe('0');
       expect(consoleWarnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('mod helper received non-numeric values: foo, 5')
+        '[templates] helper_invalid_argument helper=mod reason=non_numeric'
       );
     });
 
@@ -1000,9 +1000,21 @@ NAME={{replace (uppercase branch.name) "-" "_"}}
       // surfaces opt into raw-template fallback via { onError: 'raw' }.
       const result = renderTemplate('{{#if unclosed', {});
       expect(result).toBe('');
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Handlebars template error'),
-        expect.anything()
+      expect(consoleErrorSpy).toHaveBeenCalledWith('[templates] render_failed error_type=Error');
+    });
+
+    it('never logs template or context secrets on parse and helper failures', () => {
+      const sentinel = 'SENTINEL_TEMPLATE_SECRET_7ee84d';
+
+      expect(renderTemplate(`{{#if ${sentinel}`, { [sentinel]: sentinel })).toBe('');
+      expect(renderTemplate('{{add secret 1}}', { secret: sentinel })).toBe('0');
+
+      const logged = JSON.stringify([...consoleErrorSpy.mock.calls, ...consoleWarnSpy.mock.calls]);
+      expect(logged).not.toContain(sentinel);
+      expect(logged).not.toContain('{{#if');
+      expect(consoleErrorSpy).toHaveBeenCalledWith('[templates] render_failed error_type=Error');
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        '[templates] helper_invalid_argument helper=add reason=non_numeric'
       );
     });
 

--- a/packages/core/src/templates/handlebars-helpers.ts
+++ b/packages/core/src/templates/handlebars-helpers.ts
@@ -50,7 +50,7 @@ export function registerHandlebarsHelpers(): void {
     const numA = Number(a);
     const numB = Number(b);
     if (Number.isNaN(numA) || Number.isNaN(numB)) {
-      console.warn(`⚠️  add helper received non-numeric values: ${a}, ${b}`);
+      console.warn('[templates] helper_invalid_argument helper=add reason=non_numeric');
       return 0;
     }
     return numA + numB;
@@ -64,7 +64,7 @@ export function registerHandlebarsHelpers(): void {
     const numA = Number(a);
     const numB = Number(b);
     if (Number.isNaN(numA) || Number.isNaN(numB)) {
-      console.warn(`⚠️  sub helper received non-numeric values: ${a}, ${b}`);
+      console.warn('[templates] helper_invalid_argument helper=sub reason=non_numeric');
       return 0;
     }
     return numA - numB;
@@ -78,7 +78,7 @@ export function registerHandlebarsHelpers(): void {
     const numA = Number(a);
     const numB = Number(b);
     if (Number.isNaN(numA) || Number.isNaN(numB)) {
-      console.warn(`⚠️  mul helper received non-numeric values: ${a}, ${b}`);
+      console.warn('[templates] helper_invalid_argument helper=mul reason=non_numeric');
       return 0;
     }
     return numA * numB;
@@ -92,11 +92,11 @@ export function registerHandlebarsHelpers(): void {
     const numA = Number(a);
     const numB = Number(b);
     if (Number.isNaN(numA) || Number.isNaN(numB)) {
-      console.warn(`⚠️  div helper received non-numeric values: ${a}, ${b}`);
+      console.warn('[templates] helper_invalid_argument helper=div reason=non_numeric');
       return 0;
     }
     if (numB === 0) {
-      console.warn(`⚠️  div helper received zero divisor`);
+      console.warn('[templates] helper_invalid_argument helper=div reason=zero_divisor');
       return 0;
     }
     return numA / numB;
@@ -110,11 +110,11 @@ export function registerHandlebarsHelpers(): void {
     const numA = Number(a);
     const numB = Number(b);
     if (Number.isNaN(numA) || Number.isNaN(numB)) {
-      console.warn(`⚠️  mod helper received non-numeric values: ${a}, ${b}`);
+      console.warn('[templates] helper_invalid_argument helper=mod reason=non_numeric');
       return 0;
     }
     if (numB === 0) {
-      console.warn(`⚠️  mod helper received zero divisor`);
+      console.warn('[templates] helper_invalid_argument helper=mod reason=zero_divisor');
       return 0;
     }
     return numA % numB;
@@ -237,6 +237,8 @@ export type { RenderTemplateOnError } from '../types/template';
 export interface RenderTemplateOptions {
   /** Behavior when rendering throws. Default: `'empty'`. */
   onError?: RenderTemplateOnError;
+  /** Internal value-free failure signal for callers that must fail closed. */
+  onFailure?: (errorType: 'SyntaxError' | 'TypeError' | 'Error' | 'UnknownError') => void;
 }
 
 /**
@@ -271,9 +273,22 @@ export function renderTemplate(
     const template = Handlebars.compile(templateString);
     return template(context);
   } catch (error) {
-    console.error('❌ Handlebars template error:', error);
-    console.error('Template:', templateString);
-    console.error('Context keys:', Object.keys(context));
+    // Handlebars exceptions can quote the source line, helper arguments, or a
+    // rendered value. Templates and contexts are used for MCP credentials,
+    // environment commands, prompts, and UI previews, so neither the raw
+    // exception nor any input-derived metadata is safe to log. Keep the error
+    // type allowlisted and value-free while retaining enough signal to tell a
+    // syntax/runtime failure from an unknown thrown value.
+    const errorType =
+      error instanceof SyntaxError
+        ? 'SyntaxError'
+        : error instanceof TypeError
+          ? 'TypeError'
+          : error instanceof Error
+            ? 'Error'
+            : 'UnknownError';
+    console.error(`[templates] render_failed error_type=${errorType}`);
+    options.onFailure?.(errorType);
     if (options.onError === 'raw') {
       // Return the raw template so the user sees *something* (the unrendered
       // placeholders) rather than a silently-blank result. Used by UI

--- a/packages/core/src/tools/mcp/auth-patch.test.ts
+++ b/packages/core/src/tools/mcp/auth-patch.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from 'vitest';
+import { assertValidMCPAuthPatch, mergeMCPAuth, replaceMCPAuth } from './auth-patch';
+import { MCP_HEADER_REDACTED_SENTINEL } from './http-headers';
+
+const stored = {
+  type: 'oauth' as const,
+  oauth_client_id: 'client-id',
+  oauth_client_secret: 'client-secret',
+  oauth_scope: 'calendar.readonly',
+  oauth_compatibility_mode: 'legacy' as const,
+};
+
+describe('mergeMCPAuth', () => {
+  it('preserves omitted OAuth settings on a narrow scope patch', () => {
+    expect(mergeMCPAuth(stored, { oauth_scope: 'calendar.events' })).toEqual({
+      ...stored,
+      oauth_scope: 'calendar.events',
+    });
+  });
+
+  it('distinguishes explicit clear, redacted preservation, and omission', () => {
+    expect(
+      mergeMCPAuth(stored, {
+        oauth_client_id: null,
+        oauth_client_secret: MCP_HEADER_REDACTED_SENTINEL,
+      })
+    ).toEqual({
+      type: 'oauth',
+      oauth_client_secret: 'client-secret',
+      oauth_scope: 'calendar.readonly',
+      oauth_compatibility_mode: 'legacy',
+    });
+  });
+
+  it('replaces wholesale when the auth type changes', () => {
+    expect(mergeMCPAuth(stored, { type: 'bearer', token: 'next' })).toEqual({
+      type: 'bearer',
+      token: 'next',
+    });
+  });
+
+  it('clears the whole auth object with null', () => {
+    expect(mergeMCPAuth(stored, null)).toBeUndefined();
+    expect(replaceMCPAuth(stored, null)).toBeUndefined();
+    expect(() => assertValidMCPAuthPatch(null, { create: true })).not.toThrow();
+  });
+
+  it('round-trips redacted PUT secrets from the current row while replacing non-secrets', () => {
+    expect(
+      replaceMCPAuth(stored, {
+        type: 'oauth',
+        oauth_client_secret: MCP_HEADER_REDACTED_SENTINEL,
+        oauth_scope: 'calendar.events',
+      })
+    ).toEqual({
+      type: 'oauth',
+      oauth_client_secret: 'client-secret',
+      oauth_scope: 'calendar.events',
+    });
+  });
+
+  it('rejects every create-time secret sentinel', () => {
+    for (const input of [
+      { type: 'bearer', token: MCP_HEADER_REDACTED_SENTINEL },
+      { type: 'jwt', api_secret: MCP_HEADER_REDACTED_SENTINEL },
+      { type: 'oauth', oauth_refresh_token: MCP_HEADER_REDACTED_SENTINEL },
+    ]) {
+      expect(() => assertValidMCPAuthPatch(input, { create: true })).toThrow(/redaction sentinel/);
+    }
+  });
+
+  it('separates public CREATE credential requirements from valid incomplete saved rows', () => {
+    expect(() => assertValidMCPAuthPatch({ type: 'bearer' }, { create: true })).not.toThrow();
+    expect(() =>
+      assertValidMCPAuthPatch(
+        { type: 'bearer' },
+        { create: true, requireConfiguredCredentials: true }
+      )
+    ).toThrow(/auth\.token is required/);
+    expect(() => assertValidMCPAuthPatch({ type: 'jwt' }, { create: true })).not.toThrow();
+    expect(() =>
+      assertValidMCPAuthPatch({ type: 'jwt' }, { create: true, requireConfiguredCredentials: true })
+    ).toThrow(/auth\.api_url is required/);
+  });
+
+  it('allows an explicit secret clear to leave a closed incomplete saved mode', () => {
+    expect(mergeMCPAuth({ type: 'bearer', token: 'secret' }, { token: null })).toEqual({
+      type: 'bearer',
+    });
+    expect(
+      mergeMCPAuth(
+        {
+          type: 'jwt',
+          api_url: 'https://auth.example.test/token',
+          api_token: 'token',
+          api_secret: 'secret',
+        },
+        { api_token: null, api_secret: null }
+      )
+    ).toEqual({ type: 'jwt', api_url: 'https://auth.example.test/token' });
+  });
+
+  it('rejects field-level null on create while allowing auth:null to mean no auth', () => {
+    expect(() =>
+      assertValidMCPAuthPatch({ type: 'oauth', oauth_mode: null }, { create: true })
+    ).toThrow('auth.oauth_mode cannot be null on create');
+    expect(() => assertValidMCPAuthPatch(null, { create: true })).not.toThrow();
+  });
+
+  it('never persists a sentinel when there is no same-mode secret to restore', () => {
+    expect(
+      mergeMCPAuth(undefined, {
+        type: 'oauth',
+        oauth_client_secret: MCP_HEADER_REDACTED_SENTINEL,
+      })
+    ).toEqual({ type: 'oauth' });
+  });
+
+  it('rejects unknown fields before a misspelled secret can be persisted', () => {
+    expect(() =>
+      assertValidMCPAuthPatch({
+        type: 'oauth',
+        oauth_client_secert: 'would-escape-redaction',
+      })
+    ).toThrow('Unknown auth field: oauth_client_secert');
+  });
+
+  it('rejects fields from the wrong authentication mode and mixed partial families', () => {
+    expect(() => assertValidMCPAuthPatch({ type: 'none', token: 'must-not-survive' })).toThrow(
+      "auth.token does not apply when auth.type is 'none'"
+    );
+    expect(() => assertValidMCPAuthPatch({ type: 'none', insecure: true })).toThrow(
+      "auth.insecure does not apply when auth.type is 'none'"
+    );
+    expect(() =>
+      assertValidMCPAuthPatch({ type: 'bearer', token: 'ok', insecure: true })
+    ).not.toThrow();
+    expect(() =>
+      assertValidMCPAuthPatch({ type: 'bearer', api_secret: 'must-not-survive' })
+    ).toThrow("auth.api_secret does not apply when auth.type is 'bearer'");
+    expect(() =>
+      assertValidMCPAuthPatch({ type: 'jwt', oauth_client_secret: 'must-not-survive' })
+    ).toThrow("auth.oauth_client_secret does not apply when auth.type is 'jwt'");
+    expect(() => assertValidMCPAuthPatch({ token: 'one', oauth_scope: 'two' })).toThrow(
+      'auth patch cannot combine fields from different authentication modes'
+    );
+    expect(() => mergeMCPAuth(stored, { token: 'wrong-mode' })).toThrow(
+      "auth.token does not apply when auth.type is 'oauth'"
+    );
+    expect(() => assertValidMCPAuthPatch({ oauth_grant_type: 'password' })).toThrow(
+      /oauth_grant_type/
+    );
+  });
+
+  it('validates bounded URL and scalar auth fields', () => {
+    expect(() =>
+      assertValidMCPAuthPatch({ type: 'jwt', api_url: 'file:///tmp/token' }, { create: true })
+    ).toThrow(/HTTP\(S\)/);
+    expect(() =>
+      assertValidMCPAuthPatch(
+        { type: 'oauth', oauth_token_url: 'https://user:pass@provider.example/token' },
+        { create: true }
+      )
+    ).toThrow(/embedded credentials/);
+    expect(() =>
+      assertValidMCPAuthPatch({ type: 'bearer', token: `secret\nheader` }, { create: true })
+    ).toThrow(/control characters/);
+    expect(() =>
+      assertValidMCPAuthPatch(
+        { type: 'oauth', oauth_token_expires_at: Number.MAX_SAFE_INTEGER + 1 },
+        { create: true }
+      )
+    ).toThrow(/safe integer/);
+  });
+
+  it('clears static OAuth tokens when switching credential authority modes', () => {
+    expect(
+      mergeMCPAuth(
+        {
+          type: 'oauth',
+          oauth_mode: 'shared',
+          oauth_access_token: 'shared-access',
+          oauth_refresh_token: 'shared-refresh',
+          oauth_token_expires_at: 123,
+          oauth_client_id: 'client',
+        },
+        { oauth_mode: 'per_user' }
+      )
+    ).toEqual({ type: 'oauth', oauth_mode: 'per_user', oauth_client_id: 'client' });
+    expect(
+      mergeMCPAuth(
+        {
+          type: 'oauth',
+          oauth_mode: 'shared',
+          oauth_access_token: 'shared-access',
+          oauth_refresh_token: 'shared-refresh',
+        },
+        { oauth_mode: null }
+      )
+    ).toEqual({ type: 'oauth' });
+  });
+});

--- a/packages/core/src/tools/mcp/auth-patch.ts
+++ b/packages/core/src/tools/mcp/auth-patch.ts
@@ -1,0 +1,399 @@
+/**
+ * Secret-safe PATCH semantics for MCP authentication configuration.
+ *
+ * The public read path replaces stored secrets with the shared redaction
+ * sentinel.  A caller can therefore round-trip a read result without learning
+ * the secret: the sentinel means "preserve", omission means "preserve", and
+ * an explicit null means "clear this field".  Switching authentication type
+ * is intentionally a replacement so credentials from the old mode never
+ * survive as dead configuration.
+ */
+
+import {
+  containsTemplate,
+  hasTemplateMarker,
+  isValidMCPHttpUrlTemplate,
+} from '../../mcp/template-patterns';
+import {
+  assertPublicMCPOAuthCompatibilityMode,
+  type MCPAuth,
+  type MCPAuthPatch,
+} from '../../types/mcp';
+import { MCP_AUTH_SECRET_FIELDS } from './auth-secrets';
+import { MCP_HEADER_REDACTED_SENTINEL } from './http-headers';
+
+const secretFields = new Set<keyof MCPAuth>(MCP_AUTH_SECRET_FIELDS);
+
+const AUTH_FIELDS = new Set<keyof MCPAuth>([
+  'type',
+  'token',
+  'api_url',
+  'api_token',
+  'api_secret',
+  'oauth_authorization_url',
+  'oauth_token_url',
+  'oauth_client_id',
+  'oauth_client_secret',
+  'oauth_scope',
+  'oauth_grant_type',
+  'oauth_compatibility_mode',
+  'oauth_dcr_mode',
+  'oauth_access_token',
+  'oauth_token_expires_at',
+  'oauth_refresh_token',
+  'oauth_mode',
+  'insecure',
+]);
+
+const STRING_AUTH_FIELDS = new Set<keyof MCPAuth>([
+  'token',
+  'api_url',
+  'api_token',
+  'api_secret',
+  'oauth_authorization_url',
+  'oauth_token_url',
+  'oauth_client_id',
+  'oauth_client_secret',
+  'oauth_scope',
+  'oauth_grant_type',
+  'oauth_access_token',
+  'oauth_refresh_token',
+]);
+
+const URL_AUTH_FIELDS = new Set<keyof MCPAuth>([
+  'api_url',
+  'oauth_authorization_url',
+  'oauth_token_url',
+]);
+const MAX_AUTH_VALUE_LENGTH = 65_536;
+
+function hasControlCharacter(value: string): boolean {
+  return [...value].some((character) => {
+    const code = character.charCodeAt(0);
+    return code <= 31 || code === 127;
+  });
+}
+
+/** Stable closed-auth input failure for REST/socket error mapping. */
+export class MCPAuthValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MCPAuthValidationError';
+  }
+}
+
+const AUTH_FIELDS_BY_TYPE = {
+  none: new Set<keyof MCPAuth>(['type']),
+  bearer: new Set<keyof MCPAuth>(['type', 'token', 'insecure']),
+  jwt: new Set<keyof MCPAuth>(['type', 'api_url', 'api_token', 'api_secret', 'insecure']),
+  oauth: new Set<keyof MCPAuth>([
+    'type',
+    'oauth_authorization_url',
+    'oauth_token_url',
+    'oauth_client_id',
+    'oauth_client_secret',
+    'oauth_scope',
+    'oauth_grant_type',
+    'oauth_compatibility_mode',
+    'oauth_dcr_mode',
+    'oauth_access_token',
+    'oauth_token_expires_at',
+    'oauth_refresh_token',
+    'oauth_mode',
+    'insecure',
+  ]),
+} satisfies Record<MCPAuth['type'], ReadonlySet<keyof MCPAuth>>;
+
+const AUTH_FIELD_FAMILY = new Map<keyof MCPAuth, MCPAuth['type']>([
+  ['token', 'bearer'],
+  ['api_url', 'jwt'],
+  ['api_token', 'jwt'],
+  ['api_secret', 'jwt'],
+  ['oauth_authorization_url', 'oauth'],
+  ['oauth_token_url', 'oauth'],
+  ['oauth_client_id', 'oauth'],
+  ['oauth_client_secret', 'oauth'],
+  ['oauth_scope', 'oauth'],
+  ['oauth_grant_type', 'oauth'],
+  ['oauth_compatibility_mode', 'oauth'],
+  ['oauth_dcr_mode', 'oauth'],
+  ['oauth_access_token', 'oauth'],
+  ['oauth_token_expires_at', 'oauth'],
+  ['oauth_refresh_token', 'oauth'],
+  ['oauth_mode', 'oauth'],
+]);
+
+function assertAuthFieldFamilies(auth: Record<string, unknown>): void {
+  const requestedType = auth.type as MCPAuth['type'] | undefined;
+  const activeFields = Object.entries(auth)
+    .filter(([, value]) => value !== undefined && value !== null)
+    .map(([field]) => field as keyof MCPAuth);
+
+  if (requestedType) {
+    const allowed = AUTH_FIELDS_BY_TYPE[requestedType];
+    const invalid = activeFields.find((field) => !allowed.has(field));
+    if (invalid) {
+      throw new Error(`auth.${invalid} does not apply when auth.type is '${requestedType}'`);
+    }
+    return;
+  }
+
+  // A PATCH may omit type, but it still cannot combine fields belonging to
+  // different modes. The repository validates the merged object against the
+  // stored type before persistence, which closes the remaining partial-update
+  // case without forcing callers to resend a redacted auth object.
+  const families = new Set(
+    activeFields.map((field) => AUTH_FIELD_FAMILY.get(field)).filter((value) => value !== undefined)
+  );
+  if (families.size > 1) {
+    throw new Error('auth patch cannot combine fields from different authentication modes');
+  }
+}
+
+/**
+ * Runtime validation for the public REST/socket boundary. TypeScript types do
+ * not close JSON objects, so without this check a misspelled secret field can
+ * be persisted and later published without participating in redaction.
+ */
+export interface MCPAuthValidationOptions {
+  /** Require a complete, closed auth object and reject clear/sentinel values. */
+  create?: boolean;
+  /** Public CREATE only: require credentials needed to use bearer/JWT immediately. */
+  requireConfiguredCredentials?: boolean;
+}
+
+function validateMCPAuthPatch(value: unknown, options: MCPAuthValidationOptions = {}): void {
+  // Explicit auth:null means "no authentication" on CREATE and "clear the
+  // whole auth object" on PATCH/PUT. It is distinct from omission.
+  if (value === null) return;
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('auth must be an object');
+  }
+  const auth = value as Record<string, unknown>;
+  for (const key of Object.keys(auth)) {
+    if (!AUTH_FIELDS.has(key as keyof MCPAuth)) throw new Error(`Unknown auth field: ${key}`);
+  }
+  if (options.create && !['none', 'bearer', 'jwt', 'oauth'].includes(String(auth.type))) {
+    throw new Error('auth.type must be one of none, bearer, jwt, or oauth');
+  }
+  if (auth.type !== undefined && !['none', 'bearer', 'jwt', 'oauth'].includes(String(auth.type))) {
+    throw new Error('auth.type must be one of none, bearer, jwt, or oauth');
+  }
+  assertAuthFieldFamilies(auth);
+  for (const [key, raw] of Object.entries(auth)) {
+    if (raw === undefined) continue;
+    if (raw === null) {
+      if (options.create) throw new Error(`auth.${key} cannot be null on create`);
+      continue;
+    }
+    if (STRING_AUTH_FIELDS.has(key as keyof MCPAuth) && typeof raw !== 'string') {
+      throw new Error(`auth.${key} must be a string${options.create ? '' : ' or null'}`);
+    }
+    if (typeof raw === 'string') {
+      if (raw.length > MAX_AUTH_VALUE_LENGTH || hasControlCharacter(raw)) {
+        throw new Error(`auth.${key} is too long or contains control characters`);
+      }
+      if (hasTemplateMarker(raw) && !containsTemplate(raw)) {
+        throw new Error(`auth.${key} contains an unbalanced template delimiter`);
+      }
+      if (URL_AUTH_FIELDS.has(key as keyof MCPAuth)) {
+        if (raw.includes('{{') || raw.includes('}}')) {
+          if (isValidMCPHttpUrlTemplate(raw)) continue;
+          throw new Error(`auth.${key} must be an HTTP(S) URL using only user.env templates`);
+        }
+        let parsed: URL;
+        try {
+          parsed = new URL(raw);
+        } catch {
+          throw new Error(`auth.${key} must be a valid HTTP(S) URL`);
+        }
+        if (!['http:', 'https:'].includes(parsed.protocol) || parsed.username || parsed.password) {
+          throw new Error(`auth.${key} must be an HTTP(S) URL without embedded credentials`);
+        }
+      }
+    }
+    if (
+      options.create &&
+      secretFields.has(key as keyof MCPAuth) &&
+      typeof raw === 'string' &&
+      raw.trim() === MCP_HEADER_REDACTED_SENTINEL
+    ) {
+      throw new Error(`auth.${key} cannot use the redaction sentinel on create`);
+    }
+  }
+  if (
+    auth.oauth_token_expires_at !== undefined &&
+    auth.oauth_token_expires_at !== null &&
+    (!Number.isSafeInteger(auth.oauth_token_expires_at) || Number(auth.oauth_token_expires_at) < 0)
+  ) {
+    throw new Error('auth.oauth_token_expires_at must be a non-negative safe integer or null');
+  }
+  if (auth.insecure !== undefined && auth.insecure !== null && typeof auth.insecure !== 'boolean') {
+    throw new Error('auth.insecure must be boolean or null');
+  }
+  if (
+    auth.oauth_mode !== undefined &&
+    auth.oauth_mode !== null &&
+    !['per_user', 'shared'].includes(String(auth.oauth_mode))
+  ) {
+    throw new Error('auth.oauth_mode must be per_user, shared, or null');
+  }
+  if (
+    auth.oauth_compatibility_mode !== undefined &&
+    auth.oauth_compatibility_mode !== null &&
+    !['strict', 'legacy'].includes(String(auth.oauth_compatibility_mode))
+  ) {
+    throw new Error(
+      'auth.oauth_compatibility_mode must be either strict or legacy (or null on patch)'
+    );
+  }
+  if (
+    auth.oauth_dcr_mode !== undefined &&
+    auth.oauth_dcr_mode !== null &&
+    !['disabled', 'advertised', 'fallback'].includes(String(auth.oauth_dcr_mode))
+  ) {
+    throw new Error('auth.oauth_dcr_mode must be disabled, advertised, fallback, or null');
+  }
+  if (
+    auth.oauth_grant_type !== undefined &&
+    auth.oauth_grant_type !== null &&
+    !['client_credentials', 'authorization_code'].includes(String(auth.oauth_grant_type))
+  ) {
+    throw new Error(
+      'auth.oauth_grant_type must be client_credentials, authorization_code, or null'
+    );
+  }
+  if (
+    options.requireConfiguredCredentials &&
+    auth.type === 'bearer' &&
+    !nonEmptyString(auth.token)
+  ) {
+    throw new Error("auth.token is required when auth.type is 'bearer'");
+  }
+  if (options.requireConfiguredCredentials && auth.type === 'jwt') {
+    for (const field of ['api_url', 'api_token', 'api_secret'] as const) {
+      if (!nonEmptyString(auth[field])) {
+        throw new Error(`auth.${field} is required when auth.type is 'jwt'`);
+      }
+    }
+  }
+}
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+export function assertValidMCPAuthPatch(
+  value: unknown,
+  options: MCPAuthValidationOptions = {}
+): void {
+  try {
+    validateMCPAuthPatch(value, options);
+  } catch (error) {
+    if (error instanceof MCPAuthValidationError) throw error;
+    throw new MCPAuthValidationError(error instanceof Error ? error.message : 'Invalid MCP auth');
+  }
+}
+
+/**
+ * PUT replacement semantics with secret-safe readback round-tripping.
+ * Non-secret omissions are replaced; a redacted secret sentinel restores only
+ * the corresponding value from the current row when the auth type is unchanged.
+ */
+export function replaceMCPAuth(
+  current: MCPAuth | undefined,
+  replacement: MCPAuthPatch | null | undefined
+): MCPAuth | undefined {
+  if (replacement === null || replacement === undefined) return undefined;
+  assertValidMCPAuthPatch(replacement);
+  if (!replacement.type) {
+    throw new MCPAuthValidationError('auth.type is required when replacing authentication');
+  }
+  const next = definedAuthPatch(replacement) as MCPAuth;
+  for (const field of MCP_AUTH_SECRET_FIELDS) {
+    if (next[field] !== MCP_HEADER_REDACTED_SENTINEL) continue;
+    const stored = current?.type === next.type ? current[field] : undefined;
+    if (stored === undefined) {
+      delete (next as unknown as Record<string, unknown>)[field];
+    } else {
+      (next as unknown as Record<string, unknown>)[field] = stored;
+    }
+  }
+  if (
+    current?.type === 'oauth' &&
+    next.type === 'oauth' &&
+    (next.oauth_mode ?? 'per_user') !== (current.oauth_mode ?? 'per_user')
+  ) {
+    delete next.oauth_access_token;
+    delete next.oauth_refresh_token;
+    delete next.oauth_token_expires_at;
+  }
+  assertPublicMCPOAuthCompatibilityMode(next);
+  return next;
+}
+
+function definedAuthPatch(patch: MCPAuthPatch): Partial<MCPAuth> {
+  const next: Partial<MCPAuth> = {};
+  for (const [rawField, value] of Object.entries(patch)) {
+    const field = rawField as keyof MCPAuth;
+    if (value === undefined || value === null) continue;
+    (next as Record<string, unknown>)[field] = value;
+  }
+  return next;
+}
+
+/** Apply one auth patch without ever treating a redaction sentinel as data. */
+export function mergeMCPAuth(
+  current: MCPAuth | undefined,
+  patch: MCPAuthPatch | null | undefined
+): MCPAuth | undefined {
+  if (patch === undefined) return current;
+  if (patch === null) return undefined;
+  assertValidMCPAuthPatch(patch);
+
+  const requestedType = patch.type;
+  const changesType = requestedType !== undefined && requestedType !== current?.type;
+  if (!current || changesType) {
+    if (!requestedType) {
+      throw new MCPAuthValidationError('auth.type is required when configuring authentication');
+    }
+    const replacement = definedAuthPatch(patch) as MCPAuth;
+    // A sentinel can only refer to a value from the same stored auth mode. On
+    // create/type-switch there is nothing authorized to restore, so drop it.
+    for (const field of MCP_AUTH_SECRET_FIELDS) {
+      if (replacement[field] === MCP_HEADER_REDACTED_SENTINEL) {
+        delete (replacement as unknown as Record<string, unknown>)[field];
+      }
+    }
+    assertPublicMCPOAuthCompatibilityMode(replacement);
+    return replacement;
+  }
+
+  const merged: MCPAuth = { ...current };
+  for (const [rawField, value] of Object.entries(patch)) {
+    const field = rawField as keyof MCPAuth;
+    if (value === undefined) continue;
+    if (value === null) {
+      delete (merged as unknown as Record<string, unknown>)[field];
+      continue;
+    }
+    if (secretFields.has(field) && value === MCP_HEADER_REDACTED_SENTINEL) continue;
+    (merged as unknown as Record<string, unknown>)[field] = value;
+  }
+  if (
+    current.type === 'oauth' &&
+    'oauth_mode' in patch &&
+    (patch.oauth_mode ?? 'per_user') !== (current.oauth_mode ?? 'per_user')
+  ) {
+    // Shared tokens and per-user grants have incompatible authority. Never let
+    // a mode flip accidentally retain a static bearer from the previous mode.
+    delete merged.oauth_access_token;
+    delete merged.oauth_refresh_token;
+    delete merged.oauth_token_expires_at;
+  }
+  // A type-less PATCH is checked again after merging with the stored mode so
+  // `{ token: ... }` cannot append a bearer field to an OAuth object.
+  assertValidMCPAuthPatch(merged, { create: true });
+  assertPublicMCPOAuthCompatibilityMode(merged);
+  return merged;
+}

--- a/packages/core/src/tools/mcp/external-error.test.ts
+++ b/packages/core/src/tools/mcp/external-error.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  asMCPExternalError,
+  isMCPAbortError,
+  MCPExternalError,
+  sanitizeMCPExternalError,
+} from './external-error';
+
+describe('MCP external error boundary', () => {
+  it.each([
+    new TypeError('DNS failed for https://SENTINEL-DNS.example/private'),
+    Object.assign(new Error('TLS certificate reflected SENTINEL-TLS'), { code: 'ENOTFOUND' }),
+    { message: 'provider said SENTINEL-PROVIDER', code: 'ATTACKER_SECRET_CODE' },
+    'SENTINEL-STRING-THROW',
+  ])('returns and throws only the closed contract for %#', (failure) => {
+    const safe = sanitizeMCPExternalError(failure, { stage: 'discovery' });
+    const thrown = asMCPExternalError(failure, { stage: 'discovery' });
+    const serialized = JSON.stringify({ safe, thrown: String(thrown), stack: thrown.stack });
+
+    expect(serialized).not.toContain('SENTINEL');
+    expect(safe.diagnostic.event).toBe('mcp_external_failure');
+    expect(safe.diagnostic.stage).toBe('discovery');
+    expect(['Error', 'TypeError', 'UnknownError']).toContain(safe.diagnostic.type);
+    expect(thrown.message).toBe(safe.message);
+  });
+
+  it('allowlists stable network codes without retaining arbitrary codes', () => {
+    const allowed = sanitizeMCPExternalError(
+      Object.assign(new Error('SENTINEL'), { code: 'ECONNREFUSED' }),
+      { stage: 'jwt' }
+    );
+    const rejected = sanitizeMCPExternalError(
+      Object.assign(new Error('SENTINEL'), { code: 'SENTINEL_CODE' }),
+      { stage: 'jwt' }
+    );
+
+    expect(allowed.diagnostic.code).toBe('ECONNREFUSED');
+    expect(rejected.diagnostic.code).toBeUndefined();
+    expect(JSON.stringify({ allowed, rejected })).not.toContain('SENTINEL');
+  });
+
+  it('fails closed when hostile code and name getters throw', () => {
+    const failure = new Error('SENTINEL_HOSTILE_ERROR');
+    const codeGetter = vi.fn(() => {
+      throw new Error('SENTINEL_CODE_GETTER');
+    });
+    const nameGetter = vi.fn(() => {
+      throw new Error('SENTINEL_NAME_GETTER');
+    });
+    Object.defineProperties(failure, {
+      code: { get: codeGetter },
+      name: { get: nameGetter },
+    });
+
+    const safe = sanitizeMCPExternalError(failure, { stage: 'runtime' });
+    expect(safe).toMatchObject({
+      category: 'unknown',
+      action: 'retry',
+      diagnostic: { type: 'Error' },
+    });
+    expect(JSON.stringify(safe)).not.toContain('SENTINEL');
+    expect(codeGetter).not.toHaveBeenCalled();
+    expect(nameGetter).not.toHaveBeenCalled();
+  });
+
+  it('recognizes genuine platform and SDK abort errors without trusting hostile getters', () => {
+    const domAbort = new DOMException('SENTINEL_DOM_ABORT', 'AbortError');
+    const sdkAbort = Object.assign(new Error('SENTINEL_SDK_ABORT'), { name: 'AbortError' });
+    const codeAbort = Object.assign(new Error('SENTINEL_CODE_ABORT'), { code: 'ABORT_ERR' });
+    const hostileGetter = vi.fn(() => {
+      throw new Error('SENTINEL_HOSTILE_ABORT_GETTER');
+    });
+    const hostile = new Proxy(new Error('SENTINEL_HOSTILE_ABORT'), {
+      getOwnPropertyDescriptor(target, property) {
+        if (property === 'name' || property === 'code') {
+          return { configurable: true, get: hostileGetter };
+        }
+        return Reflect.getOwnPropertyDescriptor(target, property);
+      },
+    });
+
+    expect(isMCPAbortError(domAbort)).toBe(true);
+    expect(isMCPAbortError(sdkAbort)).toBe(true);
+    expect(isMCPAbortError(codeAbort)).toBe(true);
+    expect(isMCPAbortError(hostile)).toBe(false);
+    expect(hostileGetter).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['provider_rejected', 'reauthenticate'],
+    ['invalid_response', 'retry'],
+    ['configuration_required', 'review_configuration'],
+  ] as const)('preserves the closed %s category/action pair', (category, action) => {
+    const typed = asMCPExternalError(undefined, { stage: 'jwt', category });
+    expect(sanitizeMCPExternalError(typed, { stage: 'oauth' })).toMatchObject({
+      category,
+      action,
+      diagnostic: { stage: 'oauth' },
+    });
+  });
+
+  it('re-closes forged typed errors instead of trusting their public prose or metadata', () => {
+    const forged = new MCPExternalError({
+      category: 'provider_unavailable',
+      action: 'retry',
+      message: 'SENTINEL_FORGED_MESSAGE',
+      diagnostic: {
+        event: 'mcp_external_failure',
+        stage: 'jwt',
+        type: 'Error',
+        code: 'SENTINEL_FORGED_CODE',
+      },
+    });
+    const safe = sanitizeMCPExternalError(forged, { stage: 'oauth_callback' });
+
+    expect(JSON.stringify({ forged: String(forged), safe })).not.toContain('SENTINEL');
+    expect(safe).toMatchObject({
+      category: 'provider_unavailable',
+      action: 'retry',
+      diagnostic: { stage: 'oauth_callback', type: 'Error' },
+    });
+    expect(safe.diagnostic.code).toBeUndefined();
+  });
+
+  it('does not trust a Proxy wrapped around a nominal external error', () => {
+    const sentinel = 'SENTINEL_EXTERNAL_PROXY';
+    const getter = vi.fn(() => {
+      throw new Error(sentinel);
+    });
+    const getPrototypeOf = vi.fn(() => {
+      throw new Error(sentinel);
+    });
+    const typed = asMCPExternalError(new Error(sentinel), {
+      stage: 'oauth',
+      category: 'provider_rejected',
+    });
+    const hostile = new Proxy(typed, {
+      getPrototypeOf,
+      getOwnPropertyDescriptor(target, property) {
+        if (property === 'name' || property === 'code' || property === 'category') {
+          return { configurable: true, get: getter };
+        }
+        return Reflect.getOwnPropertyDescriptor(target, property);
+      },
+    });
+
+    const safe = sanitizeMCPExternalError(hostile, { stage: 'oauth' });
+    expect(safe).toMatchObject({ category: 'unknown', action: 'retry' });
+    expect(JSON.stringify(safe)).not.toContain(sentinel);
+    expect(getter).not.toHaveBeenCalled();
+    expect(getPrototypeOf).toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/tools/mcp/external-error.ts
+++ b/packages/core/src/tools/mcp/external-error.ts
@@ -1,0 +1,266 @@
+/**
+ * Closed, value-free classification for failures originating outside Agor's
+ * MCP trust boundary. Provider and library exceptions are untrusted input:
+ * DNS clients, TLS stacks, redirect handlers, and SDKs routinely include the
+ * requested URL or reflected response text in `message`.
+ */
+
+export const MCP_EXTERNAL_ERROR_STAGES = [
+  'jwt',
+  'oauth',
+  'oauth_metadata',
+  'oauth_callback',
+  'discovery',
+  'runtime',
+] as const;
+
+export type MCPExternalErrorStage = (typeof MCP_EXTERNAL_ERROR_STAGES)[number];
+export type MCPExternalErrorCategory =
+  | 'provider_unavailable'
+  | 'provider_rejected'
+  | 'invalid_response'
+  | 'configuration_required'
+  | 'unknown';
+export type MCPExternalErrorAction = 'retry' | 'reauthenticate' | 'review_configuration';
+export type MCPExternalErrorType = 'Error' | 'TypeError' | 'AbortError' | 'UnknownError';
+
+const ALLOWED_EXTERNAL_CODES = new Set([
+  'ABORT_ERR',
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'ENOTFOUND',
+  'ETIMEDOUT',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_HEADERS_TIMEOUT',
+  'UND_ERR_RESPONSE_STATUS_CODE',
+]);
+
+export interface SanitizedMCPExternalError {
+  category: MCPExternalErrorCategory;
+  action: MCPExternalErrorAction;
+  /** Fixed prose. It never incorporates exception, endpoint, or provider text. */
+  message: string;
+  /** Closed metadata safe for ordinary operational logs. */
+  diagnostic: {
+    event: 'mcp_external_failure';
+    stage: MCPExternalErrorStage;
+    type: MCPExternalErrorType;
+    code?: string;
+  };
+}
+
+// Nominal identity for errors created by this module. Unlike `instanceof`, a
+// WeakSet lookup does not execute a hostile Proxy's getPrototypeOf trap.
+const trustedMCPExternalErrors = new WeakSet<object>();
+
+export class MCPExternalError extends Error {
+  readonly category: MCPExternalErrorCategory;
+  readonly action: MCPExternalErrorAction;
+  readonly diagnostic: SanitizedMCPExternalError['diagnostic'];
+
+  constructor(sanitized: SanitizedMCPExternalError) {
+    const category = safeCategory(sanitized.category);
+    const contract = fixedContract(category);
+    super(contract.message);
+    this.name = 'MCPExternalError';
+    this.category = category;
+    this.action = contract.action;
+    this.diagnostic = {
+      event: 'mcp_external_failure',
+      stage: safeStage(sanitized.diagnostic?.stage),
+      type: safeDiagnosticType(sanitized.diagnostic?.type),
+      ...(safeAllowedCode(sanitized.diagnostic?.code)
+        ? { code: safeAllowedCode(sanitized.diagnostic?.code) }
+        : {}),
+    };
+    trustedMCPExternalErrors.add(this);
+  }
+}
+
+function safeCategory(category: unknown): MCPExternalErrorCategory {
+  return category === 'provider_unavailable' ||
+    category === 'provider_rejected' ||
+    category === 'invalid_response' ||
+    category === 'configuration_required' ||
+    category === 'unknown'
+    ? category
+    : 'unknown';
+}
+
+function safeStage(stage: unknown): MCPExternalErrorStage {
+  return typeof stage === 'string' &&
+    MCP_EXTERNAL_ERROR_STAGES.includes(stage as MCPExternalErrorStage)
+    ? (stage as MCPExternalErrorStage)
+    : 'runtime';
+}
+
+function safeDiagnosticType(type: unknown): MCPExternalErrorType {
+  return type === 'Error' ||
+    type === 'TypeError' ||
+    type === 'AbortError' ||
+    type === 'UnknownError'
+    ? type
+    : 'UnknownError';
+}
+
+function safeAllowedCode(code: unknown): string | undefined {
+  return typeof code === 'string' && ALLOWED_EXTERNAL_CODES.has(code) ? code : undefined;
+}
+
+function safeInstanceOf(
+  error: unknown,
+  errorClass: typeof Error | typeof TypeError | typeof DOMException
+): boolean {
+  try {
+    return error instanceof errorClass;
+  } catch {
+    return false;
+  }
+}
+
+function isTrustedDOMAbortError(error: unknown): boolean {
+  if (typeof DOMException !== 'function' || !safeInstanceOf(error, DOMException)) return false;
+  try {
+    // Invoke only the platform-owned DOMException accessor. Reading
+    // `error.name` directly could execute an attacker-controlled getter.
+    const descriptor = Object.getOwnPropertyDescriptor(DOMException.prototype, 'name');
+    return descriptor?.get?.call(error) === 'AbortError';
+  } catch {
+    return false;
+  }
+}
+
+function safeOwnDataValue(error: unknown, property: string): unknown {
+  if (!error || (typeof error !== 'object' && typeof error !== 'function')) return undefined;
+  try {
+    const descriptor = Object.getOwnPropertyDescriptor(error, property);
+    return descriptor && 'value' in descriptor ? descriptor.value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Abort recognition which never invokes an attacker-controlled `name` getter.
+ * SDKs commonly construct `Error` and assign an own data `name`, while web
+ * AbortErrors also expose the closed `ABORT_ERR` code.
+ */
+export function isMCPAbortError(error: unknown): boolean {
+  if (safeCode(error) === 'ABORT_ERR') return true;
+  if (safeOwnDataValue(error, 'name') === 'AbortError') return true;
+  return isTrustedDOMAbortError(error);
+}
+
+function safeType(error: unknown): MCPExternalErrorType {
+  if (isMCPAbortError(error)) return 'AbortError';
+  if (safeInstanceOf(error, TypeError)) return 'TypeError';
+  if (safeInstanceOf(error, Error)) return 'Error';
+  return 'UnknownError';
+}
+
+function safeCode(error: unknown): string | undefined {
+  return safeAllowedCode(safeOwnDataValue(error, 'code'));
+}
+
+function fixedContract(
+  category: MCPExternalErrorCategory
+): Pick<SanitizedMCPExternalError, 'action' | 'message'> {
+  switch (category) {
+    case 'provider_unavailable':
+      return {
+        action: 'retry',
+        message:
+          'The MCP or OAuth provider is temporarily unreachable. Check the saved configuration and retry.',
+      };
+    case 'provider_rejected':
+      return {
+        action: 'reauthenticate',
+        message:
+          'The provider rejected the MCP authentication request. Review the saved credentials or sign in again.',
+      };
+    case 'invalid_response':
+      return {
+        action: 'retry',
+        message:
+          'The provider returned an invalid MCP authentication response. Retry, then review the provider configuration.',
+      };
+    case 'configuration_required':
+      return {
+        action: 'review_configuration',
+        message:
+          'This MCP authentication configuration is incomplete. Review the saved server settings and retry.',
+      };
+    default:
+      return {
+        action: 'retry',
+        message:
+          'The MCP operation failed. Retry, then ask an administrator to review the secure operational event if it continues.',
+      };
+  }
+}
+
+/**
+ * Classify untrusted external failures without consulting `message`, `stack`,
+ * `cause`, response bodies, URLs, or other attacker/provider-controlled data.
+ */
+export function sanitizeMCPExternalError(
+  error: unknown,
+  options: {
+    stage: MCPExternalErrorStage;
+    category?: MCPExternalErrorCategory;
+  }
+): SanitizedMCPExternalError {
+  if (
+    error !== null &&
+    (typeof error === 'object' || typeof error === 'function') &&
+    trustedMCPExternalErrors.has(error)
+  ) {
+    try {
+      const category = safeCategory(safeOwnDataValue(error, 'category'));
+      const contract = fixedContract(category);
+      const diagnostic = safeOwnDataValue(error, 'diagnostic');
+      const code = safeAllowedCode(safeOwnDataValue(diagnostic, 'code'));
+      return {
+        category,
+        ...contract,
+        diagnostic: {
+          event: 'mcp_external_failure',
+          stage: safeStage(options.stage),
+          type: safeDiagnosticType(safeOwnDataValue(diagnostic, 'type')),
+          ...(code ? { code } : {}),
+        },
+      };
+    } catch {
+      // Nominal instances use own data fields, but retain the generic fallback
+      // if memory corruption or a future implementation changes that contract.
+    }
+  }
+
+  const code = safeCode(error);
+  const type = safeType(error);
+  const category = safeCategory(
+    options.category ??
+      (code || type === 'TypeError' || type === 'AbortError' ? 'provider_unavailable' : 'unknown')
+  );
+  const contract = fixedContract(category);
+  return {
+    category,
+    ...contract,
+    diagnostic: {
+      event: 'mcp_external_failure',
+      stage: safeStage(options.stage),
+      type,
+      ...(code ? { code } : {}),
+    },
+  };
+}
+
+/** Turn an unknown provider/library exception into a safe throwable. */
+export function asMCPExternalError(
+  error: unknown,
+  options: Parameters<typeof sanitizeMCPExternalError>[1]
+): MCPExternalError {
+  return new MCPExternalError(sanitizeMCPExternalError(error, options));
+}

--- a/packages/core/src/tools/mcp/jwt-auth.test.ts
+++ b/packages/core/src/tools/mcp/jwt-auth.test.ts
@@ -1,6 +1,5 @@
 import http from 'node:http';
-import { afterEach, describe, expect, it } from 'vitest';
-import { UnsafeOutboundUrlError } from '../../utils/safe-outbound-fetch';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { clearAllJWTTokens, fetchJWTToken, resolveMCPAuthHeaders } from './jwt-auth';
 import { __seedAuthCodeTokenCacheForTests, clearAuthCodeTokenCache } from './oauth-mcp-transport';
 
@@ -56,6 +55,33 @@ describe('resolveMCPAuthHeaders OAuth authority', () => {
     ).resolves.toEqual({ Authorization: 'Bearer bound-token' });
   });
 
+  it('never logs an inferred or failed secret-bearing OAuth endpoint', async () => {
+    const sentinel = 'sentinel-oauth-endpoint-09e75';
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      await expect(
+        resolveMCPAuthHeaders(
+          {
+            type: 'oauth',
+            oauth_client_id: 'client',
+            oauth_client_secret: 'secret',
+          },
+          `https://${sentinel}.invalid/mcp`,
+          { disableProcessTokenCache: true }
+        )
+      ).resolves.toBeUndefined();
+
+      const logged = JSON.stringify([...log.mock.calls, ...warn.mock.calls]);
+      expect(logged).not.toContain(sentinel);
+      expect(log).toHaveBeenCalledWith('[OAuth] Token URL inferred from MCP endpoint');
+      expect(warn).toHaveBeenCalledWith('[OAuth] Token fetch failed');
+    } finally {
+      log.mockRestore();
+      warn.mockRestore();
+    }
+  });
+
   it('propagates authority loss during client-credential fetch instead of falling back', async () => {
     let signalRequest!: () => void;
     const requestStarted = new Promise<void>((resolve) => {
@@ -108,7 +134,7 @@ describe('JWT discovery authentication outbound policy', () => {
   ])('rejects loopback, private, metadata, and non-HTTPS destination %s', async (api_url) => {
     await expect(
       fetchJWTToken({ api_url, ...credentials }, { allowLocalhostHttp: false, cache: false })
-    ).rejects.toBeInstanceOf(UnsafeOutboundUrlError);
+    ).rejects.toThrow('The MCP operation failed');
   });
 
   it('allows the narrow loopback development exception only when explicit', async () => {
@@ -119,7 +145,7 @@ describe('JWT discovery authentication outbound policy', () => {
 
     await expect(
       fetchJWTToken({ api_url, ...credentials }, { allowLocalhostHttp: false, cache: false })
-    ).rejects.toBeInstanceOf(UnsafeOutboundUrlError);
+    ).rejects.toThrow('The MCP operation failed');
     await expect(
       fetchJWTToken({ api_url, ...credentials }, { allowLocalhostHttp: true, cache: false })
     ).resolves.toBe('development-token');
@@ -133,7 +159,7 @@ describe('JWT discovery authentication outbound policy', () => {
 
     await expect(
       fetchJWTToken({ api_url, ...credentials }, { allowLocalhostHttp: true, cache: false })
-    ).rejects.toThrow('redirect is not allowed');
+    ).rejects.toThrow('The MCP operation failed');
   });
 
   it('bounds provider responses before parsing', async () => {
@@ -144,7 +170,7 @@ describe('JWT discovery authentication outbound policy', () => {
 
     await expect(
       fetchJWTToken({ api_url, ...credentials }, { allowLocalhostHttp: true, cache: false })
-    ).rejects.toThrow('response is too large');
+    ).rejects.toThrow('The MCP operation failed');
   });
 
   it('does not expose a provider response body in errors', async () => {
@@ -158,7 +184,7 @@ describe('JWT discovery authentication outbound policy', () => {
       { allowLocalhostHttp: true, cache: false }
     ).catch((cause: unknown) => cause);
     expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toBe('JWT token fetch failed (provider_rejected, status=401)');
+    expect((error as Error).message).toContain('provider rejected');
     expect((error as Error).message).not.toContain('internal-response-secret');
     expect((error as Error).message).not.toContain('error_description');
   });

--- a/packages/core/src/tools/mcp/jwt-auth.ts
+++ b/packages/core/src/tools/mcp/jwt-auth.ts
@@ -8,6 +8,7 @@
 import { createHash } from 'node:crypto';
 import type { MCPAuth } from '../../types/mcp';
 import { type OutboundDnsLookup, safeOutboundFetch } from '../../utils/safe-outbound-fetch';
+import { asMCPExternalError } from './external-error';
 import { fetchOAuthToken, inferOAuthTokenUrl } from './oauth-auth';
 
 interface JWTConfig {
@@ -80,27 +81,35 @@ export async function fetchJWTToken(
   }
 
   // Fetch new token
-  const response = await safeOutboundFetch(api_url, {
-    method: 'POST',
-    redirect: 'error',
-    timeoutMs: 15_000,
-    maxResponseBytes: 256 * 1024,
-    allowLocalhostHttp: options.allowLocalhostHttp ?? true,
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({
-      name: api_token,
-      secret: api_secret,
-    }),
-    assertCurrent: options.assertCurrent,
-    resolveDns: options.resolveDns,
-  });
+  let response: Response;
+  try {
+    response = await safeOutboundFetch(api_url, {
+      method: 'POST',
+      redirect: 'error',
+      timeoutMs: 15_000,
+      maxResponseBytes: 256 * 1024,
+      allowLocalhostHttp: options.allowLocalhostHttp ?? true,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        name: api_token,
+        secret: api_secret,
+      }),
+      assertCurrent: options.assertCurrent,
+      resolveDns: options.resolveDns,
+    });
+  } catch (error) {
+    // Network/TLS libraries may reflect the endpoint or request values. Keep
+    // their exception entirely behind the closed MCP error boundary.
+    options.assertCurrent?.();
+    throw asMCPExternalError(error, { stage: 'jwt' });
+  }
 
   if (!response.ok) {
     // Provider bodies frequently contain secrets or reflected internal data.
     // Emit only a stable category and status.
-    throw new Error(`JWT token fetch failed (provider_rejected, status=${response.status})`);
+    throw asMCPExternalError(undefined, { stage: 'jwt', category: 'provider_rejected' });
   }
 
   let data: { access_token?: string; payload?: { access_token?: string } };
@@ -108,14 +117,14 @@ export async function fetchJWTToken(
     data = (await response.json()) as typeof data;
   } catch {
     options.assertCurrent?.();
-    throw new Error('JWT token fetch failed (invalid_response)');
+    throw asMCPExternalError(undefined, { stage: 'jwt', category: 'invalid_response' });
   }
   options.assertCurrent?.();
 
   // Handle different response formats
   const token = data.access_token || data.payload?.access_token;
   if (!token) {
-    throw new Error('JWT response missing access_token field');
+    throw asMCPExternalError(undefined, { stage: 'jwt', category: 'invalid_response' });
   }
 
   // Cache the token
@@ -262,7 +271,9 @@ export async function resolveMCPAuthHeaders(
     let tokenUrl = auth.oauth_token_url;
     if (!tokenUrl && mcpUrl) {
       tokenUrl = inferOAuthTokenUrl(mcpUrl);
-      console.log(`[OAuth] Auto-detected token URL: ${tokenUrl}`);
+      // The inferred endpoint can retain user-derived origin/path material.
+      // Its presence is operationally useful; its value is not safe to log.
+      console.log('[OAuth] Token URL inferred from MCP endpoint');
     }
 
     if (!tokenUrl) {
@@ -289,11 +300,13 @@ export async function resolveMCPAuthHeaders(
       return {
         Authorization: `Bearer ${token}`,
       };
-    } catch (error) {
+    } catch {
       // Never downgrade identity/authority loss into an unauthenticated MCP
       // fallback after client credentials crossed the provider boundary.
       options.assertCurrent?.();
-      console.warn('[OAuth] Token fetch failed:', error instanceof Error ? error.message : error);
+      // Provider/network exceptions may include the endpoint, redirected URL,
+      // response body, or reflected credentials. Keep this diagnostic fixed.
+      console.warn('[OAuth] Token fetch failed');
       return undefined;
     }
   }

--- a/packages/core/src/tools/mcp/oauth-auth.test.ts
+++ b/packages/core/src/tools/mcp/oauth-auth.test.ts
@@ -13,7 +13,7 @@ describe('OAuth client-credentials egress and cache isolation', () => {
         client_id: 'client',
         client_secret: 'secret',
       })
-    ).rejects.toThrow('OAuth endpoints require HTTPS');
+    ).rejects.toThrow('The MCP operation failed');
   });
 
   it('namespaces cached bearers and allows PostgreSQL callers to bypass the cache', async () => {
@@ -80,7 +80,7 @@ describe('OAuth client-credentials egress and cache isolation', () => {
         cache: false,
       }).catch((caught: unknown) => caught);
       expect(String(error)).not.toContain(marker);
-      expect(String(error)).toContain('OAuth token fetch failed (400');
+      expect(String(error)).toContain('provider rejected');
     } finally {
       await new Promise<void>((resolve, reject) =>
         server.close((closeError) => (closeError ? reject(closeError) : resolve()))

--- a/packages/core/src/tools/mcp/oauth-auth.ts
+++ b/packages/core/src/tools/mcp/oauth-auth.ts
@@ -67,6 +67,7 @@ export interface OAuthDebugInfo {
 
 import { createHash } from 'node:crypto';
 import { safeOutboundFetch } from '../../utils/safe-outbound-fetch';
+import { asMCPExternalError, sanitizeMCPExternalError } from './external-error';
 import { resolveTokenExpiry } from './oauth-token-expiry';
 
 // Cache tokens per unique credential set to avoid cross-tenant leakage
@@ -104,24 +105,15 @@ function getCacheKey(config: OAuthConfig): string {
 }
 
 /**
- * Mask sensitive credential for logging
- */
-function maskCredential(credential?: string): string {
-  if (!credential) return '<not-provided>';
-  if (credential.length <= 8) return '***';
-  return `${credential.substring(0, 4)}...${credential.substring(credential.length - 4)}`;
-}
-
-/**
  * Sanitize OAuth config for logging (mask secrets)
  */
 function sanitizeConfigForLogging(config: OAuthConfig): Record<string, unknown> {
   return {
-    token_url: config.token_url,
-    client_id: maskCredential(config.client_id),
-    client_secret: maskCredential(config.client_secret),
-    scope: config.scope || '<none>',
-    grant_type: config.grant_type || 'client_credentials',
+    has_token_url: Boolean(config.token_url),
+    has_client_id: Boolean(config.client_id),
+    has_client_secret: Boolean(config.client_secret),
+    has_scope: Boolean(config.scope),
+    grant_type: config.grant_type === 'client_credentials' ? 'client_credentials' : 'configured',
     insecure: config.insecure || false,
   };
 }
@@ -206,13 +198,13 @@ export async function fetchOAuthToken(
         token: cached.token,
         debugInfo: {
           steps: debugSteps,
-          tokenUrl: config.token_url,
+          tokenUrl: '<configured>',
           tokenUrlSource: 'provided',
           credentialsSource: 'explicit',
-          clientIdMasked: maskCredential(config.client_id),
-          scope: config.scope,
+          clientIdMasked: '<configured>',
+          scope: config.scope ? '<configured>' : undefined,
           grantType: config.grant_type || 'client_credentials',
-          cacheKey: maskCredential(cacheKey),
+          cacheKey: '<opaque>',
           cacheHit: true,
           tokenFetchedAt: new Date(cached.fetchedAt),
           tokenExpiresAt: new Date(cached.expiresAt),
@@ -243,16 +235,16 @@ export async function fetchOAuthToken(
     body.append('scope', config.scope);
   }
 
-  addDebugStep('prepare_request', 'info', `Preparing OAuth request to ${config.token_url}`, {
+  addDebugStep('prepare_request', 'info', 'Preparing OAuth token request', {
     grant_type: grantType,
-    scope: config.scope || '<none>',
+    has_scope: Boolean(config.scope),
     content_type: 'application/x-www-form-urlencoded',
   });
 
   // Step 4: Fetch token
   let response: Response;
   try {
-    addDebugStep('fetch_token', 'info', `Sending POST request to ${config.token_url}`);
+    addDebugStep('fetch_token', 'info', 'Sending OAuth token request');
 
     response = await safeOutboundFetch(config.token_url, {
       method: 'POST',
@@ -269,43 +261,27 @@ export async function fetchOAuthToken(
 
     addDebugStep('fetch_token', 'info', `Received response with status ${response.status}`, {
       status: response.status,
-      statusText: response.statusText,
-      headers: {
-        'content-type': response.headers.get('content-type'),
-      },
     });
   } catch (error: unknown) {
     // Preserve caller authority errors rather than wrapping them as a generic
     // provider failure that an outer compatibility layer may swallow.
     config.assertCurrent?.();
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    addDebugStep('fetch_token', 'error', `Network error: ${errorMessage}`, {
-      error: errorMessage,
-      tokenUrl: config.token_url,
-    });
-    throw new Error(`OAuth token fetch failed - Network error: ${errorMessage}`);
+    const safe = sanitizeMCPExternalError(error, { stage: 'oauth' });
+    addDebugStep('fetch_token', 'error', safe.message, safe.diagnostic);
+    throw asMCPExternalError(error, { stage: 'oauth' });
   }
 
   // Step 5: Handle response
   if (!response.ok) {
     addDebugStep('handle_response', 'error', `Token fetch failed with status ${response.status}`, {
       status: response.status,
-      statusText: response.statusText,
     });
 
     // Provide helpful error messages
-    let errorMessage = `OAuth token fetch failed (${response.status} ${response.statusText})`;
-
-    if (response.status === 401) {
-      errorMessage +=
-        ' - Invalid client credentials. Check OAUTH_CLIENT_ID and OAUTH_CLIENT_SECRET.';
-    } else if (response.status === 400) {
-      errorMessage += ' - Bad request. Check grant_type, scope, or other parameters.';
-    } else if (response.status === 403) {
-      errorMessage += ' - Access forbidden. Client may not have permission for requested scope.';
-    }
-
-    throw new Error(errorMessage);
+    throw asMCPExternalError(undefined, {
+      stage: 'oauth',
+      category: 'provider_rejected',
+    });
   }
 
   // Step 6: Parse response
@@ -314,23 +290,22 @@ export async function fetchOAuthToken(
     data = (await response.json()) as OAuthTokenResponse;
     config.assertCurrent?.();
     addDebugStep('parse_response', 'success', 'Successfully parsed OAuth response', {
-      token_type: data.token_type,
       expires_in: data.expires_in,
       has_refresh_token: !!data.refresh_token,
-      scope: data.scope,
     });
   } catch (error: unknown) {
     config.assertCurrent?.();
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    addDebugStep('parse_response', 'error', `Failed to parse JSON response: ${errorMessage}`);
-    throw new Error(`OAuth response is not valid JSON: ${errorMessage}`);
+    const safe = sanitizeMCPExternalError(error, {
+      stage: 'oauth',
+      category: 'invalid_response',
+    });
+    addDebugStep('parse_response', 'error', safe.message, safe.diagnostic);
+    throw asMCPExternalError(error, { stage: 'oauth', category: 'invalid_response' });
   }
 
   if (!data.access_token) {
-    addDebugStep('parse_response', 'error', 'Response missing access_token field', {
-      response: data,
-    });
-    throw new Error('OAuth response missing access_token field');
+    addDebugStep('parse_response', 'error', 'OAuth response did not contain a usable token');
+    throw asMCPExternalError(undefined, { stage: 'oauth', category: 'invalid_response' });
   }
 
   // Step 7: Cache token. Walk the shared cascade so this client-credentials
@@ -372,14 +347,14 @@ export async function fetchOAuthToken(
       token: data.access_token,
       debugInfo: {
         steps: debugSteps,
-        tokenUrl: config.token_url,
+        tokenUrl: '<configured>',
         tokenUrlSource: 'provided',
         credentialsSource: config.client_id?.includes('{{') ? 'env_vars' : 'explicit',
-        clientIdMasked: maskCredential(config.client_id),
-        scope: config.scope,
+        clientIdMasked: '<configured>',
+        scope: config.scope ? '<configured>' : undefined,
         grantType: grantType,
         tokenExpiresIn: expiresInSeconds,
-        cacheKey: maskCredential(cacheKey),
+        cacheKey: '<opaque>',
         cacheHit: false,
         tokenFetchedAt: new Date(fetchedAt),
         tokenExpiresAt: new Date(expiresAt),

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.test.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.test.ts
@@ -7,6 +7,7 @@
  * - resolveResourceMetadataUrl(): header parse + .well-known fallback
  */
 
+import { request as httpRequest } from 'node:http';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MCPOAuthDCRDiagnostic } from '../../types/mcp.js';
 
@@ -45,6 +46,7 @@ import {
   OAuthCallbackValidationError,
   OAuthCodeExchangeError,
   parseOAuthCallback,
+  performMCPOAuthFlow,
   resolveMCPOAuthDiscovery,
   resolveResourceMetadataUrl,
   startMCPOAuthFlow,
@@ -59,6 +61,104 @@ async function rejectedError<T extends Error>(promise: Promise<unknown>): Promis
   }
   throw new Error('Expected OAuth flow to reject');
 }
+
+describe('loopback OAuth callback response', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    { validState: false, expectedHeading: 'Invalid Callback' },
+    { validState: true, expectedHeading: 'Authentication Failed' },
+  ])(
+    'validates state before provider errors (valid state: $validState) and never reflects error query HTML or secrets',
+    async ({ validState, expectedHeading }) => {
+      const sentinel = 'SENTINEL_LOOPBACK_CALLBACK_XSS_92f1';
+      const issuer = 'http://127.0.0.1:45555';
+      const metadataUrl = 'http://127.0.0.1:45554/.well-known/oauth-protected-resource';
+      globalThis.fetch = vi.fn(async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url === metadataUrl) {
+          return new Response(
+            JSON.stringify({
+              resource: 'http://127.0.0.1:45554/mcp',
+              authorization_servers: [issuer],
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } }
+          );
+        }
+        if (url.startsWith(`${issuer}/.well-known/`)) {
+          return new Response(
+            JSON.stringify({
+              issuer,
+              authorization_endpoint: `${issuer}/authorize`,
+              token_endpoint: `${issuer}/token`,
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } }
+          );
+        }
+        throw new Error('unexpected test URL');
+      }) as unknown as typeof fetch;
+
+      let callbackResponse:
+        | {
+            status: number | undefined;
+            headers: Record<string, string | string[] | undefined>;
+            body: string;
+          }
+        | undefined;
+      const flow = performMCPOAuthFlow(
+        `Bearer resource_metadata="${metadataUrl}"`,
+        'client-id',
+        async (authorizationUrl) => {
+          const auth = new URL(authorizationUrl);
+          const callback = new URL(auth.searchParams.get('redirect_uri')!);
+          callback.searchParams.set(
+            'state',
+            validState ? auth.searchParams.get('state')! : 'wrong-state'
+          );
+          callback.searchParams.set('error', `<script>${sentinel}</script>`);
+
+          callbackResponse = await new Promise<NonNullable<typeof callbackResponse>>(
+            (resolve, reject) => {
+              const request = httpRequest(callback, (response) => {
+                const chunks: Buffer[] = [];
+                response.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+                response.on('end', () =>
+                  resolve({
+                    status: response.statusCode,
+                    headers: response.headers,
+                    body: Buffer.concat(chunks).toString('utf8'),
+                  })
+                );
+              });
+              request.on('error', reject);
+              request.end();
+            }
+          );
+        }
+      );
+
+      const failure = await rejectedError(flow);
+      expect(failure.message).toBe(
+        validState ? 'No authorization code received' : 'State mismatch - possible CSRF attack'
+      );
+      expect(callbackResponse?.status).toBe(400);
+      expect(callbackResponse?.headers['content-type']).toBe('text/html; charset=utf-8');
+      expect(callbackResponse?.headers['content-security-policy']).toContain("default-src 'none'");
+      expect(callbackResponse?.headers['x-content-type-options']).toBe('nosniff');
+      expect(callbackResponse?.headers['cache-control']).toBe('no-store');
+      expect(callbackResponse?.body).toContain(expectedHeading);
+      expect(JSON.stringify({ callbackResponse, failure: String(failure) })).not.toContain(
+        sentinel
+      );
+      expect(callbackResponse?.body).not.toContain('<script>');
+    }
+  );
+});
 
 // ---------------------------------------------------------------------------
 // completeMCPOAuthFlow — token exchange request contract

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.ts
@@ -15,6 +15,7 @@ import type {
   MCPOAuthRuntimeCompatibilityMode,
 } from '../../types/mcp.js';
 import { assertSafeOAuthUrl, safeOutboundFetch } from '../../utils/safe-outbound-fetch';
+import { asMCPExternalError } from './external-error.js';
 import type { OAuthTokenResponse } from './oauth-auth.js';
 import { resolveTokenExpiry } from './oauth-token-expiry.js';
 
@@ -130,6 +131,23 @@ export class OAuthDCRFailure extends Error {
   ) {
     super(message);
     this.name = 'OAuthDCRFailure';
+  }
+}
+
+/** Stable classification for OAuth discovery/configuration policy failures. */
+export class OAuthConfigurationError extends Error {
+  constructor(
+    readonly failureCode:
+      | 'metadata_unavailable'
+      | 'metadata_incompatible'
+      | 'endpoint_override_mismatch'
+      | 'issuer_mismatch'
+      | 'pkce_required'
+      | 'client_registration_required',
+    message = `OAuth configuration failed (${failureCode})`
+  ) {
+    super(message);
+    this.name = 'OAuthConfigurationError';
   }
 }
 
@@ -456,17 +474,27 @@ async function fetchResourceMetadata(
     });
   } catch (error) {
     options.assertCurrent?.();
-    throw error;
+    throw asMCPExternalError(error, { stage: 'oauth_metadata' });
   }
   options.assertCurrent?.();
   if (!response.ok) {
-    throw new Error(
-      `Failed to fetch OAuth resource metadata from ${metadataUrl} (${response.status}). ` +
-        `The MCP server advertised OAuth support but the metadata endpoint is not available. ` +
+    throw new OAuthConfigurationError(
+      'metadata_unavailable',
+      `The OAuth resource metadata endpoint returned status ${response.status}. ` +
+        `The MCP server advertised OAuth support but its metadata is not available. ` +
         `This indicates an incomplete OAuth implementation on the server side.`
     );
   }
-  const metadata = (await response.json()) as OAuthMetadata;
+  let metadata: OAuthMetadata;
+  try {
+    metadata = (await response.json()) as OAuthMetadata;
+  } catch (error) {
+    options.assertCurrent?.();
+    throw asMCPExternalError(error, {
+      stage: 'oauth_metadata',
+      category: 'invalid_response',
+    });
+  }
   options.assertCurrent?.();
   return metadata;
 }
@@ -835,7 +863,8 @@ export async function fetchAuthorizationServerMetadata(
   }
 
   options.assertCurrent?.();
-  throw new Error(
+  throw new OAuthConfigurationError(
+    'metadata_unavailable',
     'Failed to fetch authorization server metadata.\n' +
       `Tried:\n${errors.map((e) => `  - ${e}`).join('\n')}\n\n` +
       'The authorization server may not support RFC 8414 or OIDC metadata discovery.\n' +
@@ -846,10 +875,28 @@ export async function fetchAuthorizationServerMetadata(
 // Timeout for waiting for the OAuth callback (2 minutes)
 const OAUTH_CALLBACK_TIMEOUT_MS = 120_000;
 
+const OAUTH_CALLBACK_HTML_HEADERS = {
+  'Content-Type': 'text/html; charset=utf-8',
+  'Content-Security-Policy':
+    "default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'",
+  'X-Content-Type-Options': 'nosniff',
+  'Cache-Control': 'no-store',
+} as const;
+
+const OAUTH_CALLBACK_SUCCESS_HTML =
+  '<!doctype html><html><body><h1>Authentication Successful</h1><p>You can close this window.</p></body></html>';
+const OAUTH_CALLBACK_FAILURE_HTML =
+  '<!doctype html><html><body><h1>Authentication Failed</h1><p>The provider did not complete authentication. Return to Agor and try again.</p></body></html>';
+const OAUTH_CALLBACK_INVALID_HTML =
+  '<!doctype html><html><body><h1>Invalid Callback</h1><p>The authentication callback could not be validated. Return to Agor and try again.</p></body></html>';
+
 /**
  * Start local HTTP server to receive OAuth callback
  */
-function startCallbackServer(port: number = 0): Promise<{
+function startCallbackServer(
+  expectedState: string,
+  port: number = 0
+): Promise<{
   server: http.Server;
   port: number;
   url: string;
@@ -867,29 +914,40 @@ function startCallbackServer(port: number = 0): Promise<{
       if (url.pathname === '/oauth/callback') {
         const code = url.searchParams.get('code');
         const state = url.searchParams.get('state');
-        const error = url.searchParams.get('error');
+        const hasProviderError = url.searchParams.has('error');
 
-        if (error) {
-          res.writeHead(400, { 'Content-Type': 'text/html' });
-          res.end(`<html><body><h1>Authentication Failed</h1><p>Error: ${error}</p></body></html>`);
-          callbackResolve({ code: '', state: '' });
+        // Validate the CSRF capability before interpreting any provider-controlled
+        // callback parameter. Error values are never reflected into HTML or the
+        // promise result, even when state is valid.
+        if (state !== expectedState) {
+          res.writeHead(400, OAUTH_CALLBACK_HTML_HEADERS);
+          res.end(OAUTH_CALLBACK_INVALID_HTML);
+          callbackResolve({ code: '', state: state ?? '' });
           return;
         }
 
-        if (code && state) {
-          res.writeHead(200, { 'Content-Type': 'text/html' });
-          res.end(
-            '<html><body><h1>Authentication Successful</h1><p>You can close this window.</p></body></html>'
-          );
-          callbackResolve({ code, state });
+        if (hasProviderError) {
+          res.writeHead(400, OAUTH_CALLBACK_HTML_HEADERS);
+          res.end(OAUTH_CALLBACK_FAILURE_HTML);
+          callbackResolve({ code: '', state: expectedState });
+          return;
+        }
+
+        if (code) {
+          res.writeHead(200, OAUTH_CALLBACK_HTML_HEADERS);
+          res.end(OAUTH_CALLBACK_SUCCESS_HTML);
+          callbackResolve({ code, state: expectedState });
         } else {
-          res.writeHead(400, { 'Content-Type': 'text/html' });
-          res.end(
-            '<html><body><h1>Invalid Callback</h1><p>Missing code or state parameter.</p></body></html>'
-          );
+          res.writeHead(400, OAUTH_CALLBACK_HTML_HEADERS);
+          res.end(OAUTH_CALLBACK_INVALID_HTML);
+          callbackResolve({ code: '', state: expectedState });
         }
       } else {
-        res.writeHead(404);
+        res.writeHead(404, {
+          'Content-Type': 'text/plain; charset=utf-8',
+          'X-Content-Type-Options': 'nosniff',
+          'Cache-Control': 'no-store',
+        });
         res.end('Not Found');
       }
     });
@@ -940,11 +998,9 @@ async function openBrowser(url: string): Promise<void> {
     const openModule = (await import('open')) as { default: (url: string) => Promise<unknown> };
     await openModule.default(url);
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    throw new Error(
-      `Failed to open browser automatically: ${errorMessage}\n\n` +
-        `Please open this URL manually in your browser:\n${url}`
-    );
+    // The browser launcher can include the full authorization URL (including
+    // state) in its exception. Do not reflect either value.
+    throw asMCPExternalError(error, { stage: 'oauth_callback' });
   }
 }
 
@@ -1128,7 +1184,8 @@ export async function performMCPOAuthFlow(
   // Step 1: Parse WWW-Authenticate header, fall back to pre-discovered URL
   const metadataUrl = parseWWWAuthenticate(wwwAuthenticateHeader) || resourceMetadataUrl;
   if (!metadataUrl) {
-    throw new Error(
+    throw new OAuthConfigurationError(
+      'metadata_unavailable',
       'Could not determine OAuth resource metadata URL. ' +
         'The WWW-Authenticate header does not contain resource_metadata, ' +
         'and no pre-discovered metadata URL was provided.'
@@ -1155,7 +1212,10 @@ export async function performMCPOAuthFlow(
     !resourceMetadata.authorization_servers ||
     resourceMetadata.authorization_servers.length === 0
   ) {
-    throw new Error('No authorization servers found in resource metadata');
+    throw new OAuthConfigurationError(
+      'metadata_unavailable',
+      'No authorization servers found in resource metadata'
+    );
   }
 
   // Use first authorization server
@@ -1166,8 +1226,12 @@ export async function performMCPOAuthFlow(
   });
   console.log('[MCP OAuth] Authorization server metadata resolved');
 
+  // Generate the CSRF capability before starting the listener so every
+  // callback response validates state before considering provider parameters.
+  const state = crypto.randomUUID();
+
   // Step 4: Start local callback server
-  const callback = await startCallbackServer();
+  const callback = await startCallbackServer(state);
   console.log('[MCP OAuth] Local callback server ready');
 
   try {
@@ -1210,9 +1274,6 @@ export async function performMCPOAuthFlow(
         );
       }
     }
-
-    // Generate state for CSRF protection
-    const state = crypto.randomUUID();
 
     // Step 6: Build authorization URL
     const authUrl = new URL(authServerMetadata.authorization_endpoint);
@@ -1535,7 +1596,8 @@ async function startMCPOAuthFlowWithAS(opts: {
   // registration behind.
   const tokenEndpoint = tokenUrlOverride || authServerMetadata?.token_endpoint;
   if (!tokenEndpoint) {
-    throw new Error(
+    throw new OAuthConfigurationError(
+      'metadata_unavailable',
       'No token endpoint available. Either provide oauth_token_url in the MCP server config, ' +
         'or ensure the authorization server supports RFC 8414 metadata discovery.'
     );
@@ -1543,7 +1605,8 @@ async function startMCPOAuthFlowWithAS(opts: {
   const authorizationEndpoint =
     authorizationUrlOverride || authServerMetadata?.authorization_endpoint;
   if (!authorizationEndpoint) {
-    throw new Error(
+    throw new OAuthConfigurationError(
+      'metadata_unavailable',
       'No authorization endpoint available. Either provide oauth_authorization_url in the MCP server config, ' +
         'or ensure the authorization server supports RFC 8414 metadata discovery.'
     );
@@ -1554,7 +1617,10 @@ async function startMCPOAuthFlowWithAS(opts: {
   assertSafeOAuthUrl(authorizationEndpoint, { allowLocalhostHttp });
   if (compatibilityMode !== 'legacy') {
     if (!authServerMetadata) {
-      throw new Error('MCP OAuth issuer validation requires authorization-server metadata');
+      throw new OAuthConfigurationError(
+        'metadata_unavailable',
+        'MCP OAuth issuer validation requires authorization-server metadata'
+      );
     }
     assertSafeOAuthUrl(authServerMetadata.issuer, { allowLocalhostHttp });
     const issuerMatches =
@@ -1562,7 +1628,7 @@ async function startMCPOAuthFlowWithAS(opts: {
         ? authServerMetadata.issuer === issuer
         : oauthIssuerIdentifiersMatch(authServerMetadata.issuer, issuer);
     if (!issuerMatches) {
-      throw new Error('Authorization server issuer mismatch');
+      throw new OAuthConfigurationError('issuer_mismatch', 'Authorization server issuer mismatch');
     }
     const advertisedPKCEMethods = authServerMetadata.code_challenge_methods_supported;
     if (
@@ -1570,13 +1636,17 @@ async function startMCPOAuthFlowWithAS(opts: {
         ? !advertisedPKCEMethods?.includes('S256')
         : advertisedPKCEMethods !== undefined && !advertisedPKCEMethods.includes('S256')
     ) {
-      throw new Error('Authorization server does not advertise required PKCE S256 support');
+      throw new OAuthConfigurationError(
+        'pkce_required',
+        'Authorization server does not advertise required PKCE S256 support'
+      );
     }
     if (
       compatibilityMode === 'strict' &&
       authServerMetadata.authorization_response_iss_parameter_supported !== true
     ) {
-      throw new Error(
+      throw new OAuthConfigurationError(
+        'metadata_incompatible',
         'Authorization server does not advertise the required callback issuer parameter'
       );
     }
@@ -1584,10 +1654,16 @@ async function startMCPOAuthFlowWithAS(opts: {
       authorizationUrlOverride &&
       authorizationUrlOverride !== authServerMetadata.authorization_endpoint
     ) {
-      throw new Error('MCP OAuth authorization endpoint override does not match metadata');
+      throw new OAuthConfigurationError(
+        'endpoint_override_mismatch',
+        'MCP OAuth authorization endpoint override does not match metadata'
+      );
     }
     if (tokenUrlOverride && tokenUrlOverride !== authServerMetadata.token_endpoint) {
-      throw new Error('MCP OAuth token endpoint override does not match metadata');
+      throw new OAuthConfigurationError(
+        'endpoint_override_mismatch',
+        'MCP OAuth token endpoint override does not match metadata'
+      );
     }
   }
 
@@ -1631,7 +1707,8 @@ async function startMCPOAuthFlowWithAS(opts: {
       // Keep authority/deadline failures out of the DCR diagnostic wrapper.
       opts.assertCurrent?.();
     } else if (hasFullOverrides) {
-      throw new Error(
+      throw new OAuthConfigurationError(
+        'client_registration_required',
         'OAuth client_id is required when using manual OAuth URL overrides.\n\n' +
           'Please provide a client_id in the MCP server configuration.'
       );
@@ -1639,7 +1716,8 @@ async function startMCPOAuthFlowWithAS(opts: {
       throw missingRegistrationEndpointFailure();
     }
   } else if (!actualClientId) {
-    throw new Error(
+    throw new OAuthConfigurationError(
+      'client_registration_required',
       'OAuth client_id is required because Dynamic Client Registration is disabled for this server.'
     );
   }
@@ -1734,7 +1812,12 @@ export async function startMCPOAuthFlow(
   const allowLocalhostHttp = options?.allowLocalhostHttp === true;
   const resourceUri = options?.resourceUri;
   options?.assertCurrent?.();
-  if (!resourceUri) throw new Error('MCP OAuth requires an exact protected resource URI');
+  if (!resourceUri) {
+    throw new OAuthConfigurationError(
+      'metadata_incompatible',
+      'MCP OAuth requires an exact protected resource URI'
+    );
+  }
   assertSafeOAuthUrl(resourceUri, { allowLocalhostHttp });
 
   // When AS metadata is prefetched (Reo.Dev-style discovery), there's no RFC
@@ -1742,7 +1825,8 @@ export async function startMCPOAuthFlow(
   // PKCE / DCR / auth-URL construction.
   if (options?.prefetchedAuthServerMetadata) {
     if (compatibilityMode === 'strict') {
-      throw new Error(
+      throw new OAuthConfigurationError(
+        'metadata_incompatible',
         'Authorization-server-direct discovery requires explicit marketplace or legacy mode'
       );
     }
@@ -1763,7 +1847,8 @@ export async function startMCPOAuthFlow(
       compatibilityMode === 'marketplace' &&
       !oauthIssuerOriginMatchesResource(options.prefetchedAuthServerMetadata.issuer, resourceUri)
     ) {
-      throw new Error(
+      throw new OAuthConfigurationError(
+        'issuer_mismatch',
         'Authorization-server-direct discovery issuer does not match the MCP resource origin'
       );
     }
@@ -1790,7 +1875,8 @@ export async function startMCPOAuthFlow(
   // Step 1: Parse WWW-Authenticate header, fall back to pre-discovered URL
   const metadataUrl = parseWWWAuthenticate(wwwAuthenticateHeader) || options?.resourceMetadataUrl;
   if (!metadataUrl) {
-    throw new Error(
+    throw new OAuthConfigurationError(
+      'metadata_unavailable',
       'Could not determine OAuth resource metadata URL. ' +
         'The WWW-Authenticate header does not contain resource_metadata, ' +
         'and no pre-discovered metadata URL was provided.'
@@ -1812,14 +1898,20 @@ export async function startMCPOAuthFlow(
       : compatibilityMode === 'marketplace' &&
         !marketplaceResourceMetadataMatches(metadataUrl, resourceMetadata.resource, resourceUri)
   ) {
-    throw new Error('Protected resource metadata does not match the MCP resource URI');
+    throw new OAuthConfigurationError(
+      'metadata_incompatible',
+      'Protected resource metadata does not match the MCP resource URI'
+    );
   }
 
   if (
     !resourceMetadata.authorization_servers ||
     resourceMetadata.authorization_servers.length === 0
   ) {
-    throw new Error('No authorization servers found in resource metadata');
+    throw new OAuthConfigurationError(
+      'metadata_unavailable',
+      'No authorization servers found in resource metadata'
+    );
   }
 
   // Use first authorization server

--- a/packages/core/src/tools/mcp/server-validation.ts
+++ b/packages/core/src/tools/mcp/server-validation.ts
@@ -1,0 +1,711 @@
+import { isValidUUID } from '../../lib/ids';
+import {
+  containsTemplate,
+  hasTemplateMarker,
+  isValidMCPHttpUrlTemplate,
+} from '../../mcp/template-patterns';
+import { MCP_SCOPES, MCP_TRANSPORTS, type MCPServer } from '../../types/mcp';
+import { assertValidMCPAuthPatch } from './auth-patch';
+import {
+  findDuplicateMCPCustomHeaderName,
+  isReservedMCPCustomHeaderName,
+  isValidMCPHeaderName,
+  MCP_HEADER_REDACTED_SENTINEL,
+} from './http-headers';
+
+const PUBLIC_CREATE_FIELDS = new Set([
+  'name',
+  'display_name',
+  'description',
+  'transport',
+  'command',
+  'args',
+  'url',
+  'headers',
+  'env',
+  'auth',
+  'scope',
+  'owner_user_id',
+  'enabled',
+]);
+
+const TRUSTED_CREATE_FIELDS = new Set([
+  ...PUBLIC_CREATE_FIELDS,
+  'source',
+  'import_path',
+  'catalog_entry_name',
+  'tools',
+  'resources',
+  'prompts',
+  'tool_permissions',
+]);
+
+const PUBLIC_MUTATION_FIELDS = new Set([
+  'display_name',
+  'description',
+  'transport',
+  'command',
+  'args',
+  'url',
+  'headers',
+  'env',
+  'auth',
+  'scope',
+  'enabled',
+  'replace_auth',
+  'expected_config_version',
+  'tool_permissions',
+]);
+
+const TRUSTED_MUTATION_FIELDS = new Set([
+  ...PUBLIC_MUTATION_FIELDS,
+  'tools',
+  'resources',
+  'prompts',
+]);
+
+const MAX_NAME_LENGTH = 255;
+const MAX_TEXT_LENGTH = 16_384;
+const MAX_COLLECTION_ENTRIES = 256;
+const MAX_VALUE_LENGTH = 65_536;
+const ENV_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+function hasControlCharacter(value: string): boolean {
+  return [...value].some((character) => {
+    const code = character.charCodeAt(0);
+    return code <= 31 || code === 127;
+  });
+}
+
+export interface MCPServerWriteValidationOptions {
+  operation: 'create' | 'mutation';
+  /** Trusted daemon/catalog/import paths may set provenance and capabilities. */
+  trusted: boolean;
+  /** Public payloads reject fields that cannot apply to their stated transport. */
+  enforceTransportCombination?: boolean;
+  /** Existing/imported rows may retain historical provenance missing its optional evidence. */
+  allowLegacyProvenance?: boolean;
+  /** Public CREATE requires immediately usable bearer/JWT credentials. */
+  requireConfiguredCredentials?: boolean;
+}
+
+/** Stable public-input failure carried through repository merge validation. */
+export class MCPServerWriteValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MCPServerWriteValidationError';
+  }
+}
+
+function recordOf(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new Error(`${label} must be a plain object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function optionalString(
+  record: Record<string, unknown>,
+  field: string,
+  options: { required?: boolean; max?: number; url?: boolean } = {}
+): void {
+  const value = record[field];
+  if (value === undefined) {
+    if (options.required) throw new Error(`${field} is required`);
+    return;
+  }
+  if (typeof value !== 'string') throw new Error(`${field} must be a string`);
+  if ((options.required || field !== 'description') && value.trim().length === 0) {
+    throw new Error(`${field} must not be empty`);
+  }
+  if (value.length > (options.max ?? MAX_TEXT_LENGTH)) {
+    throw new Error(`${field} is too long`);
+  }
+  if (hasControlCharacter(value)) throw new Error(`${field} contains control characters`);
+  if (options.url) {
+    if (value.includes('{{') || value.includes('}}')) {
+      if (isValidMCPHttpUrlTemplate(value)) return;
+      throw new Error(`${field} must be an HTTP(S) URL using only user.env templates`);
+    }
+    let parsed: URL;
+    try {
+      parsed = new URL(value);
+    } catch {
+      throw new Error(`${field} must be a valid HTTP(S) URL`);
+    }
+    if (!['http:', 'https:'].includes(parsed.protocol) || parsed.username || parsed.password) {
+      throw new Error(`${field} must be an HTTP(S) URL without embedded credentials`);
+    }
+  }
+}
+
+function stringArray(record: Record<string, unknown>, field: string): void {
+  const value = record[field];
+  if (value === undefined) return;
+  if (!Array.isArray(value) || value.length > MAX_COLLECTION_ENTRIES) {
+    throw new Error(`${field} must be an array of at most ${MAX_COLLECTION_ENTRIES} strings`);
+  }
+  for (const item of value) {
+    if (typeof item !== 'string' || item.length > MAX_VALUE_LENGTH || item.includes('\0')) {
+      throw new Error(`${field} must contain only bounded strings without NUL characters`);
+    }
+  }
+}
+
+function stringMap(
+  record: Record<string, unknown>,
+  field: 'headers' | 'env',
+  options: { allowSentinel?: boolean }
+): void {
+  const value = record[field];
+  if (value === undefined) return;
+  const map = recordOf(value, field);
+  const entries = Object.entries(map);
+  if (entries.length > MAX_COLLECTION_ENTRIES) {
+    throw new Error(`${field} may contain at most ${MAX_COLLECTION_ENTRIES} entries`);
+  }
+  if (field === 'headers') {
+    const duplicate = findDuplicateMCPCustomHeaderName(map);
+    if (duplicate) {
+      throw new Error(
+        `Duplicate custom HTTP header names are not allowed: ${duplicate.first} and ${duplicate.duplicate}`
+      );
+    }
+  }
+  for (const [key, item] of entries) {
+    if (!key || key.length > MAX_NAME_LENGTH || typeof item !== 'string') {
+      throw new Error(`${field} must contain bounded string keys and values`);
+    }
+    if (item.length > MAX_VALUE_LENGTH || item.includes('\0')) {
+      throw new Error(`${field}.${key} is too long or contains a NUL character`);
+    }
+    if (hasTemplateMarker(item) && !containsTemplate(item)) {
+      throw new Error(`${field}.${key} contains an unbalanced template delimiter`);
+    }
+    if (!options.allowSentinel && item.trim() === MCP_HEADER_REDACTED_SENTINEL) {
+      throw new Error(`${field}.${key} cannot use the redaction sentinel on create`);
+    }
+    if (field === 'headers' && (!isValidMCPHeaderName(key) || isReservedMCPCustomHeaderName(key))) {
+      throw new Error(`headers.${key} is not an allowed custom HTTP header`);
+    }
+    if (field === 'env' && !ENV_NAME.test(key)) {
+      throw new Error(`env.${key} is not a valid environment variable name`);
+    }
+  }
+}
+
+function toolPermissions(record: Record<string, unknown>): void {
+  const value = record.tool_permissions;
+  if (value === undefined) return;
+  const permissions = recordOf(value, 'tool_permissions');
+  if (Object.keys(permissions).length > MAX_COLLECTION_ENTRIES) {
+    throw new Error(`tool_permissions may contain at most ${MAX_COLLECTION_ENTRIES} entries`);
+  }
+  for (const [name, permission] of Object.entries(permissions)) {
+    if (
+      !name ||
+      name.length > MAX_NAME_LENGTH ||
+      !['ask', 'allow', 'deny'].includes(String(permission))
+    ) {
+      throw new Error('tool_permissions must map bounded tool names to ask, allow, or deny');
+    }
+  }
+}
+
+function closedObject(value: unknown, label: string, allowed: readonly string[]) {
+  const record = recordOf(value, label);
+  for (const key of Object.keys(record)) {
+    if (!allowed.includes(key)) throw new Error(`Unknown ${label} field: ${key}`);
+  }
+  return record;
+}
+
+function boundedRequiredString(
+  record: Record<string, unknown>,
+  field: string,
+  label: string
+): void {
+  const value = record[field];
+  if (
+    typeof value !== 'string' ||
+    value.trim().length === 0 ||
+    value.length > MAX_VALUE_LENGTH ||
+    hasControlCharacter(value)
+  ) {
+    throw new Error(`${label}.${field} must be a bounded non-empty string`);
+  }
+}
+
+function boundedOptionalString(
+  record: Record<string, unknown>,
+  field: string,
+  label: string
+): void {
+  const value = record[field];
+  if (value === undefined) return;
+  if (typeof value !== 'string' || value.length > MAX_VALUE_LENGTH || hasControlCharacter(value)) {
+    throw new Error(`${label}.${field} must be a bounded string`);
+  }
+}
+
+function boundedJsonValue(value: unknown, label: string): void {
+  let nodes = 0;
+  const visit = (nested: unknown, path: string, depth: number): void => {
+    nodes += 1;
+    if (nodes > 4096) throw new Error(`${label} is too large`);
+    if (depth > 32) throw new Error(`${label} is too deeply nested`);
+    if (
+      nested === null ||
+      typeof nested === 'boolean' ||
+      (typeof nested === 'number' && Number.isFinite(nested))
+    ) {
+      return;
+    }
+    if (typeof nested === 'string') {
+      if (nested.length > MAX_VALUE_LENGTH || hasControlCharacter(nested)) {
+        throw new Error(`${path} contains an invalid string`);
+      }
+      return;
+    }
+    if (Array.isArray(nested)) {
+      if (nested.length > MAX_COLLECTION_ENTRIES) throw new Error(`${path} is too large`);
+      for (const [index, item] of nested.entries()) {
+        visit(item, `${path}[${index}]`, depth + 1);
+      }
+      return;
+    }
+    const object = recordOf(nested, path);
+    const entries = Object.entries(object);
+    if (entries.length > MAX_COLLECTION_ENTRIES) throw new Error(`${path} is too large`);
+    for (const [key, item] of entries) {
+      if (!key || key.length > MAX_NAME_LENGTH || hasControlCharacter(key)) {
+        throw new Error(`${path} contains an invalid key`);
+      }
+      visit(item, `${path}.${key}`, depth + 1);
+    }
+  };
+  visit(value, label, 0);
+}
+
+function capabilities(record: Record<string, unknown>): void {
+  if (record.tools !== undefined) {
+    if (!Array.isArray(record.tools) || record.tools.length > MAX_COLLECTION_ENTRIES) {
+      throw new Error(`tools must be an array of at most ${MAX_COLLECTION_ENTRIES} entries`);
+    }
+    for (const [index, value] of record.tools.entries()) {
+      const tool = closedObject(value, `tools[${index}]`, ['name', 'description', 'input_schema']);
+      boundedRequiredString(tool, 'name', `tools[${index}]`);
+      boundedOptionalString(tool, 'description', `tools[${index}]`);
+      if (tool.input_schema !== undefined) {
+        recordOf(tool.input_schema, `tools[${index}].input_schema`);
+        boundedJsonValue(tool.input_schema, `tools[${index}].input_schema`);
+      }
+    }
+  }
+  if (record.resources !== undefined) {
+    if (!Array.isArray(record.resources) || record.resources.length > MAX_COLLECTION_ENTRIES) {
+      throw new Error(`resources must be an array of at most ${MAX_COLLECTION_ENTRIES} entries`);
+    }
+    for (const [index, value] of record.resources.entries()) {
+      const resource = closedObject(value, `resources[${index}]`, [
+        'uri',
+        'name',
+        'description',
+        'mimeType',
+      ]);
+      boundedRequiredString(resource, 'uri', `resources[${index}]`);
+      boundedRequiredString(resource, 'name', `resources[${index}]`);
+      boundedOptionalString(resource, 'description', `resources[${index}]`);
+      if (resource.mimeType !== undefined) {
+        boundedRequiredString(resource, 'mimeType', `resources[${index}]`);
+      }
+    }
+  }
+  if (record.prompts !== undefined) {
+    if (!Array.isArray(record.prompts) || record.prompts.length > MAX_COLLECTION_ENTRIES) {
+      throw new Error(`prompts must be an array of at most ${MAX_COLLECTION_ENTRIES} entries`);
+    }
+    for (const [index, value] of record.prompts.entries()) {
+      const prompt = closedObject(value, `prompts[${index}]`, ['name', 'description', 'arguments']);
+      boundedRequiredString(prompt, 'name', `prompts[${index}]`);
+      boundedOptionalString(prompt, 'description', `prompts[${index}]`);
+      if (prompt.arguments === undefined) continue;
+      if (!Array.isArray(prompt.arguments) || prompt.arguments.length > MAX_COLLECTION_ENTRIES) {
+        throw new Error(
+          `prompts[${index}].arguments must be an array of at most ${MAX_COLLECTION_ENTRIES} entries`
+        );
+      }
+      for (const [argumentIndex, value] of prompt.arguments.entries()) {
+        const argument = closedObject(value, `prompts[${index}].arguments[${argumentIndex}]`, [
+          'name',
+          'description',
+          'required',
+        ]);
+        boundedRequiredString(argument, 'name', `prompts[${index}].arguments[${argumentIndex}]`);
+        boundedOptionalString(
+          argument,
+          'description',
+          `prompts[${index}].arguments[${argumentIndex}]`
+        );
+        if (argument.required !== undefined && typeof argument.required !== 'boolean') {
+          throw new Error(`prompts[${index}].arguments[${argumentIndex}].required must be boolean`);
+        }
+      }
+    }
+  }
+}
+
+function assertTransportCombination(record: Record<string, unknown>, complete: boolean): void {
+  const transport = record.transport;
+  if (transport === undefined && !complete) return;
+  if (!MCP_TRANSPORTS.includes(transport as (typeof MCP_TRANSPORTS)[number])) {
+    throw new Error(`transport must be one of ${MCP_TRANSPORTS.join(', ')}`);
+  }
+  if (transport === 'stdio') {
+    if (complete && (typeof record.command !== 'string' || !record.command.trim())) {
+      throw new Error('command is required for stdio transport');
+    }
+    for (const field of ['url', 'headers', 'auth'] as const) {
+      if (record[field] !== undefined && record[field] !== null) {
+        throw new Error(`${field} does not apply to stdio transport`);
+      }
+    }
+    return;
+  }
+  if (complete && (typeof record.url !== 'string' || !record.url.trim())) {
+    throw new Error(`url is required for ${String(transport)} transport`);
+  }
+  for (const field of ['command', 'args'] as const) {
+    if (record[field] !== undefined) throw new Error(`${field} only applies to stdio transport`);
+  }
+}
+
+function assertProvenance(record: Record<string, unknown>, complete: boolean): void {
+  if (!complete && record.source === undefined) return;
+  const source = record.source ?? 'user';
+  if (!['user', 'imported', 'agor', 'catalog'].includes(String(source))) {
+    throw new Error('source must be user, imported, agor, or catalog');
+  }
+  if (source === 'imported') {
+    if (complete && (typeof record.import_path !== 'string' || !record.import_path.trim())) {
+      throw new Error('import_path is required for imported MCP servers');
+    }
+    if (record.catalog_entry_name !== undefined) {
+      throw new Error('catalog_entry_name only applies to catalog MCP servers');
+    }
+    return;
+  }
+  if (source === 'catalog') {
+    if (
+      complete &&
+      (typeof record.catalog_entry_name !== 'string' || !record.catalog_entry_name.trim())
+    ) {
+      throw new Error('catalog_entry_name is required for catalog MCP servers');
+    }
+    if (record.import_path !== undefined) {
+      throw new Error('import_path only applies to imported MCP servers');
+    }
+    return;
+  }
+  if (record.import_path !== undefined || record.catalog_entry_name !== undefined) {
+    throw new Error('import/catalog provenance fields do not apply to this MCP server source');
+  }
+}
+
+function assertLegacyCompatibleProvenance(record: Record<string, unknown>): void {
+  const source = record.source ?? 'user';
+  if (!['user', 'imported', 'agor', 'catalog'].includes(String(source))) {
+    throw new Error('source must be user, imported, agor, or catalog');
+  }
+  // Historical imports may be missing their optional path, and historical
+  // catalog rows may be missing the redundant catalog stamp. They still may
+  // not carry evidence belonging to another provenance family.
+  if (source === 'imported') {
+    if (record.catalog_entry_name !== undefined) {
+      throw new Error('catalog_entry_name only applies to catalog MCP servers');
+    }
+    return;
+  }
+  if (source === 'catalog') {
+    if (record.import_path !== undefined) {
+      throw new Error('import_path only applies to imported MCP servers');
+    }
+    return;
+  }
+  if (record.import_path !== undefined || record.catalog_entry_name !== undefined) {
+    throw new Error('import/catalog provenance fields do not apply to this MCP server source');
+  }
+}
+
+/**
+ * Closed runtime schema shared by the public Feathers boundary and the final
+ * repository persistence check. Public callers get the narrow field set;
+ * trusted catalog/import/discovery calls opt into the separate internal set.
+ */
+function validateMCPServerWrite(value: unknown, options: MCPServerWriteValidationOptions): void {
+  const record = recordOf(value, 'MCP server input');
+  const complete = options.operation === 'create';
+  const allowed = complete
+    ? options.trusted
+      ? TRUSTED_CREATE_FIELDS
+      : PUBLIC_CREATE_FIELDS
+    : options.trusted
+      ? TRUSTED_MUTATION_FIELDS
+      : PUBLIC_MUTATION_FIELDS;
+  for (const key of Object.keys(record)) {
+    if (!allowed.has(key)) throw new Error(`Unknown MCP server field: ${key}`);
+  }
+
+  optionalString(record, 'name', { required: complete, max: MAX_NAME_LENGTH });
+  optionalString(record, 'display_name', { max: MAX_NAME_LENGTH });
+  optionalString(record, 'description');
+  optionalString(record, 'command');
+  optionalString(record, 'url', { url: true });
+  optionalString(record, 'import_path');
+  optionalString(record, 'catalog_entry_name', { max: MAX_NAME_LENGTH });
+  stringArray(record, 'args');
+  stringMap(record, 'headers', { allowSentinel: !complete });
+  stringMap(record, 'env', { allowSentinel: !complete });
+  toolPermissions(record);
+  capabilities(record);
+
+  if (record.scope === undefined && complete) throw new Error('scope is required');
+  if (record.scope !== undefined && !MCP_SCOPES.includes(record.scope as never)) {
+    throw new Error(`scope must be one of ${MCP_SCOPES.join(', ')}`);
+  }
+  if (record.enabled !== undefined && typeof record.enabled !== 'boolean') {
+    throw new Error('enabled must be boolean');
+  }
+  if (record.replace_auth !== undefined && typeof record.replace_auth !== 'boolean') {
+    throw new Error('replace_auth must be boolean');
+  }
+  if (
+    record.replace_auth === true &&
+    (!Object.hasOwn(record, 'auth') || record.auth === undefined)
+  ) {
+    throw new Error('replace_auth requires auth to be provided');
+  }
+  if (record.owner_user_id !== undefined && record.owner_user_id !== null) {
+    if (typeof record.owner_user_id !== 'string' || !isValidUUID(record.owner_user_id)) {
+      throw new Error('owner_user_id must be a UUIDv7 or null');
+    }
+  }
+  if (record.expected_config_version !== undefined) {
+    if (
+      !Number.isSafeInteger(record.expected_config_version) ||
+      Number(record.expected_config_version) < 1
+    ) {
+      throw new Error('expected_config_version must be a positive safe integer');
+    }
+  }
+  if ('auth' in record && record.auth !== undefined) {
+    assertValidMCPAuthPatch(record.auth, {
+      create: complete,
+      requireConfiguredCredentials: options.requireConfiguredCredentials,
+    });
+  }
+
+  if (options.enforceTransportCombination !== false) {
+    assertTransportCombination(record, complete);
+  }
+  if (options.trusted) {
+    if (options.allowLegacyProvenance) {
+      assertLegacyCompatibleProvenance(record);
+    } else {
+      assertProvenance(record, complete);
+    }
+  }
+}
+
+export function assertValidMCPServerWrite(
+  value: unknown,
+  options: MCPServerWriteValidationOptions
+): void {
+  try {
+    validateMCPServerWrite(value, options);
+  } catch (error) {
+    if (error instanceof MCPServerWriteValidationError) throw error;
+    throw new MCPServerWriteValidationError(
+      error instanceof Error ? error.message : 'Invalid MCP server input'
+    );
+  }
+}
+
+/** Validate the fully merged row immediately before repository persistence. */
+export function assertValidEffectiveMCPServer(
+  server: Partial<MCPServer>,
+  options: { allowLegacyProvenance?: boolean } = {}
+): void {
+  const persisted = {
+    name: server.name,
+    display_name: server.display_name,
+    description: server.description,
+    transport: server.transport,
+    command: server.command,
+    args: server.args,
+    url: server.url,
+    headers: server.headers,
+    env: server.env,
+    auth: server.auth,
+    scope: server.scope,
+    owner_user_id: server.owner_user_id,
+    source: server.source,
+    import_path: server.import_path,
+    catalog_entry_name: server.catalog_entry_name,
+    enabled: server.enabled,
+    tools: server.tools,
+    resources: server.resources,
+    prompts: server.prompts,
+    tool_permissions: server.tool_permissions,
+  };
+  assertValidMCPServerWrite(persisted, {
+    operation: 'create',
+    trusted: true,
+    enforceTransportCombination: true,
+    allowLegacyProvenance: options.allowLegacyProvenance,
+  });
+}
+
+/** Fail closed on provider-controlled discovery output before it reaches JSON persistence. */
+export function assertValidDiscoveredMCPCapabilities(value: unknown): void {
+  try {
+    const record = recordOf(value, 'discovered MCP capabilities');
+    for (const key of Object.keys(record)) {
+      if (!['tools', 'resources', 'prompts'].includes(key)) {
+        throw new Error(`Unknown discovered MCP capabilities field: ${key}`);
+      }
+    }
+    capabilities(record);
+  } catch (error) {
+    if (error instanceof MCPServerWriteValidationError) throw error;
+    throw new MCPServerWriteValidationError(
+      error instanceof Error ? error.message : 'Invalid discovered MCP capabilities'
+    );
+  }
+}
+
+const ARCHIVED_MCP_SERVER_ROW_FIELDS = new Set([
+  'tenant_id',
+  'mcp_server_id',
+  'created_at',
+  'updated_at',
+  'name',
+  'transport',
+  'scope',
+  'enabled',
+  'owner_user_id',
+  'source',
+  'catalog_entry_name',
+  'data',
+]);
+
+const ARCHIVED_MCP_SERVER_DATA_FIELDS = new Set([
+  'display_name',
+  'description',
+  'import_path',
+  'catalog_entry_name',
+  'config_version',
+  'command',
+  'args',
+  'url',
+  'headers',
+  'env',
+  'auth',
+  'tools',
+  'resources',
+  'prompts',
+  'tool_permissions',
+]);
+
+/**
+ * Compatibility contract for rows emitted by the 962f74fe-era archive.
+ * Historical bearer/JWT rows may be intentionally incomplete and MCP
+ * capability descriptions/schemas were optional on the wire. Everything is
+ * still closed, sentinel-free, transport-valid, and provenance-checked.
+ */
+function assertValidArchiveCompatibleMCPServer(server: Partial<MCPServer>): void {
+  assertValidEffectiveMCPServer(server, { allowLegacyProvenance: true });
+}
+
+/** Closed validation for the physical `mcp_servers` archive row before import. */
+export function assertValidArchivedMCPServerRow(value: unknown): void {
+  try {
+    const row = recordOf(value, 'archived mcp_servers row');
+    for (const key of Object.keys(row)) {
+      if (!ARCHIVED_MCP_SERVER_ROW_FIELDS.has(key)) {
+        throw new Error(`Unknown archived mcp_servers field: ${key}`);
+      }
+    }
+    if (typeof row.mcp_server_id !== 'string' || !isValidUUID(row.mcp_server_id)) {
+      throw new Error('archived mcp_server_id must be a UUID');
+    }
+    if (typeof row.tenant_id !== 'string' || !row.tenant_id.trim()) {
+      throw new Error('archived tenant_id must be a non-empty string');
+    }
+    if (typeof row.enabled !== 'boolean') {
+      throw new Error('archived enabled must be boolean');
+    }
+    if (!['user', 'imported', 'agor', 'catalog'].includes(String(row.source))) {
+      throw new Error('archived source must be user, imported, agor, or catalog');
+    }
+    for (const field of ['created_at', 'updated_at'] as const) {
+      const timestamp = row[field];
+      // Older legal archives omitted updated_at; created_at has always been
+      // required and remains the fallback used by destination persistence.
+      if (
+        (field === 'updated_at' && (timestamp === undefined || timestamp === null)) ||
+        (typeof timestamp === 'string' && timestamp.trim() && !Number.isNaN(Date.parse(timestamp)))
+      ) {
+        continue;
+      }
+      throw new Error(`archived ${field} must be an ISO-compatible timestamp`);
+    }
+    const data = recordOf(row.data, 'archived mcp_servers.data');
+    for (const key of Object.keys(data)) {
+      if (!ARCHIVED_MCP_SERVER_DATA_FIELDS.has(key)) {
+        throw new Error(`Unknown archived mcp_servers.data field: ${key}`);
+      }
+    }
+    const revision = data.config_version;
+    if (
+      revision !== undefined &&
+      (!Number.isSafeInteger(revision) ||
+        Number(revision) < 1 ||
+        Number(revision) >= Number.MAX_SAFE_INTEGER)
+    ) {
+      throw new Error('archived MCP config_version must be a non-exhausted positive safe integer');
+    }
+    if (
+      row.catalog_entry_name !== undefined &&
+      row.catalog_entry_name !== null &&
+      data.catalog_entry_name !== undefined &&
+      row.catalog_entry_name !== data.catalog_entry_name
+    ) {
+      throw new Error('archived MCP catalog_entry_name columns disagree');
+    }
+    const catalogEntryName = row.catalog_entry_name ?? data.catalog_entry_name;
+    if (row.source === 'catalog' && (typeof catalogEntryName !== 'string' || !catalogEntryName)) {
+      throw new Error('archived catalog MCP server requires catalog_entry_name evidence');
+    }
+    assertValidArchiveCompatibleMCPServer({
+      mcp_server_id: row.mcp_server_id as MCPServer['mcp_server_id'],
+      name: row.name as MCPServer['name'],
+      transport: row.transport as MCPServer['transport'],
+      scope: row.scope as MCPServer['scope'],
+      enabled: row.enabled as MCPServer['enabled'],
+      owner_user_id: (row.owner_user_id ?? undefined) as MCPServer['owner_user_id'],
+      source: row.source as MCPServer['source'],
+      catalog_entry_name: catalogEntryName as MCPServer['catalog_entry_name'],
+      ...data,
+    });
+  } catch (error) {
+    if (error instanceof MCPServerWriteValidationError) throw error;
+    throw new MCPServerWriteValidationError(
+      error instanceof Error ? error.message : 'Invalid archived MCP server row'
+    );
+  }
+}

--- a/packages/core/src/types/mcp.ts
+++ b/packages/core/src/types/mcp.ts
@@ -39,6 +39,7 @@ export interface MCPOAuthAttemptResult {
   mcp_server_id?: MCPServerID;
   oauth_mode?: MCPOAuthMode;
   failure_code?: string;
+  recovery?: MCPAuthRecovery;
 }
 
 export interface MCPOAuthStatusResult {
@@ -117,8 +118,49 @@ export interface MCPOAuthDCRDiagnostic {
 
 export interface MCPOAuthStartFailure {
   success: false;
+  /** Stable, secret-free message retained for older clients. */
   error: string;
-  diagnostic?: MCPOAuthDCRDiagnostic;
+  /** Structured recovery contract for UI, agents, and future gateway actions. */
+  recovery?: MCPAuthRecovery;
+  redirect_uri?: string;
+}
+
+export const MCP_AUTH_RECOVERY_CATEGORIES = [
+  'authentication_required',
+  'client_registration_required',
+  'client_registration_failed',
+  'metadata_incompatible',
+  'metadata_unavailable',
+  'redirect_configuration_required',
+  'authorization_denied',
+  'configuration_changed',
+  'permission_changed',
+  'provider_unavailable',
+  'provider_rejected',
+  'invalid_response',
+  'configuration_required',
+  'unknown',
+] as const;
+export type MCPAuthRecoveryCategory = (typeof MCP_AUTH_RECOVERY_CATEGORIES)[number];
+
+export const MCP_AUTH_RECOVERY_ACTIONS = [
+  'reauthenticate',
+  'configure_client',
+  'review_compatibility',
+  'configure_redirect',
+  'save_and_retry',
+  'retry',
+  'review_configuration',
+  'contact_admin',
+] as const;
+export type MCPAuthRecoveryAction = (typeof MCP_AUTH_RECOVERY_ACTIONS)[number];
+
+/** Secret-free, provider-agnostic recovery state. */
+export interface MCPAuthRecovery {
+  category: MCPAuthRecoveryCategory;
+  action: MCPAuthRecoveryAction;
+  message: string;
+  mcp_server_id?: MCPServerID;
   redirect_uri?: string;
 }
 
@@ -333,6 +375,17 @@ export interface MCPAuth {
 }
 
 /**
+ * Public PATCH contract for auth configuration.
+ *
+ * Omitted/undefined fields are preserved, null clears one field, and a type
+ * change replaces the object. Secret fields may carry the public redaction
+ * sentinel to explicitly preserve the stored value without exposing it.
+ */
+export type MCPAuthPatch = {
+  [Field in keyof MCPAuth]?: MCPAuth[Field] | null;
+};
+
+/**
  * JSON Schema type for tool input schemas
  */
 export type JSONSchema = Record<string, unknown>;
@@ -343,7 +396,7 @@ export type JSONSchema = Record<string, unknown>;
  */
 export interface MCPTool {
   name: string; // e.g., "mcp__filesystem__list_files"
-  description: string;
+  description?: string;
   input_schema?: JSONSchema; // Optional - not all MCP servers provide schemas
 }
 
@@ -354,6 +407,7 @@ export interface MCPTool {
 export interface MCPResource {
   uri: string; // e.g., "file:///path/to/file"
   name: string;
+  description?: string;
   mimeType?: string;
 }
 
@@ -363,13 +417,13 @@ export interface MCPResource {
  */
 export interface MCPPrompt {
   name: string; // Becomes slash command
-  description: string;
+  description?: string;
   arguments?: PromptArgument[];
 }
 
 export interface PromptArgument {
   name: string;
-  description: string;
+  description?: string;
   required?: boolean;
 }
 
@@ -421,6 +475,9 @@ export interface MCPServer {
 
   // Authentication (for HTTP/SSE transports)
   auth?: MCPAuth;
+
+  /** Daemon-owned monotonic revision of editor-controlled configuration. */
+  config_version?: number;
 
   /**
    * Read-only effective policy resolved by the daemon for Settings and other
@@ -512,7 +569,8 @@ export interface CreateMCPServerInput {
   url?: string;
   headers?: Record<string, string>;
   env?: Record<string, string>;
-  auth?: MCPAuth;
+  /** null explicitly creates a server with no authentication configuration. */
+  auth?: MCPAuth | null;
   scope: MCPScope;
   owner_user_id?: UserID; // Private to this user; omit for a shared server
   source?: MCPSource;
@@ -532,7 +590,12 @@ export interface UpdateMCPServerInput {
   url?: string;
   headers?: Record<string, string>;
   env?: Record<string, string>;
-  auth?: MCPAuth;
+  /** null clears all authentication; otherwise applies MCPAuthPatch semantics. */
+  auth?: MCPAuthPatch | null;
+  /** Explicitly replace same-mode auth instead of merging it. PUT sets this by default. */
+  replace_auth?: boolean;
+  /** Optional compare-and-swap guard for concurrent editors. */
+  expected_config_version?: number;
   scope?: MCPScope;
   enabled?: boolean;
   transport?: 'stdio' | 'http' | 'sse';

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -270,7 +270,7 @@ export function isTaskExecuting(task: TaskExecutionState): boolean {
 export interface ContextUsageSnapshot {
   totalTokens: number;
   maxTokens: number;
-  /** 0–100, integer, ready to display */
+  /** Finite 0–100 percentage reported by the source tool. */
   percentage: number;
 }
 
@@ -338,13 +338,14 @@ export interface Task {
   // Model (resolved model ID used for this task, e.g., "claude-sonnet-4-5-20250929")
   model?: string;
 
-  // Raw SDK response - single source of truth for token accounting
-  // Stores the unmutated SDK event (turn.completed for Codex, Finished for Gemini, etc.)
+  // Closed SDK response projection - source of truth for token accounting.
+  // Provider prose and unknown SDK extension objects are removed before storage.
   // Access token usage, context window, costs, etc. via normalizers
   // Optional to support legacy tasks that don't have this field
   raw_sdk_response?: unknown; // Raw SDK response stored as JSON
 
-  // Normalized SDK response - computed from raw_sdk_response by executor
+  // Normalized SDK response - computed and runtime-projected by the executor,
+  // then projected again by the daemon before persistence/realtime.
   // Stored here so UI doesn't need SDK-specific normalization logic
   // Will be empty for legacy tasks (pre-normalization)
   normalized_sdk_response?: {

--- a/packages/executor/src/handlers/sdk/base-executor.test.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.test.ts
@@ -377,6 +377,13 @@ describe('executeToolTask provider-failure settlement', () => {
         hadError: true,
         errorDetails: undefined,
         rawSdkResponse: safeRawResponse,
+        rawContextUsage: {
+          totalTokens: 14,
+          maxTokens: 200_000,
+          percentage: 0.007,
+          memoryFiles: [{ path: secret }],
+          providerExtension: { secret },
+        },
       }),
     }));
 
@@ -403,7 +410,14 @@ describe('executeToolTask provider-failure settlement', () => {
         tokenUsage: { inputTokens: 10, outputTokens: 4 },
         durationMs: 42,
         costUsd: 0.12,
+        contextWindowLimit: 200_000,
+        contextUsageSnapshot: {
+          totalTokens: 14,
+          maxTokens: 200_000,
+          percentage: 0.007,
+        },
       },
+      computed_context_window: 14,
     });
     expect(JSON.stringify(patch)).not.toContain(secret);
   });

--- a/packages/executor/src/handlers/sdk/base-executor.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.ts
@@ -5,6 +5,7 @@
  * Claude, Codex, Gemini, and OpenCode executors.
  */
 
+import { projectContextUsageSnapshot, projectNormalizedSdkResponse } from '@agor/core';
 import {
   AGOR_USER_ENV_KEYS_VAR,
   type ApiKeyName,
@@ -133,7 +134,7 @@ export interface BaseTool {
     /** Raw SDK response for token accounting - stored and normalized */
     rawSdkResponse?: unknown;
     /**
-     * Authoritative context-window snapshot captured during the turn.
+     * Closed authoritative context-window snapshot captured during the turn.
      * - Claude: from the Agent SDK's `getContextUsage()` response.
      * - Codex: from the CLI's `event_msg/token_count.last_token_usage` payload.
      * When present, base-executor uses it as the source of truth for
@@ -609,9 +610,11 @@ export async function executeToolTask(params: {
       patchData.raw_sdk_response = result.rawSdkResponse;
       // `modelHint` refines context-window lookup for tools whose SDK
       // event omits the model; never used as primaryModel.
-      const normalized = normalizeRawSdkResponse(toolName, result.rawSdkResponse, {
-        modelHint: result.model,
-      });
+      const normalized = projectNormalizedSdkResponse(
+        normalizeRawSdkResponse(toolName, result.rawSdkResponse, {
+          modelHint: result.model,
+        })
+      );
       if (normalized) {
         patchData.normalized_sdk_response = normalized;
       }
@@ -631,16 +634,17 @@ export async function executeToolTask(params: {
     // The `maxTokens > 0` guard (vs `totalTokens > 0`) preserves the snapshot
     // even at the moment of auto-compaction, when `totalTokens` can legitimately
     // be near zero.
-    if (result.rawContextUsage && result.rawContextUsage.maxTokens > 0) {
-      patchData.computed_context_window = result.rawContextUsage.totalTokens;
+    const contextUsageSnapshot = projectContextUsageSnapshot(result.rawContextUsage);
+    if (contextUsageSnapshot && contextUsageSnapshot.maxTokens > 0) {
+      patchData.computed_context_window = contextUsageSnapshot.totalTokens;
 
       // Override contextWindowLimit in the normalized response with the
       // authoritative maxTokens so the UI computes percentage against the
       // model's actual reported window, and attach the snapshot itself so
       // UI consumers can prefer the agent's own displayed percentage.
       if (patchData.normalized_sdk_response) {
-        patchData.normalized_sdk_response.contextWindowLimit = result.rawContextUsage.maxTokens;
-        patchData.normalized_sdk_response.contextUsageSnapshot = result.rawContextUsage;
+        patchData.normalized_sdk_response.contextWindowLimit = contextUsageSnapshot.maxTokens;
+        patchData.normalized_sdk_response.contextUsageSnapshot = contextUsageSnapshot;
       }
     } else {
       // No authoritative event_msg/token_count snapshot was captured during the
@@ -664,6 +668,15 @@ export async function executeToolTask(params: {
           // Continue without context window - not critical
         }
       }
+    }
+
+    // Final executor-side close after every derived override. The daemon
+    // repeats this projection because old/compromised executors can bypass
+    // this process and patch normalized data directly.
+    if (patchData.normalized_sdk_response) {
+      patchData.normalized_sdk_response = projectNormalizedSdkResponse(
+        patchData.normalized_sdk_response
+      );
     }
 
     // Update task status to completed/stopped with git SHA and SDK responses

--- a/packages/executor/src/sdk-handlers/claude/claude-tool.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/claude-tool.test.ts
@@ -1,4 +1,4 @@
-import { generateId } from '@agor/core';
+import { generateId, SAFE_ZERO_TURN_PROVIDER_RESULT_MESSAGE } from '@agor/core';
 import type { Message, SessionID, TaskID } from '@agor/core/types';
 import { MessageRole } from '@agor/core/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -27,9 +27,7 @@ type Harness = {
   persisted: Message[];
 };
 
-function createHarness(
-  classifiedKind?: 'missing_credential' | 'provider_credit_exhausted'
-): Harness {
+function createHarness(classifiedKind?: 'missing_credential'): Harness {
   const sessionId = generateId() as SessionID;
   const outgoing: Partial<Message>[] = [];
   const persisted: Message[] = [];
@@ -49,9 +47,8 @@ function createHarness(
           : {}),
         ...(classifiedKind && data.metadata?.is_provider_failure_result
           ? {
-              content: 'This session needs available provider credit before it can respond.',
-              content_preview:
-                'This session needs available provider credit before it can respond.',
+              content: 'This session needs to be connected before it can run.',
+              content_preview: 'This session needs to be connected before it can run.',
               metadata: { ...data.metadata, error_kind: classifiedKind },
             }
           : {}),
@@ -159,6 +156,9 @@ describe('ClaudeTool provider-failure settlement', () => {
       const contextUsage = {
         totalTokens: 123,
         maxTokens: 200_000,
+        percentage: 0.0615,
+        memoryFiles: [{ path: 'SENTINEL_CLAUDE_MEMORY_PATH' }],
+        providerExtension: 'SENTINEL_CLAUDE_CONTEXT_EXTENSION',
       } as unknown as import('@agor/core/sdk').SDKControlGetContextUsageResponse;
       promptState.events = [
         synthesizedAssistantEvent(),
@@ -178,21 +178,29 @@ describe('ClaudeTool provider-failure settlement', () => {
       expect(result.rawSdkResponse).toMatchObject({
         subtype: 'success',
         usage: raw.usage,
-        modelUsage: raw.modelUsage,
         duration_ms: raw.duration_ms,
         total_cost_usd: raw.total_cost_usd,
       });
+      expect(result.rawSdkResponse).not.toHaveProperty('modelUsage');
       expect(result.errorDetails).toBeUndefined();
-      expect(result.rawContextUsage).toEqual(contextUsage);
+      expect(result.rawContextUsage).toEqual({
+        totalTokens: 123,
+        maxTokens: 200_000,
+        percentage: 0.0615,
+      });
+      expect(JSON.stringify(result)).not.toContain('SENTINEL_CLAUDE');
+      expect(
+        JSON.stringify({ outgoing: harness.outgoing, persisted: harness.persisted, result })
+      ).not.toContain(RAW_PROVIDER_BODY);
     }
   );
 
   it.each(['streaming', 'non-streaming'] as const)(
-    'keeps classified non-success %s results safe while preserving accounting',
+    'keeps daemon-classified non-success %s results safe while preserving accounting',
     async (mode) => {
       const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       try {
-        const harness = createHarness('provider_credit_exhausted');
+        const harness = createHarness('missing_credential');
         const raw = rawResult('error_during_execution');
         promptState.events = [resultEvent(raw)];
 
@@ -200,27 +208,30 @@ describe('ClaudeTool provider-failure settlement', () => {
 
         const persistedFailure = harness.persisted.at(-1);
         expect(persistedFailure).toMatchObject({
-          content: 'This session needs available provider credit before it can respond.',
-          metadata: { error_kind: 'provider_credit_exhausted' },
+          content: 'This session needs to be connected before it can run.',
+          metadata: { error_kind: 'missing_credential' },
         });
         expect(harness.outgoing.at(-1)?.content).toEqual([
-          { type: 'text', text: 'Agent SDK error (error_during_execution): ' },
-          { type: 'text', text: RAW_PROVIDER_BODY },
-          { type: 'text', text: '\n' },
-          { type: 'text', text: 'Credit balance is too low' },
+          {
+            type: 'text',
+            text: SAFE_ZERO_TURN_PROVIDER_RESULT_MESSAGE,
+          },
         ]);
         expect(result.rawSdkResponse).not.toHaveProperty('errors');
         expect(result.rawSdkResponse).toMatchObject({
           subtype: 'error_during_execution',
           usage: raw.usage,
-          modelUsage: raw.modelUsage,
           duration_ms: raw.duration_ms,
           num_turns: raw.num_turns,
           total_cost_usd: raw.total_cost_usd,
         });
-        expect(result.errorDetails).toBeUndefined();
+        expect(result.rawSdkResponse).not.toHaveProperty('modelUsage');
+        expect(result.errorDetails).toEqual([SAFE_ZERO_TURN_PROVIDER_RESULT_MESSAGE]);
+        expect(
+          JSON.stringify({ outgoing: harness.outgoing, persisted: harness.persisted, result })
+        ).not.toContain(RAW_PROVIDER_BODY);
         expect(errorSpy.mock.calls.flat().join(' ')).not.toContain(RAW_PROVIDER_BODY);
-        expect(errorSpy.mock.calls.flat().join(' ')).toContain('provider_credit_exhausted');
+        expect(errorSpy.mock.calls.flat().join(' ')).toContain('missing_credential');
       } finally {
         errorSpy.mockRestore();
       }
@@ -228,7 +239,7 @@ describe('ClaudeTool provider-failure settlement', () => {
   );
 
   it.each(['streaming', 'non-streaming'] as const)(
-    'keeps raw diagnostics when the daemon does not classify an executor marker in %s turns',
+    'withholds raw diagnostics when the daemon does not classify an executor marker in %s turns',
     async (mode) => {
       const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       try {
@@ -238,9 +249,20 @@ describe('ClaudeTool provider-failure settlement', () => {
 
         const result = await execute(harness.tool, mode, generateId() as TaskID);
 
-        expect(result.rawSdkResponse).toEqual(raw);
-        expect(result.errorDetails).toEqual(raw.errors);
-        expect(errorSpy.mock.calls.flat().join(' ')).toContain(RAW_PROVIDER_BODY);
+        expect(result.rawSdkResponse).not.toHaveProperty('errors');
+        expect(result.rawSdkResponse).toMatchObject({
+          subtype: 'error_during_execution',
+          usage: raw.usage,
+          duration_ms: raw.duration_ms,
+          num_turns: raw.num_turns,
+          total_cost_usd: raw.total_cost_usd,
+        });
+        expect(result.rawSdkResponse).not.toHaveProperty('modelUsage');
+        expect(result.errorDetails).toEqual([SAFE_ZERO_TURN_PROVIDER_RESULT_MESSAGE]);
+        expect(
+          JSON.stringify({ outgoing: harness.outgoing, persisted: harness.persisted, result })
+        ).not.toContain(RAW_PROVIDER_BODY);
+        expect(errorSpy.mock.calls.flat().join(' ')).not.toContain(RAW_PROVIDER_BODY);
       } finally {
         errorSpy.mockRestore();
       }

--- a/packages/executor/src/sdk-handlers/claude/claude-tool.ts
+++ b/packages/executor/src/sdk-handlers/claude/claude-tool.ts
@@ -9,8 +9,14 @@
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import {
+  projectClaudeResultResponse,
+  projectContextUsageSnapshot,
+  SAFE_ZERO_TURN_PROVIDER_RESULT_MESSAGE,
+} from '@agor/core';
 import { generateId, shortId } from '@agor/core/db';
 import type { PermissionMode as ClaudeSDKPermissionMode } from '@agor/core/sdk';
+import type { ContextUsageSnapshot } from '@agor/core/types';
 import { mapPermissionMode } from '@agor/core/utils/permission-mode-mapper';
 import type {
   BranchRepository,
@@ -116,31 +122,14 @@ function getClassifiedProviderFailureKind(
   return kind === 'missing_credential' || kind === 'provider_credit_exhausted' ? kind : undefined;
 }
 
-function buildProviderFailureContent(
-  subtype: string,
-  errors: string[]
-): Array<{ type: string; text?: string }> {
-  return [
-    { type: 'text', text: `Agent SDK error (${subtype}): ` },
-    ...errors.flatMap((error, index) => [
-      { type: 'text', text: error },
-      ...(index < errors.length - 1 ? [{ type: 'text', text: '\n' }] : []),
-    ]),
-  ];
+function buildProviderFailureContent(message: string): Array<{ type: string; text?: string }> {
+  return [{ type: 'text', text: message }];
 }
 
-function sanitizeClassifiedClaudeResponse(
-  response: import('@agor/core/sdk').SDKResultMessage | undefined,
-  kind: ClassifiedProviderFailureKind | undefined
+function sanitizeClaudeResponse(
+  response: import('@agor/core/sdk').SDKResultMessage | undefined
 ): unknown {
-  if (!response || !kind) return response;
-
-  // Provider result/error bodies can contain secrets. Accounting fields remain
-  // useful after removing only the body-bearing result fields.
-  const sanitized = { ...response } as Record<string, unknown>;
-  delete sanitized.result;
-  delete sanitized.errors;
-  return sanitized;
+  return projectClaudeResultResponse(response);
 }
 
 /**
@@ -273,13 +262,12 @@ export class ClaudeTool implements ITool {
     contextWindow?: number;
     contextWindowLimit?: number;
     model?: string;
-    modelUsage?: unknown;
     rawSdkResponse?: unknown;
-    /** Raw SDK context usage snapshot from getContextUsage() — authoritative source */
-    rawContextUsage?: import('@agor/core/sdk').SDKControlGetContextUsageResponse;
+    /** Closed canonical snapshot projected from SDK getContextUsage(). */
+    rawContextUsage?: ContextUsageSnapshot;
     wasStopped?: boolean;
     hadError?: boolean;
-    /** Error details from SDK when hadError is true (e.g., errors array from error_during_execution) */
+    /** Fixed, value-free error detail when the SDK reports an error result. */
     errorDetails?: string[];
   }> {
     if (!this.promptService || !this.messagesRepo) {
@@ -350,9 +338,8 @@ export class ClaudeTool implements ITool {
     let durationMs: number | undefined;
     let contextWindow: number | undefined;
     let contextWindowLimit: number | undefined;
-    let modelUsage: unknown | undefined;
     let rawSdkResponse: import('@agor/core/sdk').SDKResultMessage | undefined;
-    let rawContextUsage: import('@agor/core/sdk').SDKControlGetContextUsageResponse | undefined;
+    let rawContextUsage: ContextUsageSnapshot | undefined;
     let wasStopped = false;
     let hadError = false;
     let errorDetails: string[] | undefined;
@@ -402,8 +389,8 @@ export class ClaudeTool implements ITool {
                 skills: event.skills,
               },
             });
-          } catch (error) {
-            console.warn('Failed to persist slash commands to session:', error);
+          } catch {
+            console.warn('Failed to persist slash commands to session');
           }
         }
       }
@@ -664,45 +651,41 @@ export class ClaudeTool implements ITool {
       // Capture raw SDK response for token accounting
       if (event.type === 'result') {
         rawSdkResponse = event.raw_sdk_message;
-        // Detect error results from SDK (e.g., error_during_execution)
-        if (rawSdkResponse && 'subtype' in rawSdkResponse) {
-          const sdkResult = rawSdkResponse as {
-            subtype?: string;
-            errors?: string[];
-            is_error?: boolean;
-          };
-          if (sdkResult.subtype && sdkResult.subtype !== 'success') {
-            hadError = true;
-            errorSubtype = sdkResult.subtype;
-            errorDetails = sdkResult.errors;
+        const sdkResult = projectClaudeResultResponse(rawSdkResponse);
+        // Use only the closed result projection for control flow. In particular,
+        // do not inspect the provider-owned errors array even to decide whether
+        // to persist a message.
+        if (sdkResult && sdkResult.subtype !== 'success') {
+          hadError = true;
+          errorSubtype = sdkResult.subtype;
+          errorDetails = [SAFE_ZERO_TURN_PROVIDER_RESULT_MESSAGE];
 
-            // Create a system message with the error details so it's visible in the conversation UI
-            if (this.messagesService && sdkResult.errors?.length) {
-              const errorMessageId = generateId() as MessageID;
-              const persisted = await withFeathersSessionGuard(
-                sessionId,
-                this.sessionsRepo,
-                async () =>
-                  createSystemMessage(
-                    sessionId,
-                    errorMessageId,
-                    buildProviderFailureContent(sdkResult.subtype!, sdkResult.errors!),
-                    taskId,
-                    nextIndex++,
-                    resolvedModel,
-                    this.messagesService!,
-                    { is_provider_failure_result: true }
-                  )
-              );
-              classifiedProviderFailureKind ??= getClassifiedProviderFailureKind(persisted);
-            }
+          // Create a system message with the error details so it's visible in the conversation UI
+          if (this.messagesService) {
+            const errorMessageId = generateId() as MessageID;
+            const persisted = await withFeathersSessionGuard(
+              sessionId,
+              this.sessionsRepo,
+              async () =>
+                createSystemMessage(
+                  sessionId,
+                  errorMessageId,
+                  buildProviderFailureContent(SAFE_ZERO_TURN_PROVIDER_RESULT_MESSAGE),
+                  taskId,
+                  nextIndex++,
+                  resolvedModel,
+                  this.messagesService!,
+                  { is_provider_failure_result: true }
+                )
+            );
+            classifiedProviderFailureKind ??= getClassifiedProviderFailureKind(persisted);
           }
         }
       }
 
       // Capture SDK context usage snapshot (authoritative context window data)
       if (event.type === 'context_usage') {
-        rawContextUsage = event.contextUsage;
+        rawContextUsage = projectContextUsageSnapshot(event.contextUsage);
       }
 
       // Capture metadata from result events (SDK may not type this properly)
@@ -711,11 +694,6 @@ export class ClaudeTool implements ITool {
       }
       if ('duration_ms' in event && typeof event.duration_ms === 'number') {
         durationMs = event.duration_ms;
-      }
-      if ('model_usage' in event && event.model_usage) {
-        // Save full model usage for later (per-model breakdown)
-        // Token accounting now handled by ClaudeCodeNormalizer.normalizeMultiModel()
-        modelUsage = event.model_usage;
       }
 
       // Handle partial streaming events (token-level chunks)
@@ -783,7 +761,9 @@ export class ClaudeTool implements ITool {
 
           // Truncate oversized content before persisting
           const { blocks: safeAssistantContent } = truncateContentIfNeeded(
-            completeEvent.content,
+            completeEvent.isSynthesizedResult
+              ? buildProviderFailureContent(SAFE_ZERO_TURN_PROVIDER_RESULT_MESSAGE)
+              : completeEvent.content,
             completeEvent.toolUses
           );
 
@@ -881,7 +861,7 @@ export class ClaudeTool implements ITool {
         );
       } else {
         console.error(
-          `[claude-code] SDK result indicates error: subtype=${errorSubtype ?? 'unknown'}, errors=${JSON.stringify(errorDetails)}`
+          `[claude-code] SDK result indicates error: subtype=${errorSubtype ?? 'unknown'}`
         );
       }
     }
@@ -895,15 +875,11 @@ export class ClaudeTool implements ITool {
       contextWindow,
       contextWindowLimit,
       model: resolvedModel,
-      modelUsage,
-      rawSdkResponse: sanitizeClassifiedClaudeResponse(
-        rawSdkResponse,
-        classifiedProviderFailureKind
-      ),
+      rawSdkResponse: sanitizeClaudeResponse(rawSdkResponse),
       rawContextUsage,
       wasStopped,
       hadError,
-      errorDetails: classifiedProviderFailureKind ? undefined : errorDetails,
+      errorDetails,
     };
   }
 
@@ -975,13 +951,12 @@ export class ClaudeTool implements ITool {
     contextWindow?: number;
     contextWindowLimit?: number;
     model?: string;
-    modelUsage?: unknown;
     rawSdkResponse?: unknown;
-    /** Raw SDK context usage snapshot from getContextUsage() — authoritative source */
-    rawContextUsage?: import('@agor/core/sdk').SDKControlGetContextUsageResponse;
+    /** Closed canonical snapshot projected from SDK getContextUsage(). */
+    rawContextUsage?: ContextUsageSnapshot;
     wasStopped?: boolean;
     hadError?: boolean;
-    /** Error details from SDK when hadError is true (e.g., errors array from error_during_execution) */
+    /** Fixed, value-free error detail when the SDK reports an error result. */
     errorDetails?: string[];
   }> {
     if (!this.promptService || !this.messagesRepo) {
@@ -1019,9 +994,8 @@ export class ClaudeTool implements ITool {
     let durationMs: number | undefined;
     let contextWindow: number | undefined;
     let contextWindowLimit: number | undefined;
-    let modelUsage: unknown | undefined;
     let rawSdkResponse: import('@agor/core/sdk').SDKResultMessage | undefined;
-    let rawContextUsage: import('@agor/core/sdk').SDKControlGetContextUsageResponse | undefined;
+    let rawContextUsage: ContextUsageSnapshot | undefined;
     let wasStopped = false;
     let hadError = false;
     let errorDetails: string[] | undefined;
@@ -1107,45 +1081,41 @@ export class ClaudeTool implements ITool {
       // Capture raw SDK response for token accounting
       if (event.type === 'result') {
         rawSdkResponse = event.raw_sdk_message;
-        // Detect error results from SDK (e.g., error_during_execution)
-        if (rawSdkResponse && 'subtype' in rawSdkResponse) {
-          const sdkResult = rawSdkResponse as {
-            subtype?: string;
-            errors?: string[];
-            is_error?: boolean;
-          };
-          if (sdkResult.subtype && sdkResult.subtype !== 'success') {
-            hadError = true;
-            errorSubtype = sdkResult.subtype;
-            errorDetails = sdkResult.errors;
+        const sdkResult = projectClaudeResultResponse(rawSdkResponse);
+        // Use only the closed result projection for control flow. In particular,
+        // do not inspect the provider-owned errors array even to decide whether
+        // to persist a message.
+        if (sdkResult && sdkResult.subtype !== 'success') {
+          hadError = true;
+          errorSubtype = sdkResult.subtype;
+          errorDetails = [SAFE_ZERO_TURN_PROVIDER_RESULT_MESSAGE];
 
-            // Create a system message with the error details so it's visible in the conversation UI
-            if (this.messagesService && sdkResult.errors?.length) {
-              const errorMessageId = generateId() as MessageID;
-              const persisted = await withFeathersSessionGuard(
-                sessionId,
-                this.sessionsRepo,
-                async () =>
-                  createSystemMessage(
-                    sessionId,
-                    errorMessageId,
-                    buildProviderFailureContent(sdkResult.subtype!, sdkResult.errors!),
-                    taskId,
-                    nextIndex++,
-                    resolvedModel,
-                    this.messagesService!,
-                    { is_provider_failure_result: true }
-                  )
-              );
-              classifiedProviderFailureKind ??= getClassifiedProviderFailureKind(persisted);
-            }
+          // Create a system message with the error details so it's visible in the conversation UI
+          if (this.messagesService) {
+            const errorMessageId = generateId() as MessageID;
+            const persisted = await withFeathersSessionGuard(
+              sessionId,
+              this.sessionsRepo,
+              async () =>
+                createSystemMessage(
+                  sessionId,
+                  errorMessageId,
+                  buildProviderFailureContent(SAFE_ZERO_TURN_PROVIDER_RESULT_MESSAGE),
+                  taskId,
+                  nextIndex++,
+                  resolvedModel,
+                  this.messagesService!,
+                  { is_provider_failure_result: true }
+                )
+            );
+            classifiedProviderFailureKind ??= getClassifiedProviderFailureKind(persisted);
           }
         }
       }
 
       // Capture SDK context usage snapshot (authoritative context window data)
       if (event.type === 'context_usage') {
-        rawContextUsage = event.contextUsage;
+        rawContextUsage = projectContextUsageSnapshot(event.contextUsage);
       }
 
       // Capture metadata from result events (SDK may not type this properly)
@@ -1154,11 +1124,6 @@ export class ClaudeTool implements ITool {
       }
       if ('duration_ms' in event && typeof event.duration_ms === 'number') {
         durationMs = event.duration_ms;
-      }
-      if ('model_usage' in event && event.model_usage) {
-        // Save full model usage for later (per-model breakdown)
-        // Token accounting now handled by ClaudeCodeNormalizer.normalizeMultiModel()
-        modelUsage = event.model_usage;
       }
 
       // Skip partial events in non-streaming mode
@@ -1175,10 +1140,13 @@ export class ClaudeTool implements ITool {
         // Create message with session guard (handles deleted sessions gracefully)
         const created = await withFeathersSessionGuard(sessionId, this.sessionsRepo, async () => {
           if (completeEvent.role === MessageRole.ASSISTANT) {
+            const safeContent = completeEvent.isSynthesizedResult
+              ? buildProviderFailureContent(SAFE_ZERO_TURN_PROVIDER_RESULT_MESSAGE)
+              : completeEvent.content;
             const persisted = await createAssistantMessage(
               sessionId,
               messageId,
-              completeEvent.content,
+              safeContent,
               completeEvent.toolUses,
               taskId,
               nextIndex++,
@@ -1230,7 +1198,7 @@ export class ClaudeTool implements ITool {
         );
       } else {
         console.error(
-          `[claude-code] SDK result indicates error: subtype=${errorSubtype ?? 'unknown'}, errors=${JSON.stringify(errorDetails)}`
+          `[claude-code] SDK result indicates error: subtype=${errorSubtype ?? 'unknown'}`
         );
       }
     }
@@ -1244,15 +1212,11 @@ export class ClaudeTool implements ITool {
       contextWindow,
       contextWindowLimit,
       model: resolvedModel,
-      modelUsage,
-      rawSdkResponse: sanitizeClassifiedClaudeResponse(
-        rawSdkResponse,
-        classifiedProviderFailureKind
-      ),
+      rawSdkResponse: sanitizeClaudeResponse(rawSdkResponse),
       rawContextUsage,
       wasStopped,
       hadError,
-      errorDetails: classifiedProviderFailureKind ? undefined : errorDetails,
+      errorDetails,
     };
   }
 

--- a/packages/executor/src/sdk-handlers/claude/message-builder.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/message-builder.test.ts
@@ -1,4 +1,4 @@
-import { generateId } from '@agor/core';
+import { generateId, SAFE_ZERO_TURN_PROVIDER_RESULT_MESSAGE } from '@agor/core';
 import type { Message, MessageID, SessionID, TaskID } from '@agor/core/types';
 import { MessageRole } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
@@ -213,6 +213,12 @@ describe('createSystemMessage', () => {
       is_provider_failure_result: true,
       model: 'claude-sonnet-4-6',
     });
+    expect(result.content).toEqual([
+      { type: 'text', text: SAFE_ZERO_TURN_PROVIDER_RESULT_MESSAGE },
+    ]);
+    expect(JSON.stringify(vi.mocked(messagesService.create).mock.calls)).not.toContain(
+      'Credit balance is too low'
+    );
   });
 
   it('returns the daemon-confirmed system message after message hooks transform it', async () => {

--- a/packages/executor/src/sdk-handlers/claude/message-builder.ts
+++ b/packages/executor/src/sdk-handlers/claude/message-builder.ts
@@ -5,7 +5,7 @@
  * Handles user messages, assistant messages, and token usage extraction.
  */
 
-import { generateId } from '@agor/core';
+import { generateId, SAFE_ZERO_TURN_PROVIDER_RESULT_MESSAGE } from '@agor/core';
 import type { Message, MessageID, MessageSource, SessionID, TaskID } from '@agor/core/types';
 import { MessageRole } from '@agor/core/types';
 import type { TokenUsage } from '../../types/token-usage.js';
@@ -179,8 +179,11 @@ export async function createAssistantMessage(
   tokenUsage?: TokenUsage,
   isZeroTurnResult?: boolean
 ): Promise<Message> {
+  const safeContent = isZeroTurnResult
+    ? [{ type: 'text', text: SAFE_ZERO_TURN_PROVIDER_RESULT_MESSAGE }]
+    : content;
   // Extract text content for preview
-  const textBlocks = content.filter((b) => b.type === 'text').map((b) => b.text || '');
+  const textBlocks = safeContent.filter((b) => b.type === 'text').map((b) => b.text || '');
   const fullTextContent = textBlocks.join('');
   const contentPreview = fullTextContent.substring(0, 200);
 
@@ -192,7 +195,7 @@ export async function createAssistantMessage(
     index: nextIndex,
     timestamp: new Date().toISOString(),
     content_preview: contentPreview,
-    content: content as Message['content'],
+    content: safeContent as Message['content'],
     tool_uses: toolUses,
     task_id: taskId,
     parent_tool_use_id: parentToolUseId || undefined,
@@ -250,6 +253,9 @@ export async function createSystemMessage(
   messagesService: MessagesService,
   metadata?: Pick<NonNullable<Message['metadata']>, 'is_provider_failure_result'>
 ): Promise<Message> {
+  const safeContent = metadata?.is_provider_failure_result
+    ? [{ type: 'text', text: SAFE_ZERO_TURN_PROVIDER_RESULT_MESSAGE }]
+    : content;
   const message: Message = {
     message_id: messageId,
     session_id: sessionId,
@@ -257,8 +263,8 @@ export async function createSystemMessage(
     role: MessageRole.SYSTEM,
     index: nextIndex,
     timestamp: new Date().toISOString(),
-    content_preview: extractContentPreview(content),
-    content: content as Message['content'],
+    content_preview: extractContentPreview(safeContent),
+    content: safeContent as Message['content'],
     task_id: taskId,
     metadata: {
       ...metadata,

--- a/packages/executor/src/sdk-handlers/claude/message-processor.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/message-processor.test.ts
@@ -1,4 +1,4 @@
-import { generateId } from '@agor/core';
+import { generateId, SAFE_ZERO_TURN_PROVIDER_RESULT_MESSAGE } from '@agor/core';
 import type { Message, MessageID, SessionID } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
 import type { MessagesService } from '../base/index.js';
@@ -20,7 +20,7 @@ function systemMsg(payload: Record<string, unknown>) {
 }
 
 describe('SDKMessageProcessor result logging', () => {
-  it('is silent by default while preserving synthesized and raw result events', async () => {
+  it('is silent and replaces synthesized provider text before emitting a message', async () => {
     const resultMessage = {
       type: 'result',
       subtype: 'success',
@@ -56,7 +56,7 @@ describe('SDKMessageProcessor result logging', () => {
         {
           type: 'complete',
           role: 'assistant',
-          content: [{ type: 'text', text: 'final response' }],
+          content: [{ type: 'text', text: SAFE_ZERO_TURN_PROVIDER_RESULT_MESSAGE }],
           toolUses: undefined,
           parent_tool_use_id: null,
           agentSessionId: undefined,
@@ -75,7 +75,7 @@ describe('SDKMessageProcessor result logging', () => {
     }
   });
 
-  it('carries the exact #2288 zero-turn result into executor-owned message metadata', async () => {
+  it('withholds the #2288 zero-turn provider body from persistence metadata', async () => {
     const processor = createProcessor();
     const events = await processor.process({
       type: 'result',
@@ -115,7 +115,10 @@ describe('SDKMessageProcessor result logging', () => {
       complete?.isSynthesizedResult
     );
 
-    expect(message.content).toEqual([{ type: 'text', text: 'Credit balance is too low' }]);
+    expect(message.content).toEqual([
+      { type: 'text', text: SAFE_ZERO_TURN_PROVIDER_RESULT_MESSAGE },
+    ]);
+    expect(JSON.stringify(message)).not.toContain('Credit balance is too low');
     expect(message.metadata?.is_zero_turn_result).toBe(true);
   });
 });

--- a/packages/executor/src/sdk-handlers/claude/message-processor.ts
+++ b/packages/executor/src/sdk-handlers/claude/message-processor.ts
@@ -11,6 +11,7 @@
  * - Yield structured events for database persistence
  */
 
+import { projectClaudeResultResponse, SAFE_ZERO_TURN_PROVIDER_RESULT_MESSAGE } from '@agor/core';
 import {
   SUPPRESSED_CLAUDE_STATUSES,
   shouldSuppressClaudeSystemEvent,
@@ -25,7 +26,7 @@ import type {
   SDKUserMessage,
   SDKUserMessageReplay,
 } from '@agor/core/sdk';
-import type { SessionID } from '@agor/core/types';
+import type { ContextUsageSnapshot, SessionID } from '@agor/core/types';
 import { MessageRole } from '@agor/core/types';
 
 /**
@@ -81,8 +82,8 @@ export type ProcessedEvent =
       parent_tool_use_id?: string | null;
       agentSessionId?: string;
       resolvedModel?: string;
-      /** Set on the synthesized result message emitted for a zero-turn success
-       * (no real assistant turns) — the only signal safe to gate auth classification on. */
+      /** Set on the fixed, synthesized message emitted for a zero-turn success
+       * (no real assistant turns). Raw provider result prose is never copied. */
       isSynthesizedResult?: boolean;
     }
   | {
@@ -110,7 +111,9 @@ export type ProcessedEvent =
     }
   | {
       type: 'result';
-      raw_sdk_message: SDKResultMessage; // Pass the entire SDK message unchanged
+      /** Internal-only SDK value used for accounting before the executor applies
+       * the closed persistence projection. Never persist or publish directly. */
+      raw_sdk_message: SDKResultMessage;
       agentSessionId?: string;
     }
   | {
@@ -147,8 +150,8 @@ export type ProcessedEvent =
     }
   | {
       type: 'context_usage';
-      /** Raw response from SDK getContextUsage() — authoritative context window snapshot */
-      contextUsage: import('@agor/core/sdk').SDKControlGetContextUsageResponse;
+      /** Closed canonical projection of SDK getContextUsage(). */
+      contextUsage: ContextUsageSnapshot;
     }
   | {
       type: 'stopped';
@@ -524,17 +527,11 @@ export class SDKMessageProcessor {
   private handleResult(msg: SDKResultMessage): ProcessedEvent[] {
     const events: ProcessedEvent[] = [];
 
-    // The SDK puts final output text in result.result for both normal prompts and local commands.
-    // For local commands (e.g. /usage, /cost), this is the ONLY output (no assistant messages).
-    // For normal prompts, assistant messages are already streamed separately.
-    // We emit result text as a system message when no assistant messages were produced.
-    if (
-      msg.subtype === 'success' &&
-      'result' in msg &&
-      msg.result &&
-      typeof msg.result === 'string' &&
-      msg.result.trim().length > 0
-    ) {
+    // A zero-turn result is provider-controlled text with no model message boundary.
+    // Never copy it into conversation content: messages are persisted and published
+    // in realtime before any downstream UI can distinguish a provider failure from
+    // a local command result.
+    if (projectClaudeResultResponse(msg)?.subtype === 'success') {
       const hasAssistantMessages = this.state.assistantMessageCount > 0;
       if (!hasAssistantMessages) {
         events.push({
@@ -543,7 +540,7 @@ export class SDKMessageProcessor {
           content: [
             {
               type: 'text',
-              text: msg.result,
+              text: SAFE_ZERO_TURN_PROVIDER_RESULT_MESSAGE,
             },
           ],
           toolUses: undefined,
@@ -558,7 +555,7 @@ export class SDKMessageProcessor {
     events.push(
       {
         type: 'result',
-        raw_sdk_message: msg, // Pass the entire SDK message unchanged
+        raw_sdk_message: msg,
         agentSessionId: this.state.capturedAgentSessionId,
       },
       {
@@ -779,7 +776,7 @@ export class SDKMessageProcessor {
     if (type === 'auth_status') {
       const isAuth = msg.isAuthenticating as boolean | undefined;
       const error = msg.error as string | undefined;
-      if (error) return `Authentication error: ${error}`;
+      if (error) return 'Authentication failed. Review the saved provider configuration.';
       return isAuth ? 'Authenticating...' : 'Authentication complete';
     }
 

--- a/packages/executor/src/sdk-handlers/claude/prompt-service.background-tasks.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/prompt-service.background-tasks.test.ts
@@ -43,6 +43,8 @@ function fakeQuery(messages: SDKMessage[] | (() => AsyncGenerator<SDKMessage>)) 
     totalTokens: 15,
     maxTokens: 200_000,
     percentage: 0.0075,
+    memoryFiles: [{ path: 'SENTINEL_CONTEXT_MEMORY', type: 'project', tokens: 2 }],
+    providerExtension: 'SENTINEL_CONTEXT_EXTENSION',
   });
   const generator =
     typeof messages === 'function'
@@ -121,6 +123,11 @@ describe('ClaudePromptService background task query lifetime', () => {
     // `end` is an internal processor sentinel and is never yielded upstream.
     expect(events.filter((event) => event.type === 'end')).toHaveLength(0);
     expect(events.filter((event) => event.type === 'context_usage')).toHaveLength(1);
+    expect(events.find((event) => event.type === 'context_usage')).toEqual({
+      type: 'context_usage',
+      contextUsage: { totalTokens: 15, maxTokens: 200_000, percentage: 0.0075 },
+    });
+    expect(JSON.stringify(events)).not.toContain('SENTINEL_CONTEXT');
     expect(query.getContextUsage).toHaveBeenCalledTimes(1);
     expect(query.releaseInput).toHaveBeenCalledTimes(1);
     const terminalResult = events.filter((event) => event.type === 'result').at(-1);

--- a/packages/executor/src/sdk-handlers/claude/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/claude/prompt-service.ts
@@ -5,7 +5,9 @@
  * Automatically loads CLAUDE.md and uses preset system prompts matching Claude Code CLI.
  */
 
+import { projectContextUsageSnapshot } from '@agor/core';
 import { shortId } from '@agor/core/db';
+import { isMCPAbortError, sanitizeMCPExternalError } from '@agor/core/mcp';
 import type { PermissionMode, SDKResultMessage } from '@agor/core/sdk';
 import type {
   BranchRepository,
@@ -306,11 +308,19 @@ If you continue to see authentication errors, please contact your Agor administr
                     `⚠️  getContextUsage() did not respond within ${ClaudePromptService.CONTEXT_USAGE_TIMEOUT_MS}ms; settling turn without a context snapshot`
                   );
                 } else {
-                  yield { type: 'context_usage', contextUsage } as ProcessedEvent;
+                  const snapshot = projectContextUsageSnapshot(contextUsage);
+                  if (snapshot) {
+                    yield { type: 'context_usage', contextUsage: snapshot } as ProcessedEvent;
+                  } else {
+                    console.warn(
+                      '⚠️  getContextUsage() returned an invalid context snapshot; settling turn without it'
+                    );
+                  }
                 }
               } catch (error) {
+                const safe = sanitizeMCPExternalError(error, { stage: 'runtime' });
                 console.warn(
-                  `⚠️  getContextUsage() unavailable (subprocess may have exited): ${error instanceof Error ? error.message : String(error)}`
+                  `⚠️  getContextUsage() unavailable category=${safe.category} type=${safe.diagnostic.type}`
                 );
               } finally {
                 // Release the held input iterable so the SDK can close stdin
@@ -349,10 +359,7 @@ If you continue to see authentication errors, please contact your Agor administr
 
       // Check if this is an AbortError from AbortController.abort()
       // This is EXPECTED during stop - the SDK throws AbortError when cancelled
-      if (
-        error instanceof Error &&
-        (error.name === 'AbortError' || error.message.includes('abort'))
-      ) {
+      if (isMCPAbortError(error)) {
         console.log(`🛑 [Stop] Query aborted for session ${shortId(sessionId)} - this is expected`);
         // Yield stopped event to signal execution was halted
         yield { type: 'stopped' } as ProcessedEvent;
@@ -360,25 +367,18 @@ If you continue to see authentication errors, please contact your Agor administr
         return;
       }
 
-      // Get actual error message from stderr if available
+      // stderr and SDK exceptions can contain MCP URLs, headers, or reflected
+      // provider payloads. Retain only presence + closed failure metadata.
       const stderrOutput = getStderr();
-      const errorContext = stderrOutput ? `\n\nClaude Code stderr output:\n${stderrOutput}` : '';
-
-      // Enhance error with context
-      const enhancedError = new Error(
-        `Claude SDK error after ${state.messageCount} messages: ${error instanceof Error ? error.message : String(error)}${errorContext}`
-      );
-      // Preserve original stack
-      if (error instanceof Error && error.stack) {
-        enhancedError.stack = error.stack;
-      }
+      const safe = sanitizeMCPExternalError(error, { stage: 'runtime' });
       console.error(`❌ SDK iteration failed:`, {
         sessionId: shortId(sessionId),
         messageCount: state.messageCount,
-        error: error instanceof Error ? error.message : String(error),
-        stderr: stderrOutput || '(no stderr output)',
+        category: safe.category,
+        type: safe.diagnostic.type,
+        hasStderr: Boolean(stderrOutput),
       });
-      throw enhancedError;
+      throw new Error(safe.message);
     }
   }
 
@@ -487,10 +487,7 @@ If you continue to see authentication errors, please contact your Agor administr
       }
     } catch (error) {
       // Check if this is an AbortError from interrupt() - this is EXPECTED during stop
-      if (
-        error instanceof Error &&
-        (error.name === 'AbortError' || error.message.includes('abort'))
-      ) {
+      if (isMCPAbortError(error)) {
         console.log(
           `🛑 [Stop] Query aborted via interrupt() for session ${shortId(sessionId)} (non-streaming) - this is expected`
         );
@@ -502,8 +499,7 @@ If you continue to see authentication errors, please contact your Agor administr
           outputTokens: tokenUsage?.output_tokens || 0,
         };
       }
-      // Re-throw other errors
-      throw error;
+      throw new Error(sanitizeMCPExternalError(error, { stage: 'runtime' }).message);
     }
 
     // Extract token counts from SDK result metadata

--- a/packages/executor/src/sdk-handlers/claude/query-builder.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/query-builder.test.ts
@@ -239,6 +239,38 @@ describe('setupQuery - Local Settings Support', () => {
     });
   });
 
+  it('does not log or dispatch secret-bearing MCP auth exceptions', async () => {
+    const sentinel = 'SENTINEL_CLAUDE_AUTH_EXCEPTION_7f1a';
+    const deps = createMockDeps();
+    deps.sessionMCPRepo = {} as any;
+    deps.mcpServerRepo = {} as any;
+    vi.mocked(getMcpServersForSession).mockResolvedValue([
+      {
+        server: {
+          mcp_server_id: 'server-secret',
+          name: 'remote',
+          transport: 'http',
+          url: 'https://example.test/mcp',
+          auth: { type: 'jwt' },
+        },
+      } as any,
+    ]);
+    vi.mocked(resolveMCPAuthHeaders).mockRejectedValue(
+      new Error(`TLS provider reflected ${sentinel}`)
+    );
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      await setupQuery('test-session' as SessionID, 'test prompt', deps);
+      const calls = vi.mocked(Claude.query).mock.calls;
+      expect(JSON.stringify(warn.mock.calls)).not.toContain(sentinel);
+      expect(JSON.stringify(calls)).not.toContain(sentinel);
+      const mcpServers = calls[0][0].options.mcpServers as Record<string, Record<string, unknown>>;
+      expect(mcpServers.remote.headers).toBeUndefined();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   it('does not block gateway startup on unauthenticated OAuth servers with custom headers', async () => {
     const deps = createMockDeps();
     vi.mocked(deps.sessionsRepo.findById).mockResolvedValue({

--- a/packages/executor/src/sdk-handlers/claude/query-builder.ts
+++ b/packages/executor/src/sdk-handlers/claude/query-builder.ts
@@ -23,6 +23,7 @@ import {
   getMcpServersForSession,
   listMcpToolsWithPermission,
   PERMISSIONS_BLOCKED_WITHOUT_PROMPT,
+  sanitizeMCPExternalError,
 } from '@agor/core/mcp';
 import { getDaemonUrl } from '../../config.js';
 import type {
@@ -339,8 +340,8 @@ export async function setupQuery(
               break;
             }
           }
-        } catch (error) {
-          console.warn('⚠️  Failed to check MCP server timestamps:', error);
+        } catch {
+          console.warn('⚠️  Failed to check MCP server timestamps');
         }
       }
 
@@ -464,8 +465,8 @@ export async function setupQuery(
         // Convert to SDK format
         const mcpConfig: MCPServersConfig = {};
         const deniedTools: string[] = [];
-        const missingAuthServers: string[] = [];
-        const unresolvedAuthServers: string[] = [];
+        const missingAuthServerIds: string[] = [];
+        const unresolvedAuthServerIds: string[] = [];
 
         for (const { server } of attachableServers) {
           // Infer transport if missing (backwards compatibility)
@@ -502,12 +503,15 @@ export async function setupQuery(
             }
             if (missingRequiredAuth) {
               // Auth-backed remote server but no usable token. Track one concise summary below.
-              missingAuthServers.push(server.name);
+              missingAuthServerIds.push(server.mcp_server_id);
               canAlwaysLoad = false;
             }
           } catch (error) {
-            const message = error instanceof Error ? error.message : String(error);
-            unresolvedAuthServers.push(`${server.name}: ${message}`);
+            const safe = sanitizeMCPExternalError(error, { stage: 'runtime' });
+            console.warn(
+              `   ⚠️  Failed to resolve MCP auth server_id=${server.mcp_server_id} category=${safe.category} type=${safe.diagnostic.type}`
+            );
+            unresolvedAuthServerIds.push(server.mcp_server_id);
             canAlwaysLoad = false;
           }
 
@@ -542,16 +546,16 @@ export async function setupQuery(
           ...(queryOptions.mcpServers || {}),
           ...mcpConfig,
         };
-        if (missingAuthServers.length > 0) {
+        if (missingAuthServerIds.length > 0) {
           console.warn(
-            `   ⚠️  ${missingAuthServers.length} MCP server(s) have configured auth but no valid token: ` +
-              `${formatListForLog(missingAuthServers)}. Check Settings → MCP Servers.`
+            `   ⚠️  ${missingAuthServerIds.length} MCP server(s) have configured auth but no valid token; ` +
+              `server_ids=${formatListForLog(missingAuthServerIds)}. Check Settings → MCP Servers.`
           );
         }
-        if (unresolvedAuthServers.length > 0) {
+        if (unresolvedAuthServerIds.length > 0) {
           console.warn(
-            `   ⚠️  Failed to resolve MCP auth for ${unresolvedAuthServers.length} server(s): ` +
-              formatListForLog(unresolvedAuthServers, 3)
+            `   ⚠️  Failed to resolve MCP auth for ${unresolvedAuthServerIds.length} server(s); ` +
+              `server_ids=${formatListForLog(unresolvedAuthServerIds, 3)}`
           );
         }
         if (deniedTools.length > 0) {
@@ -562,7 +566,10 @@ export async function setupQuery(
         }
       }
     } catch (error) {
-      console.warn('⚠️  Failed to fetch MCP servers for session:', error);
+      const safe = sanitizeMCPExternalError(error, { stage: 'runtime' });
+      console.warn(
+        `⚠️  Failed to fetch MCP servers for session category=${safe.category} type=${safe.diagnostic.type}`
+      );
       // Continue without MCP servers - non-fatal error
     }
   }
@@ -642,11 +649,11 @@ export async function setupQuery(
     });
   } catch (syncError) {
     // This is rare - SDK usually returns AsyncGenerator that throws later
-    console.error(`❌ CRITICAL: query() threw synchronous error (very unusual):`, syncError);
-    console.error(`   CWD: ${cwd}`);
-    console.error(`   API key set: ${deps.apiKey ? 'YES' : 'NO'}`);
-    console.error(`   Resume session: ${queryOptions.resume || 'none (fresh session)'}`);
-    throw syncError;
+    const safe = sanitizeMCPExternalError(syncError, { stage: 'runtime' });
+    console.error(
+      `❌ CRITICAL: query() threw synchronously category=${safe.category} type=${safe.diagnostic.type}`
+    );
+    throw new Error(safe.message);
   }
 
   // Store stderr buffer getter for error reporting

--- a/packages/executor/src/sdk-handlers/codex/app-server-client.ts
+++ b/packages/executor/src/sdk-handlers/codex/app-server-client.ts
@@ -1,5 +1,6 @@
 import { type ChildProcessWithoutNullStreams, spawn } from 'node:child_process';
 import { createInterface } from 'node:readline';
+import { sanitizeMCPExternalError } from '@agor/core/mcp';
 
 interface JsonRpcResponse<T = unknown> {
   id: number;
@@ -104,7 +105,7 @@ export class CodexAppServerClient {
       };
 
       child.once('error', (error) => {
-        rejectStartup(new Error(`Failed to start Codex app-server: ${error.message}`));
+        rejectStartup(new Error(sanitizeMCPExternalError(error, { stage: 'runtime' }).message));
       });
 
       child.once('spawn', () => resolve());
@@ -185,11 +186,7 @@ export class CodexAppServerClient {
 
     if (response.error) {
       pending.reject(
-        new Error(
-          `Codex app-server request failed: ${
-            response.error.message ?? JSON.stringify(response.error)
-          }`
-        )
+        new Error(sanitizeMCPExternalError(response.error, { stage: 'runtime' }).message)
       );
       return;
     }

--- a/packages/executor/src/sdk-handlers/codex/codex-tool.ts
+++ b/packages/executor/src/sdk-handlers/codex/codex-tool.ts
@@ -9,6 +9,7 @@
 
 import { execSync } from 'node:child_process';
 import { generateId, shortId } from '@agor/core/db';
+import { sanitizeMCPExternalError } from '@agor/core/mcp';
 import type {
   BranchRepository,
   MCPOAuthAuthHeadersRepository,
@@ -352,12 +353,12 @@ export class CodexTool implements ITool {
                 currentMessageId = newMessageId;
                 streamStarted = true;
               } catch (err) {
-                console.error(`[Codex] Streaming start failed for ${newMessageId}:`, err);
+                const safe = sanitizeMCPExternalError(err, { stage: 'runtime' });
+                console.error(
+                  `[Codex] Streaming start failed message_id=${newMessageId} category=${safe.category} type=${safe.diagnostic.type}`
+                );
                 try {
-                  await streamingCallbacks.onStreamError(
-                    newMessageId,
-                    err instanceof Error ? err : new Error(String(err))
-                  );
+                  await streamingCallbacks.onStreamError(newMessageId, new Error(safe.message));
                 } catch {
                   /* best-effort */
                 }
@@ -372,12 +373,12 @@ export class CodexTool implements ITool {
             try {
               await streamingCallbacks.onStreamChunk(currentMessageId, event.textChunk);
             } catch (err) {
-              console.error(`[Codex] Streaming chunk failed for ${currentMessageId}:`, err);
+              const safe = sanitizeMCPExternalError(err, { stage: 'runtime' });
+              console.error(
+                `[Codex] Streaming chunk failed message_id=${currentMessageId} category=${safe.category} type=${safe.diagnostic.type}`
+              );
               try {
-                await streamingCallbacks.onStreamError(
-                  currentMessageId,
-                  err instanceof Error ? err : new Error(String(err))
-                );
+                await streamingCallbacks.onStreamError(currentMessageId, new Error(safe.message));
               } catch {
                 /* best-effort */
               }
@@ -517,12 +518,15 @@ export class CodexTool implements ITool {
                   await streamingCallbacks.onStreamEnd(assistantMessageId);
                 }
               } catch (err) {
-                console.error(`[Codex] Streaming callback failed for ${assistantMessageId}:`, err);
+                const safe = sanitizeMCPExternalError(err, { stage: 'runtime' });
+                console.error(
+                  `[Codex] Streaming callback failed message_id=${assistantMessageId} category=${safe.category} type=${safe.diagnostic.type}`
+                );
                 // Notify UI so it can clear spinner/pending state
                 try {
                   await streamingCallbacks.onStreamError(
                     assistantMessageId,
-                    err instanceof Error ? err : new Error(String(err))
+                    new Error(safe.message)
                   );
                 } catch {
                   /* best-effort */
@@ -544,7 +548,10 @@ export class CodexTool implements ITool {
                   await streamingCallbacks.onThinkingEnd(assistantMessageId);
                 }
               } catch (err) {
-                console.error(`[Codex] Thinking callback failed for ${assistantMessageId}:`, err);
+                const safe = sanitizeMCPExternalError(err, { stage: 'runtime' });
+                console.error(
+                  `[Codex] Thinking callback failed message_id=${assistantMessageId} category=${safe.category} type=${safe.diagnostic.type}`
+                );
               }
             }
 

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
@@ -711,7 +711,7 @@ describe('CodexPromptService - prompt flow client initialization', () => {
           mockStreamFailure = new Error('event iterator failed after thread capture');
 
           await expect(tool.executePromptWithStreaming(sessionId, 'continue')).rejects.toThrow(
-            'event iterator failed after thread capture'
+            'The Codex turn was interrupted before completion. Retry the prompt.'
           );
         }
       );
@@ -1297,7 +1297,7 @@ describe('CodexPromptService - tool payload mapping', () => {
     });
   });
 
-  it('preserves MCP error message on failure', () => {
+  it('sanitizes MCP provider error messages on failure', () => {
     const service = new CodexPromptService(
       mockMessagesRepo,
       mockSessionsRepo,
@@ -1327,9 +1327,52 @@ describe('CodexPromptService - tool payload mapping', () => {
       id: 'mcp-2',
       name: 'agor.agor_execute_tool',
       input: {},
-      output: 'permission denied',
+      output:
+        'The MCP operation failed. Retry, then ask an administrator to review the secure operational event if it continues.',
       status: 'failed',
     });
+  });
+
+  it('does not invoke or retain hostile MCP error metadata getters', () => {
+    const service = new CodexPromptService(
+      mockMessagesRepo,
+      mockSessionsRepo,
+      mockSessionMCPServerRepo,
+      mockBranchesRepo,
+      undefined,
+      'test-api-key',
+      mockDb
+    );
+    const sentinel = 'SENTINEL_CODEX_METADATA_GETTER';
+    const providerError = new Error(sentinel);
+    Object.defineProperties(providerError, {
+      code: {
+        get() {
+          throw new Error(sentinel);
+        },
+      },
+      name: {
+        get() {
+          throw new Error(sentinel);
+        },
+      },
+    });
+
+    const toolUse = (service as any).itemToToolUse(
+      {
+        id: 'mcp-hostile',
+        type: 'mcp_tool_call',
+        server: 'agor',
+        tool: 'agor_execute_tool',
+        arguments: {},
+        error: providerError,
+        status: 'failed',
+      },
+      'completed'
+    );
+
+    expect(JSON.stringify(toolUse)).not.toContain(sentinel);
+    expect(toolUse.output).toContain('The MCP operation failed');
   });
 
   it('falls back to structured_content when MCP content blocks are empty', () => {
@@ -1442,7 +1485,7 @@ describe('CodexPromptService - tool payload mapping', () => {
           // no-op
         }
       })()
-    ).rejects.toThrow('Codex stream error: stream exploded');
+    ).rejects.toThrow('The MCP operation failed');
 
     expect(mockSessionsRepo.update).toHaveBeenCalledWith('session-1', {
       sdk_session_id: null,
@@ -1541,6 +1584,36 @@ describe('CodexPromptService - event_msg terminal handling (issue #1749)', () =>
     delete process.env.OPENAI_BASE_URL;
     vi.clearAllMocks();
     appServerMocks.forkCodexThreadViaAppServer.mockReset();
+  });
+
+  it('projects turn completion accounting without raw SDK extension metadata', async () => {
+    const { service } = await makeInitializedStreamingService('existing-thread-id');
+    const sentinel = 'SENTINEL_CODEX_COMPLETION_METADATA';
+    mockStreamEvents = [
+      {
+        type: 'turn.completed',
+        usage: {
+          input_tokens: 8,
+          cached_input_tokens: 2,
+          output_tokens: 3,
+          reasoning_output_tokens: 1,
+        },
+        metadata: { exception: new Error(sentinel) },
+      },
+    ];
+
+    const completed = (await drain(service)).find((event) => event.type === 'complete');
+
+    expect(completed?.rawSdkEvent).toEqual({
+      type: 'turn.completed',
+      usage: {
+        input_tokens: 8,
+        cached_input_tokens: 2,
+        output_tokens: 3,
+        reasoning_output_tokens: 1,
+      },
+    });
+    expect(JSON.stringify(completed)).not.toContain(sentinel);
   });
 
   it('surfaces event_msg agent_message via the actual "message" field (real rollout shape)', async () => {
@@ -1836,7 +1909,7 @@ describe('CodexPromptService - event_msg terminal handling (issue #1749)', () =>
     });
   });
 
-  it('ignores reconnect progress until turn.completed and preserves the existing thread', async () => {
+  it('treats the SDK-defined fatal error event as authoritative without parsing reconnect prose', async () => {
     const { service } = await makeInitializedStreamingService('existing-thread-id');
 
     const reconnectMessage =
@@ -1848,40 +1921,80 @@ describe('CodexPromptService - event_msg terminal handling (issue #1749)', () =>
         usage: { input_tokens: 5, cached_input_tokens: 0, output_tokens: 2 },
       },
     ];
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-    const emitted: Array<Record<string, unknown>> = [];
-    for await (const event of service.promptSessionStreaming('session-1' as any, 'go')) {
-      emitted.push(event as Record<string, unknown>);
-    }
-
-    expect(emitted.some((event) => event.type === 'complete')).toBe(true);
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining(reconnectMessage));
+    await expect(drain(service)).rejects.toThrow('The MCP operation failed');
     expect(mockSessionsRepo.update).not.toHaveBeenCalled();
-    warn.mockRestore();
   });
 
   it.each([
     ['fresh', null],
     ['established', 'existing-thread-id'],
   ])(
-    'lets turn.failed remain authoritative after reconnect progress for a %s thread',
+    'classifies a real SDK-shaped turn.failed as unknown for a %s thread',
     async (_threadKind, sdkSessionId) => {
       const { service } = await makeInitializedStreamingService(sdkSessionId);
 
       mockStreamEvents = [
-        { type: 'error', message: 'Reconnecting... 2/5' },
         { type: 'turn.failed', error: { message: 'provider rejected the turn' } },
       ];
-      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-      await expect(drain(service)).rejects.toThrow('provider rejected the turn');
+      await expect(drain(service)).rejects.toThrow('The MCP operation failed');
 
-      expect(warn).toHaveBeenCalledWith(expect.stringContaining('Reconnecting... 2/5'));
       expect(mockSessionsRepo.update).not.toHaveBeenCalled();
-      warn.mockRestore();
     }
   );
+
+  it('never logs or returns a secret-bearing runtime provider exception', async () => {
+    const { service } = await makeInitializedStreamingService('existing-thread-id');
+    const sentinel = 'SENTINEL_CODEX_RUNTIME_PROVIDER_4e2b';
+    mockStreamEvents = [
+      {
+        type: 'turn.failed',
+        error: { message: `TLS failure for https://${sentinel}.example.test` },
+      },
+    ];
+    const spies = [
+      vi.spyOn(console, 'log').mockImplementation(() => undefined),
+      vi.spyOn(console, 'warn').mockImplementation(() => undefined),
+      vi.spyOn(console, 'error').mockImplementation(() => undefined),
+      vi.spyOn(console, 'debug').mockImplementation(() => undefined),
+    ];
+    try {
+      const failure = await drain(service).catch((error: unknown) => error);
+      expect(String(failure)).not.toContain(sentinel);
+      expect(JSON.stringify(spies.flatMap((spy) => spy.mock.calls))).not.toContain(sentinel);
+      expect(JSON.stringify(mockSessionsRepo.update.mock.calls)).not.toContain(sentinel);
+    } finally {
+      for (const spy of spies) spy.mockRestore();
+    }
+  });
+
+  it('does not claim reauthentication authority from arbitrary ThreadError prose', async () => {
+    const { service } = await makeInitializedStreamingService('existing-thread-id');
+    mockStreamEvents = [
+      {
+        type: 'turn.failed',
+        error: { message: 'provider_rejected SENTINEL_REJECTED_BODY' },
+      },
+    ];
+
+    const failure = await drain(service).catch((error: unknown) => error);
+    expect(String(failure)).toContain('The MCP operation failed');
+    expect(String(failure)).not.toContain('SENTINEL_REJECTED_BODY');
+    expect(String(failure)).not.toContain('sign in again');
+  });
+
+  it('reports missing local Codex authentication as configuration required', async () => {
+    const { service } = await makeInitializedStreamingService('existing-thread-id');
+    (service as any).apiKey = '';
+    (service as any).useNativeAuth = false;
+    mockStreamEvents = [
+      { type: 'turn.failed', error: { message: 'SENTINEL_MISSING_AUTH_PROVIDER_BODY' } },
+    ];
+
+    await expect(drain(service)).rejects.toThrow(
+      'This MCP authentication configuration is incomplete. Review the saved server settings and retry.'
+    );
+  });
 
   it.each([
     ['reconnecting... 2/5', 'lowercase'],
@@ -1893,7 +2006,7 @@ describe('CodexPromptService - event_msg terminal handling (issue #1749)', () =>
 
     mockStreamEvents = [{ type: 'error', message }];
 
-    await expect(drain(service)).rejects.toThrow(`Codex stream error: ${message}`);
+    await expect(drain(service)).rejects.toThrow('The MCP operation failed');
 
     expect(mockSessionsRepo.update).not.toHaveBeenCalled();
   });
@@ -1914,7 +2027,7 @@ describe('CodexPromptService - event_msg terminal handling (issue #1749)', () =>
       ];
 
       await expect(drain(service)).rejects.toThrow(
-        'Codex stream ended without a terminal completion event'
+        'Codex ended the turn without a completion event'
       );
 
       if (sdkSessionId === null) {
@@ -1958,8 +2071,8 @@ describe('CodexPromptService - event_msg terminal handling (issue #1749)', () =>
 
       await expect(drain(service)).rejects.toThrow(
         failurePoint === 'before event iteration'
-          ? 'runStreamed aborted unexpectedly'
-          : 'event iterator failed'
+          ? 'Codex could not start the turn. Retry the prompt.'
+          : 'The Codex turn was interrupted before completion. Retry the prompt.'
       );
 
       if (sdkSessionId === null) {
@@ -2186,6 +2299,67 @@ describe('CodexPromptService - buildMcpServersConfig', () => {
       url: 'https://example.com/mcp',
       default_tools_approval_mode: 'approve',
     });
+  });
+
+  it('never logs a resolved remote URL even when Codex MCP debugging is enabled', async () => {
+    const secretUrl = 'https://example.test/mcp?credential=do-not-log';
+    mcpScopingMocks.getMcpServersForSession.mockResolvedValue([
+      {
+        server: {
+          name: 'remote-secret-url',
+          transport: 'http',
+          url: secretUrl,
+        },
+      },
+    ]);
+    const previous = process.env.AGOR_DEBUG_CODEX;
+    process.env.AGOR_DEBUG_CODEX = '1';
+    const debug = vi.spyOn(console, 'debug').mockImplementation(() => undefined);
+    try {
+      await (makeService() as any).buildMcpServersConfig(
+        '019e3700-aaaa-bbbb-cccc-dddddddddddd',
+        undefined,
+        { sessionOwnerId }
+      );
+      expect(JSON.stringify(debug.mock.calls)).not.toContain(secretUrl);
+      expect(JSON.stringify(debug.mock.calls)).not.toContain('do-not-log');
+    } finally {
+      debug.mockRestore();
+      if (previous === undefined) delete process.env.AGOR_DEBUG_CODEX;
+      else process.env.AGOR_DEBUG_CODEX = previous;
+    }
+  });
+
+  it('never logs secret-bearing auth resolution exceptions', async () => {
+    const sentinel = 'SENTINEL_AUTH_EXCEPTION_3c90';
+    mcpScopingMocks.getMcpServersForSession.mockResolvedValue([
+      {
+        server: {
+          mcp_server_id: '01900000-0000-7000-8000-000000000091',
+          name: 'remote-auth-error',
+          transport: 'http',
+          url: 'https://example.test/mcp',
+          auth: { type: 'bearer', token: 'configured' },
+        },
+      },
+    ]);
+    mcpAuthMocks.resolveMCPAuthHeaders.mockRejectedValueOnce(
+      new Error(`provider endpoint included ${sentinel}`)
+    );
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      await (makeService() as any).buildMcpServersConfig(
+        '019e3700-aaaa-bbbb-cccc-dddddddddddd',
+        undefined,
+        { sessionOwnerId }
+      );
+      expect(JSON.stringify(warn.mock.calls)).not.toContain(sentinel);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('Auth header resolution failed server_id=')
+      );
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it('passes custom HTTP headers through Codex env_http_headers without inlining secrets', async () => {

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -29,11 +29,15 @@ import * as path from 'node:path';
 import { loadManagedAgenticToolSdk } from '@agor/core/agentic-integrations';
 import { shortId } from '@agor/core/db';
 import {
+  asMCPExternalError,
   getMcpServersForSession,
+  isMCPAbortError,
   listMcpToolsWithPermission,
+  MCPExternalError,
   PERMISSIONS_BLOCKED_WITHOUT_PROMPT,
+  sanitizeMCPExternalError,
 } from '@agor/core/mcp';
-import type { CodexOptions, Thread, ThreadItem } from '@agor/core/sdk';
+import type { CodexOptions, Thread, ThreadItem, TurnCompletedEvent } from '@agor/core/sdk';
 import { renderAgorSystemPrompt } from '@agor/core/templates/session-context';
 import { mergeMCPRemoteHeaders } from '@agor/core/tools/mcp/http-headers';
 import { resolveMCPAuthHeaders } from '@agor/core/tools/mcp/jwt-auth';
@@ -115,10 +119,73 @@ function applyMcpToolPermissions(config: CodexConfigObject, server: MCPServer): 
 }
 const GATEWAY_MCP_STARTUP_TIMEOUT_MS = 30_000;
 
-const DEBUG_CODEX = process.env.AGOR_DEBUG_CODEX === '1' || process.env.DEBUG?.includes('codex');
+type CodexLifecycleFailureCode =
+  | 'stream_start_failed'
+  | 'stream_interrupted'
+  | 'stream_ended_without_completion';
+
+const CODEX_LIFECYCLE_MESSAGES: Record<CodexLifecycleFailureCode, string> = {
+  stream_start_failed: 'Codex could not start the turn. Retry the prompt.',
+  stream_interrupted: 'The Codex turn was interrupted before completion. Retry the prompt.',
+  stream_ended_without_completion:
+    'Codex ended the turn without a completion event. Retry the prompt; restart the session if it continues.',
+};
+
+function projectCodexCompletedEvent(
+  event: TurnCompletedEvent
+): import('../../types/sdk-response').CodexSdkResponse {
+  // The SDK object is an external runtime value even though its declared type
+  // is closed. Project the documented accounting fields so extension metadata
+  // (including exception objects) cannot reach Task persistence or realtime.
+  let usage: unknown;
+  try {
+    usage = Reflect.get(event, 'usage');
+  } catch {
+    usage = undefined;
+  }
+  const count = (field: string): number => {
+    if (!usage || typeof usage !== 'object') return 0;
+    try {
+      const value = Reflect.get(usage, field);
+      return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0 ? value : 0;
+    } catch {
+      return 0;
+    }
+  };
+
+  return {
+    type: 'turn.completed',
+    usage: {
+      input_tokens: count('input_tokens'),
+      cached_input_tokens: count('cached_input_tokens'),
+      output_tokens: count('output_tokens'),
+      reasoning_output_tokens: count('reasoning_output_tokens'),
+    },
+  };
+}
+
+class CodexLifecycleError extends Error {
+  readonly failureCode: CodexLifecycleFailureCode;
+
+  constructor(failureCode: CodexLifecycleFailureCode) {
+    super(CODEX_LIFECYCLE_MESSAGES[failureCode]);
+    this.name = 'CodexLifecycleError';
+    this.failureCode = failureCode;
+  }
+}
+
+function isKnownCodexBoundaryError(
+  error: unknown
+): error is CodexLifecycleError | MCPExternalError {
+  try {
+    return error instanceof CodexLifecycleError || error instanceof MCPExternalError;
+  } catch {
+    return false;
+  }
+}
 
 function codexDebug(...args: unknown[]): void {
-  if (DEBUG_CODEX) {
+  if (process.env.AGOR_DEBUG_CODEX === '1' || process.env.DEBUG?.includes('codex')) {
     console.debug(...args);
   }
 }
@@ -349,8 +416,8 @@ export class CodexPromptService {
     // (also true for Gemini/Copilot — broader gap). This sweep self-heals
     // long-running daemons that accumulate stale `agor-codex-instructions-*`
     // across crashes / unclean shutdowns / never-fired close hooks.
-    void this.sweepStaleInstructionsFiles().catch((err) => {
-      console.warn('⚠️  [Codex] Stale-instructions-file sweep failed:', err);
+    void this.sweepStaleInstructionsFiles().catch(() => {
+      console.warn('⚠️  [Codex] Stale-instructions-file sweep failed');
     });
   }
 
@@ -543,7 +610,10 @@ export class CodexPromptService {
     try {
       await Promise.resolve(close.call(candidate));
     } catch (error) {
-      console.warn('⚠️  [Codex] Failed to close previous SDK client:', error);
+      const safe = sanitizeMCPExternalError(error, { stage: 'runtime' });
+      console.warn(
+        `⚠️  [Codex] Failed to close previous SDK client category=${safe.category} type=${safe.diagnostic.type}`
+      );
     }
   }
 
@@ -585,11 +655,9 @@ export class CodexPromptService {
     let filePath = path.join(os.tmpdir(), fileName);
     try {
       await fs.writeFile(filePath, agorSystemPrompt, { encoding: 'utf-8', mode: 0o600 });
-    } catch (writeError) {
+    } catch {
       const fallbackBase = path.join(os.homedir(), '.agor', 'tmp');
-      console.warn(
-        `⚠️  [Codex] Failed to write instructions file in ${os.tmpdir()} (${(writeError as Error).message}), falling back to ${fallbackBase}`
-      );
+      console.warn('⚠️  [Codex] Primary instructions-file write failed; using fallback storage');
       await fs.mkdir(fallbackBase, { recursive: true, mode: 0o700 });
       filePath = path.join(fallbackBase, fileName);
       await fs.writeFile(filePath, agorSystemPrompt, { encoding: 'utf-8', mode: 0o600 });
@@ -725,11 +793,11 @@ export class CodexPromptService {
       codexDebug(`   📝 [Codex MCP] Configuring STDIO server: ${server.name} -> ${serverName}`);
       if (server.command) {
         serverConfig.command = server.command;
-        codexDebug(`      command: ${server.command}`);
+        codexDebug('      command: configured');
       }
       if (server.args && server.args.length > 0) {
         serverConfig.args = server.args as CodexConfigValue[];
-        codexDebug(`      args: ${JSON.stringify(server.args)}`);
+        codexDebug(`      args: ${server.args.length} configured value(s)`);
       }
       if (server.env && Object.keys(server.env).length > 0) {
         serverConfig.env = server.env as CodexConfigObject;
@@ -752,7 +820,8 @@ export class CodexPromptService {
       codexDebug(`   📝 [Codex MCP] Configuring HTTP server: ${server.name} -> ${serverName}`);
       if (server.url) {
         serverConfig.url = server.url;
-        codexDebug(`      url: ${server.url}`);
+        // The resolved URL can contain user-derived path/query material. Do
+        // not log it; the server name and transport above are sufficient.
       }
 
       // Resolve the Authorization header via the shared MCP auth helper —
@@ -815,10 +884,12 @@ export class CodexPromptService {
               : `check credentials for ${server.name}`;
           console.warn(`      💡 Go to Settings → MCP Servers → ${action}.`);
         }
-      } catch (error) {
+      } catch {
+        // Auth-resolution exceptions may include a provider endpoint or
+        // reflected credential material. Recovery is surfaced by the daemon;
+        // executor logs retain only a stable category and server identity.
         console.warn(
-          `   ⚠️  [Codex MCP] Failed to resolve auth headers for "${server.name}":`,
-          error instanceof Error ? error.message : String(error)
+          `   ⚠️  [Codex MCP] Auth header resolution failed server_id=${server.mcp_server_id}`
         );
         canRequireServer = false;
       }
@@ -909,8 +980,8 @@ export class CodexPromptService {
             mcpOutput = item.result.content as Array<Record<string, unknown>>;
           } else if (item.result?.structured_content !== undefined) {
             mcpOutput = JSON.stringify(item.result.structured_content, null, 2);
-          } else if (item.error?.message) {
-            mcpOutput = item.error.message;
+          } else if (item.error) {
+            mcpOutput = sanitizeMCPExternalError(item.error, { stage: 'runtime' }).message;
           }
         }
         return {
@@ -1084,6 +1155,7 @@ export class CodexPromptService {
     const shouldAutoApproveApps =
       effectivePermissionMode === 'allow-all' &&
       configuredSandboxMode !== 'read-only' &&
+      sandboxModeEnvOverride !== 'read-only' &&
       sandboxMode !== 'read-only' &&
       approvalPolicy === 'never' &&
       networkAccess === true;
@@ -1202,8 +1274,8 @@ export class CodexPromptService {
             break;
           }
         }
-      } catch (error) {
-        console.warn('⚠️  [Codex] Failed to check MCP server timestamps:', error);
+      } catch {
+        console.warn('⚠️  [Codex] Failed to check MCP server timestamps');
       }
     }
 
@@ -1253,7 +1325,10 @@ export class CodexPromptService {
           await thread.run(slashCommand);
           console.log(`✅ [Codex] Thread settings updated successfully`);
         } catch (error) {
-          console.error(`❌ [Codex] Failed to update thread settings:`, error);
+          const safe = sanitizeMCPExternalError(error, { stage: 'runtime' });
+          console.error(
+            `❌ [Codex] Failed to update thread settings category=${safe.category} type=${safe.diagnostic.type}`
+          );
           // Continue anyway - the user's prompt will still be sent
         }
       }
@@ -1276,6 +1351,7 @@ export class CodexPromptService {
       }
     };
 
+    let runtimePhase: 'starting' | 'streaming' = 'starting';
     try {
       codexDebug(
         `▶️  [Codex] Running prompt: "${prompt.substring(0, 50)}${prompt.length > 50 ? '...' : ''}"`
@@ -1299,6 +1375,7 @@ export class CodexPromptService {
       codexDebug(`🎬 [Codex] Starting runStreamed() for session ${shortId(sessionId)}`);
       const turnOptions = abortController ? { signal: abortController.signal } : undefined;
       const { events } = await thread.runStreamed(prompt, turnOptions);
+      runtimePhase = 'streaming';
       codexDebug(`✅ [Codex] runStreamed() returned, starting event iteration`);
 
       const currentMessage: Array<{
@@ -1545,9 +1622,8 @@ export class CodexPromptService {
               // Surface non-fatal item-level errors as assistant text so users can see
               // what happened instead of dropping them silently.
               if ('message' in event.item && event.item.type === 'error') {
-                const errorContent = [
-                  { type: 'text', text: `[Codex item error] ${event.item.message}` },
-                ];
+                const safe = sanitizeMCPExternalError(event.item, { stage: 'runtime' });
+                const errorContent = [{ type: 'text', text: `[Codex item error] ${safe.message}` }];
                 yield {
                   type: 'complete',
                   content: errorContent,
@@ -1574,7 +1650,7 @@ export class CodexPromptService {
               threadId,
               resolvedModel,
               usage: mappedUsage,
-              rawSdkEvent: event, // Pass through the actual SDK event (UNMUTATED)
+              rawSdkEvent: projectCodexCompletedEvent(event),
               rawContextUsage: contextUsage,
             };
 
@@ -1585,51 +1661,25 @@ export class CodexPromptService {
 
           case 'turn.failed': {
             receivedTerminalEvent = true;
-            // Classify error for better user-facing messages
-            const errorMessage =
-              typeof event.error === 'string' ? event.error : JSON.stringify(event.error, null, 2);
-
-            // Detect 401/auth errors and provide actionable guidance
-            if (errorMessage.includes('401') || errorMessage.includes('Unauthorized')) {
-              const hasApiKey = !!this.apiKey;
-              const guidance = hasApiKey
-                ? 'Your OPENAI_API_KEY may be invalid or expired. Check Settings > Codex > Authentication, or run `codex login` for ChatGPT subscription auth.'
-                : this.useNativeAuth
-                  ? 'No API key configured and ChatGPT subscription auth (~/.codex/auth.json) was rejected or missing. Run `codex login` from the branch terminal, or add an API key in Settings > Codex > Authentication.'
-                  : 'No API key configured. Add one in Settings > Codex > Authentication, or sign in via `codex login`.';
-              console.error(
-                `❌ [Codex] Authentication failed for session ${shortId(sessionId)}: ${guidance}`
-              );
-              throw new Error(`Codex authentication failed: ${guidance}`);
-            }
-
-            // Log full error details for non-auth failures
+            const classification = {
+              stage: 'runtime' as const,
+              ...(!this.apiKey && !this.useNativeAuth
+                ? { category: 'configuration_required' as const }
+                : {}),
+            };
+            const safe = sanitizeMCPExternalError(event.error, classification);
             console.error(
-              `❌ [Codex] Turn failed for session ${shortId(sessionId)}:`,
-              errorMessage
+              `❌ [Codex] Turn failed for session ${shortId(sessionId)} category=${safe.category} type=${safe.diagnostic.type}`
             );
-            throw new Error(`Codex execution failed: ${errorMessage}`);
+            throw asMCPExternalError(event.error, classification);
           }
 
           case 'error': {
-            const streamErrorMessage = (event as { message?: unknown }).message;
-            if (
-              typeof streamErrorMessage === 'string' &&
-              /^Reconnecting\.\.\.\s*\d+\s*\/\s*\d+\b/.test(streamErrorMessage)
-            ) {
-              console.warn(`⚠️  [Codex] ${streamErrorMessage}`);
-              break;
-            }
-
-            // Fatal stream-level error from Codex SDK.
-            // Surface this as a task failure so users see it in the conversation.
-            throw new Error(
-              `Codex stream error: ${
-                (event as { message?: unknown; error?: unknown }).message ||
-                (event as { message?: unknown; error?: unknown }).error ||
-                'unknown'
-              }`
-            );
+            // The public SDK defines every `error` event as unrecoverable and
+            // exposes only an arbitrary provider/CLI message. It has no typed
+            // reconnect/auth discriminator, so do not parse prose to invent
+            // control flow or recovery state.
+            throw asMCPExternalError(event, { stage: 'runtime' });
           }
 
           default:
@@ -1643,16 +1693,10 @@ export class CodexPromptService {
       // exited without emitting a terminal event (turn.completed / task_complete / turn_complete),
       // which is the bug described in issue #1749.
       if (!didStop) {
-        throw new Error(
-          'Codex stream ended without a terminal completion event (turn.completed, task_complete, or turn_complete). ' +
-            'The Codex process may have exited unexpectedly (check the executor logs for exit code 0 clues). ' +
-            'This is usually resolved by retrying the prompt; if it persists, restart the session.'
-        );
+        throw new CodexLifecycleError('stream_ended_without_completion');
       }
     } catch (error) {
-      const wasCancelled =
-        abortController?.signal.aborted === true ||
-        (error instanceof Error && error.name === 'AbortError');
+      const wasCancelled = abortController?.signal.aborted === true || isMCPAbortError(error);
       if (wasCancelled) {
         console.log(
           `🛑 [Stop] Codex query aborted for session ${shortId(sessionId)} - this is expected`
@@ -1667,9 +1711,14 @@ export class CodexPromptService {
         await clearFreshThreadResumeState();
       }
 
-      // Don't log here — error will be logged by the caller (base-executor)
-      // to avoid duplicate error output in daemon logs
-      throw error;
+      if (isKnownCodexBoundaryError(error)) throw error;
+
+      // Convert opaque SDK lifecycle failures to local, fixed control-flow
+      // errors. Provider failures emitted as typed events above retain their
+      // closed MCP category/action contract instead of being flattened here.
+      throw new CodexLifecycleError(
+        runtimePhase === 'starting' ? 'stream_start_failed' : 'stream_interrupted'
+      );
     }
   }
 
@@ -1777,10 +1826,9 @@ export class CodexPromptService {
     for (const filePath of candidatePaths) {
       try {
         await fs.unlink(filePath);
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
-          console.warn(`⚠️  Failed to remove Codex instructions file at ${filePath}:`, error);
-        }
+      } catch {
+        // Best-effort cleanup; exception objects may contain reflected paths.
+        console.warn('⚠️  Failed to remove a Codex instructions file');
       }
     }
     this.instructionsFilePaths.delete(sessionId);

--- a/packages/executor/src/sdk-handlers/gemini/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/gemini/prompt-service.test.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@google/gemini-cli-core', () => ({
   ApprovalMode: { DEFAULT: 'default', AUTO_EDIT: 'autoEdit', YOLO: 'yolo' },
+  GeminiEventType: { Error: 'error' },
 }));
 
 import { GeminiPromptService } from './prompt-service.js';
@@ -216,6 +217,43 @@ describe('GeminiPromptService', () => {
 
       await expect(gen1.next()).rejects.toThrow('not found');
       await expect(gen2.next()).rejects.toThrow('not found');
+    });
+
+    it('never logs or returns a secret-bearing provider error event', async () => {
+      const sessionId = 'provider-error-session' as SessionID;
+      const sentinel = 'SENTINEL_GEMINI_PROVIDER_d4c2';
+      vi.mocked(mockSessionsRepo.findById).mockResolvedValue({
+        created_by: 'user-1',
+        model_config: null,
+      } as never);
+      const sendMessageStream = vi.fn(async function* () {
+        yield {
+          type: 'error',
+          value: new Error(`TLS failure for https://${sentinel}.example.test`),
+        };
+      });
+      (
+        service as unknown as {
+          getOrCreateClient: () => Promise<{ sendMessageStream: typeof sendMessageStream }>;
+        }
+      ).getOrCreateClient = vi.fn().mockResolvedValue({ sendMessageStream });
+      const spies = [
+        vi.spyOn(console, 'log').mockImplementation(() => undefined),
+        vi.spyOn(console, 'warn').mockImplementation(() => undefined),
+        vi.spyOn(console, 'error').mockImplementation(() => undefined),
+        vi.spyOn(console, 'debug').mockImplementation(() => undefined),
+      ];
+
+      try {
+        const failure = await service
+          .promptSessionStreaming(sessionId, 'test prompt')
+          .next()
+          .catch((error: unknown) => error);
+        expect(String(failure)).not.toContain(sentinel);
+        expect(JSON.stringify(spies.flatMap((spy) => spy.mock.calls))).not.toContain(sentinel);
+      } finally {
+        for (const spy of spies) spy.mockRestore();
+      }
     });
   });
 

--- a/packages/executor/src/sdk-handlers/gemini/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/gemini/prompt-service.ts
@@ -23,11 +23,15 @@ import type { Part } from '@google/genai';
 const Gemini = await loadManagedAgenticToolSdk<typeof GeminiTypes>('gemini');
 type ResumedSessionData = GeminiTypes.ResumedSessionData;
 
+class GeminiSessionNotFoundError extends Error {}
+
 import { shortId } from '@agor/core/db';
 import {
   getMcpServersForSession,
+  isMCPAbortError,
   listMcpToolsWithPermission,
   PERMISSIONS_BLOCKED_WITHOUT_PROMPT,
+  sanitizeMCPExternalError,
 } from '@agor/core/mcp';
 import { getDaemonUrl } from '../../config.js';
 import type {
@@ -162,7 +166,7 @@ export class GeminiPromptService {
       // Get session metadata for model
       const session = await this.sessionsRepo.findById(sessionId);
       if (!session) {
-        throw new Error(`Session ${sessionId} not found`);
+        throw new GeminiSessionNotFoundError(`Session ${sessionId} not found`);
       }
 
       // Context user for per-user OAuth/API-key resolution — the task creator
@@ -217,11 +221,9 @@ export class GeminiPromptService {
         for await (const event of stream) {
           reportSdkActivity(onActivity, 'gemini', String(event.type));
           // Debug logging for all events
-          const eventValue = 'value' in event ? event.value : undefined;
-          console.debug(
-            `[Gemini Event] ${event.type}:`,
-            eventValue ? JSON.stringify(eventValue).slice(0, 100) : '(no value)'
-          );
+          // Event values may include MCP tool results or provider errors.
+          // Logging the closed event type is sufficient for stream diagnosis.
+          console.debug(`[Gemini Event] type=${event.type}`);
 
           // Handle different event types from Gemini SDK
           switch (event.type) {
@@ -345,34 +347,17 @@ export class GeminiPromptService {
             }
 
             case Gemini.GeminiEventType.Error: {
-              // Error occurred during execution
               const errorValue = 'value' in event ? event.value : 'Unknown error';
-              console.error(`Gemini SDK error: ${JSON.stringify(errorValue)}`);
-
-              // Extract meaningful error message
-              let errorMessage = 'Unknown error';
-              if (typeof errorValue === 'object' && errorValue !== null) {
-                if (
-                  'error' in errorValue &&
-                  typeof errorValue.error === 'object' &&
-                  errorValue.error !== null
-                ) {
-                  const errorObj = errorValue.error as { message?: string };
-                  errorMessage = errorObj.message || JSON.stringify(errorValue);
-                } else {
-                  errorMessage = JSON.stringify(errorValue);
-                }
-              } else if (typeof errorValue === 'string') {
-                errorMessage = errorValue;
-              }
-
-              throw new Error(`Gemini execution failed: ${errorMessage}`);
+              const safe = sanitizeMCPExternalError(errorValue, { stage: 'runtime' });
+              console.error(
+                `Gemini SDK error category=${safe.category} type=${safe.diagnostic.type}`
+              );
+              throw new Error(safe.message);
             }
 
             case Gemini.GeminiEventType.Thought: {
-              // Agent thinking/reasoning (could stream to UI in future)
-              const thoughtValue = 'value' in event ? event.value : '';
-              console.debug(`[Gemini Thought] ${thoughtValue}`);
+              // Thought values can contain provider-reflected tool/auth data.
+              // The closed event type logged above is sufficient diagnostics.
               break;
             }
 
@@ -381,14 +366,12 @@ export class GeminiPromptService {
               console.warn(
                 '[Gemini] Tool call needs confirmation - this should not happen in AUTO_EDIT/YOLO mode!'
               );
-              console.warn('[Gemini] Confirmation details:', JSON.stringify(event.value, null, 2));
               break;
             }
 
             default: {
-              // Log other event types for debugging
-              const debugValue = 'value' in event ? event.value : '';
-              console.debug(`[Gemini Event] ${event.type}:`, debugValue);
+              // Unknown SDK event payloads are untrusted and may reflect URLs,
+              // headers, or provider error bodies. Never stringify them.
               break;
             }
           }
@@ -474,23 +457,23 @@ export class GeminiPromptService {
                   response: {
                     error:
                       completedCall.status === 'error'
-                        ? completedCall.response?.error?.message || 'Tool execution failed'
+                        ? sanitizeMCPExternalError(completedCall.response?.error, {
+                            stage: 'runtime',
+                          }).message
                         : 'Tool execution returned no response',
                   },
                 },
               } as Part);
             }
           } catch (error) {
+            const safe = sanitizeMCPExternalError(error, { stage: 'runtime' });
             console.error(
-              `[Gemini Loop] Error processing completed tool ${completedCall.request.name}:`,
-              error
+              `[Gemini Loop] Error processing completed tool category=${safe.category} type=${safe.diagnostic.type}`
             );
-            // On error, create a function response part with the error
-            const errorMessage = error instanceof Error ? error.message : String(error);
             functionResponseParts.push({
               functionResponse: {
                 name: completedCall.request.name,
-                response: { error: errorMessage },
+                response: { error: safe.message },
               },
             } as Part);
           }
@@ -513,13 +496,17 @@ export class GeminiPromptService {
       }
     } catch (error) {
       // Check if error is from abort
-      if (error instanceof Error && error.name === 'AbortError') {
+      if (isMCPAbortError(error)) {
         console.log(`🛑 Gemini execution stopped for session ${sessionId}`);
         // Don't re-throw abort errors - this is expected behavior
         return;
       }
-      console.error('Gemini streaming error:', error);
-      throw error;
+      if (error instanceof GeminiSessionNotFoundError) throw error;
+      const safe = sanitizeMCPExternalError(error, { stage: 'runtime' });
+      console.error(
+        `Gemini streaming error category=${safe.category} type=${safe.diagnostic.type}`
+      );
+      throw new Error(safe.message);
     } finally {
       outerAbortSignal?.removeEventListener('abort', forwardOuterAbort);
       if (this.activeControllers.get(sessionId) === abortController) {
@@ -634,8 +621,9 @@ export class GeminiPromptService {
           console.log(`🔄 [Gemini] Refreshed authentication using ${authMethod}`);
         } catch (error) {
           // Log but don't throw - let the subsequent prompt attempt fail with a better error
+          const safe = sanitizeMCPExternalError(error, { stage: 'runtime' });
           console.warn(
-            `⚠️  [Gemini] refreshAuth() failed: ${error instanceof Error ? error.message : String(error)}`
+            `⚠️  [Gemini] refreshAuth() failed category=${safe.category} type=${safe.diagnostic.type}`
           );
           console.warn(`   Continuing anyway - prompt may fail if credentials are invalid`);
         }
@@ -763,9 +751,9 @@ export class GeminiPromptService {
             const authHeaders = await resolveMCPAuthHeaders(server.auth, server.url);
             headers = mergeMCPRemoteHeaders({ custom: server.headers, auth: authHeaders });
           } catch (error) {
+            const safe = sanitizeMCPExternalError(error, { stage: 'runtime' });
             console.warn(
-              `   ⚠️  Failed to resolve MCP auth headers for ${server.name}:`,
-              error instanceof Error ? error.message : String(error)
+              `   ⚠️  Failed to resolve MCP auth headers server_id=${server.mcp_server_id} category=${safe.category} type=${safe.diagnostic.type}`
             );
           }
 
@@ -837,7 +825,10 @@ export class GeminiPromptService {
           );
         }
       } catch (error) {
-        console.warn('⚠️  Failed to fetch MCP servers for Gemini session:', error);
+        const safe = sanitizeMCPExternalError(error, { stage: 'runtime' });
+        console.warn(
+          `⚠️  Failed to fetch MCP servers for Gemini session category=${safe.category} type=${safe.diagnostic.type}`
+        );
         // Continue without MCP servers - non-fatal error
       }
     }
@@ -893,11 +884,11 @@ export class GeminiPromptService {
       const authMethod = authType === Gemini.AuthType.LOGIN_WITH_GOOGLE ? 'OAuth' : 'API key';
       console.log(`🔐 [Gemini] Authenticated using ${authMethod}`);
     } catch (error) {
-      const err = error as Error;
-      console.error(`❌ [Gemini] Authentication failed:`, err.message);
-      throw new Error(
-        `Gemini authentication failed: ${err.message}. Please configure GEMINI_API_KEY or run 'gemini login' to authenticate with OAuth.`
+      const safe = sanitizeMCPExternalError(error, { stage: 'runtime' });
+      console.error(
+        `❌ [Gemini] Authentication failed category=${safe.category} type=${safe.diagnostic.type}`
       );
+      throw new Error(safe.message);
     }
 
     // Try to load existing session file from SDK's filesystem storage

--- a/packages/executor/src/types/sdk-response.ts
+++ b/packages/executor/src/types/sdk-response.ts
@@ -1,11 +1,13 @@
 /**
  * SDK Response Types - Raw responses from each agentic tool SDK
  *
- * These types represent the exact, unaltered responses from each SDK.
- * They are stored in tasks.raw_sdk_response for debugging and auditing.
+ * These types represent the SDK response shapes used for token accounting.
+ * Before tasks.raw_sdk_response persistence, executor adapters project away
+ * provider error bodies and unknown extension metadata.
  *
  * IMPORTANT: These are the ACTUAL SDK types, imported directly from each SDK.
- * No transformations, no calculated fields - just pure SDK responses.
+ * The provider SDK types remain the source of truth for the allowlisted shape;
+ * the runtime values are deliberately not persisted verbatim.
  */
 
 import type { MessageID } from '@agor/core/types';
@@ -61,8 +63,7 @@ export type ClaudeCodeSdkResponseTyped = SDKResultMessage & {
 // ============================================================================
 
 /**
- * Codex SDK Response - Direct import from Codex SDK
- * This is the actual TurnCompletedEvent type with no modifications
+ * Codex SDK Response - closed accounting projection of TurnCompletedEvent.
  */
 export type CodexSdkResponse = TurnCompletedEvent;
 

--- a/scripts/check-multitenancy-boundaries.mjs
+++ b/scripts/check-multitenancy-boundaries.mjs
@@ -49,6 +49,10 @@ const checks = [
       'apps/agor-daemon/src/services/artifacts.ts': 1,
       'apps/agor-daemon/src/services/boards.ts': 2,
       'apps/agor-daemon/src/services/repos.ts': 1,
+      // Real REST + Socket.IO contract harness: the one authenticated test
+      // connection is joined to a local-only channel so transport-level
+      // response and realtime secret redaction can be asserted end to end.
+      'apps/agor-daemon/src/services/mcp-servers.write-transport.integration.test.ts': 2,
       // Socket/browser integration harness explicitly joins one authenticated
       // connection to its verified tenant before asserting hard-delete
       // publication containment.


### PR DESCRIPTION
## Stack / scope

This is an **independent large PR stacked on #2530**. Its base is `marketplace-hub-ux`; it should not be folded into #2530 or retargeted to `main` until the stack is ready.

Rebased onto finalized #2530 head `711aedb7f0e0dcdd84381f0a11bd76c45e9c9555`, which includes final #2480 head `5232d8d6e3b9f1ede81fe0763509aaeed8aea8e0`.

It delivers the self-contained, reviewable safety and recovery portion of #2500. **#2501 is explicitly excluded.**

## What this delivers

### Secret-safe, closed MCP mutation contract

- Closes public MCP server CREATE/PATCH/PUT schemas, including top-level fields, auth mode combinations, transports, capabilities, source/provenance, ranges, and daemon-owned fields.
- Preserves PATCH omission, redaction-sentinel preservation, explicit `null` clearing, PUT replacement, and `replace_auth: false` compatibility semantics without returning or broadcasting stored secrets.
- Keeps `config_version` daemon-owned with editor CAS, checked monotonic increments, conflict recovery, and fail-closed exhaustion handling that cannot create a revision ABA.
- Makes OAuth-relevant server mutation, grant deletion, and pending-flow invalidation atomic on SQLite and PostgreSQL transaction paths.
- Canonicalizes short MCP server IDs before locking, snapshots, cleanup, comparison, and mutation.
- Clears incompatible credentials and bindings during shared/per-user OAuth mode changes.

### Recovery contract and actionable UX

- Introduces closed, typed, surface-neutral MCP recovery categories/actions with fixed sanitized prose.
- Applies the contract consistently across OAuth start, polling, callback, status, discovery, JWT testing, and executor/provider failures.
- Adds explicit secret-clear controls, truthful bearer/JWT “Needs configuration” actions, OAuth-only sign-in actions, accessible keyboard behavior, conflict “Reload latest” handling, managed Marketplace policy recomputation, and polite transition announcements.
- Keeps trusted Marketplace credential-requirement control errors intact while sanitizing genuinely external failures.

### Boundary hardening

- Validates templated URL/header/env/auth values through shared marker and resolved-value checks; unmatched opening or closing Handlebars delimiters fail closed.
- Prevents raw templates, rendered values, URLs, headers, provider exceptions, redirect values, and credentials from entering logs or public errors.
- Adds hostile-object-safe external error classification that does not invoke arbitrary getters/prototypes.
- Projects Claude/raw/normalized SDK results through closed runtime allowlists at both executor creation and daemon Task-patch boundaries before persistence or realtime publication.
- Fixes OAuth loopback callback handling so provider-controlled errors are not reflected before state validation and cannot produce an HTML/XSS disclosure.
- Closes discovery capability and tenant archive import validation while retaining explicitly supported legacy archive compatibility.
- Documents storage accurately: MCP secrets are stored according to deployment storage security and are redacted at API, realtime, log, and UI boundaries; this PR does not claim application-layer encryption.

## Explicitly deferred

This PR does **not** claim strict active-turn credential revocation or security-linearized hot reload. It also does **not** expand collaborator/delegated access to raw MCP credentials.

Both require an authoritative daemon-mediated egress/capability boundary covering HTTP and redirects, JWT/OAuth refresh, long-lived SDK transports, stdio, remote executors, PostgreSQL visibility, crash recovery, and provider side effects. The design and incremental migration plan are in:

- `context/explorations/mcp-authoritative-egress-gateway.md`

Accordingly:

- strict active-turn revocation / hot reload is deferred;
- collaborator or delegated raw-secret delivery is deferred;
- existing owner/admin raw-config boundaries remain in place;
- this PR provides configuration safety, durable cleanup, sanitized recovery, and bounded UX improvements rather than claiming an egress guarantee it cannot enforce.

## Validation

All source-mode commands used `AGOR_MANAGED_AGENTIC_TOOLS=0`. This is required for executor source tests because the managed agentic-tools loader bypasses the workspace SDK mocks used by those suites.

Post-rebase validation at `2eda3f14e16dde27d246bf8d962c63bd331ca712`:

- Core MCP/auth/schema/import/repository suites: **565 passed, 23 conditional tests skipped** across 18 files
- Daemon MCP/OAuth/catalog/hooks/repository integration suites: **298 passed, 14 conditional tests skipped** across 13 files
- Executor Claude/Codex/Gemini/Copilot and SDK suites: **403 passed** across 31 files
- UI MCP/recovery/accessibility suites: **123 passed** across 12 files
- Core, daemon, executor, and UI source-mode typechecks: passed
- Biome/lint: passed across **2,545 files**
- Frontend design-system fixtures: **330 passed**
- Short-ID, multitenancy, daemon-filesystem, and realtime boundary checks: passed
- PostgreSQL/RLS CI: **193 passed, 0 failed, 0 skipped** across 37 files
- Chromium browser CI: **30 passed** across 6 real-browser files
- Range-diff maps both published commits to the rebased stack; the additive Marketplace `replace_auth` fix is patch-identical. One integration-only follow-up updates the repaired base's transport-replacement fixture to satisfy the closed effective-row contract. The obsolete Discord wizard timeout-only commit was dropped after the base split that test into dedicated files, avoiding the sole stacked-merge conflict.

### Validation limitations

- No local `AGOR_TEST_POSTGRES_URL` / admin database was available, so local conditional PostgreSQL cases account for the skips above. The required non-superuser PostgreSQL/RLS GitHub Actions job passed all 193 tests.
- No Playwright MCP browser tool was attached, so no managed interactive browser pass was possible and Puppeteer was not substituted. The CI Chromium browser suite passed all 30 tests. The managed environment was running but its existing watch process was unhealthy because generated workspace declarations were stale/missing after the rebase; source-mode typechecks remained green.

## Review status

- Correctness final review at `9a799f8f3f93bea10af9539b2a1ef4ff0e14c1d3`: **zero P0–P3, MERGEABLE**
- Architecture final review: **SHIP**







