### PR TITLE
feat(mcp): add authoritative egress gateway

### DIFF
--- a/apps/agor-daemon/src/mcp-egress/capability.test.ts
+++ b/apps/agor-daemon/src/mcp-egress/capability.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { issueMCPEgressCapability, verifyMCPEgressCapability } from './capability.js';
+
+const secret = 'gateway-capability-test-secret';
+const claims = {
+  tid: 'tenant-a',
+  task_id: 'task-a',
+  session_id: 'session-a',
+  principal_user_id: 'prompter-a',
+  credential_user_id: 'owner-a',
+  mcp_server_id: 'server-a',
+  config_version: 7,
+  material_hash: 'opaque-material-binding',
+  grant_identity: '3:opaque-grant-binding',
+  rollout_mode: 'enforced' as const,
+  jti: 'capability-a',
+};
+
+describe('MCP egress capability', () => {
+  it('is opaque, task-live, and contains no reusable provider credential material', () => {
+    const token = issueMCPEgressCapability(claims, secret);
+    expect(token).toMatch(/^agor_mcp_cap_v1\.[A-Za-z0-9_-]+$/);
+    expect(token).not.toContain(claims.tid);
+    expect(token).not.toContain(claims.task_id);
+    expect(verifyMCPEgressCapability(token, secret)).toMatchObject(claims);
+  });
+
+  it('rejects tampering, the wrong daemon secret, invalid mode, and invalid authority version', () => {
+    const token = issueMCPEgressCapability(claims, secret);
+    const offset = Math.floor(token.length / 2);
+    const replacement = token[offset] === 'A' ? 'B' : 'A';
+    expect(() =>
+      verifyMCPEgressCapability(
+        `${token.slice(0, offset)}${replacement}${token.slice(offset + 1)}`,
+        secret
+      )
+    ).toThrow();
+    expect(() => verifyMCPEgressCapability(token, 'other-daemon-secret')).toThrow();
+    expect(() =>
+      verifyMCPEgressCapability(
+        issueMCPEgressCapability({ ...claims, rollout_mode: 'observe' } as never, secret),
+        secret
+      )
+    ).toThrow();
+    expect(() =>
+      verifyMCPEgressCapability(
+        issueMCPEgressCapability({ ...claims, config_version: 0 }, secret),
+        secret
+      )
+    ).toThrow();
+  });
+});

--- a/apps/agor-daemon/src/mcp-egress/capability.ts
+++ b/apps/agor-daemon/src/mcp-egress/capability.ts
@@ -1,0 +1,99 @@
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'node:crypto';
+import type { MCPEgressGatewayMode, MCPServerID } from '@agor/core/types';
+
+const CAPABILITY_PREFIX = 'agor_mcp_cap_v1';
+const CAPABILITY_AAD = Buffer.from(`${CAPABILITY_PREFIX}:task-live`, 'utf8');
+const NONCE_BYTES = 12;
+const TAG_BYTES = 16;
+
+/**
+ * Daemon-only routing authority, never a provider credential. Claims are
+ * authenticated and encrypted so the executor receives an opaque value rather
+ * than another inspectable JWT. It has no wall-clock expiry because every use
+ * revalidates the live Task and current durable config/grant/material versions.
+ */
+export interface MCPEgressCapabilityClaims {
+  type: 'mcp-egress-capability';
+  tid: string;
+  task_id: string;
+  session_id: string;
+  principal_user_id: string;
+  credential_user_id: string;
+  mcp_server_id: MCPServerID | string;
+  config_version: number;
+  material_hash: string;
+  grant_identity?: string;
+  rollout_mode: MCPEgressGatewayMode;
+  jti: string;
+}
+
+export type IssueMCPEgressCapabilityClaims = Omit<MCPEgressCapabilityClaims, 'type'>;
+
+function capabilityKey(secret: string): Buffer {
+  return createHash('sha256').update('agor:mcp-egress:capability-key:v1\0').update(secret).digest();
+}
+
+function validateClaims(value: unknown): MCPEgressCapabilityClaims {
+  if (!value || typeof value !== 'object') throw new Error('Invalid MCP egress capability');
+  const claims = value as MCPEgressCapabilityClaims;
+  if (claims.type !== 'mcp-egress-capability') throw new Error('Invalid MCP egress capability');
+  for (const item of [
+    claims.tid,
+    claims.task_id,
+    claims.session_id,
+    claims.principal_user_id,
+    claims.credential_user_id,
+    claims.mcp_server_id,
+    claims.material_hash,
+    claims.jti,
+  ]) {
+    if (typeof item !== 'string' || !item) throw new Error('Incomplete MCP egress capability');
+  }
+  if (!Number.isSafeInteger(claims.config_version) || claims.config_version < 1) {
+    throw new Error('Invalid MCP config version');
+  }
+  if (claims.rollout_mode !== 'compatibility' && claims.rollout_mode !== 'enforced') {
+    throw new Error('Invalid MCP rollout mode');
+  }
+  if (claims.grant_identity !== undefined && typeof claims.grant_identity !== 'string') {
+    throw new Error('Invalid MCP grant identity');
+  }
+  return claims;
+}
+
+export function issueMCPEgressCapability(
+  claims: IssueMCPEgressCapabilityClaims,
+  secret: string
+): string {
+  const nonce = randomBytes(NONCE_BYTES);
+  const cipher = createCipheriv('aes-256-gcm', capabilityKey(secret), nonce);
+  cipher.setAAD(CAPABILITY_AAD);
+  const plaintext = Buffer.from(
+    JSON.stringify({ ...claims, type: 'mcp-egress-capability' }),
+    'utf8'
+  );
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  return `${CAPABILITY_PREFIX}.${Buffer.concat([nonce, cipher.getAuthTag(), ciphertext]).toString('base64url')}`;
+}
+
+export function verifyMCPEgressCapability(
+  token: string,
+  secret: string
+): MCPEgressCapabilityClaims {
+  const [prefix, encoded, extra] = token.split('.');
+  if (prefix !== CAPABILITY_PREFIX || !encoded || extra !== undefined) {
+    throw new Error('Invalid MCP egress capability');
+  }
+  const envelope = Buffer.from(encoded, 'base64url');
+  if (envelope.byteLength <= NONCE_BYTES + TAG_BYTES) {
+    throw new Error('Invalid MCP egress capability');
+  }
+  const nonce = envelope.subarray(0, NONCE_BYTES);
+  const tag = envelope.subarray(NONCE_BYTES, NONCE_BYTES + TAG_BYTES);
+  const ciphertext = envelope.subarray(NONCE_BYTES + TAG_BYTES);
+  const decipher = createDecipheriv('aes-256-gcm', capabilityKey(secret), nonce);
+  decipher.setAAD(CAPABILITY_AAD);
+  decipher.setAuthTag(tag);
+  const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+  return validateClaims(JSON.parse(plaintext.toString('utf8')));
+}

--- a/apps/agor-daemon/src/mcp-egress/coordination.ts
+++ b/apps/agor-daemon/src/mcp-egress/coordination.ts
@@ -1,0 +1,53 @@
+import {
+  getMCPEgressGatewayMode,
+  MCPServerRepository,
+  type TenantScopeAwareDatabase,
+} from '@agor/core/db';
+import type { HookContext, MCPServerID } from '@agor/core/types';
+import type { MCPEgressGateway } from './gateway.js';
+
+type GatewayAbortCoordinator = Pick<MCPEgressGateway, 'abortServer' | 'abortTenant'>;
+
+/** Durable session detach first, then a scoped local cancellation accelerator. */
+export async function coordinateSessionMCPRevocation<T>(input: {
+  db: TenantScopeAwareDatabase;
+  gateway: GatewayAbortCoordinator;
+  tenantId?: string;
+  serverIds: string[];
+  mutate: () => Promise<T>;
+}): Promise<T> {
+  const result = await input.mutate();
+  const mode = await getMCPEgressGatewayMode(input.db);
+  if (mode !== 'compatibility' && mode !== 'enforced') return result;
+  if (!input.tenantId) return result;
+  for (const requestedId of [...new Set(input.serverIds)]) {
+    const serverId = await new MCPServerRepository(input.db)
+      .resolveCanonicalId(requestedId)
+      .catch(() => requestedId as MCPServerID);
+    input.gateway.abortServer(input.tenantId, serverId, 'server_detached');
+  }
+  return result;
+}
+
+/** Actual mcp-servers after-write coordination shared by patch/update/remove. */
+export function coordinateMCPServerMutationAfterWrite(
+  context: HookContext,
+  gateway: Pick<MCPEgressGateway, 'abortServer'> | undefined
+): void {
+  const tenantId = context.params.tenant?.tenant_id;
+  const serverId = (context.result as { mcp_server_id?: unknown } | undefined)?.mcp_server_id;
+  if (tenantId && typeof serverId === 'string') {
+    gateway?.abortServer(tenantId, serverId, 'stale_capability');
+  }
+}
+
+/** Durable rollout write first, then tenant-scoped local cancellation. */
+export async function coordinateMCPEgressRolloutChange<T>(input: {
+  gateway: Pick<MCPEgressGateway, 'abortTenant'>;
+  tenantId?: string;
+  mutate: () => Promise<T>;
+}): Promise<T> {
+  const result = await input.mutate();
+  if (input.tenantId) input.gateway.abortTenant(input.tenantId);
+  return result;
+}

--- a/apps/agor-daemon/src/mcp-egress/executor-env.test.ts
+++ b/apps/agor-daemon/src/mcp-egress/executor-env.test.ts
@@ -1,0 +1,82 @@
+import type { MCPServer } from '@agor/core/types';
+import { describe, expect, it } from 'vitest';
+import { scrubMCPSecretsFromExecutorEnv } from './executor-env.js';
+
+describe('mediated MCP executor environment scrub', () => {
+  it('removes every referenced/literal credential source without low-entropy collisions', () => {
+    const env = {
+      MCP_KEY: 'referenced-secret-value',
+      DUPLICATE: 'literal-bearer-secret',
+      JWT_CLIENT: 'jwt-client-secret',
+      RAW_HEADER_SECRET: 'literal-header-secret',
+      DEBUG: '1',
+      NODE_ENV: 'test',
+      AGOR_USER_ENV_KEYS: 'MCP_KEY,DEBUG,NODE_ENV',
+    };
+    scrubMCPSecretsFromExecutorEnv(env, [
+      {
+        transport: 'http',
+        url: 'https://provider.example/{{ user.env.MCP_KEY }}',
+        headers: {
+          'X-Secret': 'literal-bearer-secret',
+          Authorization: 'Bearer literal-header-secret',
+        },
+        auth: { type: 'jwt', api_token: 'jwt-client-name', api_secret: 'jwt-client-secret' },
+      } as MCPServer,
+    ]);
+
+    expect(env).toEqual({ DEBUG: '1', NODE_ENV: 'test', AGOR_USER_ENV_KEYS: 'DEBUG,NODE_ENV' });
+  });
+
+  it('scrubs stdio secret environments even though stdio is excluded before spawn', () => {
+    const env = { STDIO_SECRET: 'secret-bearing-stdio-value', SAFE: 'available' };
+    scrubMCPSecretsFromExecutorEnv(env, [
+      {
+        transport: 'stdio',
+        env: { SECRET: '{{ user.env.STDIO_SECRET }}' },
+      } as MCPServer,
+    ]);
+    expect(env).toEqual({ SAFE: 'available' });
+  });
+
+  it('binds default, helper, nested, and fallback user.env expressions', () => {
+    const env = {
+      PRIMARY: 'primary-secret',
+      FALLBACK: 'fallback-secret',
+      NESTED: 'nested-secret',
+      SAFE: 'kept',
+    };
+    scrubMCPSecretsFromExecutorEnv(env, [
+      {
+        transport: 'http',
+        url: 'https://provider.example/{{default user.env.PRIMARY user.env.FALLBACK}}',
+        headers: { 'X-Nested': '{{uppercase (default user.env.NESTED user.env.FALLBACK)}}' },
+      } as MCPServer,
+    ]);
+    expect(env).toEqual({ SAFE: 'kept' });
+  });
+
+  it.each([
+    '{{@root.user.env.SECRET}}',
+    '{{this.user.env.SECRET}}',
+    '{{./user.env.SECRET}}',
+    '{{lookup user.env user.env.KEY_NAME}}',
+    '{{lookup (lookup user "env") "SECRET"}}',
+    '{{#with user}}{{env.SECRET}}{{/with}}',
+  ])('excludes indeterminate template %s and scrubs every user env key', (template) => {
+    const env = {
+      KEY_NAME: 'SECRET',
+      SECRET: 'never-export',
+      SECOND: 'also-never-export',
+      SAFE: 'kept',
+      AGOR_USER_ENV_KEYS: 'KEY_NAME,SECRET,SECOND',
+    };
+    scrubMCPSecretsFromExecutorEnv(env, [
+      {
+        transport: 'http',
+        url: `https://provider.example/${template}`,
+      } as MCPServer,
+    ]);
+    expect(env).toEqual({ SAFE: 'kept' });
+  });
+});

--- a/apps/agor-daemon/src/mcp-egress/executor-env.ts
+++ b/apps/agor-daemon/src/mcp-egress/executor-env.ts
@@ -1,0 +1,94 @@
+import { AGOR_USER_ENV_KEYS_VAR } from '@agor/core/config';
+import { extractMCPTemplateDependencies } from '@agor/core/mcp';
+import type { MCPServer } from '@agor/core/types';
+
+function highSignal(value: string): boolean {
+  return value.length >= 8 && new Set(value).size >= 4;
+}
+
+function highSignalUrlValue(value: string): boolean {
+  return value.length >= 16 && new Set(value).size >= 8;
+}
+
+function leaves(value: unknown): string[] {
+  if (typeof value === 'string') return [value];
+  if (Array.isArray(value)) return value.flatMap(leaves);
+  if (value && typeof value === 'object') return Object.values(value).flatMap(leaves);
+  return [];
+}
+
+function urlValues(url?: string): string[] {
+  if (!url) return [];
+  try {
+    const parsed = new URL(url);
+    return [
+      ...parsed.pathname.split('/').map((part) => {
+        try {
+          return decodeURIComponent(part);
+        } catch {
+          return part;
+        }
+      }),
+      ...parsed.searchParams.values(),
+    ];
+  } catch {
+    return [];
+  }
+}
+
+function credentialVariants(value: string): string[] {
+  return [value, value.replace(/^(?:Bearer|Basic)\s+/i, '')];
+}
+
+function authSecrets(auth: MCPServer['auth']): string[] {
+  if (!auth) return [];
+  return [
+    auth.token,
+    auth.api_token,
+    auth.api_secret,
+    auth.oauth_client_id,
+    auth.oauth_client_secret,
+    auth.oauth_access_token,
+    auth.oauth_refresh_token,
+  ].filter((value): value is string => typeof value === 'string');
+}
+
+/**
+ * Defense in depth for every mediated task, including servers that projection
+ * later omits. Removing DEBUG=1-style values would be a collision, not secrecy.
+ */
+export function scrubMCPSecretsFromExecutorEnv(
+  executorEnv: Record<string, string>,
+  servers: MCPServer[]
+): void {
+  const referencedKeys = new Set<string>();
+  const literalValues = new Set<string>();
+  for (const server of servers) {
+    const dependencies = extractMCPTemplateDependencies(server);
+    if (!dependencies.valid && dependencies.mightReferenceUserEnv) {
+      for (const key of (executorEnv[AGOR_USER_ENV_KEYS_VAR] ?? '').split(',').filter(Boolean)) {
+        delete executorEnv[key];
+      }
+      delete executorEnv[AGOR_USER_ENV_KEYS_VAR];
+      continue;
+    }
+    for (const key of dependencies.keys) referencedKeys.add(key);
+    const candidates = [
+      ...leaves(server.env),
+      ...leaves(server.headers),
+      ...authSecrets(server.auth),
+      ...urlValues(server.url).filter(highSignalUrlValue),
+    ];
+    for (const value of candidates.flatMap(credentialVariants)) {
+      if (highSignal(value) && !value.includes('{{')) literalValues.add(value);
+    }
+  }
+  for (const [key, value] of Object.entries(executorEnv)) {
+    if (referencedKeys.has(key) || literalValues.has(value)) delete executorEnv[key];
+  }
+  const remainingKeys = (executorEnv[AGOR_USER_ENV_KEYS_VAR] ?? '')
+    .split(',')
+    .filter((key) => key && !referencedKeys.has(key) && key in executorEnv);
+  if (remainingKeys.length) executorEnv[AGOR_USER_ENV_KEYS_VAR] = remainingKeys.join(',');
+  else delete executorEnv[AGOR_USER_ENV_KEYS_VAR];
+}

--- a/apps/agor-daemon/src/mcp-egress/gateway.postgres.test.ts
+++ b/apps/agor-daemon/src/mcp-egress/gateway.postgres.test.ts
@@ -1,0 +1,358 @@
+/** Active-active provider-observation proof. Requires two PostgreSQL pools. */
+import http from 'node:http';
+import {
+  BranchRepository,
+  createDatabase,
+  createTenantScopedDatabaseProxy,
+  generateId,
+  initializeDatabase,
+  MCPServerRepository,
+  RepoRepository,
+  runWithTenantDatabaseScope,
+  runWithTenantDatabaseTransaction,
+  SessionMCPServerRepository,
+  SessionRepository,
+  setMCPEgressGatewayMode,
+  TaskRepository,
+  type TenantScopeAwareDatabase,
+  UsersRepository,
+} from '@agor/core/db';
+import type { Application } from '@agor/core/feathers';
+import { TaskStatus, type TenantID, type UserID, type UUID } from '@agor/core/types';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { issueMCPEgressCapability } from './capability.js';
+import { MCPEgressGateway, mcpEgressMaterialHash } from './gateway.js';
+
+const postgresUrl = process.env.AGOR_TEST_POSTGRES_URL;
+const usesPostgresSchema = process.env.AGOR_DB_DIALECT === 'postgresql';
+
+describe.skipIf(!postgresUrl || !usesPostgresSchema)(
+  'MCP egress final admission (PostgreSQL HA)',
+  () => {
+    let rawA: ReturnType<typeof createDatabase>;
+    let rawB: ReturnType<typeof createDatabase>;
+    let dbA: TenantScopeAwareDatabase;
+    let dbB: TenantScopeAwareDatabase;
+    const servers: http.Server[] = [];
+
+    beforeAll(async () => {
+      rawA = createDatabase({ dialect: 'postgresql', url: postgresUrl! });
+      rawB = createDatabase({ dialect: 'postgresql', url: postgresUrl! });
+      await initializeDatabase(rawA);
+      dbA = createTenantScopedDatabaseProxy(rawA, {
+        requireScope: true,
+        label: 'MCP egress daemon A',
+      });
+      dbB = createTenantScopedDatabaseProxy(rawB, {
+        requireScope: true,
+        label: 'MCP egress daemon B',
+      });
+    });
+
+    afterAll(async () => {
+      await Promise.all(
+        servers.map((server) => new Promise<void>((resolve) => server.close(() => resolve())))
+      );
+      await Promise.all([
+        (rawA as typeof rawA & { $client: { end(): Promise<void> } }).$client.end(),
+        (rawB as typeof rawB & { $client: { end(): Promise<void> } }).$client.end(),
+      ]);
+    });
+
+    async function provider(handler: http.RequestListener): Promise<string> {
+      const server = http.createServer(handler);
+      servers.push(server);
+      await new Promise<void>((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(0, '127.0.0.1', resolve);
+      });
+      const address = server.address();
+      if (!address || typeof address === 'string') throw new Error('Expected TCP listener');
+      return `http://localhost:${address.port}/mcp`;
+    }
+
+    async function seed(tenantId: TenantID, url: string) {
+      return runWithTenantDatabaseScope(dbA, tenantId, async (scoped) => {
+        const user = await new UsersRepository(scoped).create({
+          email: `${generateId()}@example.test`,
+          name: 'HA gateway owner',
+          role: 'member',
+        });
+        const repo = await new RepoRepository(scoped).create({
+          repo_id: generateId() as UUID,
+          slug: `ha-egress-${generateId()}`,
+          name: 'HA egress',
+          repo_type: 'remote',
+          remote_url: 'https://example.test/repo.git',
+          local_path: `/tmp/${generateId()}`,
+          default_branch: 'main',
+        });
+        const branch = await new BranchRepository(scoped).create({
+          branch_id: generateId(),
+          repo_id: repo.repo_id,
+          name: 'ha-egress',
+          ref: 'main',
+          branch_unique_id: Math.floor(Math.random() * 1_000_000),
+          path: `/tmp/${generateId()}`,
+          created_by: user.user_id as UUID,
+        });
+        const session = await new SessionRepository(scoped).create({
+          session_id: generateId(),
+          branch_id: branch.branch_id,
+          agentic_tool: 'codex',
+          created_by: user.user_id as UserID,
+        });
+        const task = await new TaskRepository(scoped).create({
+          task_id: generateId(),
+          session_id: session.session_id,
+          created_by: user.user_id,
+          full_prompt: 'HA admission race',
+          status: TaskStatus.RUNNING,
+          message_range: {
+            start_index: 0,
+            end_index: 0,
+            start_timestamp: new Date().toISOString(),
+          },
+          git_state: { ref_at_start: 'main', sha_at_start: 'test' },
+          tool_use_count: 0,
+        });
+        const mcpServer = await new MCPServerRepository(scoped).create({
+          name: `ha-egress-${generateId()}`,
+          transport: 'http',
+          url,
+          scope: 'session',
+          source: 'user',
+          enabled: true,
+          owner_user_id: user.user_id as UserID,
+          auth: { type: 'bearer', token: 'ha-provider-secret' },
+        });
+        await new SessionMCPServerRepository(scoped).addServer(
+          session.session_id,
+          mcpServer.mcp_server_id
+        );
+        await setMCPEgressGatewayMode(scoped, 'enforced', user.user_id);
+        return { user, session, task, mcpServer };
+      });
+    }
+
+    it('observes daemon-B commit before daemon-A final check and sends zero provider requests', async () => {
+      const tenantId = `mcp-egress-ha-${generateId()}` as TenantID;
+      let providerRequests = 0;
+      const url = await provider((_request, response) => {
+        providerRequests += 1;
+        response.writeHead(200, { 'content-type': 'application/json' });
+        response.end('{"jsonrpc":"2.0","id":1,"result":{}}');
+      });
+      const seeded = await seed(tenantId, url);
+      let releaseDns!: () => void;
+      let dnsStarted!: () => void;
+      const dnsGate = new Promise<void>((resolve) => (releaseDns = resolve));
+      const dnsObserved = new Promise<void>((resolve) => (dnsStarted = resolve));
+      const jwtSecret = 'postgres-ha-gateway-signing-key';
+      const gateway = new MCPEgressGateway({
+        db: dbA,
+        app: { get: () => undefined, service: () => ({}) } as unknown as Application,
+        jwtSecret,
+        branchRbacEnabled: false,
+        allowLocalhostHttp: true,
+        resolveDns: async () => {
+          dnsStarted();
+          await dnsGate;
+          return [{ address: '127.0.0.1', family: 4 }];
+        },
+      });
+      const capability = issueMCPEgressCapability(
+        {
+          tid: tenantId,
+          task_id: seeded.task.task_id,
+          session_id: seeded.session.session_id,
+          principal_user_id: seeded.user.user_id,
+          credential_user_id: seeded.user.user_id,
+          mcp_server_id: seeded.mcpServer.mcp_server_id,
+          config_version: seeded.mcpServer.config_version ?? 1,
+          material_hash: mcpEgressMaterialHash(seeded.mcpServer, {}, jwtSecret),
+          rollout_mode: 'enforced',
+          jti: generateId(),
+        },
+        jwtSecret
+      );
+
+      const pending = gateway.forward({
+        serverId: seeded.mcpServer.mcp_server_id,
+        headers: new Headers({ 'x-agor-mcp-capability': capability }),
+        method: 'POST',
+        body: new TextEncoder().encode('{"jsonrpc":"2.0","id":1,"method":"initialize"}'),
+      });
+      await dnsObserved;
+      await runWithTenantDatabaseScope(dbB, tenantId, (scoped) =>
+        new MCPServerRepository(scoped).update(seeded.mcpServer.mcp_server_id, {
+          description: 'committed by daemon B',
+          expected_config_version: seeded.mcpServer.config_version,
+        })
+      );
+      releaseDns();
+
+      await expect(pending).rejects.toMatchObject({ code: 'stale_capability' });
+      expect(providerRequests).toBe(0);
+
+      const wrongTenantCapability = issueMCPEgressCapability(
+        {
+          tid: `other-${tenantId}`,
+          task_id: seeded.task.task_id,
+          session_id: seeded.session.session_id,
+          principal_user_id: seeded.user.user_id,
+          credential_user_id: seeded.user.user_id,
+          mcp_server_id: seeded.mcpServer.mcp_server_id,
+          config_version: seeded.mcpServer.config_version ?? 1,
+          material_hash: mcpEgressMaterialHash(seeded.mcpServer, {}, jwtSecret),
+          rollout_mode: 'enforced',
+          jti: generateId(),
+        },
+        jwtSecret
+      );
+      await expect(
+        gateway.forward({
+          serverId: seeded.mcpServer.mcp_server_id,
+          headers: new Headers({ 'x-agor-mcp-capability': wrongTenantCapability }),
+          method: 'POST',
+          body: new TextEncoder().encode('{"jsonrpc":"2.0","id":2,"method":"initialize"}'),
+        })
+      ).rejects.toMatchObject({ code: 'rollout_changed' });
+      expect(providerRequests).toBe(0);
+    });
+
+    it('allows a provider-observed request admitted before daemon-B commits', async () => {
+      const tenantId = `mcp-egress-ha-admitted-${generateId()}` as TenantID;
+      let releaseProvider!: () => void;
+      let providerStarted!: () => void;
+      const providerGate = new Promise<void>((resolve) => (releaseProvider = resolve));
+      const providerObserved = new Promise<void>((resolve) => (providerStarted = resolve));
+      let providerRequests = 0;
+      const url = await provider(async (_request, response) => {
+        providerRequests += 1;
+        providerStarted();
+        await providerGate;
+        response.writeHead(200, { 'content-type': 'application/json' });
+        response.end('{"jsonrpc":"2.0","id":1,"result":{"admitted":true}}');
+      });
+      const seeded = await seed(tenantId, url);
+      const jwtSecret = 'postgres-ha-admitted-key';
+      const gateway = new MCPEgressGateway({
+        db: dbA,
+        app: { get: () => undefined, service: () => ({}) } as unknown as Application,
+        jwtSecret,
+        branchRbacEnabled: false,
+        allowLocalhostHttp: true,
+        resolveDns: async () => [{ address: '127.0.0.1', family: 4 }],
+      });
+      const capability = issueMCPEgressCapability(
+        {
+          tid: tenantId,
+          task_id: seeded.task.task_id,
+          session_id: seeded.session.session_id,
+          principal_user_id: seeded.user.user_id,
+          credential_user_id: seeded.user.user_id,
+          mcp_server_id: seeded.mcpServer.mcp_server_id,
+          config_version: seeded.mcpServer.config_version ?? 1,
+          material_hash: mcpEgressMaterialHash(seeded.mcpServer, {}, jwtSecret),
+          rollout_mode: 'enforced',
+          jti: generateId(),
+        },
+        jwtSecret
+      );
+      const pending = gateway.forward({
+        serverId: seeded.mcpServer.mcp_server_id,
+        headers: new Headers({ 'x-agor-mcp-capability': capability }),
+        method: 'POST',
+        body: new TextEncoder().encode('{"jsonrpc":"2.0","id":1,"method":"initialize"}'),
+      });
+      await providerObserved;
+      await runWithTenantDatabaseScope(dbB, tenantId, (scoped) =>
+        new MCPServerRepository(scoped).update(seeded.mcpServer.mcp_server_id, {
+          description: 'commit after provider observation',
+          expected_config_version: seeded.mcpServer.config_version,
+        })
+      );
+      releaseProvider();
+      await expect((await pending).response.json()).resolves.toMatchObject({
+        result: { admitted: true },
+      });
+      expect(providerRequests).toBe(1);
+    });
+
+    it('keeps a concurrent config+detach commit out of one repeatable-read authority snapshot', async () => {
+      const tenantId = `mcp-egress-ha-snapshot-${generateId()}` as TenantID;
+      let providerRequests = 0;
+      const url = await provider((_request, response) => {
+        providerRequests += 1;
+        response.writeHead(200, { 'content-type': 'application/json' });
+        response.end('{"jsonrpc":"2.0","id":1,"result":{}}');
+      });
+      const seeded = await seed(tenantId, url);
+      let checkpointCount = 0;
+      let releaseSnapshot!: () => void;
+      let finalSnapshotStarted!: () => void;
+      const snapshotGate = new Promise<void>((resolve) => (releaseSnapshot = resolve));
+      const snapshotObserved = new Promise<void>((resolve) => (finalSnapshotStarted = resolve));
+      const jwtSecret = 'postgres-ha-snapshot-key';
+      const gateway = new MCPEgressGateway({
+        db: dbA,
+        app: { get: () => undefined, service: () => ({}) } as unknown as Application,
+        jwtSecret,
+        branchRbacEnabled: false,
+        allowLocalhostHttp: true,
+        resolveDns: async () => [{ address: '127.0.0.1', family: 4 }],
+        authoritySnapshotCheckpoint: async () => {
+          checkpointCount += 1;
+          if (checkpointCount === 2) {
+            finalSnapshotStarted();
+            await snapshotGate;
+          }
+        },
+      });
+      const capability = issueMCPEgressCapability(
+        {
+          tid: tenantId,
+          task_id: seeded.task.task_id,
+          session_id: seeded.session.session_id,
+          principal_user_id: seeded.user.user_id,
+          credential_user_id: seeded.user.user_id,
+          mcp_server_id: seeded.mcpServer.mcp_server_id,
+          config_version: seeded.mcpServer.config_version ?? 1,
+          material_hash: mcpEgressMaterialHash(seeded.mcpServer, {}, jwtSecret),
+          rollout_mode: 'enforced',
+          jti: generateId(),
+        },
+        jwtSecret
+      );
+      const pending = gateway.forward({
+        serverId: seeded.mcpServer.mcp_server_id,
+        headers: new Headers({ 'x-agor-mcp-capability': capability }),
+        method: 'POST',
+        body: new TextEncoder().encode('{"jsonrpc":"2.0","id":1,"method":"initialize"}'),
+      });
+      await snapshotObserved;
+      await runWithTenantDatabaseTransaction(dbB, tenantId, async (scoped) => {
+        await new MCPServerRepository(scoped).update(seeded.mcpServer.mcp_server_id, {
+          description: 'committed mixed-read adversary',
+          expected_config_version: seeded.mcpServer.config_version,
+        });
+        await new SessionMCPServerRepository(scoped).removeServer(
+          seeded.session.session_id,
+          seeded.mcpServer.mcp_server_id
+        );
+      });
+      releaseSnapshot();
+      await expect(pending).resolves.toBeDefined();
+      expect(providerRequests).toBe(1);
+      await expect(
+        gateway.forward({
+          serverId: seeded.mcpServer.mcp_server_id,
+          headers: new Headers({ 'x-agor-mcp-capability': capability }),
+          method: 'POST',
+          body: new TextEncoder().encode('{"jsonrpc":"2.0","id":2,"method":"initialize"}'),
+        })
+      ).rejects.toMatchObject({ code: expect.stringMatching(/stale_capability|server_detached/) });
+    });
+  }
+);

--- a/apps/agor-daemon/src/mcp-egress/gateway.test.ts
+++ b/apps/agor-daemon/src/mcp-egress/gateway.test.ts
@@ -1,0 +1,1226 @@
+import { randomUUID } from 'node:crypto';
+import { rm } from 'node:fs/promises';
+import http from 'node:http';
+import {
+  BranchRepository,
+  createDatabaseAsync,
+  MCPServerRepository,
+  RepoRepository,
+  runMigrations,
+  runWithTenantDatabaseTransaction,
+  SessionMCPServerRepository,
+  SessionRepository,
+  setMCPEgressGatewayMode,
+  TaskRepository,
+  type TenantScopeAwareDatabase,
+  UserMCPOAuthTokenRepository,
+  UsersRepository,
+} from '@agor/core/db';
+import type { Application } from '@agor/core/feathers';
+import { refreshAndPersistToken } from '@agor/core/tools/mcp/oauth-refresh';
+import {
+  type MCPServer,
+  type MCPServerID,
+  TaskStatus,
+  type UserID,
+  type UUID,
+} from '@agor/core/types';
+import type { OutboundDnsLookup } from '@agor/core/utils/safe-outbound-fetch';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { issueMCPEgressCapability } from './capability.js';
+import {
+  coordinateMCPEgressRolloutChange,
+  coordinateMCPServerMutationAfterWrite,
+  coordinateSessionMCPRevocation,
+} from './coordination.js';
+import {
+  MCPEgressGateway,
+  MCPEgressGatewayError,
+  mcpEgressEligibility,
+  mcpEgressMaterialHash,
+  mcpOAuthGrantIdentity,
+  projectMCPServerForExecutor,
+} from './gateway.js';
+import { createMCPEgressHttpHandler } from './http-handler.js';
+
+const listeners: http.Server[] = [];
+const databases: Array<{ $client?: { close?: () => void } }> = [];
+const files: string[] = [];
+
+async function listen(handler: http.RequestListener): Promise<string> {
+  const server = http.createServer(handler);
+  listeners.push(server);
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('Expected TCP listener');
+  return `http://127.0.0.1:${address.port}`;
+}
+
+function asLocalhost(url: string): string {
+  return url.replace('127.0.0.1', 'localhost');
+}
+
+afterEach(async () => {
+  await Promise.all(
+    listeners
+      .splice(0)
+      .map((server) => new Promise<void>((resolve) => server.close(() => resolve())))
+  );
+  for (const database of databases.splice(0)) database.$client?.close?.();
+  await Promise.all(files.splice(0).map((file) => rm(file, { force: true })));
+});
+
+interface HarnessOptions {
+  dbUrl?: string;
+  server: Pick<MCPServer, 'transport'> &
+    Partial<
+      Pick<
+        MCPServer,
+        'url' | 'command' | 'args' | 'env' | 'headers' | 'auth' | 'tool_permissions' | 'scope'
+      >
+    >;
+  jwtSecret?: string;
+  resolveDns?: OutboundDnsLookup;
+  oauthAccessToken?: string;
+  oauthRefreshToken?: string;
+  oauthExpiresAt?: Date | null;
+  separatePrincipal?: boolean;
+  branchRbacEnabled?: boolean;
+  authoritySnapshotCheckpoint?: () => Promise<void>;
+  oauthAuthHeadersCreate?: (params: {
+    mcp_egress_assert_current?: () => Promise<void>;
+  }) => Promise<{ headers: Record<string, { authorization?: string; error?: string }> }>;
+  capabilityServerTransform?: (server: MCPServer) => MCPServer;
+}
+
+async function harness(options: HarnessOptions) {
+  const rawDb = await createDatabaseAsync({
+    dialect: 'sqlite',
+    url: options.dbUrl ?? ':memory:',
+  });
+  databases.push(rawDb as typeof rawDb & { $client?: { close?: () => void } });
+  await runMigrations(rawDb);
+  const user = await new UsersRepository(rawDb).create({
+    email: `${randomUUID()}@example.com`,
+    name: 'Gateway transport owner',
+    role: 'member',
+  });
+  const principal = options.separatePrincipal
+    ? await new UsersRepository(rawDb).create({
+        email: `${randomUUID()}@example.com`,
+        name: 'Gateway prompting principal',
+        role: 'member',
+      })
+    : user;
+  const repo = await new RepoRepository(rawDb).create({
+    repo_id: randomUUID() as UUID,
+    slug: `gateway-${randomUUID()}`,
+    name: 'Gateway test',
+    repo_type: 'remote',
+    remote_url: 'https://example.invalid/gateway.git',
+    local_path: `/tmp/${randomUUID()}`,
+    default_branch: 'main',
+  });
+  const branch = await new BranchRepository(rawDb).create({
+    branch_id: randomUUID(),
+    repo_id: repo.repo_id,
+    name: 'gateway-test',
+    ref: 'main',
+    branch_unique_id: Date.now() % 1_000_000,
+    path: `/tmp/${randomUUID()}`,
+    created_by: user.user_id as UUID,
+    others_can: options.separatePrincipal ? 'prompt' : undefined,
+  });
+  const session = await new SessionRepository(rawDb).create({
+    session_id: randomUUID(),
+    branch_id: branch.branch_id,
+    agentic_tool: 'codex',
+    created_by: user.user_id as UserID,
+  });
+  const task = await new TaskRepository(rawDb).create({
+    task_id: randomUUID(),
+    session_id: session.session_id,
+    created_by: principal.user_id,
+    full_prompt: 'exercise authoritative MCP egress',
+    status: TaskStatus.RUNNING,
+    message_range: { start_index: 0, end_index: 0, start_timestamp: new Date().toISOString() },
+    git_state: { ref_at_start: 'main', sha_at_start: 'test' },
+    tool_use_count: 0,
+  });
+  const server = await new MCPServerRepository(rawDb).create({
+    name: `gateway-${randomUUID()}`,
+    ...options.server,
+    scope: options.server.scope ?? 'global',
+    source: 'user',
+    enabled: true,
+    owner_user_id: user.user_id as UserID,
+  });
+  if (server.scope === 'session') {
+    await new SessionMCPServerRepository(rawDb).addServer(session.session_id, server.mcp_server_id);
+  }
+  const rolloutMode = 'enforced' as const;
+  await setMCPEgressGatewayMode(rawDb, rolloutMode, user.user_id);
+  let grantIdentity: string | undefined;
+  const oauthTokenUserId =
+    server.auth?.type === 'oauth' && (server.auth.oauth_mode ?? 'per_user') === 'shared'
+      ? null
+      : (user.user_id as UserID);
+  if (server.auth?.type === 'oauth') {
+    await new UserMCPOAuthTokenRepository(rawDb).saveToken(oauthTokenUserId, server.mcp_server_id, {
+      accessToken: options.oauthAccessToken ?? 'oauth-access-token-initial',
+      refreshToken: options.oauthRefreshToken,
+      expiresAt: options.oauthExpiresAt,
+      clientId: server.auth.oauth_client_id ?? 'gateway-test-oauth-client',
+      grantBinding: {
+        generation: 1,
+        version: 4,
+        fingerprint: 'gateway-test-binding-v1',
+        metadataUri: 'https://auth.example.test/.well-known/oauth-protected-resource',
+        resourceUri: server.url ?? 'https://provider.example.test/mcp',
+        issuer: 'https://auth.example.test',
+        authorizationEndpoint: 'https://auth.example.test/authorize',
+        tokenEndpoint: server.auth.oauth_token_url ?? 'https://auth.example.test/token',
+        redirectUri: 'https://daemon.example.test/mcp-servers/oauth-callback',
+      },
+    });
+    grantIdentity = mcpOAuthGrantIdentity(
+      await new UserMCPOAuthTokenRepository(rawDb).getToken(oauthTokenUserId, server.mcp_server_id)
+    );
+  }
+  const jwtSecret = options.jwtSecret ?? 'gateway-test-signing-key';
+  const app = {
+    get: () => undefined,
+    service: (path: string) => {
+      if (path !== 'mcp-servers/oauth-auth-headers') return {};
+      return {
+        create: async (_data: unknown, params: unknown) => {
+          if (options.oauthAuthHeadersCreate) {
+            return options.oauthAuthHeadersCreate(
+              params as { mcp_egress_assert_current?: () => Promise<void> }
+            );
+          }
+          const current = await new UserMCPOAuthTokenRepository(rawDb).getToken(
+            oauthTokenUserId,
+            server.mcp_server_id
+          );
+          return {
+            headers: {
+              [server.mcp_server_id]: current
+                ? { authorization: `Bearer ${current.oauth_access_token}` }
+                : { error: 'needs_reauth' },
+            },
+          };
+        },
+      };
+    },
+  } as unknown as Application;
+  const gateway = new MCPEgressGateway({
+    db: rawDb as unknown as TenantScopeAwareDatabase,
+    app,
+    jwtSecret,
+    branchRbacEnabled: options.branchRbacEnabled ?? false,
+    allowLocalhostHttp: true,
+    resolveDns: options.resolveDns,
+    authoritySnapshotCheckpoint: options.authoritySnapshotCheckpoint,
+  });
+  const capability = issueMCPEgressCapability(
+    {
+      tid: 'default',
+      task_id: task.task_id,
+      session_id: session.session_id,
+      principal_user_id: principal.user_id,
+      credential_user_id: user.user_id,
+      mcp_server_id: server.mcp_server_id,
+      config_version: server.config_version ?? 1,
+      material_hash: mcpEgressMaterialHash(
+        options.capabilityServerTransform?.(server) ?? server,
+        {},
+        jwtSecret
+      ),
+      grant_identity: grantIdentity,
+      rollout_mode: rolloutMode,
+      jti: randomUUID(),
+    },
+    jwtSecret
+  );
+  const request = (method = 'POST', body?: string) =>
+    gateway.forward({
+      serverId: server.mcp_server_id,
+      headers: new Headers({
+        'x-agor-mcp-capability': capability,
+        authorization: 'executor-injected-authorization',
+      }),
+      method,
+      body: body ? new TextEncoder().encode(body) : undefined,
+    });
+  const routeRequest = async (method = 'POST', body?: string) => {
+    let status = 200;
+    let payload: unknown;
+    let responseBody: unknown;
+    const response = {
+      headersSent: false,
+      status(code: number) {
+        status = code;
+        return this;
+      },
+      setHeader() {
+        return this;
+      },
+      json(value: unknown) {
+        payload = value;
+        this.headersSent = true;
+        return this;
+      },
+      end(value?: unknown) {
+        responseBody = value;
+        this.headersSent = true;
+        return this;
+      },
+    };
+    await createMCPEgressHttpHandler(gateway)(
+      {
+        params: { serverId: server.mcp_server_id },
+        body: body ? JSON.parse(body) : undefined,
+        headers: { 'x-agor-mcp-capability': capability },
+        method,
+      } as never,
+      response as never
+    );
+    return { status, payload, responseBody };
+  };
+  return {
+    rawDb,
+    gateway,
+    server,
+    session,
+    task,
+    user,
+    principal,
+    branch,
+    capability,
+    jwtSecret,
+    oauthTokenUserId,
+    request,
+    routeRequest,
+  };
+}
+
+const initialize = JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize' });
+
+describe('authoritative MCP gateway real transport', () => {
+  it('projects only bounded HTTP servers and excludes stdio and ask authority up front', () => {
+    expect(
+      mcpEgressEligibility({ transport: 'stdio', command: 'never-spawn' } as MCPServer)
+    ).toEqual({ eligible: false, reason: 'transport_not_mediated' });
+    expect(
+      mcpEgressEligibility({
+        transport: 'http',
+        url: 'https://provider.example/mcp',
+        tool_permissions: { destructive: 'ask' },
+      } as MCPServer)
+    ).toEqual({ eligible: false, reason: 'approval_not_mediated' });
+    for (const template of [
+      '{{@root.user.env.SECRET}}',
+      '{{this.user.env.SECRET}}',
+      '{{./user.env.SECRET}}',
+      '{{lookup user.env "SECRET"}}',
+      '{{#with user}}{{env.SECRET}}{{/with}}',
+    ]) {
+      expect(
+        mcpEgressEligibility({
+          transport: 'http',
+          url: `https://provider.example/${template}`,
+        } as MCPServer)
+      ).toEqual({ eligible: false, reason: 'template_configuration' });
+    }
+    const projected = projectMCPServerForExecutor(
+      {
+        mcp_server_id: 'server-safe-shape',
+        transport: 'http',
+        url: 'https://provider.example/credential-path-value',
+        command: 'never-export',
+        args: ['never-export'],
+        env: { PROVIDER_KEY: 'never-export' },
+        headers: { 'X-Provider-Key': 'never-export' },
+        auth: { type: 'bearer', token: 'never-export' },
+      } as MCPServer,
+      'https://daemon.example/mcp-egress/server-safe-shape',
+      'opaque-capability'
+    );
+    expect(projected).toMatchObject({
+      transport: 'http',
+      url: 'https://daemon.example/mcp-egress/server-safe-shape',
+      headers: { 'X-Agor-Mcp-Capability': 'opaque-capability' },
+    });
+    expect(projected).not.toHaveProperty('auth');
+    expect(projected).not.toHaveProperty('env');
+    expect(projected).not.toHaveProperty('command');
+    expect(projected).not.toHaveProperty('args');
+  });
+
+  it('injects the reusable credential only at the daemon-owned provider boundary', async () => {
+    const secret = 'provider-secret-never-exported';
+    let authorization: string | undefined;
+    const url = await listen((request, response) => {
+      authorization = request.headers.authorization;
+      response.writeHead(200, { 'content-type': 'application/json', 'x-private': secret });
+      response.end('{"jsonrpc":"2.0","id":1,"result":{}}');
+    });
+    const h = await harness({
+      server: { transport: 'http', url: `${url}/mcp`, auth: { type: 'bearer', token: secret } },
+    });
+
+    expect(h.capability).not.toContain(secret);
+    const forwarded = await h.request('POST', initialize);
+    expect(authorization).toBe(`Bearer ${secret}`);
+    expect([...forwarded.response.headers.keys()]).not.toContain('x-private');
+    expect(await forwarded.response.text()).not.toContain(secret);
+  });
+
+  it('rejects GET before provider dispatch', async () => {
+    let providerRequests = 0;
+    const url = await listen((_request, response) => {
+      providerRequests += 1;
+      response.end();
+    });
+    const h = await harness({ server: { transport: 'http', url, auth: { type: 'none' } } });
+    await expect(h.request('GET')).rejects.toMatchObject({
+      status: 405,
+      code: 'method_not_mediated',
+    });
+    expect(providerRequests).toBe(0);
+  });
+
+  it('reconstructs SSE from validated JSON data only and drops every control field', async () => {
+    const secret = 'sse-control-secret-value';
+    const url = await listen((_request, response) => {
+      response.writeHead(200, { 'content-type': 'text/event-stream' });
+      response.end(
+        `: ${secret}\nid: ${secret}\nevent: ${secret}\nretry: 1000\ndata: {"jsonrpc":"2.0","id":1,"result":"safe"}\n\n`
+      );
+    });
+    const h = await harness({
+      server: { transport: 'http', url, auth: { type: 'bearer', token: secret } },
+    });
+    const text = await (await h.request('POST', initialize)).response.text();
+    expect(text).toBe('data: {"jsonrpc":"2.0","id":1,"result":"safe"}\n\n');
+    expect(text).not.toContain(secret);
+  });
+
+  it('bounds concurrent response memory and sockets per task', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => (release = resolve));
+    let providerRequests = 0;
+    const url = await listen(async (_request, response) => {
+      providerRequests += 1;
+      await gate;
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end('{"jsonrpc":"2.0","id":1,"result":{}}');
+    });
+    const h = await harness({ server: { transport: 'http', url, auth: { type: 'none' } } });
+    const held = Array.from({ length: 4 }, () => h.request('POST', initialize));
+    await vi.waitFor(() => expect(providerRequests).toBe(4));
+    expect(h.gateway.status('default')).toMatchObject({
+      inFlightRequests: 4,
+      activeRequests: 4,
+      providerInFlightRequests: 4,
+      reservedRequests: 0,
+    });
+    await expect(h.request('POST', initialize)).rejects.toMatchObject({
+      status: 429,
+      code: 'egress_capacity_exceeded',
+    });
+    release();
+    await Promise.all(held);
+  });
+
+  it('aborts only the tenant whose rollout changed', () => {
+    const gateway = new MCPEgressGateway({
+      db: {} as TenantScopeAwareDatabase,
+      app: {} as Application,
+      jwtSecret: 'tenant-abort-test',
+      branchRbacEnabled: false,
+    });
+    const tenantA = new AbortController();
+    const tenantB = new AbortController();
+    const reservations = (
+      gateway as unknown as {
+        reservations: Map<
+          string,
+          {
+            tenantId: string;
+            taskId: string;
+            serverId: string;
+            controller: AbortController;
+            startedAt: number;
+          }
+        >;
+      }
+    ).reservations;
+    reservations.set('tenant-a-request', {
+      tenantId: 'tenant-a',
+      taskId: 'task-a',
+      serverId: 'server-a',
+      controller: tenantA,
+      startedAt: Date.now(),
+    });
+    reservations.set('tenant-b-request', {
+      tenantId: 'tenant-b',
+      taskId: 'task-b',
+      serverId: 'server-b',
+      controller: tenantB,
+      startedAt: Date.now(),
+    });
+
+    expect(gateway.abortTenant('tenant-a')).toBe(1);
+    expect(tenantA.signal.aborted).toBe(true);
+    expect(tenantA.signal.reason).toBeInstanceOf(MCPEgressGatewayError);
+    expect(tenantA.signal.reason).toMatchObject({ code: 'rollout_changed', status: 409 });
+    expect(tenantB.signal.aborted).toBe(false);
+  });
+
+  it('uses one durable material identity across OAuth hook enrichment and routine refresh', () => {
+    const base = {
+      mcp_server_id: 'oauth-material',
+      config_version: 4,
+      transport: 'http',
+      url: 'https://provider.example/mcp',
+      auth: { type: 'oauth', oauth_client_id: 'durable-client' },
+    } as MCPServer;
+    const enriched = {
+      ...base,
+      auth: {
+        ...base.auth,
+        oauth_access_token: 'routine-access-token',
+        oauth_refresh_token: 'routine-refresh-token',
+        oauth_token_expires_at: Date.now() + 60_000,
+      },
+    } as MCPServer;
+    expect(mcpEgressMaterialHash(enriched, {}, 'hash-key')).toBe(
+      mcpEgressMaterialHash(base, {}, 'hash-key')
+    );
+    const helperServer = {
+      ...base,
+      url: 'https://provider.example/{{uppercase (default user.env.TENANT user.env.FALLBACK)}}',
+    } as MCPServer;
+    expect(
+      mcpEgressMaterialHash(
+        helperServer,
+        { TENANT: 'secret-before', FALLBACK: 'fallback' },
+        'hash-key'
+      )
+    ).not.toBe(
+      mcpEgressMaterialHash(
+        helperServer,
+        { TENANT: 'secret-after', FALLBACK: 'fallback' },
+        'hash-key'
+      )
+    );
+  });
+
+  it('admits the first request from an OAuth token-and-expiry-enriched projection', async () => {
+    const provider = await listen((_request, response) => {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end('{"jsonrpc":"2.0","id":1,"result":{}}');
+    });
+    const h = await harness({
+      server: {
+        transport: 'http',
+        url: provider,
+        auth: { type: 'oauth', oauth_client_id: 'durable-client' },
+      },
+      capabilityServerTransform: (server) => ({
+        ...server,
+        auth: {
+          ...server.auth!,
+          oauth_access_token: 'hook-enriched-live-token',
+          oauth_token_expires_at: Date.now() + 3_600_000,
+        },
+      }),
+    });
+
+    await expect(h.request('POST', initialize)).resolves.toBeDefined();
+  });
+
+  it.each([
+    { mutation: 'task completion', oauthMode: 'per_user' },
+    { mutation: 'session detach', oauthMode: 'per_user' },
+    { mutation: 'server mutation', oauthMode: 'per_user' },
+    { mutation: 'tenant rollout', oauthMode: 'per_user' },
+    { mutation: 'tenant rollout', oauthMode: 'shared' },
+    { mutation: 'shutdown', oauthMode: 'per_user' },
+  ] as const)(
+    'rechecks $mutation after refresh DNS for a $oauthMode grant without quarantining it',
+    async ({ mutation, oauthMode }) => {
+      let tokenRequests = 0;
+      const tokenUrl = asLocalhost(
+        await listen((_request, response) => {
+          tokenRequests += 1;
+          response.writeHead(200, { 'content-type': 'application/json' });
+          response.end('{"access_token":"refreshed-access-token","expires_in":3600}');
+        })
+      );
+      const mcpUrl = await listen((_request, response) => {
+        response.writeHead(200, { 'content-type': 'application/json' });
+        response.end('{"jsonrpc":"2.0","id":1,"result":{}}');
+      });
+      let dnsStarted!: () => void;
+      let releaseDns!: () => void;
+      const dnsObserved = new Promise<void>((resolve) => (dnsStarted = resolve));
+      const dnsGate = new Promise<void>((resolve) => (releaseDns = resolve));
+      const h = await harness({
+        server: {
+          transport: 'http',
+          scope: 'session',
+          url: mcpUrl,
+          auth: {
+            type: 'oauth',
+            oauth_mode: oauthMode,
+            oauth_client_id: 'durable-client-id',
+            oauth_token_url: tokenUrl,
+          },
+        },
+        oauthAccessToken: 'prior-valid-access-token',
+        oauthRefreshToken: 'refresh-secret-never-sent-stale',
+        oauthExpiresAt: new Date(0),
+        oauthAuthHeadersCreate: async (params) => {
+          const observed = await new UserMCPOAuthTokenRepository(h.rawDb).getToken(
+            h.oauthTokenUserId,
+            h.server.mcp_server_id
+          );
+          if (!observed) throw new Error('Expected OAuth grant');
+          const token = await refreshAndPersistToken({
+            db: h.rawDb,
+            userId: h.oauthTokenUserId,
+            mcpServerId: h.server.mcp_server_id,
+            observedRefreshVersion: {
+              grantGeneration: observed.grant_generation,
+              grantBindingFingerprint: observed.grant_binding_fingerprint,
+              refreshGeneration: observed.refresh_generation,
+            },
+            validateGrant: async () => true,
+            allowLocalhostHttpDevelopment: true,
+            resolveDns: async () => {
+              dnsStarted();
+              await dnsGate;
+              return [{ address: '127.0.0.1', family: 4 }];
+            },
+            assertCurrent: params.mcp_egress_assert_current,
+          });
+          return {
+            headers: {
+              [h.server.mcp_server_id]: { authorization: `Bearer ${token}` },
+            },
+          };
+        },
+      });
+
+      // Exercise the production Express handler so the stable structured
+      // reason is proven at the executor-visible route boundary.
+      const pending = h.routeRequest('POST', initialize);
+      await dnsObserved;
+      await new Promise((resolve) => setTimeout(resolve, 2));
+      const reservedStatus = h.gateway.status('default');
+      expect(reservedStatus).toMatchObject({
+        inFlightRequests: 1,
+        activeRequests: 1,
+        providerInFlightRequests: 0,
+        reservedRequests: 1,
+      });
+      expect(reservedStatus.oldestRequestMs).toBeGreaterThan(0);
+      if (mutation === 'task completion') {
+        await new TaskRepository(h.rawDb).update(h.task.task_id, {
+          status: TaskStatus.COMPLETED,
+        });
+      } else if (mutation === 'session detach') {
+        await coordinateSessionMCPRevocation({
+          db: h.rawDb,
+          gateway: h.gateway,
+          tenantId: 'default',
+          serverIds: [h.server.mcp_server_id],
+          mutate: () =>
+            new SessionMCPServerRepository(h.rawDb).removeServer(
+              h.session.session_id,
+              h.server.mcp_server_id
+            ),
+        });
+      } else if (mutation === 'server mutation') {
+        const updated = await new MCPServerRepository(h.rawDb).update(h.server.mcp_server_id, {
+          description: 'changed while refresh DNS was held',
+          expected_config_version: h.server.config_version,
+        });
+        coordinateMCPServerMutationAfterWrite(
+          { params: { tenant: { tenant_id: 'default' } }, result: updated } as never,
+          h.gateway
+        );
+      } else if (mutation === 'tenant rollout') {
+        await coordinateMCPEgressRolloutChange({
+          gateway: h.gateway,
+          tenantId: 'default',
+          mutate: () => setMCPEgressGatewayMode(h.rawDb, 'off', h.user.user_id),
+        });
+      } else {
+        h.gateway.close();
+      }
+      releaseDns();
+
+      const expectedCode =
+        mutation === 'task completion'
+          ? 'principal_revoked'
+          : mutation === 'session detach'
+            ? 'server_detached'
+            : mutation === 'server mutation'
+              ? 'stale_capability'
+              : mutation === 'tenant rollout'
+                ? 'rollout_changed'
+                : 'egress_unavailable';
+      const routeResponse = await pending;
+      expect(routeResponse).toMatchObject({
+        status:
+          expectedCode === 'principal_revoked' || expectedCode === 'server_detached'
+            ? 403
+            : expectedCode === 'egress_unavailable'
+              ? 503
+              : 409,
+      });
+      expect(routeResponse.payload).toMatchObject({ error: { data: { code: expectedCode } } });
+      expect(tokenRequests).toBe(0);
+      const retained = await new UserMCPOAuthTokenRepository(h.rawDb).getToken(
+        h.oauthTokenUserId,
+        h.server.mcp_server_id
+      );
+      expect(retained).toMatchObject({
+        oauth_access_token: 'prior-valid-access-token',
+        oauth_refresh_token: 'refresh-secret-never-sent-stale',
+        refresh_status: 'idle',
+        refresh_generation: 0,
+        refresh_success_generation: 0,
+      });
+      expect(retained?.refresh_claim_id).toBeUndefined();
+      expect(retained?.refresh_claimed_at).toBeUndefined();
+    }
+  );
+
+  it('prefers the durable authority reason over a mismatched local abort accelerator', async () => {
+    let providerRequests = 0;
+    const url = asLocalhost(
+      await listen((_request, response) => {
+        providerRequests += 1;
+        response.writeHead(200, { 'content-type': 'application/json' });
+        response.end('{"jsonrpc":"2.0","id":1,"result":{}}');
+      })
+    );
+    let dnsStarted!: () => void;
+    let releaseDns!: () => void;
+    const dnsObserved = new Promise<void>((resolve) => (dnsStarted = resolve));
+    const dnsGate = new Promise<void>((resolve) => (releaseDns = resolve));
+    const h = await harness({
+      server: { transport: 'http', url, auth: { type: 'none' } },
+      resolveDns: async () => {
+        dnsStarted();
+        await dnsGate;
+        return [{ address: '127.0.0.1', family: 4 }];
+      },
+    });
+
+    const pending = h.routeRequest('POST', initialize);
+    await dnsObserved;
+    await new MCPServerRepository(h.rawDb).update(h.server.mcp_server_id, {
+      description: 'durable config mutation must win',
+      expected_config_version: h.server.config_version,
+    });
+    // Deliberately use the other closed accelerator reason. The route must
+    // still report the current durable config-version failure.
+    h.gateway.abortServer('default', h.server.mcp_server_id, 'server_detached');
+    releaseDns();
+
+    await expect(pending).resolves.toMatchObject({
+      status: 409,
+      payload: { error: { data: { code: 'stale_capability' } } },
+    });
+    expect(providerRequests).toBe(0);
+  });
+
+  it('fails closed for every stdio server without spawning or writing a process', async () => {
+    const marker = `/tmp/mcp-egress-stdio-${randomUUID()}`;
+    const h = await harness({
+      server: {
+        transport: 'stdio',
+        command: process.execPath,
+        args: ['-e', `require('node:fs').writeFileSync(${JSON.stringify(marker)}, 'spawned')`],
+        env: { MCP_SECRET: 'stdio-secret-never-exported' },
+      },
+    });
+
+    await expect(h.request('POST', initialize)).rejects.toMatchObject({
+      code: 'transport_not_mediated',
+    });
+    await expect(import('node:fs/promises').then(({ access }) => access(marker))).rejects.toThrow();
+  });
+
+  it('scans decoded JSON and URL-path credential material but ignores low-entropy DEBUG values', async () => {
+    const pathSecret = 'path-secret-9f8c7b6a';
+    const url = await listen((_request, response) => {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ jsonrpc: '2.0', id: 1, result: `escaped:${pathSecret}` }));
+    });
+    const h = await harness({
+      server: {
+        transport: 'http',
+        url: `${url}/mcp/${pathSecret}`,
+        auth: { type: 'none' },
+        env: { DEBUG: '1' },
+      },
+    });
+    await expect(h.request('POST', initialize)).rejects.toMatchObject({
+      code: 'credential_reflection_blocked',
+    });
+
+    const harmlessUrl = await listen((_request, response) => {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end('{"jsonrpc":"2.0","id":1,"result":"DEBUG=1 initialize"}');
+    });
+    const harmless = await harness({
+      server: {
+        transport: 'http',
+        url: `${harmlessUrl}/initialize`,
+        auth: { type: 'none' },
+        env: { DEBUG: '1' },
+      },
+    });
+    await expect(
+      (await harmless.request('POST', initialize)).response.json()
+    ).resolves.toMatchObject({
+      result: 'DEBUG=1 initialize',
+    });
+  });
+
+  it('uses a second SQLite connection to prove a commit before final admission prevents provider observation', async () => {
+    const file = `/tmp/mcp-egress-race-${randomUUID()}.db`;
+    files.push(file);
+    let releaseDns!: () => void;
+    let dnsStarted!: () => void;
+    const dnsGate = new Promise<void>((resolve) => (releaseDns = resolve));
+    const dnsObserved = new Promise<void>((resolve) => (dnsStarted = resolve));
+    let providerRequests = 0;
+    const provider = asLocalhost(
+      await listen((_request, response) => {
+        providerRequests += 1;
+        response.writeHead(200, { 'content-type': 'application/json' });
+        response.end('{"jsonrpc":"2.0","id":1,"result":{}}');
+      })
+    );
+    const h = await harness({
+      dbUrl: `file:${file}`,
+      server: {
+        transport: 'http',
+        url: `${provider}/mcp`,
+        auth: { type: 'bearer', token: 'cross-connection-secret' },
+      },
+      resolveDns: async () => {
+        dnsStarted();
+        await dnsGate;
+        return [{ address: '127.0.0.1', family: 4 }];
+      },
+    });
+    const dbB = await createDatabaseAsync({ dialect: 'sqlite', url: `file:${file}` });
+    databases.push(dbB as typeof dbB & { $client?: { close?: () => void } });
+
+    const pending = h.request('POST', initialize);
+    await dnsObserved;
+    await new MCPServerRepository(dbB).update(h.server.mcp_server_id, {
+      description: 'committed by daemon B',
+      expected_config_version: h.server.config_version,
+    });
+    releaseDns();
+
+    await expect(pending).rejects.toMatchObject({ code: 'stale_capability' });
+    expect(providerRequests).toBe(0);
+  });
+
+  it('holds one SQLite authority snapshot across config/detach/reattach constituent reads', async () => {
+    const file = `/tmp/mcp-egress-snapshot-${randomUUID()}.db`;
+    files.push(file);
+    let checkpointCount = 0;
+    let releaseSnapshot!: () => void;
+    let finalSnapshotStarted!: () => void;
+    const snapshotGate = new Promise<void>((resolve) => (releaseSnapshot = resolve));
+    const snapshotObserved = new Promise<void>((resolve) => (finalSnapshotStarted = resolve));
+    let providerRequests = 0;
+    const url = await listen((_request, response) => {
+      providerRequests += 1;
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end('{"jsonrpc":"2.0","id":1,"result":{}}');
+    });
+    const h = await harness({
+      dbUrl: `file:${file}`,
+      server: { transport: 'http', url, scope: 'session', auth: { type: 'none' } },
+      authoritySnapshotCheckpoint: async () => {
+        checkpointCount += 1;
+        if (checkpointCount === 2) {
+          finalSnapshotStarted();
+          await snapshotGate;
+        }
+      },
+    });
+    const dbB = await createDatabaseAsync({ dialect: 'sqlite', url: `file:${file}` });
+    databases.push(dbB as typeof dbB & { $client?: { close?: () => void } });
+    const pending = h.request('POST', initialize);
+    await snapshotObserved;
+    const mutate = () =>
+      runWithTenantDatabaseTransaction(dbB, undefined, async (tx) => {
+        await new SessionMCPServerRepository(tx).removeServer(
+          h.session.session_id,
+          h.server.mcp_server_id
+        );
+        await new MCPServerRepository(tx).update(h.server.mcp_server_id, {
+          description: 'atomic mixed-read adversary',
+          expected_config_version: h.server.config_version,
+        });
+        await new SessionMCPServerRepository(tx).addServer(
+          h.session.session_id,
+          h.server.mcp_server_id
+        );
+      });
+    const contendingMutation = expect(mutate()).rejects.toMatchObject({ code: 'SQLITE_BUSY' });
+    await contendingMutation;
+    releaseSnapshot();
+    await expect(pending).resolves.toBeDefined();
+    await new MCPServerRepository(dbB).update(h.server.mcp_server_id, {
+      description: 'committed after the admitted snapshot',
+      expected_config_version: h.server.config_version,
+    });
+    expect(providerRequests).toBe(1);
+    await expect(h.request('POST', initialize)).rejects.toMatchObject({ code: 'stale_capability' });
+  });
+
+  it('truthfully allows an already-admitted cross-daemon request to complete after a commit', async () => {
+    const file = `/tmp/mcp-egress-admitted-${randomUUID()}.db`;
+    files.push(file);
+    let releaseProvider!: () => void;
+    let providerStarted!: () => void;
+    const providerGate = new Promise<void>((resolve) => (releaseProvider = resolve));
+    const providerObserved = new Promise<void>((resolve) => (providerStarted = resolve));
+    let providerRequests = 0;
+    const url = await listen(async (_request, response) => {
+      providerRequests += 1;
+      providerStarted();
+      await providerGate;
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end('{"jsonrpc":"2.0","id":1,"result":{"admitted":true}}');
+    });
+    const h = await harness({
+      dbUrl: `file:${file}`,
+      server: { transport: 'http', url, auth: { type: 'bearer', token: 'admitted-secret' } },
+    });
+    const dbB = await createDatabaseAsync({ dialect: 'sqlite', url: `file:${file}` });
+    databases.push(dbB as typeof dbB & { $client?: { close?: () => void } });
+
+    const pending = h.request('POST', initialize);
+    await providerObserved;
+    await new MCPServerRepository(dbB).update(h.server.mcp_server_id, {
+      description: 'commit after provider observation',
+      expected_config_version: h.server.config_version,
+    });
+    releaseProvider();
+
+    await expect((await pending).response.json()).resolves.toMatchObject({
+      result: { admitted: true },
+    });
+    expect(providerRequests).toBe(1);
+    await expect(h.request('POST', initialize)).rejects.toMatchObject({ code: 'stale_capability' });
+  });
+
+  it('never follows provider redirects for mediated methods', async () => {
+    let targetRequests = 0;
+    const base = await listen((request, response) => {
+      if (request.url === '/target') {
+        targetRequests += 1;
+        response.writeHead(200, { 'content-type': 'application/json' });
+        response.end('{"jsonrpc":"2.0","id":1,"result":{}}');
+        return;
+      }
+      response.writeHead(302, { location: '/target' });
+      response.end();
+    });
+    const h = await harness({
+      server: { transport: 'http', url: `${base}/source`, auth: { type: 'none' } },
+    });
+    await expect(h.request('POST', initialize)).rejects.toThrow('redirect');
+    expect(targetRequests).toBe(0);
+  });
+
+  it('rechecks session attachment immediately before provider send', async () => {
+    let releaseDns!: () => void;
+    let dnsStarted!: () => void;
+    const dnsGate = new Promise<void>((resolve) => (releaseDns = resolve));
+    const dnsObserved = new Promise<void>((resolve) => (dnsStarted = resolve));
+    let providerRequests = 0;
+    const provider = asLocalhost(
+      await listen((_request, response) => {
+        providerRequests += 1;
+        response.writeHead(200, { 'content-type': 'application/json' });
+        response.end('{"jsonrpc":"2.0","id":1,"result":{}}');
+      })
+    );
+    const h = await harness({
+      server: { transport: 'http', url: provider, scope: 'session', auth: { type: 'none' } },
+      resolveDns: async () => {
+        dnsStarted();
+        await dnsGate;
+        return [{ address: '127.0.0.1', family: 4 }];
+      },
+    });
+    const pending = h.request('POST', initialize);
+    await dnsObserved;
+    await new SessionMCPServerRepository(h.rawDb).removeServer(
+      h.session.session_id,
+      h.server.mcp_server_id
+    );
+    releaseDns();
+    await expect(pending).rejects.toMatchObject({ code: 'server_detached' });
+    expect(providerRequests).toBe(0);
+  });
+
+  it('rechecks branch ACL for a collaborating principal immediately before provider send', async () => {
+    let releaseDns!: () => void;
+    let dnsStarted!: () => void;
+    const dnsGate = new Promise<void>((resolve) => (releaseDns = resolve));
+    const dnsObserved = new Promise<void>((resolve) => (dnsStarted = resolve));
+    let providerRequests = 0;
+    const provider = asLocalhost(
+      await listen((_request, response) => {
+        providerRequests += 1;
+        response.writeHead(200, { 'content-type': 'application/json' });
+        response.end('{"jsonrpc":"2.0","id":1,"result":{}}');
+      })
+    );
+    const h = await harness({
+      server: { transport: 'http', url: provider, auth: { type: 'none' } },
+      separatePrincipal: true,
+      branchRbacEnabled: true,
+      resolveDns: async () => {
+        dnsStarted();
+        await dnsGate;
+        return [{ address: '127.0.0.1', family: 4 }];
+      },
+    });
+    const pending = h.request('POST', initialize);
+    await dnsObserved;
+    await new BranchRepository(h.rawDb).update(h.branch.branch_id, { others_can: 'view' });
+    releaseDns();
+
+    await expect(pending).rejects.toMatchObject({ code: 'branch_revoked' });
+    expect(providerRequests).toBe(0);
+  });
+
+  it('coordinates OAuth grant deletion at final send while routine token rotation preserves grant identity', async () => {
+    let releaseDns!: () => void;
+    let dnsStarted!: () => void;
+    const dnsGate = new Promise<void>((resolve) => (releaseDns = resolve));
+    const dnsObserved = new Promise<void>((resolve) => (dnsStarted = resolve));
+    let providerRequests = 0;
+    const provider = asLocalhost(
+      await listen((_request, response) => {
+        providerRequests += 1;
+        response.writeHead(200, { 'content-type': 'application/json' });
+        response.end('{"jsonrpc":"2.0","id":1,"result":{}}');
+      })
+    );
+    const h = await harness({
+      server: { transport: 'http', url: provider, auth: { type: 'oauth', oauth_mode: 'per_user' } },
+      oauthAccessToken: 'oauth-token-before-refresh',
+      resolveDns: async () => {
+        dnsStarted();
+        await dnsGate;
+        return [{ address: '127.0.0.1', family: 4 }];
+      },
+    });
+    const tokens = new UserMCPOAuthTokenRepository(h.rawDb);
+    const pending = h.request('POST', initialize);
+    await dnsObserved;
+    await tokens.deleteToken(h.user.user_id as UserID, h.server.mcp_server_id as MCPServerID);
+    releaseDns();
+    await expect(pending).rejects.toMatchObject({ code: 'grant_changed' });
+    expect(providerRequests).toBe(0);
+
+    const rotated = await harness({
+      server: {
+        transport: 'http',
+        url: provider.replace('localhost', '127.0.0.1'),
+        auth: { type: 'oauth', oauth_mode: 'per_user' },
+      },
+      oauthAccessToken: 'oauth-token-old-value',
+    });
+    await new UserMCPOAuthTokenRepository(rotated.rawDb).saveToken(
+      rotated.user.user_id as UserID,
+      rotated.server.mcp_server_id,
+      { accessToken: 'oauth-token-routinely-refreshed' }
+    );
+    await expect(rotated.request('POST', initialize)).resolves.toBeDefined();
+    expect(providerRequests).toBe(1);
+
+    await new UserMCPOAuthTokenRepository(rotated.rawDb).saveToken(
+      rotated.user.user_id as UserID,
+      rotated.server.mcp_server_id,
+      {
+        accessToken: 'replacement-grant-token',
+        clientId: 'replacement-client',
+        grantBinding: {
+          generation: 2,
+          version: 4,
+          fingerprint: 'gateway-test-binding-v2',
+          metadataUri: 'https://auth.example.test/.well-known/oauth-protected-resource',
+          resourceUri: rotated.server.url!,
+          issuer: 'https://auth.example.test',
+          authorizationEndpoint: 'https://auth.example.test/authorize',
+          tokenEndpoint: 'https://auth.example.test/token',
+          redirectUri: 'https://daemon.example.test/mcp-servers/oauth-callback',
+        },
+      }
+    );
+    await expect(rotated.request('POST', initialize)).rejects.toMatchObject({
+      code: 'grant_changed',
+    });
+    expect(providerRequests).toBe(1);
+  });
+
+  it('revalidates authority immediately before JWT minting and never exports JWT client secrets', async () => {
+    let releaseDns!: () => void;
+    let dnsStarted!: () => void;
+    const dnsGate = new Promise<void>((resolve) => (releaseDns = resolve));
+    const dnsObserved = new Promise<void>((resolve) => (dnsStarted = resolve));
+    let mintRequests = 0;
+    let mcpRequests = 0;
+    const mintUrl = asLocalhost(
+      await listen((_request, response) => {
+        mintRequests += 1;
+        response.writeHead(200, { 'content-type': 'application/json' });
+        response.end('{"access_token":"minted-provider-jwt"}');
+      })
+    );
+    const mcpUrl = asLocalhost(
+      await listen((_request, response) => {
+        mcpRequests += 1;
+        response.writeHead(200, { 'content-type': 'application/json' });
+        response.end('{"jsonrpc":"2.0","id":1,"result":{}}');
+      })
+    );
+    const h = await harness({
+      server: {
+        transport: 'http',
+        url: mcpUrl,
+        auth: {
+          type: 'jwt',
+          api_url: mintUrl,
+          api_token: 'jwt-client-name',
+          api_secret: 'jwt-client-secret-never-exported',
+        },
+      },
+      resolveDns: async () => {
+        dnsStarted();
+        await dnsGate;
+        return [{ address: '127.0.0.1', family: 4 }];
+      },
+    });
+    const pending = h.request('POST', initialize);
+    await dnsObserved;
+    await new MCPServerRepository(h.rawDb).update(h.server.mcp_server_id, {
+      description: 'JWT authority revoked before mint dispatch',
+      expected_config_version: h.server.config_version,
+    });
+    releaseDns();
+
+    await expect(pending).rejects.toMatchObject({ code: 'stale_capability' });
+    expect(mintRequests).toBe(0);
+    expect(mcpRequests).toBe(0);
+    expect(h.capability).not.toContain('jwt-client-secret-never-exported');
+  });
+
+  it('enforces task lifetime and tool policy before provider send', async () => {
+    let providerRequests = 0;
+    const url = await listen((_request, response) => {
+      providerRequests += 1;
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end('{"jsonrpc":"2.0","id":1,"result":{}}');
+    });
+    const denied = await harness({
+      server: {
+        transport: 'http',
+        url,
+        auth: { type: 'none' },
+        tool_permissions: { 'dangerous.write': 'deny' },
+      },
+    });
+    await expect(
+      denied.request(
+        'POST',
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/call',
+          params: { name: 'dangerous.write', arguments: {} },
+        })
+      )
+    ).rejects.toMatchObject({ code: 'tool_denied' });
+
+    const ended = await harness({
+      server: { transport: 'http', url, auth: { type: 'none' } },
+    });
+    await new TaskRepository(ended.rawDb).update(ended.task.task_id, {
+      status: TaskStatus.COMPLETED,
+    });
+    await expect(ended.request('POST', initialize)).rejects.toMatchObject({
+      code: 'principal_revoked',
+    });
+
+    const demoted = await harness({
+      server: { transport: 'http', url, auth: { type: 'none' } },
+    });
+    await new UsersRepository(demoted.rawDb).update(demoted.user.user_id, { role: 'viewer' });
+    await expect(demoted.request('POST', initialize)).rejects.toMatchObject({
+      code: 'principal_revoked',
+    });
+    expect(providerRequests).toBe(0);
+  });
+});
+
+describe.runIf(process.env.AGOR_RUN_MCP_EGRESS_BENCHMARK === '1')(
+  'MCP egress SQLite admission benchmark',
+  () => {
+    it('reports the durable no-send authority check on an explicitly quiet host', async () => {
+      const h = await harness({
+        server: {
+          transport: 'http',
+          url: 'https://provider.example/mcp',
+          auth: { type: 'bearer', token: 'benchmark-provider-secret' },
+        },
+      });
+      for (let index = 0; index < 20; index += 1) {
+        await h.gateway.checkAdmission(h.capability, h.server.mcp_server_id);
+      }
+      const samples: number[] = [];
+      for (let index = 0; index < 200; index += 1) {
+        const started = performance.now();
+        await h.gateway.checkAdmission(h.capability, h.server.mcp_server_id);
+        samples.push(performance.now() - started);
+      }
+      samples.sort((a, b) => a - b);
+      const percentile = (value: number) => samples[Math.ceil(samples.length * value) - 1]!;
+      const result = {
+        samples: samples.length,
+        p50_ms: Number(percentile(0.5).toFixed(3)),
+        p95_ms: Number(percentile(0.95).toFixed(3)),
+        p99_ms: Number(percentile(0.99).toFixed(3)),
+      };
+      console.info(`MCP_EGRESS_SQLITE_ADMISSION_BENCHMARK ${JSON.stringify(result)}`);
+      // Host scheduling dominates small local samples. The opt-in result is
+      // evidence to compare with a quiet-host baseline, not a CI release gate
+      // and not evidence for PostgreSQL/HA availability.
+      expect(result.samples).toBe(200);
+    });
+  }
+);

--- a/apps/agor-daemon/src/mcp-egress/gateway.ts
+++ b/apps/agor-daemon/src/mcp-egress/gateway.ts
@@ -1,0 +1,955 @@
+import { createHmac, randomUUID } from 'node:crypto';
+import {
+  BranchRepository,
+  decryptApiKey,
+  GatewayChannelRepository,
+  getMCPEgressGatewayMode,
+  isEncrypted,
+  MCPServerRepository,
+  runWithTenantDatabaseTransaction,
+  SessionMCPServerRepository,
+  SessionRepository,
+  TaskRepository,
+  type TenantScopeAwareDatabase,
+  type TenantScopedDatabase,
+  UserMCPOAuthTokenRepository,
+  UsersRepository,
+} from '@agor/core/db';
+import type { Application } from '@agor/core/feathers';
+import { getConnector } from '@agor/core/gateway';
+import {
+  buildMCPTemplateContextFromEnv,
+  extractMCPTemplateDependencies,
+  isMCPServerUsableInSession,
+  resolveMcpServerTemplates,
+} from '@agor/core/mcp';
+import { mergeMCPRemoteHeaders } from '@agor/core/tools/mcp/http-headers';
+import { fetchJWTToken, resolveMCPAuthHeaders } from '@agor/core/tools/mcp/jwt-auth';
+import { OAuthRefreshAuthorityCancelledError } from '@agor/core/tools/mcp/oauth-refresh';
+import type {
+  AuthenticatedParams,
+  GatewayEnvVar,
+  MCPServer,
+  Session,
+  SessionID,
+  UserID,
+} from '@agor/core/types';
+import { hasMinimumRole, ROLES, TaskStatus } from '@agor/core/types';
+import {
+  type OutboundDnsLookup,
+  OutboundPreDispatchAuthorityError,
+  safeOutboundFetch,
+} from '@agor/core/utils/safe-outbound-fetch';
+import { getDaemonMetrics } from '../metrics/index.js';
+import { resolveSessionPromptAccess } from '../utils/branch-authorization.js';
+import { type MCPEgressCapabilityClaims, verifyMCPEgressCapability } from './capability.js';
+
+const ACTIVE_TASK_STATES = new Set<import('@agor/core/types').TaskStatus>([
+  TaskStatus.DISPATCHING,
+  TaskStatus.RUNNING,
+  TaskStatus.AWAITING_PERMISSION,
+  TaskStatus.AWAITING_INPUT,
+]);
+const MAX_REQUEST_BYTES = 4 * 1024 * 1024;
+const MAX_RESPONSE_BYTES = 16 * 1024 * 1024;
+const RESPONSE_TIMEOUT_MS = 30_000;
+const SECRET_MIN_LENGTH = 8;
+const MAX_PROCESS_IN_FLIGHT = 32;
+const MAX_TENANT_IN_FLIGHT = 16;
+const MAX_TASK_IN_FLIGHT = 4;
+const MAX_SERVER_IN_FLIGHT = 8;
+
+export type MCPEgressEligibility =
+  | { eligible: true }
+  | {
+      eligible: false;
+      reason: 'transport_not_mediated' | 'approval_not_mediated' | 'template_configuration';
+    };
+
+/** Shared by executor projection and final admission; unsupported means omit/fail closed. */
+export function mcpEgressEligibility(server: MCPServer): MCPEgressEligibility {
+  if (server.transport !== 'http' || !server.url) {
+    return { eligible: false, reason: 'transport_not_mediated' };
+  }
+  if (Object.values(server.tool_permissions ?? {}).includes('ask')) {
+    return { eligible: false, reason: 'approval_not_mediated' };
+  }
+  if (!extractMCPTemplateDependencies(server).valid) {
+    return { eligible: false, reason: 'template_configuration' };
+  }
+  return { eligible: true };
+}
+
+/** The only MCP server shape an executor may receive in a mediated mode. */
+export function projectMCPServerForExecutor(
+  server: MCPServer,
+  gatewayUrl: string,
+  capability: string
+): MCPServer {
+  const {
+    command: _command,
+    args: _args,
+    env: _env,
+    auth: _auth,
+    headers: _headers,
+    url: _url,
+    ...safeMetadata
+  } = server;
+  return {
+    ...safeMetadata,
+    transport: 'http',
+    url: gatewayUrl,
+    headers: { 'X-Agor-Mcp-Capability': capability },
+  };
+}
+
+export class MCPEgressGatewayError extends Error {
+  constructor(
+    readonly status: number,
+    readonly code: string,
+    message: string
+  ) {
+    super(message);
+    this.name = 'MCPEgressGatewayError';
+  }
+}
+
+export type MCPEgressServerAbortReason = 'server_detached' | 'stale_capability';
+
+function abortReasonError(reason: MCPEgressServerAbortReason | 'rollout_changed' | 'shutdown') {
+  switch (reason) {
+    case 'server_detached':
+      return new MCPEgressGatewayError(403, 'server_detached', 'MCP server was detached');
+    case 'stale_capability':
+      return new MCPEgressGatewayError(
+        409,
+        'stale_capability',
+        'MCP server configuration changed; reconnect this task'
+      );
+    case 'rollout_changed':
+      return new MCPEgressGatewayError(
+        409,
+        'rollout_changed',
+        'MCP gateway rollout changed; reconnect this task'
+      );
+    case 'shutdown':
+      return new MCPEgressGatewayError(
+        503,
+        'egress_unavailable',
+        'MCP gateway egress is temporarily unavailable'
+      );
+  }
+}
+
+function closedAbortReason(reason: unknown): MCPEgressGatewayError {
+  return reason instanceof MCPEgressGatewayError ? reason : abortReasonError('shutdown');
+}
+
+interface GatewayOptions {
+  db: TenantScopeAwareDatabase;
+  app: Application;
+  jwtSecret: string;
+  branchRbacEnabled: boolean;
+  allowLocalhostHttp?: boolean;
+  resolveDns?: OutboundDnsLookup;
+  /** Test seam proving all constituent reads share one native snapshot. */
+  authoritySnapshotCheckpoint?: () => Promise<void>;
+}
+
+interface CurrentAuthority {
+  unresolvedServer: MCPServer;
+  server: MCPServer;
+  env: Record<string, string>;
+}
+
+interface InFlight {
+  tenantId: string;
+  taskId: string;
+  serverId: string;
+  controller: AbortController;
+  startedAt: number;
+}
+
+function capabilityToken(headers: Headers): string {
+  const token = headers.get('x-agor-mcp-capability');
+  if (!token) {
+    throw new MCPEgressGatewayError(401, 'capability_required', 'MCP gateway capability required');
+  }
+  return token;
+}
+
+function protocolRequestHeaders(input: Headers): Headers {
+  const output = new Headers();
+  for (const name of [
+    'accept',
+    'content-type',
+    'mcp-protocol-version',
+    'mcp-session-id',
+    'last-event-id',
+  ]) {
+    const value = input.get(name);
+    if (value) output.set(name, value);
+  }
+  return output;
+}
+
+function publicResponseHeaders(input: Headers, secrets: string[]): Headers {
+  const output = new Headers();
+  for (const name of [
+    'content-type',
+    'cache-control',
+    'mcp-session-id',
+    'mcp-protocol-version',
+    'retry-after',
+  ]) {
+    const value = input.get(name);
+    if (value && !containsSecret(value, secrets)) output.set(name, value);
+  }
+  return output;
+}
+
+function usefulSecret(value: string): boolean {
+  if (value.length < SECRET_MIN_LENGTH) return false;
+  return new Set(value).size >= 4;
+}
+
+function usefulLiteralUrlSecret(value: string): boolean {
+  return value.length >= 16 && new Set(value).size >= 8;
+}
+
+function secretVariants(value: string): string[] {
+  const raw = value.replace(/^(?:Bearer|Basic)\s+/i, '');
+  return [value, raw].filter(usefulSecret);
+}
+
+function containsSecret(value: string, secrets: string[]): boolean {
+  return secrets.some((secret) => value.includes(secret));
+}
+
+function stringLeaves(value: unknown): string[] {
+  if (typeof value === 'string') return [value];
+  if (Array.isArray(value)) return value.flatMap(stringLeaves);
+  if (value && typeof value === 'object') return Object.values(value).flatMap(stringLeaves);
+  return [];
+}
+
+function urlMaterial(url?: string): string[] {
+  if (!url) return [];
+  try {
+    const parsed = new URL(url);
+    return [
+      ...parsed.pathname.split('/').flatMap((part) => {
+        try {
+          return [decodeURIComponent(part)];
+        } catch {
+          return [part];
+        }
+      }),
+      ...[...parsed.searchParams.values()],
+    ];
+  } catch {
+    return [url];
+  }
+}
+
+function authSecretMaterial(auth: MCPServer['auth']): string[] {
+  if (!auth) return [];
+  return [
+    auth.token,
+    auth.api_token,
+    auth.api_secret,
+    auth.oauth_client_id,
+    auth.oauth_client_secret,
+    auth.oauth_access_token,
+    auth.oauth_refresh_token,
+  ].filter((value): value is string => typeof value === 'string');
+}
+
+function assertNoDecodedSecret(value: unknown, secrets: string[]): void {
+  if (typeof value === 'string') {
+    if (containsSecret(value, secrets)) {
+      throw new MCPEgressGatewayError(
+        502,
+        'credential_reflection_blocked',
+        'The MCP response reflected daemon-owned credential material'
+      );
+    }
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) assertNoDecodedSecret(item, secrets);
+    return;
+  }
+  if (value && typeof value === 'object') {
+    for (const [key, item] of Object.entries(value)) {
+      assertNoDecodedSecret(key, secrets);
+      assertNoDecodedSecret(item, secrets);
+    }
+  }
+}
+
+function validateBufferedMCPResponse(
+  response: Response,
+  body: Uint8Array,
+  secrets: string[]
+): Uint8Array {
+  if (body.byteLength === 0) return body;
+  const contentType = response.headers.get('content-type')?.split(';', 1)[0]?.trim().toLowerCase();
+  const text = Buffer.from(body).toString('utf8');
+  if (contentType === 'application/json' || contentType?.endsWith('+json')) {
+    try {
+      assertNoDecodedSecret(JSON.parse(text), secrets);
+      return body;
+    } catch (error) {
+      if (error instanceof MCPEgressGatewayError) throw error;
+      throw new MCPEgressGatewayError(
+        502,
+        'invalid_mcp_json',
+        'Provider returned invalid MCP JSON'
+      );
+    }
+  }
+  if (contentType === 'text/event-stream') {
+    const events = text.split(/\r?\n\r?\n/);
+    const released: string[] = [];
+    for (const event of events) {
+      const data = event
+        .split(/\r?\n/)
+        .filter((line) => line.startsWith('data:'))
+        .map((line) => line.slice(5).trimStart())
+        .join('\n');
+      if (!data || data === '[DONE]') continue;
+      try {
+        const parsed = JSON.parse(data);
+        assertNoDecodedSecret(parsed, secrets);
+        released.push(`data: ${JSON.stringify(parsed)}\n\n`);
+      } catch (error) {
+        if (error instanceof MCPEgressGatewayError) throw error;
+        throw new MCPEgressGatewayError(
+          502,
+          'unstructured_sse_not_mediated',
+          'Only bounded JSON MCP SSE events are mediated'
+        );
+      }
+    }
+    return new TextEncoder().encode(released.join(''));
+  }
+  throw new MCPEgressGatewayError(
+    502,
+    'unstructured_response_not_mediated',
+    'Only bounded JSON or JSON SSE MCP responses are mediated'
+  );
+}
+
+function requestedToolNames(body?: Uint8Array): string[] {
+  if (!body?.byteLength) return [];
+  try {
+    const value = JSON.parse(Buffer.from(body).toString('utf8')) as
+      | { method?: unknown; params?: { name?: unknown } }
+      | Array<{ method?: unknown; params?: { name?: unknown } }>;
+    const requests = Array.isArray(value) ? value : [value];
+    return requests.flatMap((request) =>
+      request.method === 'tools/call' && typeof request.params?.name === 'string'
+        ? [request.params.name]
+        : []
+    );
+  } catch {
+    return [];
+  }
+}
+
+function templateKeys(server: MCPServer): Set<string> {
+  const dependencies = extractMCPTemplateDependencies(server);
+  if (!dependencies.valid) {
+    throw new MCPEgressGatewayError(
+      409,
+      'template_dependency_unknown',
+      'MCP template dependencies cannot be determined'
+    );
+  }
+  return dependencies.keys;
+}
+
+function durableAuthMaterial(auth: MCPServer['auth']): MCPServer['auth'] {
+  if (!auth) return auth;
+  const {
+    oauth_access_token: _access,
+    oauth_refresh_token: _refresh,
+    oauth_token_expires_at: _expires,
+    ...durable
+  } = auth;
+  return durable as MCPServer['auth'];
+}
+
+export function mcpEgressMaterialHash(
+  server: MCPServer,
+  env: Record<string, string>,
+  secret: string
+): string {
+  const referenced = [...templateKeys(server)].sort().map((key) => [key, env[key] ?? null]);
+  return createHmac('sha256', secret)
+    .update('agor:mcp-egress-material:v2\0')
+    .update(
+      JSON.stringify({
+        configVersion: server.config_version ?? 1,
+        url: server.url,
+        command: server.command,
+        args: server.args,
+        env: server.env,
+        headers: server.headers,
+        auth: durableAuthMaterial(server.auth),
+        referenced,
+      })
+    )
+    .digest('base64url');
+}
+
+export function mcpOAuthGrantIdentity(
+  row: {
+    grant_generation?: number;
+    grant_binding_fingerprint?: string | null;
+  } | null
+): string | undefined {
+  if (!row) return undefined;
+  return `${row.grant_generation ?? 0}:${row.grant_binding_fingerprint ?? '<unbound>'}`;
+}
+
+export async function resolveMCPEgressEnvironment(
+  tenantDb: TenantScopedDatabase,
+  userId: string,
+  session: Pick<Session, 'session_id' | 'custom_context'>
+): Promise<Record<string, string>> {
+  const { createUserProcessEnvironment } = await import('@agor/core/config');
+  const gatewaySource = (session.custom_context as Record<string, unknown> | undefined)
+    ?.gateway_source as { channel_id?: string } | undefined;
+  let gatewayEnv: GatewayEnvVar[] | undefined;
+  if (gatewaySource?.channel_id) {
+    const channel = await new GatewayChannelRepository(tenantDb).findById(gatewaySource.channel_id);
+    if (channel?.agentic_config?.envVars) {
+      gatewayEnv = channel.agentic_config.envVars.map((entry) => ({
+        ...entry,
+        value:
+          entry.value && isEncrypted(entry.value)
+            ? (() => {
+                try {
+                  return decryptApiKey(entry.value);
+                } catch {
+                  throw new MCPEgressGatewayError(
+                    503,
+                    'credential_decryption_failed',
+                    'MCP credential material could not be decrypted'
+                  );
+                }
+              })()
+            : entry.value,
+      }));
+    }
+    if (channel) {
+      const connectorEnv = getConnector(channel.channel_type, channel.config).sessionEnv?.() ?? [];
+      const present = new Set((gatewayEnv ?? []).map((entry) => entry.key));
+      gatewayEnv = [
+        ...(gatewayEnv ?? []),
+        ...connectorEnv.filter((entry) => !present.has(entry.key)),
+      ];
+    }
+  }
+  return createUserProcessEnvironment(
+    userId as UserID,
+    tenantDb,
+    undefined,
+    gatewayEnv,
+    session.session_id as SessionID
+  );
+}
+
+export class MCPEgressGateway {
+  private readonly inFlight = new Map<string, InFlight>();
+  private readonly reservations = new Map<string, InFlight>();
+
+  constructor(private readonly options: GatewayOptions) {}
+
+  verify(token: string): MCPEgressCapabilityClaims {
+    try {
+      return verifyMCPEgressCapability(token, this.options.jwtSecret);
+    } catch {
+      throw new MCPEgressGatewayError(401, 'invalid_capability', 'MCP capability is invalid');
+    }
+  }
+
+  /** Reproducible admission benchmark/probe; it resolves no provider credential and sends nothing. */
+  async checkAdmission(token: string, serverId: string): Promise<void> {
+    const claims = this.verify(token);
+    if (claims.mcp_server_id !== serverId) {
+      throw new MCPEgressGatewayError(
+        403,
+        'capability_scope_mismatch',
+        'Capability/server mismatch'
+      );
+    }
+    await this.currentAuthority(claims);
+  }
+
+  status(tenantId: string) {
+    const providerRequests = [...this.inFlight.values()].filter(
+      (request) => request.tenantId === tenantId
+    );
+    const reservations = [...this.reservations.values()].filter(
+      (request) => request.tenantId === tenantId
+    );
+    const activeRequests = [...providerRequests, ...reservations];
+    return {
+      // Keep the established field as a total so existing health consumers do
+      // not silently omit credential/admission reservations.
+      inFlightRequests: activeRequests.length,
+      activeRequests: activeRequests.length,
+      providerInFlightRequests: providerRequests.length,
+      reservedRequests: reservations.length,
+      oldestRequestMs: activeRequests.length
+        ? Math.max(...activeRequests.map((request) => Date.now() - request.startedAt))
+        : 0,
+    };
+  }
+
+  /** Best-effort availability accelerator. Correctness comes from DB revalidation. */
+  abortServer(
+    tenantId: string,
+    serverId: string,
+    reason: MCPEgressServerAbortReason = 'stale_capability'
+  ): number {
+    let aborted = 0;
+    for (const request of [...this.inFlight.values(), ...this.reservations.values()]) {
+      if (request.tenantId === tenantId && request.serverId === serverId) {
+        request.controller.abort(abortReasonError(reason));
+        aborted += 1;
+      }
+    }
+    return aborted;
+  }
+
+  abortTenant(tenantId: string): number {
+    let aborted = 0;
+    for (const request of [...this.inFlight.values(), ...this.reservations.values()]) {
+      if (request.tenantId === tenantId) {
+        request.controller.abort(abortReasonError('rollout_changed'));
+        aborted += 1;
+      }
+    }
+    return aborted;
+  }
+
+  close(): void {
+    for (const request of [...this.inFlight.values(), ...this.reservations.values()]) {
+      request.controller.abort(abortReasonError('shutdown'));
+    }
+  }
+
+  /** Resolve a pre-socket cancellation without trusting arbitrary signal text. */
+  private async rejectPreDispatch(
+    claims: MCPEgressCapabilityClaims,
+    abortReason: unknown
+  ): Promise<never> {
+    try {
+      // The committed database state is authoritative when it can return a
+      // structured rejection. The local abort is only an accelerator.
+      await this.currentAuthority(claims);
+    } catch (error) {
+      if (error instanceof MCPEgressGatewayError) throw error;
+    }
+    throw closedAbortReason(abortReason);
+  }
+
+  private async assertCurrentOrAbort(
+    claims: MCPEgressCapabilityClaims,
+    signal: AbortSignal
+  ): Promise<void> {
+    // Revalidate first so a committed mutation wins over its local hint.
+    await this.currentAuthority(claims);
+    if (signal.aborted) throw closedAbortReason(signal.reason);
+  }
+
+  private assertCapacity(claims: MCPEgressCapabilityClaims): void {
+    const requests = [...this.inFlight.values(), ...this.reservations.values()];
+    const exceeded =
+      requests.length >= MAX_PROCESS_IN_FLIGHT ||
+      requests.filter((item) => item.tenantId === claims.tid).length >= MAX_TENANT_IN_FLIGHT ||
+      requests.filter((item) => item.taskId === claims.task_id).length >= MAX_TASK_IN_FLIGHT ||
+      requests.filter((item) => item.serverId === claims.mcp_server_id).length >=
+        MAX_SERVER_IN_FLIGHT;
+    if (exceeded) {
+      throw new MCPEgressGatewayError(
+        429,
+        'egress_capacity_exceeded',
+        'MCP gateway capacity is temporarily exhausted; retry with backoff'
+      );
+    }
+  }
+
+  private async currentAuthority(claims: MCPEgressCapabilityClaims): Promise<CurrentAuthority> {
+    return runWithTenantDatabaseTransaction(
+      this.options.db,
+      claims.tid,
+      async (tenantDb) => {
+        const mode = await getMCPEgressGatewayMode(tenantDb);
+        if (mode !== claims.rollout_mode || (mode !== 'compatibility' && mode !== 'enforced')) {
+          throw new MCPEgressGatewayError(
+            409,
+            'rollout_changed',
+            'MCP gateway rollout changed; reconnect this task'
+          );
+        }
+        const [task, session, server, principal, credentialUser] = await Promise.all([
+          new TaskRepository(tenantDb).findById(claims.task_id),
+          new SessionRepository(tenantDb).findById(claims.session_id),
+          new MCPServerRepository(tenantDb).findById(claims.mcp_server_id),
+          new UsersRepository(tenantDb).findById(claims.principal_user_id),
+          new UsersRepository(tenantDb).findById(claims.credential_user_id),
+        ]);
+        if (
+          !task ||
+          task.session_id !== claims.session_id ||
+          task.created_by !== claims.principal_user_id ||
+          !ACTIVE_TASK_STATES.has(task.status) ||
+          !session ||
+          session.created_by !== claims.credential_user_id ||
+          !server ||
+          !server.enabled ||
+          !principal ||
+          !credentialUser ||
+          !hasMinimumRole(principal.role, ROLES.MEMBER) ||
+          !hasMinimumRole(credentialUser.role, ROLES.MEMBER) ||
+          !isMCPServerUsableInSession(server, session)
+        ) {
+          throw new MCPEgressGatewayError(403, 'principal_revoked', 'MCP task authority changed');
+        }
+        await this.options.authoritySnapshotCheckpoint?.();
+        const eligibility = mcpEgressEligibility(server);
+        if (!eligibility.eligible) {
+          throw new MCPEgressGatewayError(
+            501,
+            eligibility.reason,
+            eligibility.reason === 'approval_not_mediated'
+              ? 'This server requires one-shot approval and is excluded from mediation'
+              : eligibility.reason === 'template_configuration'
+                ? 'This server uses a template form the gateway cannot mediate; use static user.env.KEY references with supported balanced helpers'
+                : 'This phase mediates only bounded Streamable HTTP; stdio and legacy SSE fail closed'
+          );
+        }
+        if ((server.config_version ?? 1) !== claims.config_version) {
+          throw new MCPEgressGatewayError(
+            409,
+            'stale_capability',
+            'MCP server configuration changed; reconnect this task'
+          );
+        }
+        if (server.scope !== 'global') {
+          const attached = await new SessionMCPServerRepository(tenantDb).listServers(
+            claims.session_id as SessionID,
+            true
+          );
+          if (!attached.some((candidate) => candidate.mcp_server_id === server.mcp_server_id)) {
+            throw new MCPEgressGatewayError(403, 'server_detached', 'MCP server was detached');
+          }
+        }
+        if (this.options.branchRbacEnabled) {
+          const branchRepository = new BranchRepository(tenantDb);
+          const branch = await branchRepository.findById(session.branch_id);
+          if (!branch) throw new MCPEgressGatewayError(403, 'branch_revoked', 'Branch unavailable');
+          const access = await branchRepository.resolveUserAccess(
+            branch,
+            claims.principal_user_id as UserID
+          );
+          if (
+            !resolveSessionPromptAccess({
+              branch,
+              session,
+              userId: claims.principal_user_id as UserID,
+              isOwner: access.is_owner,
+              userRole: principal.role,
+              branchPermission: access.can,
+            }).allowed
+          ) {
+            throw new MCPEgressGatewayError(403, 'branch_revoked', 'Branch permission changed');
+          }
+        }
+        if (server.auth?.type === 'oauth') {
+          const tokenUserId =
+            (server.auth.oauth_mode ?? 'per_user') === 'shared'
+              ? null
+              : (claims.credential_user_id as UserID);
+          const grant = await new UserMCPOAuthTokenRepository(tenantDb).getToken(
+            tokenUserId,
+            server.mcp_server_id
+          );
+          if (!claims.grant_identity || mcpOAuthGrantIdentity(grant) !== claims.grant_identity) {
+            throw new MCPEgressGatewayError(
+              401,
+              'grant_changed',
+              'MCP OAuth grant was replaced or revoked; reconnect this task'
+            );
+          }
+        } else if (claims.grant_identity) {
+          throw new MCPEgressGatewayError(409, 'grant_changed', 'MCP grant identity changed');
+        }
+        const env = await resolveMCPEgressEnvironment(tenantDb, claims.credential_user_id, session);
+        if (mcpEgressMaterialHash(server, env, this.options.jwtSecret) !== claims.material_hash) {
+          throw new MCPEgressGatewayError(
+            409,
+            'credential_material_changed',
+            'MCP credential material changed; reconnect this task'
+          );
+        }
+        const resolved = resolveMcpServerTemplates(server, buildMCPTemplateContextFromEnv(env));
+        if (!resolved.isValid) {
+          throw new MCPEgressGatewayError(
+            409,
+            'template_resolution_failed',
+            'MCP template resolution failed'
+          );
+        }
+        return { unresolvedServer: server, server: resolved.server, env };
+      },
+      { postgresIsolationLevel: 'repeatable read' }
+    );
+  }
+
+  private async credentialHeaders(
+    claims: MCPEgressCapabilityClaims,
+    server: MCPServer,
+    assertCurrent: () => Promise<void>
+  ): Promise<Headers> {
+    let authHeaders: Record<string, string> | undefined;
+    if (server.auth?.type === 'oauth') {
+      let result: { headers: Record<string, { authorization?: string; error?: string }> };
+      try {
+        result = (await this.options.app
+          .service('mcp-servers/oauth-auth-headers')
+          .create({ mcp_server_ids: [server.mcp_server_id] }, {
+            provider: undefined,
+            tenant: { tenant_id: claims.tid },
+            session_id: claims.session_id,
+            user: {
+              user_id: claims.credential_user_id,
+              role: 'service',
+              _isServiceAccount: true,
+            },
+            mcp_egress_assert_current: assertCurrent,
+          } as unknown as AuthenticatedParams)) as typeof result;
+      } catch (error) {
+        // Preserve the typed known-no-send outcome, while allowing durable
+        // authority to supersede the local accelerator reason when reachable.
+        if (error instanceof OAuthRefreshAuthorityCancelledError) {
+          return this.rejectPreDispatch(claims, error.authorityCause);
+        }
+        // A non-refresh service failure may still have raced a mutation before
+        // credential resolution completed; prefer the current gateway reason.
+        await assertCurrent();
+        throw error;
+      }
+      const entry = result.headers[server.mcp_server_id];
+      if (!entry?.authorization) {
+        throw new MCPEgressGatewayError(
+          401,
+          entry?.error ?? 'needs_reauth',
+          'MCP OAuth authentication requires recovery'
+        );
+      }
+      authHeaders = { Authorization: entry.authorization };
+    } else if (server.auth?.type === 'jwt') {
+      const { api_url: apiUrl, api_token: apiToken, api_secret: apiSecret } = server.auth;
+      if (!apiUrl || !apiToken || !apiSecret) {
+        throw new MCPEgressGatewayError(
+          401,
+          'credential_resolution_failed',
+          'MCP JWT credential configuration is incomplete'
+        );
+      }
+      let token: string;
+      try {
+        token = await fetchJWTToken(
+          { api_url: apiUrl, api_token: apiToken, api_secret: apiSecret },
+          {
+            allowLocalhostHttp: this.options.allowLocalhostHttp === true,
+            cacheNamespace: `${claims.tid}:${server.mcp_server_id}:${claims.config_version}`,
+            cache: false,
+            resolveDns: this.options.resolveDns,
+            assertBeforeDispatch: async () => {
+              await assertCurrent();
+            },
+          }
+        );
+      } catch (error) {
+        // The shared JWT helper intentionally sanitizes provider failures. If
+        // its dispatch assertion lost authority, reloading here restores the
+        // stable gateway reason without exposing the provider exception.
+        await this.currentAuthority(claims);
+        throw error;
+      }
+      authHeaders = { Authorization: `Bearer ${token}` };
+    } else {
+      authHeaders = await resolveMCPAuthHeaders(server.auth, server.url, {
+        allowLocalhostHttp: this.options.allowLocalhostHttp === true,
+        cacheNamespace: `${claims.tid}:${server.mcp_server_id}:${claims.config_version}`,
+        disableProcessTokenCache: true,
+      });
+      if (server.auth && server.auth.type !== 'none' && !authHeaders?.Authorization) {
+        throw new MCPEgressGatewayError(
+          401,
+          'credential_resolution_failed',
+          'MCP credential resolution failed closed'
+        );
+      }
+    }
+    return new Headers(authHeaders);
+  }
+
+  private responseSecrets(
+    unresolvedServer: MCPServer,
+    resolvedServer: MCPServer,
+    env: Record<string, string>,
+    headers: Headers
+  ): string[] {
+    const values = [
+      ...headers.values(),
+      ...stringLeaves(resolvedServer.env),
+      ...stringLeaves(resolvedServer.headers),
+      ...authSecretMaterial(resolvedServer.auth),
+      ...urlMaterial(resolvedServer.url).filter(usefulLiteralUrlSecret),
+      ...[...templateKeys(unresolvedServer)].flatMap((key) => (env[key] ? [env[key]] : [])),
+    ];
+    return [...new Set(values.flatMap(secretVariants))];
+  }
+
+  async forward(input: {
+    serverId: string;
+    headers: Headers;
+    method: string;
+    body?: Uint8Array;
+  }): Promise<{
+    response: Response;
+    claims: MCPEgressCapabilityClaims;
+  }> {
+    if (input.method !== 'POST' && input.method !== 'DELETE') {
+      throw new MCPEgressGatewayError(
+        405,
+        'method_not_mediated',
+        'This MCP gateway phase mediates only bounded POST and DELETE requests'
+      );
+    }
+    const claims = this.verify(capabilityToken(input.headers));
+    if (claims.mcp_server_id !== input.serverId) {
+      throw new MCPEgressGatewayError(
+        403,
+        'capability_scope_mismatch',
+        'Capability/server mismatch'
+      );
+    }
+    if (input.body && input.body.byteLength > MAX_REQUEST_BYTES) {
+      throw new MCPEgressGatewayError(413, 'request_too_large', 'MCP gateway request is too large');
+    }
+    this.assertCapacity(claims);
+    const reservationId = randomUUID();
+    const controller = new AbortController();
+    this.reservations.set(reservationId, {
+      tenantId: claims.tid,
+      taskId: claims.task_id,
+      serverId: input.serverId,
+      controller,
+      startedAt: Date.now(),
+    });
+    let admitted: CurrentAuthority;
+    let credentials: Headers;
+    try {
+      // This one native snapshot is the source of every server-controlled
+      // value below: policy, credential configuration, destination, custom
+      // headers, template material, and reflection candidates.
+      admitted = await this.currentAuthority(claims);
+      for (const toolName of requestedToolNames(input.body)) {
+        const permission = admitted.server.tool_permissions?.[toolName];
+        if (permission === 'deny') {
+          throw new MCPEgressGatewayError(403, 'tool_denied', 'MCP tool is disabled');
+        }
+        if (permission === 'ask') {
+          throw new MCPEgressGatewayError(
+            403,
+            'approval_not_mediated',
+            'This server requires one-shot tool approval and must be reconfigured before mediation'
+          );
+        }
+      }
+      const assertCurrent = async () => {
+        await this.assertCurrentOrAbort(claims, controller.signal);
+      };
+      credentials = await this.credentialHeaders(claims, admitted.server, assertCurrent);
+    } catch (error) {
+      this.reservations.delete(reservationId);
+      throw error;
+    }
+    const headers = protocolRequestHeaders(input.headers);
+    const finalHeaders = new Headers(
+      mergeMCPRemoteHeaders({
+        custom: admitted.server.headers,
+        auth: Object.fromEntries(credentials.entries()),
+      })
+    );
+    for (const [name, value] of finalHeaders) headers.set(name, value);
+    const requestId = randomUUID();
+    const tracked: InFlight = {
+      tenantId: claims.tid,
+      taskId: claims.task_id,
+      serverId: input.serverId,
+      controller,
+      startedAt: Date.now(),
+    };
+    this.reservations.delete(reservationId);
+    this.inFlight.set(requestId, tracked);
+    const timer = getDaemonMetrics(this.options.app).startTimer('mcp_egress.proxy_ms', {
+      transport: 'http-buffered',
+    });
+    try {
+      // Defensible linearization point: each outbound hop is admitted only
+      // after this durable current-version/identity check completes. A mutation
+      // committed later may allow this already-admitted request to complete.
+      const assertCurrent = async () => {
+        await this.assertCurrentOrAbort(claims, controller.signal);
+      };
+      const response = await safeOutboundFetch(admitted.server.url!, {
+        method: input.method,
+        headers,
+        body: input.method === 'DELETE' ? undefined : input.body,
+        redirect: 'error',
+        timeoutMs: RESPONSE_TIMEOUT_MS,
+        maxResponseBytes: MAX_RESPONSE_BYTES,
+        allowLocalhostHttp: this.options.allowLocalhostHttp === true,
+        signal: controller.signal,
+        resolveDns: this.options.resolveDns,
+        assertCurrent,
+      });
+      const body = new Uint8Array(await response.arrayBuffer());
+      const secrets = this.responseSecrets(
+        admitted.unresolvedServer,
+        admitted.server,
+        admitted.env,
+        finalHeaders
+      );
+      const releasedBody = validateBufferedMCPResponse(response, body, secrets);
+      timer({ outcome: 'complete' });
+      return {
+        response: new Response(releasedBody, {
+          status: response.status,
+          headers: publicResponseHeaders(response.headers, secrets),
+        }),
+        claims,
+      };
+    } catch (error) {
+      timer({ outcome: controller.signal.aborted ? 'aborted' : 'error' });
+      // Re-resolve the authoritative rejection when possible; otherwise only
+      // the closed local abort vocabulary may cross the route boundary.
+      if (error instanceof OutboundPreDispatchAuthorityError) {
+        return this.rejectPreDispatch(claims, error.authorityCause);
+      }
+      throw error;
+    } finally {
+      this.inFlight.delete(requestId);
+    }
+  }
+}

--- a/apps/agor-daemon/src/mcp-egress/http-handler.ts
+++ b/apps/agor-daemon/src/mcp-egress/http-handler.ts
@@ -1,0 +1,61 @@
+import type { Request, Response } from 'express';
+import { type MCPEgressGateway, MCPEgressGatewayError } from './gateway.js';
+
+/** The production Express boundary for mediated MCP provider requests. */
+export function createMCPEgressHttpHandler(gateway: Pick<MCPEgressGateway, 'forward'>) {
+  return async (req: Request, res: Response): Promise<void> => {
+    try {
+      const serverId = String(req.params.serverId ?? '');
+      const body =
+        req.body == null
+          ? undefined
+          : req.body instanceof Uint8Array
+            ? new Uint8Array(req.body)
+            : new TextEncoder().encode(
+                typeof req.body === 'string' ? req.body : JSON.stringify(req.body)
+              );
+      const gatewayHeaders = new Headers();
+      for (const [name, rawValue] of Object.entries(req.headers)) {
+        if (typeof rawValue === 'string') gatewayHeaders.set(name, rawValue);
+        else if (Array.isArray(rawValue)) gatewayHeaders.set(name, rawValue.join(', '));
+      }
+      const forwarded = await gateway.forward({
+        serverId,
+        headers: gatewayHeaders,
+        method: req.method,
+        body,
+      });
+      res.status(forwarded.response.status);
+      forwarded.response.headers.forEach((value, name) => {
+        res.setHeader(name, value);
+      });
+      res.end(Buffer.from(await forwarded.response.arrayBuffer()));
+    } catch (error) {
+      const gatewayError =
+        error instanceof MCPEgressGatewayError
+          ? error
+          : new MCPEgressGatewayError(
+              503,
+              'egress_unavailable',
+              'MCP gateway egress is temporarily unavailable'
+            );
+      const safeServerId = String(req.params.serverId ?? '').replace(/[^A-Za-z0-9_-]/g, '_');
+      console.warn(
+        `[MCP Egress] event=request_rejected server_id=${safeServerId || '<invalid>'} code=${gatewayError.code}`
+      );
+      if (!res.headersSent) {
+        const id =
+          req.body && typeof req.body === 'object' && 'id' in req.body
+            ? (req.body as { id?: unknown }).id
+            : null;
+        res.status(gatewayError.status).json({
+          jsonrpc: '2.0',
+          id,
+          error: { code: -32003, message: gatewayError.message, data: { code: gatewayError.code } },
+        });
+      } else {
+        res.end();
+      }
+    }
+  };
+}

--- a/apps/agor-daemon/src/mcp-egress/rollout.test.ts
+++ b/apps/agor-daemon/src/mcp-egress/rollout.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { validateMCPEgressRolloutChange } from './rollout.js';
+
+describe('MCP egress rollout guard', () => {
+  it('keeps emergency downgrade available only with explicit raw-secret acknowledgement', () => {
+    expect(
+      validateMCPEgressRolloutChange({
+        currentMode: 'enforced',
+        nextMode: 'off',
+        acknowledgeRawSecretDowngrade: false,
+        verifiedLegacyExecutorsFenced: false,
+      })
+    ).toBe('raw_secret_downgrade_acknowledgement_required');
+    expect(
+      validateMCPEgressRolloutChange({
+        currentMode: 'enforced',
+        nextMode: 'off',
+        acknowledgeRawSecretDowngrade: true,
+        verifiedLegacyExecutorsFenced: false,
+      })
+    ).toBeUndefined();
+  });
+
+  it('requires an independently verified legacy-executor fence before enforcement', () => {
+    expect(
+      validateMCPEgressRolloutChange({
+        currentMode: 'compatibility',
+        nextMode: 'enforced',
+        acknowledgeRawSecretDowngrade: false,
+        verifiedLegacyExecutorsFenced: false,
+      })
+    ).toBe('legacy_executor_fence_attestation_required');
+    expect(
+      validateMCPEgressRolloutChange({
+        currentMode: 'compatibility',
+        nextMode: 'enforced',
+        acknowledgeRawSecretDowngrade: false,
+        verifiedLegacyExecutorsFenced: true,
+      })
+    ).toBeUndefined();
+  });
+});

--- a/apps/agor-daemon/src/mcp-egress/rollout.ts
+++ b/apps/agor-daemon/src/mcp-egress/rollout.ts
@@ -1,0 +1,28 @@
+import type { MCPEgressGatewayMode } from '@agor/core/types';
+
+export type MCPEgressRolloutViolation =
+  | 'raw_secret_downgrade_acknowledgement_required'
+  | 'legacy_executor_fence_attestation_required';
+
+export function validateMCPEgressRolloutChange(input: {
+  currentMode: MCPEgressGatewayMode;
+  nextMode: MCPEgressGatewayMode;
+  acknowledgeRawSecretDowngrade: boolean;
+  verifiedLegacyExecutorsFenced: boolean;
+}): MCPEgressRolloutViolation | undefined {
+  if (
+    (input.currentMode === 'compatibility' || input.currentMode === 'enforced') &&
+    (input.nextMode === 'off' || input.nextMode === 'observe') &&
+    !input.acknowledgeRawSecretDowngrade
+  ) {
+    return 'raw_secret_downgrade_acknowledgement_required';
+  }
+  if (
+    input.nextMode === 'enforced' &&
+    input.currentMode !== 'enforced' &&
+    !input.verifiedLegacyExecutorsFenced
+  ) {
+    return 'legacy_executor_fence_attestation_required';
+  }
+  return undefined;
+}

--- a/apps/agor-daemon/src/mcp/tools/mcp-servers.oauth-hooks.integration.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/mcp-servers.oauth-hooks.integration.test.ts
@@ -11,6 +11,7 @@ import { MCP_HEADER_REDACTED_SENTINEL } from '@agor/core/tools/mcp/http-headers'
 import type { MCPServerID, UserID } from '@agor/core/types';
 import type { McpServer } from '@modelcontextprotocol/server';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mcpEgressMaterialHash } from '../../mcp-egress/gateway.js';
 import { type RegisterHooksContext, registerHooks } from '../../register-hooks.js';
 import {
   fingerprintMCPOAuthGrantConfiguration,
@@ -216,6 +217,23 @@ describe('MCP OAuth status through Feathers response hooks', () => {
     expect(projected.auth?.oauth_access_token).toBe(MCP_HEADER_REDACTED_SENTINEL);
     expect(JSON.stringify(projected)).not.toContain('configured-client-secret');
     expect(JSON.stringify(projected)).not.toContain('durable-grant-access');
+
+    // Exercise the production after-hook projection used by an in-process
+    // executor lookup. Runtime token and expiry enrichment must not change the
+    // durable gateway material identity used by first admission.
+    const executorProjected = await app.service('mcp-servers').get(server.mcp_server_id, {
+      authenticated: true,
+      provider: undefined,
+      query: { forUserId: user.user_id },
+      user: { ...user, role: 'service', _isServiceAccount: true },
+      authentication: { payload: { type: 'internal' } },
+      tenant: { tenant_id: 'default', source: 'static' },
+    } as never);
+    expect(executorProjected.auth?.oauth_access_token).toBe('durable-grant-access');
+    expect(executorProjected.auth?.oauth_token_expires_at).toEqual(expect.any(Number));
+    expect(mcpEgressMaterialHash(executorProjected, {}, 'projection-hash-key')).toBe(
+      mcpEgressMaterialHash(savedServer!, {}, 'projection-hash-key')
+    );
 
     const handlers = new Map<string, ToolHandler>();
     const mcp = {

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -29,6 +29,7 @@ import {
   BoardRepository,
   type BranchRepository,
   CardRepository,
+  getMCPEgressGatewayMode,
   isPostgresDatabaseHandle,
   requireCurrentTenantId,
   runWithTenantDatabaseScope,
@@ -115,6 +116,7 @@ import {
 } from './hooks/classify-missing-credential.js';
 import { gatewayRouteHook } from './hooks/gateway-route.js';
 import { validateMessageCreate } from './hooks/validate-message-create.js';
+import { coordinateMCPServerMutationAfterWrite } from './mcp-egress/coordination.js';
 import { resolveForUserIdWithGate } from './oauth-auth-helpers.js';
 import { protectExternalPermissionMessageWrites } from './permissions/permission-message-boundary.js';
 import type { RedisRealtimeRuntime } from './realtime/redis-realtime.js';
@@ -1068,6 +1070,33 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     realtimeRelay,
     deployment,
   } = ctx;
+  const redactMCPServerSecretFieldsForGatewayMode = async (context: HookContext) => {
+    if (
+      context.params.provider &&
+      context.params.tenant?.tenant_id &&
+      ['compatibility', 'enforced'].includes(await getMCPEgressGatewayMode(db))
+    ) {
+      if (context.event) context.dispatch = redactMCPServerPayload(context.result);
+      context.result = redactMCPServerPayload(context.result);
+      return context;
+    }
+    return redactMCPServerSecretFields(context);
+  };
+  const abortMcpInFlightAfterWrite = async (context: HookContext) => {
+    const gateway = (
+      app as unknown as {
+        mcpEgressGateway?: {
+          abortServer(
+            tenantId: string,
+            serverId: string,
+            reason?: 'server_detached' | 'stale_capability'
+          ): number;
+        };
+      }
+    ).mcpEgressGateway;
+    coordinateMCPServerMutationAfterWrite(context, gateway);
+    return context;
+  };
 
   // Used by classifyMissingCredentialFailure to look up the acting user for
   // a failed task (no service-layer equivalent already in ctx).
@@ -2466,21 +2495,21 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       remove: [authorizeMcpServerWriteHook],
     },
     after: {
-      find: [injectPerUserOAuthTokens, redactMCPServerSecretFields],
+      find: [injectPerUserOAuthTokens, redactMCPServerSecretFieldsForGatewayMode],
       get: [
         denyMcpServerGetOfAnotherUsersPrivate,
         injectPerUserOAuthTokens,
-        redactMCPServerSecretFields,
+        redactMCPServerSecretFieldsForGatewayMode,
       ],
-      create: [redactMCPServerSecretFields],
-      patch: [redactMCPServerSecretFields],
-      update: [redactMCPServerSecretFields],
+      create: [redactMCPServerSecretFieldsForGatewayMode],
+      patch: [abortMcpInFlightAfterWrite, redactMCPServerSecretFieldsForGatewayMode],
+      update: [abortMcpInFlightAfterWrite, redactMCPServerSecretFieldsForGatewayMode],
       // `remove` returns the deleted row: the adapter loads it in full before
       // deleting so it can return it, and that same object becomes the
       // `removed` payload broadcast to every authenticated connection in the
       // tenant. Without this it is the one method that hands out raw `env`,
       // `headers`, and `auth` — a delete is not an exemption from redaction.
-      remove: [redactMCPServerSecretFields],
+      remove: [abortMcpInFlightAfterWrite, redactMCPServerSecretFieldsForGatewayMode],
     },
   });
 

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -6,6 +6,7 @@
  * Extracted from index.ts for maintainability.
  */
 
+import { randomUUID } from 'node:crypto';
 import { Transform } from 'node:stream';
 import type { SessionInitializationRequest } from '@agor/core/api';
 import {
@@ -29,12 +30,15 @@ import {
   bindRepositoryToTenantUnitOfWork,
   generateId,
   getCurrentTenantId,
+  getMCPEgressGatewayMode,
   MCPCatalogCandidateRepository,
+  MCPServerRepository,
   MessagesRepository,
   resolveMcpMemberPolicy,
   runWithTenantDatabaseScope,
   ScheduleRepository,
   type SessionRepository,
+  setMCPEgressGatewayMode,
   setMcpMemberPolicy,
   shortId,
   TaskRepository,
@@ -68,6 +72,7 @@ import type {
   HookContext,
   MCPMemberPolicy,
   MCPMemberPolicySetting,
+  MCPServer,
   MCPServerID,
   Message,
   MessageID,
@@ -138,6 +143,21 @@ import {
   publicHealthDb,
 } from './health/payload.js';
 import { registerHealthProbeRoutes } from './health/routes.js';
+import { issueMCPEgressCapability } from './mcp-egress/capability.js';
+import {
+  coordinateMCPEgressRolloutChange,
+  coordinateSessionMCPRevocation,
+} from './mcp-egress/coordination.js';
+import {
+  MCPEgressGateway,
+  mcpEgressEligibility,
+  mcpEgressMaterialHash,
+  mcpOAuthGrantIdentity,
+  projectMCPServerForExecutor,
+  resolveMCPEgressEnvironment,
+} from './mcp-egress/gateway.js';
+import { createMCPEgressHttpHandler } from './mcp-egress/http-handler.js';
+import { validateMCPEgressRolloutChange } from './mcp-egress/rollout.js';
 import { createFeathersMetricsHook } from './metrics/feathers.js';
 import { getDaemonMetrics } from './metrics/index.js';
 import { resolveForUserIdWithGate } from './oauth-auth-helpers.js';
@@ -733,6 +753,42 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   const usersService = app.service('users');
   const tasksService = app.service('tasks') as unknown as TasksServiceImpl;
   const reposService = app.service('repos') as unknown as ReposServiceImpl;
+  const mcpEgressGateway = new MCPEgressGateway({
+    db,
+    app,
+    jwtSecret,
+    branchRbacEnabled,
+  });
+  // Internal composition seam used by MCP mutation hooks. It is never exposed
+  // as a Feathers service and carries no serializable credential material.
+  (app as unknown as { mcpEgressGateway?: MCPEgressGateway }).mcpEgressGateway = mcpEgressGateway;
+
+  const mcpEgressHttpHandler = createMCPEgressHttpHandler(mcpEgressGateway);
+  // @ts-expect-error FeathersJS app extends Express.
+  app.post('/mcp-egress/:serverId', mcpEgressHttpHandler);
+  // @ts-expect-error FeathersJS app extends Express.
+  app.delete('/mcp-egress/:serverId', mcpEgressHttpHandler);
+  // Streamable HTTP GET opens a server-stream channel. This phase cannot
+  // mediate it without unbounded buffering, so reject before capability or DNS work.
+  // @ts-expect-error FeathersJS app extends Express.
+  app.all('/mcp-egress/:serverId', (req: Request, res: Response) => {
+    const safeServerId = String(req.params.serverId ?? '').replace(/[^A-Za-z0-9_-]/g, '_');
+    console.warn(
+      `[MCP Egress] event=request_rejected server_id=${safeServerId || '<invalid>'} code=method_not_mediated`
+    );
+    res
+      .status(405)
+      .setHeader('allow', 'POST, DELETE')
+      .json({
+        jsonrpc: '2.0',
+        id: null,
+        error: {
+          code: -32003,
+          message: 'This MCP gateway phase mediates only bounded POST and DELETE requests',
+          data: { code: 'method_not_mediated' },
+        },
+      });
+  });
   const tenantIdentityAround = createTenantDatabaseScopeAroundHook({
     db,
     config,
@@ -4241,9 +4297,124 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     return session;
   };
 
-  // ============================================================================
-  // Session MCP servers routes
-  // ============================================================================
+  const projectMcpServersForExecutor = async (
+    servers: MCPServer[],
+    session: Session,
+    params: RouteParams
+  ): Promise<MCPServer[]> => {
+    const payload = (
+      params as RouteParams & {
+        authentication?: {
+          payload?: { type?: unknown; task_id?: unknown; sub?: unknown; tenant_id?: unknown };
+        };
+      }
+    ).authentication?.payload;
+    const tenantId =
+      (params as RouteParams & { tenant?: { tenant_id?: string } }).tenant?.tenant_id ??
+      getCurrentTenantId();
+    if (!tenantId) throw new NotAuthenticated('MCP gateway projection requires tenant identity');
+    const mode = await getMCPEgressGatewayMode(db);
+    if (payload?.type !== 'executor-session' || typeof payload.task_id !== 'string') {
+      if (mode === 'compatibility' || mode === 'enforced') {
+        throw new Forbidden(
+          'MCP credentials are available only through a live task-scoped daemon capability'
+        );
+      }
+      return servers;
+    }
+    if (mode === 'off') return servers;
+    if (mode === 'observe') {
+      for (const server of servers) {
+        console.info(
+          `[MCP Egress] event=direct_client_observed transport=${server.transport} server_id=${server.mcp_server_id}`
+        );
+      }
+      return servers;
+    }
+    const gatewayBaseUrl =
+      config.daemon?.public_url ?? config.daemon?.base_url ?? `http://localhost:${_DAEMON_PORT}`;
+    return runWithTenantDatabaseScope(db, tenantId, async (tenantDb) => {
+      const task = await new TaskRepository(tenantDb).findById(payload.task_id as string);
+      if (!task || task.session_id !== session.session_id) {
+        throw new Forbidden('Executor task scope is no longer current');
+      }
+      const resolvedEnv = await resolveMCPEgressEnvironment(tenantDb, session.created_by, session);
+      const projected: MCPServer[] = [];
+      for (const server of servers) {
+        const eligibility = mcpEgressEligibility(server);
+        if (!eligibility.eligible) {
+          console.info(
+            `[MCP Egress] event=projection_excluded reason=${eligibility.reason} transport=${server.transport} server_id=${server.mcp_server_id}`
+          );
+          continue;
+        }
+        let grantIdentity: string | undefined;
+        if (server.auth?.type === 'oauth') {
+          const tokenUserId =
+            (server.auth.oauth_mode ?? 'per_user') === 'shared'
+              ? null
+              : (session.created_by as import('@agor/core/types').UserID);
+          const grant = await new UserMCPOAuthTokenRepository(tenantDb).getToken(
+            tokenUserId,
+            server.mcp_server_id
+          );
+          grantIdentity = mcpOAuthGrantIdentity(grant);
+          if (!grantIdentity) {
+            console.info(
+              `[MCP Egress] event=projection_excluded reason=oauth_reauth_required server_id=${server.mcp_server_id}`
+            );
+            continue;
+          }
+        }
+        const capability = issueMCPEgressCapability(
+          {
+            tid: tenantId,
+            task_id: task.task_id,
+            session_id: session.session_id,
+            principal_user_id: task.created_by,
+            credential_user_id: session.created_by,
+            mcp_server_id: server.mcp_server_id,
+            config_version: server.config_version ?? 1,
+            material_hash: mcpEgressMaterialHash(server, resolvedEnv, jwtSecret),
+            grant_identity: grantIdentity,
+            rollout_mode: mode,
+            jti: randomUUID(),
+          },
+          jwtSecret
+        );
+        projected.push(
+          projectMCPServerForExecutor(
+            server,
+            new URL(
+              `/mcp-egress/${encodeURIComponent(server.mcp_server_id)}`,
+              gatewayBaseUrl
+            ).toString(),
+            capability
+          )
+        );
+      }
+      return projected;
+    });
+  };
+
+  // Relationship mutation is authoritative in its existing transaction. New
+  // calls re-check attachment state in PostgreSQL/SQLite. Local cancellation is
+  // an availability accelerator only; already-admitted calls may complete.
+  const coordinateSessionMcpRevocation = async <T>(
+    _sessionId: string,
+    serverIds: string[],
+    params: RouteParams,
+    mutate: () => Promise<T>
+  ): Promise<T> => {
+    const tenantId = (params as AuthenticatedParams).tenant?.tenant_id ?? getCurrentTenantId();
+    return coordinateSessionMCPRevocation({
+      db,
+      gateway: mcpEgressGateway,
+      tenantId,
+      serverIds,
+      mutate,
+    });
+  };
 
   registerAuthenticatedRoute(
     app,
@@ -4309,15 +4480,32 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
               (entry): entry is Exclude<(typeof withMetadata)[number], null> => entry !== null
             )
             .filter((entry) => isMCPServerUsableInSession(entry.server, session));
-          return shouldExposeMCPServerSecrets(params, {
-            allowSessionToken: true,
-            sessionId: id,
-          })
-            ? entries
-            : entries.map((entry) => ({
-                ...entry,
-                server: redactMCPServerSecrets(entry.server),
-              }));
+          if (
+            shouldExposeMCPServerSecrets(params, {
+              allowSessionToken: true,
+              sessionId: id,
+            })
+          ) {
+            // Project the full set once: mode/task/environment authority is
+            // shared by this response, and omitted servers must not leave
+            // protocol-incomplete `{ server: undefined }` list entries.
+            const projectedServers = await projectMcpServersForExecutor(
+              entries.map((entry) => entry.server),
+              session,
+              params
+            );
+            const projectedById = new Map(
+              projectedServers.map((server) => [server.mcp_server_id, server])
+            );
+            return entries.flatMap((entry) => {
+              const server = projectedById.get(entry.server.mcp_server_id);
+              return server ? [{ ...entry, server }] : [];
+            });
+          }
+          return entries.map((entry) => ({
+            ...entry,
+            server: redactMCPServerSecrets(entry.server),
+          }));
         }
         const sessionServerRefs = await sessionMCPServersService.listServers(
           id as import('@agor/core/types').SessionID,
@@ -4370,7 +4558,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           allowSessionToken: true,
           sessionId: id,
         })
-          ? servers
+          ? projectMcpServersForExecutor(servers, session, params)
           : servers.map(redactMCPServerSecrets);
       },
       async create(data: { mcpServerId: string }, params: RouteParams) {
@@ -4423,11 +4611,21 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         const serverIds = [...new Set(data.mcpServerIds)] as Array<
           import('@agor/core/types').MCPServerID
         >;
+        const existing = await sessionMCPServersService.listServers(
+          id as import('@agor/core/types').SessionID,
+          false,
+          params
+        );
+        const removedServerIds = existing
+          .map((item) => item.mcp_server_id)
+          .filter((serverId) => !serverIds.includes(serverId));
         try {
-          await sessionMCPServersService.setServers(
-            id as import('@agor/core/types').SessionID,
-            serverIds,
-            params
+          await coordinateSessionMcpRevocation(id, removedServerIds, params, () =>
+            sessionMCPServersService.setServers(
+              id as import('@agor/core/types').SessionID,
+              serverIds,
+              params
+            )
           );
         } catch (error) {
           if (error instanceof MCPServerNotUsableError) {
@@ -4454,10 +4652,12 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         if (!mcpId) throw new Error('MCP Server ID required');
         await requireSessionScopedConfigOwnerOrAdmin(id, params);
 
-        await sessionMCPServersService.removeServer(
-          id as import('@agor/core/types').SessionID,
-          mcpId as import('@agor/core/types').MCPServerID,
-          params
+        await coordinateSessionMcpRevocation(id, [mcpId], params, () =>
+          sessionMCPServersService.removeServer(
+            id as import('@agor/core/types').SessionID,
+            mcpId as import('@agor/core/types').MCPServerID,
+            params
+          )
         );
 
         const relationship = {
@@ -4479,12 +4679,16 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         if (!mcpId) throw new Error('MCP Server ID required');
         if (typeof data.enabled !== 'boolean') throw new Error('enabled field required');
         await requireSessionScopedConfigOwnerOrAdmin(id, params);
-        return sessionMCPServersService.toggleServer(
-          id as import('@agor/core/types').SessionID,
-          mcpId as import('@agor/core/types').MCPServerID,
-          data.enabled,
-          params
-        );
+        const toggle = () =>
+          sessionMCPServersService.toggleServer(
+            id as import('@agor/core/types').SessionID,
+            mcpId as import('@agor/core/types').MCPServerID,
+            data.enabled,
+            params
+          );
+        return data.enabled
+          ? toggle()
+          : coordinateSessionMcpRevocation(id, [mcpId], params, toggle);
       },
       // biome-ignore lint/suspicious/noExplicitAny: Service type not compatible with Express
     } as any,
@@ -4557,6 +4761,144 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       // fails instead of a reason it is off.
       find: { role: ROLES.VIEWER, action: 'read the MCP member policy' },
       patch: { role: ROLES.ADMIN, action: 'change the MCP member policy' },
+    },
+    requireAuth
+  );
+
+  registerAuthenticatedRoute(
+    app,
+    '/mcp-egress/status',
+    {
+      async find(params: RouteParams) {
+        const tenantId = (params as AuthenticatedParams).tenant?.tenant_id ?? getCurrentTenantId();
+        if (!tenantId) throw new NotAuthenticated('MCP gateway status requires tenant identity');
+        const mode = await getMCPEgressGatewayMode(db);
+        const runtime = mcpEgressGateway.status(tenantId);
+        const mediated = mode === 'compatibility' || mode === 'enforced';
+        const visibleServerPage = params.user?.user_id
+          ? await new MCPServerRepository(db).findAll({
+              enabled: true,
+              usableByUserId: params.user.user_id,
+              limit: 101,
+            })
+          : [];
+        const excludedServersTruncated = visibleServerPage.length > 100;
+        const visibleServers = visibleServerPage.slice(0, 100);
+        const excludedServers = (
+          await Promise.all(
+            visibleServers.map(async (server) => {
+              const eligibility = mcpEgressEligibility(server);
+              if (!eligibility.eligible) {
+                return {
+                  mcp_server_id: server.mcp_server_id,
+                  name: server.display_name ?? server.name,
+                  reason: eligibility.reason,
+                  recovery:
+                    eligibility.reason === 'approval_not_mediated'
+                      ? 'Change ask rules to allow/deny, or wait for task-bound approval receipts.'
+                      : eligibility.reason === 'template_configuration'
+                        ? 'Use only static user.env.KEY references with balanced supported helpers; relative, lookup, and scoped templates are excluded.'
+                        : 'Configure bounded Streamable HTTP; stdio, legacy SSE, and WebSocket are unavailable in mediated modes.',
+                };
+              }
+              if (server.auth?.type === 'oauth') {
+                const tokenUserId =
+                  (server.auth.oauth_mode ?? 'per_user') === 'shared'
+                    ? null
+                    : (params.user!.user_id as import('@agor/core/types').UserID);
+                const grant = await new UserMCPOAuthTokenRepository(db).getToken(
+                  tokenUserId,
+                  server.mcp_server_id
+                );
+                if (!mcpOAuthGrantIdentity(grant)) {
+                  return {
+                    mcp_server_id: server.mcp_server_id,
+                    name: server.display_name ?? server.name,
+                    reason: 'oauth_reauth_required' as const,
+                    recovery: 'Reconnect this MCP server to create a current OAuth grant.',
+                  };
+                }
+              }
+              return undefined;
+            })
+          )
+        ).filter((entry) => entry !== undefined);
+        return {
+          mode,
+          supported_transports: mediated ? ['streamable-http-buffered'] : [],
+          unsupported_transports: [
+            'stdio',
+            'legacy-sse-endpoint-handoff',
+            'websocket',
+            'unbounded-streaming-response',
+            'servers-requiring-ask-approval',
+          ],
+          in_flight_requests: runtime.activeRequests,
+          provider_in_flight_requests: runtime.providerInFlightRequests,
+          reserved_requests: runtime.reservedRequests,
+          oldest_request_ms: runtime.oldestRequestMs,
+          excluded_servers: excludedServers,
+          excluded_servers_truncated: excludedServersTruncated,
+          // The status read proves this database request succeeded; it is not
+          // an independent admission-path availability probe.
+          admission_available: null,
+          operator: hasMinimumRole(params.user?.role, ROLES.ADMIN),
+          guarantee: mediated
+            ? 'No request hop is admitted after a committed config, grant, task, attachment, role, or rollout change. Requests admitted before that commit may complete.'
+            : 'Direct mode has no gateway admission or revocation guarantee.',
+        };
+      },
+      async patch(
+        _id: unknown,
+        data: {
+          mode?: unknown;
+          acknowledge_raw_secret_downgrade?: unknown;
+          verified_legacy_executors_fenced?: unknown;
+        },
+        params: RouteParams
+      ) {
+        if (!['off', 'observe', 'compatibility', 'enforced'].includes(String(data?.mode))) {
+          throw new BadRequest('mode must be off, observe, compatibility, or enforced');
+        }
+        const nextMode = data.mode as import('@agor/core/types').MCPEgressGatewayMode;
+        const currentMode = await getMCPEgressGatewayMode(db);
+        if (currentMode === nextMode) return { mode: nextMode };
+        const violation = validateMCPEgressRolloutChange({
+          currentMode,
+          nextMode,
+          acknowledgeRawSecretDowngrade: data.acknowledge_raw_secret_downgrade === true,
+          verifiedLegacyExecutorsFenced: data.verified_legacy_executors_fenced === true,
+        });
+        // Emergency rollback remains available even with active calls. It is an
+        // explicit restoration of direct credential projection, not revocation.
+        if (violation === 'raw_secret_downgrade_acknowledgement_required') {
+          throw new BadRequest(
+            'acknowledge_raw_secret_downgrade must be true because rollback restores direct credential egress'
+          );
+        }
+        if (violation === 'legacy_executor_fence_attestation_required') {
+          throw new BadRequest(
+            'verified_legacy_executors_fenced must be true after pre-gateway executors are terminated'
+          );
+        }
+        const tenantId = (params as AuthenticatedParams).tenant?.tenant_id ?? getCurrentTenantId();
+        await coordinateMCPEgressRolloutChange({
+          gateway: mcpEgressGateway,
+          tenantId,
+          mutate: async () => {
+            await setMCPEgressGatewayMode(db, nextMode, params.user?.user_id);
+            console.warn(
+              `[SECURITY] event=mcp_egress_rollout_changed tenant_id=${(params as AuthenticatedParams).tenant?.tenant_id ?? '<unknown>'} actor_user_id=${params.user?.user_id ?? '<unknown>'} previous_mode=${currentMode} next_mode=${nextMode} raw_secret_downgrade_acknowledged=${data.acknowledge_raw_secret_downgrade === true}`
+            );
+          },
+        });
+        return { mode: nextMode };
+      },
+      // biome-ignore lint/suspicious/noExplicitAny: custom Feathers route method shape
+    } as any,
+    {
+      find: { role: ROLES.MEMBER, action: 'view MCP gateway status' },
+      patch: { role: ROLES.ADMIN, action: 'configure MCP gateway rollout' },
     },
     requireAuth
   );
@@ -4930,6 +5272,18 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         // user, matching the existing `database`/`execution` fields below —
         // not admin-only).
         const migrations = await probePendingMigrations(db);
+        const mcpEgressMode = await getMCPEgressGatewayMode(db);
+        const healthTenantId =
+          (params as AuthenticatedParams | undefined)?.tenant?.tenant_id ?? getCurrentTenantId();
+        const mcpEgressRuntime = healthTenantId
+          ? mcpEgressGateway.status(healthTenantId)
+          : {
+              inFlightRequests: 0,
+              activeRequests: 0,
+              providerInFlightRequests: 0,
+              reservedRequests: 0,
+              oldestRequestMs: 0,
+            };
 
         return {
           ...publicResponse,
@@ -4949,6 +5303,20 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           },
           mcp: {
             enabled: config.daemon?.mcpEnabled !== false,
+            egress: {
+              mode: mcpEgressMode,
+              // A health read cannot prove the next admission. Keep this
+              // explicitly unknown rather than turning DB reachability into a
+              // false 99.99% gateway availability claim.
+              admissionAvailable: null,
+              // Backward-compatible name; this is the same truthful total as
+              // activeRequests, not provider-only transport work.
+              inFlightRequests: mcpEgressRuntime.inFlightRequests,
+              activeRequests: mcpEgressRuntime.activeRequests,
+              providerInFlightRequests: mcpEgressRuntime.providerInFlightRequests,
+              reservedRequests: mcpEgressRuntime.reservedRequests,
+              oldestRequestMs: mcpEgressRuntime.oldestRequestMs,
+            },
           },
           // Execution mode surfaced so admins can confirm which security tier
           // the daemon booted under. Docker env overrides (AGOR_SET_RBAC_FLAG,

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -32,6 +32,7 @@ import {
   GatewayChannelRepository,
   generateId,
   getCurrentTenantId,
+  getMCPEgressGatewayMode,
   inArray,
   isPostgresDatabaseHandle,
   MCPCatalogCandidateRepository,
@@ -122,6 +123,7 @@ import {
   inOpenCodeNativeStateMutationSlot,
   type OpenCodeNativeStateMutationFence,
 } from './integrations/opencode/native-state-coordinator.js';
+import { scrubMCPSecretsFromExecutorEnv } from './mcp-egress/executor-env.js';
 import { getDaemonMetrics } from './metrics/index.js';
 import {
   runInOAuthTenantScope,
@@ -1263,6 +1265,25 @@ function createExecuteHandler(
         throw new Error(`Missing required environment variables: ${missingVars.join(', ')}`);
       }
     }
+
+    // MCP-only secret material is resolved by the daemon proxy. Remove both
+    // referenced keys and high-signal literal-value collisions from the
+    // executor environment; short/low-entropy values such as DEBUG=1 are not
+    // classified as credentials.
+    await runWithTenantDatabaseScope(db, tenantId, async (tenantDb) => {
+      const mode = await getMCPEgressGatewayMode(tenantDb);
+      if (mode !== 'compatibility' && mode !== 'enforced') return;
+      const attached = await new SessionMCPServerRepository(tenantDb).listServers(
+        sessionId as SessionID,
+        true
+      );
+      const global = await new MCPServerRepository(tenantDb).findAll({
+        scope: 'global',
+        enabled: true,
+        usableByUserId: session.created_by,
+      });
+      scrubMCPSecretsFromExecutorEnv(executorEnv, [...attached, ...global]);
+    });
 
     executorEnv.DAEMON_URL = daemonUrl;
 
@@ -4455,6 +4476,21 @@ export async function registerMCPServices(
       }
       const tenantId = tenantIdFromParams(params);
       if (!tenantId) throw new NotAuthenticated('oauth-auth-headers requires tenant identity');
+      const mcpEgressAssertCurrent = (
+        params as
+          | (AuthenticatedParams & {
+              mcp_egress_assert_current?: () => void | Promise<void>;
+            })
+          | undefined
+      )?.mcp_egress_assert_current;
+      const egressMode = await runInOAuthTenantScope(db, tenantId, () =>
+        getMCPEgressGatewayMode(db)
+      );
+      if (params?.provider && (egressMode === 'compatibility' || egressMode === 'enforced')) {
+        throw new Forbidden(
+          'MCP OAuth headers are daemon-only while authoritative egress mediation is enabled'
+        );
+      }
       if (trustedSessionExecutor) {
         if (!executorSessionId) {
           throw new Forbidden('oauth-auth-headers requires executor session scope');
@@ -4490,9 +4526,12 @@ export async function registerMCPServices(
           }
         }
       }
-      const { needsRefresh, refreshAndPersistToken, InvalidGrantError } = await import(
-        '@agor/core/tools/mcp/oauth-refresh'
-      );
+      const {
+        needsRefresh,
+        refreshAndPersistToken,
+        InvalidGrantError,
+        OAuthRefreshAuthorityCancelledError,
+      } = await import('@agor/core/tools/mcp/oauth-refresh');
 
       /**
        * The grant owner's current standing, for the refresh paths below.
@@ -4614,9 +4653,11 @@ export async function registerMCPServices(
                     refreshGeneration: row.refresh_generation,
                   },
                   validateGrant: refreshGrantValidator(tenantId, serverId as MCPServerID),
+                  assertCurrent: mcpEgressAssertCurrent,
                 });
                 headers[serverId] = { authorization: `Bearer ${observed}` };
-              } catch {
+              } catch (refreshErr) {
+                if (refreshErr instanceof OAuthRefreshAuthorityCancelledError) throw refreshErr;
                 headers[serverId] = { error: 'needs_reauth' };
               }
               return;
@@ -4636,8 +4677,10 @@ export async function registerMCPServices(
                     refreshGeneration: row.refresh_generation,
                   },
                   validateGrant: refreshGrantValidator(tenantId, serverId as MCPServerID),
+                  assertCurrent: mcpEgressAssertCurrent,
                 });
               } catch (refreshErr) {
+                if (refreshErr instanceof OAuthRefreshAuthorityCancelledError) throw refreshErr;
                 if (refreshErr instanceof InvalidGrantError) {
                   headers[serverId] = { error: 'needs_reauth' };
                   return;
@@ -4659,6 +4702,7 @@ export async function registerMCPServices(
 
             headers[serverId] = { authorization: `Bearer ${accessToken}` };
           } catch (err) {
+            if (err instanceof OAuthRefreshAuthorityCancelledError) throw err;
             externalFailure('OAuth AuthHeaders', 'oauth', err);
             headers[serverId] = { error: 'unknown_error' };
           }

--- a/apps/agor-daemon/src/utils/realtime-publish-policy.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish-policy.ts
@@ -302,6 +302,10 @@ export const REALTIME_PUBLISH_POLICY = {
     why: 'Caller-private acknowledgement; an explicit empty user-room invalidation refreshes every affected owner/admin device.',
   },
   'mcp-member-policy': { audience: 'none', why: 'Policy read for the caller.' },
+  'mcp-egress/status': {
+    audience: 'none',
+    why: 'Tenant-scoped rollout and health status; Settings refetches explicitly.',
+  },
 
   // ---------------------------------------------------------------------------
   // Silent: CRUD services with no realtime consumer. Denying costs nothing

--- a/apps/agor-docs/content/guide/mcp-egress-gateway.mdx
+++ b/apps/agor-docs/content/guide/mcp-egress-gateway.mdx
@@ -1,0 +1,186 @@
+# MCP egress gateway operations
+
+Agor's MCP egress gateway keeps reusable bearer, JWT-client, OAuth, custom-header,
+and referenced environment secrets in the daemon. Eligible executors receive an
+authenticated-encrypted opaque capability scoped to one tenant, live Task, Session, principal,
+credential owner, server, saved `config_version`, credential-material binding,
+and OAuth grant identity. The capability is routing authority, not a provider
+credential.
+
+The daemon resolves the final credential and owns every provider dispatch. The
+capability has no fixed one-hour expiry: it remains usable for a long-running
+Task, while every use reloads the Task and rejects it as soon as that Task is no
+longer live. It cannot be reused for another task, user, tenant, session, or
+server.
+
+## Exact guarantee
+
+For each outbound HTTP hop, Agor validates the durable Task, users, attachment,
+branch access, rollout mode, server `config_version`, referenced environment
+material, and OAuth grant identity immediately before opening that hop's socket.
+Therefore:
+
+> **No request hop is admitted after a relevant mutation has committed. A
+> request admitted before that commit may complete and may already have been
+> observed by the provider.**
+
+All constituent reads use one SQLite immediate transaction or PostgreSQL
+repeatable-read snapshot. Runtime OAuth access/refresh values are excluded from
+the canonical durable material identity; grant generation and binding remain included.
+
+This is an admission guarantee, not a claim that `request.end()` proves physical
+provider receipt or that Agor can retract bytes already accepted by a provider.
+A local `AbortController` cancels matching work as a best-effort accelerator.
+Its reasons are a closed set of safe gateway codes; durable revalidation wins
+when available, and an unknown shutdown is reported only as generic egress
+unavailability. It is not a cross-daemon correctness primitive. Active-active
+daemons obtain the same decision from PostgreSQL; Redis is not required for correctness.
+
+Credential rotation that preserves an OAuth grant's generation and binding does
+not invalidate that grant. Disconnect, `invalid_grant` deletion, grant
+replacement, binding change, configuration change, detach, task completion, or
+principal/role loss prevents the next admission.
+
+OAuth refresh is part of this boundary: after token-endpoint DNS resolution and
+immediately before a refresh token, client secret, or Basic header is sent, the
+OAuth service rechecks the same task/session/tenant/server/rollout assertion.
+An authority rejection at that point is a typed, known no-send cancellation:
+the exact refresh claim returns to idle and the prior grant remains usable.
+Failures after dispatch remain ambiguous and keep their stricter recovery state.
+
+## Rollout modes
+
+Configure the per-tenant mode in **Settings → MCP Servers**.
+
+| Mode | Behavior |
+| --- | --- |
+| `off` | Direct MCP configuration and reusable credentials reach executors. No gateway guarantee. |
+| `observe` | Direct behavior remains, with secret-free observation logs. No gateway guarantee. |
+| `compatibility` | Eligible servers use opaque capabilities. Ineligible servers are omitted rather than receiving raw secrets. |
+| `enforced` | The same supported set is mediated and every raw-secret projection path fails closed. Enabling it requires an operator attestation that pre-gateway executors were terminated. |
+
+An administrator can always make an emergency downgrade to `observe` or `off`,
+even while local requests exist. The UI requires an explicit raw-secret-egress
+acknowledgement, and the daemon writes a security audit log with tenant, actor,
+and old/new modes. A downgrade restores direct secrets; it is an escape hatch,
+not a revocation operation.
+
+## Supported and refused transports
+
+This phase deliberately supports a small, reviewable set:
+
+- **Bounded Streamable HTTP:** `POST` and `DELETE`; protocol headers; JSON responses; and
+  JSON-only SSE responses that terminate within 30 seconds and 16 MiB. Each
+  SSE response is reconstructed from validated JSON `data` fields only. GET,
+  unsupported methods, and every redirect are refused before a second send.
+- **All stdio:** refused in both compatibility and enforced modes, before any
+  process spawn or pipe write. Agor does not claim stdio revocation in this
+  phase.
+- **Legacy SSE endpoint handoff and WebSocket:** refused. Current SDK seams do
+  not let the daemon own every subsequent send.
+- **Unbounded or non-JSON streaming:** refused. The gateway buffers a bounded
+  response before releasing it so it never retains an indefinite unscanned
+  tail.
+- **Servers with any `ask` tool rule:** omitted with the actionable
+  `approval_not_mediated` reason. The canonical permission flow does not yet
+  issue a one-shot task/server/tool receipt that the gateway can consume.
+  `deny` is independently checked at the gateway before egress.
+- **Indeterminate templates:** omitted with `template_configuration`. Gateway
+  templates may use absolute `user.env.KEY` references and registered static
+  helpers (including nested/default fallback expressions). `@root`, `this`,
+  relative paths, blocks, partials, dynamic/unknown helpers, and `lookup` are
+  not mediated. If such a template might name user environment data, Agor
+  scrubs every user-defined environment key from the executor as defense in
+  depth while leaving unrelated servers available.
+
+Remote and delegated executors do not receive a silent raw-secret fallback in a
+mediated mode. If their SDK cannot consume the HTTP capability projection, the
+MCP server is unavailable for that task.
+
+Connection pooling is disabled: a pooled socket could bypass destination
+validation and obscure the per-hop admission point.
+
+Admission also reserves bounded process/tenant/task/server capacity before any
+credential work (32/16/4/8 concurrent calls respectively). Exhaustion returns
+`429 egress_capacity_exceeded`; clients should retry with bounded backoff. This
+bounds the 16 MiB response buffers and open sockets.
+
+## Reflection boundary
+
+The MCP provider is an intentional credential recipient and therefore a trust
+boundary. Agor does **not** claim to stop a malicious provider from encoding or
+exfiltrating a credential it received.
+
+To close accidental reflection, the daemon builds candidate values from final
+authorization/custom headers, resolved auth and environment fields, every
+referenced user environment value, and URL path/query material. Candidates
+shorter than eight characters or with fewer than four distinct characters are
+ignored; untemplated literal URL parts use a stricter 16-character/eight-distinct
+floor, so common paths and values such as `DEBUG=1` do not create false positives. The gateway
+parses JSON and each JSON SSE `data` frame, inspects decoded string values, and
+releases only a bounded, validated body. Public MCP response headers are
+allowlisted and scanned. Provider bodies, URLs, and errors are never logged.
+
+## Operations and health
+
+`GET /mcp-egress/status` is tenant-scoped and available to members; only admins
+see rollout controls. It reports the mode, exact guarantee, supported/refused
+transports, and **process-local** active capacity count, split into provider
+in-flight requests and credential/admission reservations. Oldest age covers
+both phases. It reports admission
+availability as unknown unless an independent probe exists rather than
+manufacturing a healthy value from the status request itself. It also lists
+each visible server excluded for transport, `ask`, or missing OAuth authority
+with a recovery action; non-admins can read these diagnostics but cannot change
+rollout mode. Detail is bounded to 100 visible servers per response and reports
+when additional diagnostics were truncated. Non-admins do not see a noisy
+default-off banner when there are zero calls and zero exclusions; admins retain
+the compact rollout control.
+
+`GET /health` reports the rollout mode, database probe, local in-flight count,
+and oldest local request. Useful metrics are:
+
+- `mcp_egress.proxy_ms` by outcome and transport;
+- rejected gateway requests by stable, secret-free reason in logs;
+- database health/latency from the normal daemon health path.
+
+The target budgets remain <=5 ms p95 and <=25 ms p99 admission and <=20 ms p95
+forwarding overhead. This phase has no measured HA/99.99% availability evidence. It performs one
+initial authority/material load and one final durable authority check per
+physical hop; it does not maintain lease, mutation, quarantine, or outbox rows.
+Run the checked-in SQLite benchmark harness after storage or authorization-path
+changes. PostgreSQL/HA numbers require `AGOR_TEST_POSTGRES_URL` and the managed
+HA environment.
+
+On a quiet, otherwise idle host, the implementation review run on 2026-08-25 measured 200 warmed SQLite
+admissions at p50 3.450 ms, p95 4.236 ms, and p99 5.088 ms. Reproduce it with
+`AGOR_RUN_MCP_EGRESS_BENCHMARK=1 pnpm --filter @agor/daemon exec vitest run
+src/mcp-egress/gateway.test.ts`. These local figures are not a PostgreSQL/HA
+availability measurement. The opt-in harness reports host-sensitive figures and
+does not enforce them as a CI release threshold; run it only on a quiet idle host
+and compare with a recorded baseline.
+
+A crash loses only best-effort local cancellation state. The next daemon does
+not mass-quarantine servers: enforced admission still fails closed when its
+durable checks are unavailable, and already-observed provider work remains
+outside the stronger claim.
+
+## Migration and rollback
+
+There is no schema migration in this phase. The mode uses existing tenant app
+variables, authority uses existing MCP `config_version`, and OAuth uses the
+existing grant generation/binding.
+
+1. Deploy with every tenant at `off`.
+2. Use `observe` to inventory direct clients and transports.
+3. Enable `compatibility`; verify that required servers are eligible and that
+   omitted `ask`, stdio, SSE-handoff, and WebSocket servers show actionable
+   status.
+4. Terminate every executor created before mediation, independently verify the
+   fence, then attest and enable `enforced`.
+
+To recover availability, an admin may explicitly downgrade. Rolling back to a
+binary without gateway support also restores raw-secret projection even if the
+tenant row says `enforced`; treat that software rollback as the same audited
+security downgrade. Conversation handles and unrelated tasks are not invalidated
+by an MCP server mutation.

--- a/apps/agor-docs/content/guide/mcp-servers.mdx
+++ b/apps/agor-docs/content/guide/mcp-servers.mdx
@@ -21,7 +21,7 @@ Editing authentication is patch-safe: leaving a saved secret blank preserves it,
 
 Connecting an entry again opens a new session but reuses the same owner-specific install. Supplying a new bearer token verifies and atomically rotates that stored install; the previous token is not retained in another catalog row. Remove the MCP server in **Settings → MCP Servers** to delete Agor's stored configuration and token.
 
-> **Active-turn limitation:** Configuration changes are resolved for subsequent Task dispatches, but Agor does not yet mediate every request made by an MCP client that an already-running provider SDK owns. Editing, detaching, or removing a server is therefore not a synchronous revocation boundary for an active turn. Stop the active Task and revoke the token or OAuth grant at the provider when access must end immediately. Strong active revocation requires the planned daemon-mediated MCP egress gateway.
+> **Revocation depends on gateway mode:** In `off` and `observe`, an active SDK may own a direct provider connection, so an edit is not a synchronous revocation boundary. In `compatibility` and `enforced`, eligible bounded Streamable HTTP servers use task-scoped daemon capabilities; all stdio, legacy SSE endpoint handoff, WebSocket, unbounded streaming, and servers requiring `ask` approval are omitted or fail closed. No new request hop is admitted after a relevant mutation commits, but a request admitted before that commit may complete. See [MCP egress operations](/guide/mcp-egress-gateway).
 
 ## Catalog curation for operators
 

--- a/apps/agor-docs/lib/docsNavigation.ts
+++ b/apps/agor-docs/lib/docsNavigation.ts
@@ -26,6 +26,7 @@ export const guideNavigation: Record<string, NavigationItem> = {
   knowledge: 'Knowledge',
   'internal-mcp': 'Agor MCP Server',
   'mcp-servers': 'External MCP Servers',
+  'mcp-egress-gateway': 'MCP Egress Operations',
   'multiplayer-social': 'Multiplayer & Social',
   'environment-configuration': 'Environments',
   scheduler: 'Scheduler',

--- a/apps/agor-ui/src/components/SettingsModal/MCPEgressGatewayStatus.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPEgressGatewayStatus.test.tsx
@@ -1,0 +1,119 @@
+import type { AgorClient } from '@agor-live/client';
+import { render, screen, waitFor } from '@testing-library/react';
+import { App as AntdApp } from 'antd';
+import { describe, expect, it, vi } from 'vitest';
+import { MCPEgressGatewayStatus } from './MCPEgressGatewayStatus';
+
+function clientFor(status: object) {
+  return {
+    service: (path: string) =>
+      path === 'mcp-egress/status' ? { find: vi.fn().mockResolvedValue(status) } : {},
+  } as unknown as AgorClient;
+}
+
+describe('MCPEgressGatewayStatus', () => {
+  it('renders the exact enforced guarantee and truthful transport lists', async () => {
+    const client = clientFor({
+      mode: 'enforced',
+      supported_transports: ['streamable-http-buffered'],
+      unsupported_transports: ['stdio', 'websocket', 'unbounded-streaming-response'],
+      in_flight_requests: 2,
+      provider_in_flight_requests: 1,
+      reserved_requests: 1,
+      oldest_request_ms: 12,
+      excluded_servers: [
+        {
+          mcp_server_id: 'stdio-server',
+          name: 'Local stdio',
+          reason: 'transport_not_mediated',
+          recovery: 'Configure bounded Streamable HTTP.',
+        },
+      ],
+      excluded_servers_truncated: true,
+      admission_available: null,
+      operator: false,
+      guarantee:
+        'No request hop is admitted after a committed authority change. Requests admitted before that commit may complete.',
+    });
+
+    render(
+      <AntdApp>
+        <MCPEgressGatewayStatus client={client} connectionReady />
+      </AntdApp>
+    );
+
+    const status = await screen.findByRole('status');
+    expect(status).toHaveAttribute('aria-live', 'polite');
+    expect(status).toHaveTextContent('All stdio and unsupported transports fail closed');
+    expect(
+      screen.getByRole('list', { name: 'MCP gateway supported transports' })
+    ).toHaveTextContent('streamable-http-buffered');
+    expect(
+      screen.getByRole('list', { name: 'MCP gateway unsupported transports' })
+    ).toHaveTextContent('stdiowebsocketunbounded-streaming-response');
+    expect(status).toHaveTextContent('Requests admitted before that commit may complete');
+    expect(status).toHaveTextContent('admission not independently probed');
+    expect(status).toHaveTextContent('2 local active');
+    expect(status).toHaveTextContent('1 provider in flight');
+    expect(status).toHaveTextContent('1 admission reserved');
+    expect(
+      screen.getByRole('list', { name: 'MCP servers excluded from gateway mediation' })
+    ).toHaveTextContent('Local stdio: Configure bounded Streamable HTTP.');
+    expect(status).toHaveTextContent('Showing the first 100 server diagnostics');
+    expect(
+      screen.queryByRole('combobox', { name: 'MCP gateway rollout mode' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('always renders the default-off warning even with zero counts', async () => {
+    const find = vi.fn().mockResolvedValue({
+      mode: 'off',
+      supported_transports: [],
+      unsupported_transports: ['stdio'],
+      in_flight_requests: 0,
+      provider_in_flight_requests: 0,
+      reserved_requests: 0,
+      oldest_request_ms: 0,
+      excluded_servers: [],
+      excluded_servers_truncated: false,
+      admission_available: null,
+      operator: true,
+      guarantee: 'Direct mode has no gateway admission guarantee.',
+    });
+    const client = { service: () => ({ find }) } as unknown as AgorClient;
+    render(
+      <AntdApp>
+        <MCPEgressGatewayStatus client={client} connectionReady />
+      </AntdApp>
+    );
+
+    expect(await screen.findByText('MCP gateway is off')).toBeInTheDocument();
+    expect(screen.getByText(/reusable credentials/)).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: 'MCP gateway rollout mode' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Refresh MCP gateway status' })).toBeInTheDocument();
+    await waitFor(() => expect(find).toHaveBeenCalledTimes(1));
+  });
+
+  it('does not render noisy operator state for a non-operator in default-off mode', async () => {
+    const client = clientFor({
+      mode: 'off',
+      supported_transports: [],
+      unsupported_transports: ['stdio'],
+      in_flight_requests: 0,
+      provider_in_flight_requests: 0,
+      reserved_requests: 0,
+      oldest_request_ms: 0,
+      excluded_servers: [],
+      excluded_servers_truncated: false,
+      admission_available: null,
+      operator: false,
+      guarantee: 'Direct mode has no gateway admission guarantee.',
+    });
+    render(
+      <AntdApp>
+        <MCPEgressGatewayStatus client={client} connectionReady />
+      </AntdApp>
+    );
+    await waitFor(() => expect(screen.queryByRole('status')).not.toBeInTheDocument());
+  });
+});

--- a/apps/agor-ui/src/components/SettingsModal/MCPEgressGatewayStatus.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPEgressGatewayStatus.tsx
@@ -1,0 +1,277 @@
+import { Alert, Button, Flex, Modal, Select, Space, Tag, Typography } from 'antd';
+import { useCallback, useEffect, useState } from 'react';
+
+type GatewayMode = 'off' | 'observe' | 'compatibility' | 'enforced';
+
+interface GatewayStatus {
+  mode: GatewayMode;
+  supported_transports: string[];
+  unsupported_transports: string[];
+  in_flight_requests: number;
+  provider_in_flight_requests: number;
+  reserved_requests: number;
+  oldest_request_ms: number;
+  excluded_servers: Array<{
+    mcp_server_id: string;
+    name: string;
+    reason: string;
+    recovery: string;
+  }>;
+  excluded_servers_truncated: boolean;
+  admission_available: boolean | null;
+  operator: boolean;
+  guarantee: string;
+}
+
+interface Props {
+  client: import('@agor-live/client').AgorClient | null;
+  connectionReady: boolean;
+}
+
+const modeCopy: Record<
+  GatewayMode,
+  { title: string; description: string; type: 'info' | 'warning' | 'success' }
+> = {
+  off: {
+    title: 'MCP gateway is off',
+    description: 'Executors receive direct MCP configuration and reusable credentials.',
+    type: 'warning',
+  },
+  observe: {
+    title: 'MCP gateway is observing',
+    description:
+      'Direct credentials still reach executors; observations do not provide revocation.',
+    type: 'warning',
+  },
+  compatibility: {
+    title: 'MCP gateway compatibility rollout',
+    description:
+      'Eligible bounded Streamable HTTP servers use task-scoped daemon capabilities. Ineligible servers are omitted rather than receiving credentials.',
+    type: 'info',
+  },
+  enforced: {
+    title: 'MCP gateway is enforced',
+    description:
+      'Only eligible bounded Streamable HTTP servers are projected. All stdio and unsupported transports fail closed.',
+    type: 'success',
+  },
+};
+
+function service(client: Props['client'], path: string) {
+  return client?.service(path as never) as unknown as {
+    find?: () => Promise<unknown>;
+    patch?: (id: null, data: unknown) => Promise<unknown>;
+  };
+}
+
+export function MCPEgressGatewayStatus({ client, connectionReady }: Props) {
+  const [status, setStatus] = useState<GatewayStatus | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const refresh = useCallback(async () => {
+    const find = service(client, 'mcp-egress/status')?.find;
+    if (!client || !connectionReady || typeof find !== 'function') return;
+    setBusy(true);
+    try {
+      setStatus((await find()) as GatewayStatus);
+      setError(null);
+    } catch {
+      setError(
+        'Gateway status is unavailable. Mediated MCP calls fail closed when admission cannot be checked.'
+      );
+    } finally {
+      setBusy(false);
+    }
+  }, [client, connectionReady]);
+
+  useEffect(() => {
+    setStatus(null);
+    void refresh();
+  }, [refresh]);
+
+  if (!status && !error) return null;
+  if (error) {
+    return (
+      <Alert
+        role="status"
+        aria-live="polite"
+        type="warning"
+        showIcon
+        title="MCP gateway status unavailable"
+        description={
+          <Space orientation="vertical">
+            <span>{error}</span>
+            <Button
+              loading={busy}
+              onClick={() => void refresh()}
+              aria-label="Retry MCP gateway status"
+            >
+              Retry
+            </Button>
+          </Space>
+        }
+        style={{ marginBottom: 16 }}
+      />
+    );
+  }
+  if (!status) return null;
+  if (
+    !status.operator &&
+    status.mode === 'off' &&
+    status.in_flight_requests === 0 &&
+    status.excluded_servers.length === 0
+  ) {
+    return null;
+  }
+
+  const copy = modeCopy[status.mode];
+  const applyMode = async (
+    mode: GatewayMode,
+    acknowledgeRawSecretDowngrade = false,
+    verifiedLegacyExecutorsFenced = false
+  ) => {
+    const patch = service(client, 'mcp-egress/status')?.patch;
+    if (typeof patch !== 'function') return;
+    setBusy(true);
+    try {
+      await patch(null, {
+        mode,
+        ...(acknowledgeRawSecretDowngrade ? { acknowledge_raw_secret_downgrade: true } : {}),
+        ...(verifiedLegacyExecutorsFenced ? { verified_legacy_executors_fenced: true } : {}),
+      });
+      setActionError(null);
+      await refresh();
+    } catch {
+      setActionError('The rollout change was refused. Review daemon logs and retry.');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const selectMode = (mode: GatewayMode) => {
+    if (
+      (status.mode === 'compatibility' || status.mode === 'enforced') &&
+      (mode === 'off' || mode === 'observe')
+    ) {
+      Modal.confirm({
+        title: 'Restore raw credential egress?',
+        content:
+          'Emergency rollback remains available, but it can send reusable MCP credentials to new executors. This acknowledgement is audited.',
+        okText: 'Acknowledge and downgrade',
+        okButtonProps: { danger: true, 'aria-label': 'Acknowledge raw credential downgrade' },
+        onOk: () => applyMode(mode, true),
+      });
+      return;
+    }
+    if (mode === 'enforced' && status.mode !== 'enforced') {
+      Modal.confirm({
+        title: 'Confirm legacy executors are fenced',
+        content:
+          'Terminate executors started before mediation. Gateway counters cannot prove legacy direct clients are gone.',
+        okText: 'I verified the fence',
+        onOk: () => applyMode(mode, false, true),
+      });
+      return;
+    }
+    void applyMode(mode);
+  };
+
+  return (
+    <Alert
+      role="status"
+      aria-live="polite"
+      type={copy.type}
+      showIcon
+      title={copy.title}
+      description={
+        <Flex vertical gap={8}>
+          <Typography.Text>{copy.description}</Typography.Text>
+          <Typography.Text>{status.guarantee}</Typography.Text>
+          <Space wrap>
+            <Tag>{status.in_flight_requests} local active</Tag>
+            <Tag>{status.provider_in_flight_requests} provider in flight</Tag>
+            <Tag>{status.reserved_requests} admission reserved</Tag>
+            {status.oldest_request_ms > 0 && <Tag>oldest {status.oldest_request_ms} ms</Tag>}
+            <Tag>
+              admission{' '}
+              {status.admission_available === null
+                ? 'not independently probed'
+                : status.admission_available
+                  ? 'available'
+                  : 'unavailable'}
+            </Tag>
+          </Space>
+          <div>
+            <Typography.Text strong>Supported now</Typography.Text>
+            <ul aria-label="MCP gateway supported transports">
+              {status.supported_transports.length ? (
+                status.supported_transports.map((transport) => <li key={transport}>{transport}</li>)
+              ) : (
+                <li>None in this rollout mode</li>
+              )}
+            </ul>
+            <Typography.Text strong>
+              Not mediated (fails closed when mediation is active)
+            </Typography.Text>
+            <ul aria-label="MCP gateway unsupported transports">
+              {status.unsupported_transports.map((transport) => (
+                <li key={transport}>{transport}</li>
+              ))}
+            </ul>
+          </div>
+          <Typography.Text type="secondary">
+            Agor does not claim provider-side cancellation or revocation for a request admitted
+            before a mutation commits.
+          </Typography.Text>
+          {status.excluded_servers.length > 0 && (
+            <div>
+              <Typography.Text strong>Servers requiring action</Typography.Text>
+              <ul aria-label="MCP servers excluded from gateway mediation">
+                {status.excluded_servers.map((server) => (
+                  <li key={server.mcp_server_id}>
+                    <Typography.Text>{server.name}</Typography.Text>: {server.recovery}{' '}
+                    <Typography.Text type="secondary">({server.reason})</Typography.Text>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {status.excluded_servers_truncated && (
+            <Typography.Text type="secondary">
+              Showing the first 100 server diagnostics. Narrow the server inventory for complete
+              recovery details.
+            </Typography.Text>
+          )}
+          <div role="alert" aria-live="assertive">
+            {actionError}
+          </div>
+          <Space wrap>
+            {status.operator && (
+              <Select<GatewayMode>
+                aria-label="MCP gateway rollout mode"
+                value={status.mode}
+                style={{ width: 200 }}
+                disabled={busy}
+                options={['off', 'observe', 'compatibility', 'enforced'].map((value) => ({
+                  value: value as GatewayMode,
+                  label: value,
+                }))}
+                onChange={selectMode}
+              />
+            )}
+            <Button
+              loading={busy}
+              onClick={() => void refresh()}
+              aria-label="Refresh MCP gateway status"
+            >
+              Refresh
+            </Button>
+          </Space>
+        </Flex>
+      }
+      style={{ marginBottom: 16 }}
+    />
+  );
+}

--- a/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
@@ -65,6 +65,7 @@ import {
 } from '../MCPServer/memberPolicy';
 import { useOAuthBrowserEventAttempt } from '../MCPServer/useOAuthBrowserEventAttempt';
 import { AdaptiveSettingsModal } from './AdaptiveSettingsModal';
+import { MCPEgressGatewayStatus } from './MCPEgressGatewayStatus';
 import { MCPMemberPolicySetting } from './MCPMemberPolicySetting';
 import { ResponsiveSettingsHeader } from './ResponsiveSettingsHeader';
 import { SettingsActionGroup } from './SettingsActionGroup';
@@ -974,7 +975,20 @@ const MCPServersTableForIdentity: React.FC<MCPServersTableProps> = ({
       // is a pane away rather than a band above them.
       defaultActiveKey="servers"
       items={[
-        { key: 'servers', label: 'Servers', children: serversPane },
+        {
+          key: 'servers',
+          label: 'Servers',
+          children: (
+            <>
+              <MCPEgressGatewayStatus
+                key={durableAuthorityKey ?? '__mcp-egress-status__'}
+                client={client}
+                connectionReady={connectionReady}
+              />
+              {serversPane}
+            </>
+          ),
+        },
         {
           key: 'policy',
           // Ungated on purpose: this is the answer to "why is New MCP Server

--- a/context/explorations/mcp-authoritative-egress-gateway.md
+++ b/context/explorations/mcp-authoritative-egress-gateway.md
@@ -1,227 +1,202 @@
-# Authoritative MCP egress gateway
+# Authoritative MCP egress gateway — implemented phase
 
-Status: issue-ready design; not implemented by the #2500 auth-mutation slice.
+Status: structural implementation for #2500, stacked on #2553. #2501 is not in
+scope.
 
-## Why lifecycle invalidation is insufficient
+## Security objective
 
-Today an executor gives a provider SDK an MCP configuration containing an
-endpoint or process command and, for some transports, credential material. Once
-that SDK owns the client, a daemon-side generation check cannot close the gap
-between “checked” and “sent.” Stopping a Task after a configuration write is an
-availability optimization, not a revocation boundary:
+Reusable MCP provider credentials never cross the daemon/executor boundary in a
+mediated rollout mode. Executors receive only an opaque authenticated-encrypted capability
+bound to:
 
-- PostgreSQL does not expose an uncommitted “mutation pending” row to another
-  transaction.
-- A remote executor acknowledgement proves only that it sent an acknowledgement,
-  not that a third-party SDK or subprocess stopped.
-- an HTTP request or provider side effect already accepted before revocation
-  cannot be recalled;
-- credential-bearing environment and stdio process startup happen outside the
-  daemon's request checks; and
-- crash recovery cannot safely infer that an unobserved provider is quiescent.
+- tenant, live Task, Session, prompting principal, and credential owner;
+- one MCP server and its existing monotonic `config_version`;
+- an HMAC of every saved credential-bearing configuration field plus referenced
+  session/user environment material;
+- OAuth grant generation/binding identity when applicable; and
+- the tenant rollout mode and a unique capability id.
 
-The strong invariant therefore requires one owner for both credential use and
-MCP egress. No executor or provider SDK may receive a reusable raw credential or
-open a provider transport directly.
+There is intentionally no wall-clock expiry. Long tasks do not break after one
+hour; every use reloads the Task and all current authority. Terminal/revoked
+Tasks make the capability unusable. The capability contains neither endpoint,
+headers, environment, access/refresh token, bearer token, JWT client secret, nor
+minted provider token.
 
-## Target invariant and linearization point
+The daemon owns template/environment resolution, OAuth refresh lookup, JWT
+minting, final header injection, pinned destination validation, redirect policy,
+and the outbound socket.
 
-For each `(tenant, credential principal, MCP server)` authority:
+## Chosen linearization contract
 
-1. Every tool request obtains a gateway read lease before credentials are
-   resolved and retains it until the response, cancellation, or bounded timeout.
-2. An authority mutation obtains the corresponding write lease. New read leases
-   stop immediately. The mutation becomes authoritative only after admitted
-   reads have completed or the gateway has closed their owned transports.
-3. The write transaction increments a durable authority epoch, changes config or
-   grants, records an outbox event, and commits. A request may dispatch only when
-   its read lease and observed epoch are still current at the gateway's final
-   send boundary.
-4. Raw bearer, JWT, OAuth, header, and environment secrets remain inside the
-   gateway/credential store. Executors carry an opaque, short-lived capability
-   naming the tenant, Task, Session, prompter principal, server, and authority
-   epoch.
+This phase does not implement a durable drain/lease state machine. That design
+cannot honestly prove provider observation or transport teardown merely from a
+JavaScript enqueue or `request.end()` acknowledgement, and crash recovery would
+turn routine restarts into unsafe mass quarantine.
 
-“No old request after revocation” means no provider request is _admitted or
-dispatched after the write lease linearization point_. A provider side effect
-completed by a request admitted before that point is historical and cannot be
-undone. The mutation API must either wait for those admitted operations or fail
-closed with a bounded, actionable `egress_drain_failed` result; it must not claim
-to revoke already-completed provider effects.
+Instead, every physical HTTP hop has one explicit admission point: after pinned
+DNS resolution and immediately before socket construction, the gateway reloads
+and checks the durable authority/version/grant. The contract is:
 
-## Components
+> No hop is admitted after a relevant mutation commits. A hop admitted before
+> the commit may complete and may already have been observed by the provider.
 
-### Gateway-facing MCP transport
+All constituent authority reads use one SQLite immediate transaction or
+PostgreSQL repeatable-read snapshot. Runtime OAuth access/refresh values are
+excluded from canonical durable material; grant generation/binding remains explicit.
 
-Expose an Agor-controlled MCP endpoint per effective server (or one endpoint
-with a server capability). Claude, Codex, Gemini, Cursor, OpenCode, and delegated
-executors connect only to that endpoint. The gateway validates the opaque Task
-capability, resolves the current effective server through the canonical branch,
-Session, Task, role/policy, attachment, and principal owners, and forwards
-JSON-RPC under a read lease.
+Mutations use their existing transactions. MCP configuration updates already
+advance `config_version` atomically. Attachment removal commits its relationship
+change. OAuth disconnect/invalid-grant paths delete or replace the durable grant
+identity. Task/user/role/branch changes remain in their canonical authorities.
+The gateway does not duplicate these state machines.
 
-The Task capability is not a credential cache. It is audience-bound to the
-gateway, short lived, non-transferable across tenant/Task/server, and checked
-against durable Task activity and authority epoch on every call.
+An in-process `AbortController` map cancels matching local calls after observed
+writes and rollout changes. It is an availability accelerator only. A second
+daemon does not need its hint for correctness. PostgreSQL supplies HA visibility;
+SQLite uses the same repository checks. Redis may later accelerate cancellation
+but must never decide admission. Local hints carry only closed structured gateway
+codes; the durable authority reason supersedes a hint when revalidation succeeds,
+and unknown shutdowns collapse to generic egress unavailability.
 
-### HTTP, SSE, and long-lived transports
+## Transport boundary
 
-- The gateway owns DNS pinning, connection establishment, request bodies, and
-  response streaming.
-- Authorization is injected only after the final authority check. Redirects are
-  either refused or followed by the gateway under the existing safe-outbound
-  policy, with a new lease/epoch check at every hop. Authorization is never
-  forwarded to a different origin.
-- SSE, WebSocket, and streamable-HTTP connections are registered under the read
-  lease. A write lease closes them and waits for gateway-observed closure; an
-  executor acknowledgement is not part of the proof.
-- Each JSON-RPC tool invocation has its own admission record even when it shares
-  a pooled connection, so revocation can stop new calls without treating a TCP
-  socket as authority.
+Supported:
 
-### OAuth, JWT, and refresh
+- bounded Streamable HTTP `POST` and `DELETE`;
+- fully buffered JSON responses;
+- fully buffered JSON-only SSE responses that terminate within 30 seconds and
+  16 MiB.
 
-- OAuth access/refresh tokens and registered client secrets stay in the daemon's
-  credential store. Refresh runs inside the gateway immediately before a call
-  that needs it and rechecks the grant binding before returning an internal
-  header value to the sender component.
-- Routine access-token rotation retains the grant identity/authorization epoch
-  and does not acquire an authority write lease. Reauthentication, disconnect,
-  grant revocation, OAuth mode changes, client/binding changes, and subject
-  changes do.
-- JWT client-credential exchanges are performed inside the gateway. The minted
-  bearer is request-local or bounded to the current read lease and is never
-  returned to a remote executor.
-- OAuth start, callback, polling, disconnect, and runtime failures use the same
-  closed recovery categories already exposed by the daemon; provider details
-  remain in redacted secure telemetry.
+GET/server-stream channels, unsupported methods, and all redirects are refused.
 
-### stdio
+Refused before credential resolution/spawn:
 
-Stdio cannot be made strong by proxying only HTTP. The gateway (or a co-located
-trusted egress worker) must own the subprocess, its credential-bearing
-environment, stdin/stdout JSON-RPC, and process group. Executors talk to the
-gateway, never spawn the configured command. Acquiring a write lease stops
-admission, closes pipes, terminates the gateway-owned process group, verifies
-process absence, and only then commits the mutation. Delegated platforms need a
-reviewed worker with the same contract; until then strong revocation is
-unsupported for delegated stdio and must fail closed rather than silently fall
-back to direct execution.
+- all stdio in compatibility and enforced modes;
+- legacy SSE endpoint handoff;
+- WebSocket;
+- unbounded or unstructured streaming; and
+- a server with any `ask` tool rule, until the canonical permission service can
+  mint a one-shot tenant/task/session/server/tool receipt.
 
-### PostgreSQL, SQLite, and multiple daemons
+`deny` tool rules are checked again against decoded `tools/call` input. Remote or
+delegated executors fail closed; no mediated path silently projects raw config.
+Connection pooling is disabled so a previous socket cannot bypass per-hop DNS
+and admission checks.
 
-Database state is authority; Redis is only a wake-up hint.
+Capacity reservations bound concurrent calls to 32/process, 16/tenant, 4/task,
+and 8/server before credential work. Exhaustion fails with a retryable bounded
+429, limiting buffered response memory and sockets.
 
-- PostgreSQL uses short transactions, not an HTTP-long outer transaction. A
-  per-authority row contains the epoch and mutation state. A write operation
-  claims it with a row/advisory lock, sets durable `draining`, and coordinates
-  with gateway-owned active leases before committing the new epoch.
-- Active distributed leases need a bounded TTL plus gateway heartbeat and an
-  ownership token. Expiry is not proof of third-party teardown, so an expired
-  gateway owner leaves the authority quarantined until that owner is fenced by
-  infrastructure or an operator-approved recovery verifies it cannot send.
-- SQLite uses `BEGIN IMMEDIATE` and the same state machine without pretending it
-  supplies cross-host coordination.
-- Outbox delivery accelerates connection closure and UI refresh. Every gateway
-  admission reads the durable epoch, so missed Redis events and daemon restarts
-  converge lazily.
+## Credential authority
 
-## Durable mutation state machine
+Bearer/custom/environment material is resolved only in the daemon. JWT client
+credentials go through `fetchJWTToken` with the same async durable assertion
+immediately before the token-provider dispatch; process token caching is disabled
+for gateway calls. OAuth authentication uses the canonical daemon OAuth service,
+and refresh-token exchanges carry the same task/session/tenant/server assertion
+through DNS resolution to the instant before the credential-bearing token request.
+A rejected assertion or caller authority cancellation before socket construction
+is typed as a known no-send outcome. PostgreSQL releases only the exact claimed
+grant back to idle; SQLite removes only the matching in-process flight. Neither
+path deletes or quarantines the prior per-user/shared grant. Real failures after
+socket construction remain ambiguous.
+A capability records grant generation and binding fingerprint. Final admission
+reloads that identity, so disconnect, invalid-grant deletion, replacement, or
+binding change stops the send. Routine access-token refresh keeps the same grant
+identity and therefore does not unnecessarily revoke a task.
 
-Use an idempotent operation keyed by `(tenant, authority, requested mutation
-fingerprint)`:
+Gateway templates use a strict subset of the shared Handlebars renderer: absolute
+`user.env.KEY` values and the registered static helpers, including nested/default
+fallback expressions. Relative/context-changing paths, `@root`, `this`, `./`,
+blocks, partials, unknown/dynamic helpers, and `lookup` are ineligible. When an
+ineligible form might name user environment material, projection omits only that
+server and executor defense-in-depth scrubs every user-defined environment key.
 
-1. `requested`: mutation payload is validated and durably staged under the
-   deployment's documented storage controls, but is not authoritative.
-2. `draining`: new gateway reads are refused; current owned reads are cancelled
-   or allowed to finish within policy.
-3. `ready_to_commit`: all registered gateway transports are observably closed.
-4. `committed`: config/grant change and epoch increment committed atomically;
-   an outbox row announces the new epoch.
-5. `failed` or `quarantined`: mutation did not become authoritative. Access stays
-   disabled only when absence of an old gateway owner cannot be proven. The API
-   returns an operational recovery code and an admin can retry the same operation.
+## Provider and reflection trust
 
-Startup reconciliation resumes idempotent operations from durable state. It
-never waits forever for an acknowledgement from a process that may not exist.
-Quarantine has an explicit owner, reason, timestamp, and operator recovery path.
+The configured MCP provider and configured token provider are credential
+recipients. A malicious provider can reversibly encode or exfiltrate what it
+receives; this system does not claim otherwise.
 
-## Migration and compatibility
+Accidental reflection is closed at a structured boundary. Secret candidates come
+from final auth/custom headers, auth configuration, resolved server environment,
+all referenced environment values (including templates used in URL path/query),
+and decoded URL path/query material. The baseline is eight characters and four
+distinct characters; untemplated literal URL parts use a stricter 16/eight
+floor to avoid treating common path names as credentials. JSON and each JSON SSE
+`data` frame are parsed and decoded before inspection. Only allowlisted, scanned
+response headers and the validated bounded body reach the executor. Non-JSON,
+oversized, or non-terminating responses fail closed, so no indefinite unscanned
+tail exists.
 
-1. **Observe:** inventory every direct MCP configuration/credential handoff and
-   emit secret-free telemetry for transports and SDKs in use.
-2. **HTTP opt-in:** introduce the gateway behind a per-tenant feature flag. Keep
-   direct mode behavior unchanged and label it as non-strong; do not mix direct
-   and gateway clients for one authority.
-3. **SDK adapters:** configure every provider SDK with the gateway endpoint and
-   opaque capability. Preserve `sdk_session_id` and conversation resume handles;
-   a transport refresh must not erase conversation state.
-4. **Remote executors:** require gateway reachability and capability audience
-   validation. Never export raw config as a compatibility fallback.
-5. **stdio worker:** move process ownership and env injection into the trusted
-   egress worker before enabling strong mode for stdio.
-6. **Enforce:** once a tenant has no observed direct clients, make direct
-   credential/config endpoints unavailable to executor tokens and enable the
-   write-lease mutation contract.
+This is not a DLP guarantee against arbitrary reversible encodings.
 
-Archives and existing MCP rows require no data-shape migration before rollout.
-Today MCP auth/header/env secrets are stored in MCP JSON and OAuth grants in the
-token tables according to the deployment's storage security; API, realtime,
-and UI projections redact them, but the JSON is not application-encrypted by
-this design. The gateway migration changes who may resolve and exercise those
-values. Older executors remain supported only in explicitly non-strong mode
-during rollout.
+## Rollout and product contract
 
-The existing owner/admin raw session-config route remains a compatibility path
-for local executors. It must not be widened to collaborators or delegated
-executors: a repeated Task check immediately before returning a raw secret does
-not mediate the later provider send. Collaborator/delegated execution becomes
-supported only when its SDK receives a gateway capability rather than raw MCP
-configuration.
+Per-tenant modes:
 
-## Latency and availability budgets
+- `off`: raw legacy projection;
+- `observe`: raw projection plus secret-free observations;
+- `compatibility`: only eligible servers are capability-projected; unsupported
+  servers are omitted;
+- `enforced`: identical mediated transport set and all legacy raw-secret paths
+  fail closed.
 
-These are rollout gates, not aspirations to measure after enforcement:
+Enforcement requires explicit confirmation that executors created before the
+rollout were terminated. Emergency downgrade remains possible at any time, with
+an explicit acknowledgement that reusable credentials will again reach
+executors and a security audit log of tenant, actor, previous mode, and new mode.
+There is no quarantine UI or recovery state.
 
-- capability validation and lease admission add at most 5 ms p95 and 25 ms p99
-  within one region, excluding provider latency;
-- gateway forwarding adds at most 20 ms p95 to ordinary HTTP JSON-RPC calls and
-  must not buffer streaming responses beyond protocol framing;
-- routine access-token refresh may consume the provider's latency but must add
-  no authority write/drain cycle;
-- mutation drain defaults to 10 seconds and has a 30-second hard ceiling, after
-  which it returns `egress_drain_failed` or leaves the authority explicitly
-  quarantined rather than waiting indefinitely;
-- the gateway targets 99.99% monthly admission availability. Loss of the
-  authoritative database/lease owner fails closed for new MCP calls; control
-  plane and non-MCP conversation work remain available;
-- capability/epoch lookups require bounded caches with a maximum 1-second TTL,
-  invalidated eagerly by outbox hints but always checked at the final gateway
-  send boundary for write-draining authorities.
+Operators always receive a compact status control, including `off` with zero
+calls. To avoid a noisy unusable operator banner, non-admins see nothing for the
+default `off`/zero-call/zero-exclusion state and receive useful diagnostics once
+there is mediated or actionable state. Lists are semantic,
+buttons have accessible names, and status/error changes use polite/assertive live
+regions. It never labels stdio, WebSocket, endpoint-handoff SSE, or unbounded
+streaming as mediated.
 
-## Acceptance tests for the gateway phase
+## Query shape and budgets
 
-- Held HTTP body send, redirect, pooled connection, SSE, and WebSocket tests
-  prove no send occurs after write-lease admission.
-- OAuth/JWT refresh tests hold credential resolution across revocation and prove
-  no old or newly minted bearer leaves the gateway.
-- Stdio tests hold a JSON-RPC request and credential-bearing environment while
-  mutation terminates and verifies the process group.
-- Collaborator, role/policy, branch grant/group/visibility, attachment,
-  Marketplace permission/removal, OAuth disconnect/reauth, and deletion tests
-  exercise the canonical effective-authority resolver.
-- PostgreSQL tests use two real connections/daemons and cover transaction
-  visibility, lock loss, crash between each state, outbox replay, and restart.
-- Remote-executor tests kill the gateway owner and prove quarantine rather than
-  accepting an unverifiable acknowledgement.
-- Provider-side-effect tests document the admitted-before-linearization case and
-  prove mutations either wait for it or return the bounded drain failure.
+A normal call loads one consistent authority/material snapshot and forwards
+only the server, destination, headers, and material from that snapshot. It
+performs one current-version/identity check immediately before
+each physical dispatch. Redirects pay the latter once per hop. There are no
+lease renewals, durable mutation polling, outbox reconciliation, quarantine
+counts, or long credential-decryption transactions.
 
-## Explicitly deferred from the current #2500 slice
+Target budgets remain <=5 ms p95 / <=25 ms p99 admission and <=20 ms p95 forwarding
+overhead. This phase does not claim measured HA or 99.99% availability evidence. MCP alone fails closed if durable
+authority is unavailable; unrelated Tasks and conversation handles remain live.
+The repository includes a reproducible SQLite benchmark harness. PostgreSQL/HA
+measurements are conditional on the managed environment and
+`AGOR_TEST_POSTGRES_URL`.
 
-The current delivery does not add runtime generations, authority watermarks,
-remote quiescence acknowledgements, or strict hot reload. It provides safe
-configuration mutation and actionable recovery. Existing Tasks may retain the
-MCP clients with which their turn started; subsequent Task dispatch resolves the
-saved configuration again. Strong active revocation and authoritative live
-reload belong to this gateway phase.
+Reference quiet-host SQLite run (2026-08-25, 200 warmed no-send admission checks): p50
+3.450 ms, p95 4.236 ms, p99 5.088 ms. The harness is gated by
+`AGOR_RUN_MCP_EGRESS_BENCHMARK=1`; these figures do not substitute for HA/PG
+measurement. The harness reports rather than enforcing host-sensitive latency
+thresholds and is not a release gate.
+
+## Tests required at review
+
+- opaque capability content, long-task lifetime, stale config, terminal Task,
+  revoked principal/role, ACL and attachment removal, and cross-tenant scope;
+- real two-connection SQLite and PostgreSQL provider-observation races for
+  mutation-before-admission and admission-before-mutation;
+- redirect refusal, bounded body/time/capacity, JSON/SSE decoded reflection, short
+  low-entropy false positives, and safe response headers/logs;
+- OAuth grant deletion/replacement and routine refresh, JWT mint mutation, and
+  bearer/custom/env credential non-export;
+- stdio refusal before spawn/write, ask/deny exclusion, malicious executor
+  headers, and remote raw-secret fallback refusal;
+- rollout guards, emergency downgrade acknowledgement/audit, health/status types,
+  tenant isolation, source-mode tests, lint, boundaries, and UI keyboard/a11y.
+
+## Migration and rollback
+
+No schema migration is needed. This phase reuses tenant app variables,
+`mcp_servers.config_version`, canonical OAuth grants, Tasks, users, branch access,
+and session attachments. Rollout begins at `off`. Binary rollback to a version
+without the gateway is equivalent to an explicit raw-secret downgrade regardless
+of the saved tenant mode and must be handled as a security rollback.

--- a/packages/core/src/db/database-wrapper.ts
+++ b/packages/core/src/db/database-wrapper.ts
@@ -52,7 +52,10 @@ export function txAsDb(tx: unknown): Database {
 export async function runDatabaseTransaction<T>(
   db: Database,
   work: (tx: Database) => Promise<T>,
-  options: { sqliteImmediate?: boolean } = {}
+  options: {
+    sqliteImmediate?: boolean;
+    postgresIsolationLevel?: 'read committed' | 'repeatable read' | 'serializable';
+  } = {}
 ): Promise<T> {
   // Literal-memory SQLite decorates both the libsql client and Drizzle's
   // transaction callback at database creation, so this helper and direct
@@ -62,13 +65,19 @@ export async function runDatabaseTransaction<T>(
     db as unknown as {
       transaction(
         callback: (tx: unknown) => Promise<T>,
-        config?: { behavior: 'immediate' }
+        config?:
+          | { behavior: 'immediate' }
+          | { isolationLevel: 'read committed' | 'repeatable read' | 'serializable' }
       ): Promise<T>;
     }
   ).transaction.bind(db);
   return transaction(
     (tx) => work(txAsDb(tx)),
-    isSQLiteDatabase(db) && options.sqliteImmediate ? { behavior: 'immediate' } : undefined
+    isSQLiteDatabase(db) && options.sqliteImmediate
+      ? { behavior: 'immediate' }
+      : options.postgresIsolationLevel
+        ? { isolationLevel: options.postgresIsolationLevel }
+        : undefined
   );
 }
 

--- a/packages/core/src/db/repositories/index.ts
+++ b/packages/core/src/db/repositories/index.ts
@@ -29,6 +29,7 @@ export * from './knowledge-attribution';
 export * from './knowledge-embedding-work';
 export * from './knowledge-semantic-settings';
 export * from './mcp-catalog-candidates';
+export * from './mcp-egress-settings';
 export * from './mcp-marketplace';
 export * from './mcp-member-policy';
 export * from './mcp-oauth-pending-flows';

--- a/packages/core/src/db/repositories/mcp-egress-settings.ts
+++ b/packages/core/src/db/repositories/mcp-egress-settings.ts
@@ -1,0 +1,34 @@
+import type { MCPEgressGatewayMode } from '../../types';
+import { MCP_EGRESS_GATEWAY_MODES } from '../../types';
+import type { Database, TenantScopedDatabase } from '../client';
+import { AppVariableRepository } from './app-variables';
+
+export const MCP_EGRESS_SETTINGS_NAMESPACE = 'mcp-egress-gateway';
+export const MCP_EGRESS_MODE_KEY = 'mode';
+
+export async function getMCPEgressGatewayMode(
+  db: Database | TenantScopedDatabase
+): Promise<MCPEgressGatewayMode> {
+  const raw = await new AppVariableRepository(db as Database).getPlain(
+    MCP_EGRESS_SETTINGS_NAMESPACE,
+    MCP_EGRESS_MODE_KEY
+  );
+  return MCP_EGRESS_GATEWAY_MODES.includes(raw as MCPEgressGatewayMode)
+    ? (raw as MCPEgressGatewayMode)
+    : 'off';
+}
+
+export async function setMCPEgressGatewayMode(
+  db: Database | TenantScopedDatabase,
+  mode: MCPEgressGatewayMode,
+  updatedBy?: string
+): Promise<void> {
+  if (!MCP_EGRESS_GATEWAY_MODES.includes(mode)) throw new Error('Invalid MCP egress gateway mode');
+  await new AppVariableRepository(db as Database).set({
+    namespace: MCP_EGRESS_SETTINGS_NAMESPACE,
+    key: MCP_EGRESS_MODE_KEY,
+    value: mode,
+    content_type: 'text/plain',
+    updated_by: updatedBy as import('../../types').UserID | undefined,
+  });
+}

--- a/packages/core/src/db/repositories/mcp-servers.test.ts
+++ b/packages/core/src/db/repositories/mcp-servers.test.ts
@@ -227,6 +227,20 @@ describe('MCPServerRepository.findAll', () => {
     expect(stdioServers).toHaveLength(1);
     expect(stdioServers[0].name).toBe('stdio-1');
   });
+
+  dbTest('bounds and paginates status-style server scans', async ({ db }) => {
+    const repo = new MCPServerRepository(db);
+    for (const name of ['page-1', 'page-2', 'page-3']) {
+      await repo.create(createMCPServerData({ name }));
+    }
+
+    const first = await repo.findAll({ limit: 1, offset: 0 });
+    const second = await repo.findAll({ limit: 1, offset: 1 });
+
+    expect(first).toHaveLength(1);
+    expect(second).toHaveLength(1);
+    expect(first[0]!.mcp_server_id).not.toBe(second[0]!.mcp_server_id);
+  });
 });
 
 // ============================================================================

--- a/packages/core/src/db/repositories/mcp-servers.ts
+++ b/packages/core/src/db/repositories/mcp-servers.ts
@@ -14,7 +14,7 @@ import type {
   UpdateMCPServerInput,
   UserID,
 } from '@agor/core/types';
-import { and, eq, isNull, like, or, sql } from 'drizzle-orm';
+import { and, asc, eq, isNull, like, or, sql } from 'drizzle-orm';
 import { generateId } from '../../lib/ids';
 import {
   assertValidMCPAuthPatch,
@@ -579,6 +579,16 @@ export class MCPServerRepository
 
       if (conditions.length > 0) {
         query = query.where(and(...conditions));
+      }
+
+      if (filters?.limit !== undefined || filters?.offset !== undefined) {
+        query = query.orderBy(asc(mcpServers.mcp_server_id));
+      }
+      if (filters?.limit !== undefined) {
+        query = query.limit(Math.max(1, Math.min(1000, Math.trunc(filters.limit))));
+      }
+      if (filters?.offset !== undefined) {
+        query = query.offset(Math.max(0, Math.trunc(filters.offset)));
       }
 
       const rows = await query.all();

--- a/packages/core/src/db/tenant-scope.ts
+++ b/packages/core/src/db/tenant-scope.ts
@@ -252,7 +252,8 @@ export async function runWithTenantDatabaseScope<T>(
 export async function runWithTenantDatabaseTransaction<T>(
   db: TenantScopeAwareDatabase | RawDatabase | Database,
   tenantId: TenantID | string | undefined,
-  work: (db: TenantScopedDatabase) => Promise<T>
+  work: (db: TenantScopedDatabase) => Promise<T>,
+  options: { postgresIsolationLevel?: 'repeatable read' | 'serializable' } = {}
 ): Promise<T> {
   const { existingScope, effectiveTenantId } = resolveTenantBoundary(tenantId, 'transaction');
   if (existingScope?.kind === 'system') {
@@ -276,7 +277,7 @@ export async function runWithTenantDatabaseTransaction<T>(
         await configurePostgresTenantScope(tx, baseDb, effectiveTenantId);
         return enterOwnedTenantDatabaseScope(tx, effectiveTenantId, true, callbacks, work);
       },
-      { sqliteImmediate: true }
+      { sqliteImmediate: true, postgresIsolationLevel: options.postgresIsolationLevel }
     );
 
   // SQLite requests normally have an identity-only DB scope. Temporarily leave

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -52,9 +52,11 @@ export {
 export {
   buildMCPTemplateContextFromEnv,
   containsTemplate,
+  extractMCPTemplateDependencies,
   hasTemplateMarker,
   isUserEnvPlaceholder,
   type MCPTemplateContext,
+  type MCPTemplateDependencies,
   type MCPTemplateResolutionResult,
   resolveMcpServerEnv,
   resolveMcpServersTemplates,

--- a/packages/core/src/mcp/template-resolver.test.ts
+++ b/packages/core/src/mcp/template-resolver.test.ts
@@ -4,6 +4,7 @@ import type { MCPServer, MCPServerID } from '../types';
 import { isValidMCPHttpUrlTemplate } from './template-patterns';
 import {
   buildMCPTemplateContextFromEnv,
+  extractMCPTemplateDependencies,
   isUserEnvPlaceholder,
   resolveMcpServerEnv,
   resolveMcpServerTemplates,
@@ -51,6 +52,36 @@ describe('isValidMCPHttpUrlTemplate', () => {
     expect(isValidMCPHttpUrlTemplate('{{ lookup user.env "MCP_URL" }}')).toBe(false);
     expect(isValidMCPHttpUrlTemplate('file://{{ user.env.PATH }}')).toBe(false);
     expect(isValidMCPHttpUrlTemplate('https://{{ user.env.BROKEN }')).toBe(false);
+  });
+});
+
+describe('extractMCPTemplateDependencies', () => {
+  it('binds every absolute dependency in supported default/helper/nested expressions', () => {
+    const result = extractMCPTemplateDependencies(
+      createTestServer({
+        transport: 'http',
+        url: 'https://example.test/{{uppercase (default user.env.PRIMARY user.env.FALLBACK)}}',
+        headers: { 'X-Tenant': '{{replace user.env.TENANT "-" "_"}}' },
+      })
+    );
+    expect(result.valid).toBe(true);
+    expect([...result.keys].sort()).toEqual(['FALLBACK', 'PRIMARY', 'TENANT']);
+  });
+
+  it.each([
+    '{{@root.user.env.SECRET}}',
+    '{{this.user.env.SECRET}}',
+    '{{./user.env.SECRET}}',
+    '{{lookup user.env "SECRET"}}',
+    '{{lookup (lookup user "env") user.env.KEY}}',
+    '{{#with user}}{{env.SECRET}}{{/with}}',
+    '{{unknownHelper user.env.SECRET}}',
+  ])('rejects indeterminate gateway grammar: %s', (template) => {
+    expect(
+      extractMCPTemplateDependencies(
+        createTestServer({ transport: 'http', url: `https://example.test/${template}` })
+      )
+    ).toMatchObject({ valid: false, mightReferenceUserEnv: true });
   });
 });
 

--- a/packages/core/src/mcp/template-resolver.ts
+++ b/packages/core/src/mcp/template-resolver.ts
@@ -49,6 +49,7 @@
  * It will automatically filter to only user-defined variables.
  */
 
+import Handlebars from 'handlebars';
 import { AGOR_USER_ENV_KEYS_VAR } from '../config/env-resolver';
 import { renderTemplate } from '../templates/handlebars-helpers';
 import type { MCPAuth, MCPServer } from '../types';
@@ -83,6 +84,121 @@ export interface MCPTemplateResolutionResult {
   isValid: boolean;
   /** Human-readable error message if not valid */
   errorMessage?: string;
+}
+
+export interface MCPTemplateDependencies {
+  keys: Set<string>;
+  valid: boolean;
+  mightReferenceUserEnv: boolean;
+}
+
+const MCP_TEMPLATE_HELPERS = new Set([
+  'add',
+  'sub',
+  'mul',
+  'div',
+  'mod',
+  'uppercase',
+  'lowercase',
+  'replace',
+  'eq',
+  'neq',
+  'gt',
+  'lt',
+  'gte',
+  'lte',
+  'default',
+  'json',
+  'isDefined',
+]);
+
+/** Parse with the same Handlebars grammar as rendering and conservatively bind user.env paths. */
+export function extractMCPTemplateDependencies(server: MCPServer): MCPTemplateDependencies {
+  const keys = new Set<string>();
+  let valid = true;
+  let mightReferenceUserEnv = false;
+  const seen = new WeakSet<object>();
+  const values = [
+    server.url,
+    ...Object.values(server.env ?? {}),
+    ...Object.values(server.headers ?? {}),
+    ...Object.values(server.auth ?? {}),
+  ];
+  const walk = (node: unknown, parent?: Record<string, unknown>, parentKey?: string): void => {
+    if (!node || typeof node !== 'object') return;
+    if (seen.has(node)) return;
+    seen.add(node);
+    const record = node as Record<string, unknown>;
+    if (
+      record.type === 'BlockStatement' ||
+      record.type === 'PartialStatement' ||
+      record.type === 'PartialBlockStatement' ||
+      record.type === 'Decorator' ||
+      record.type === 'DecoratorBlock'
+    ) {
+      // Relative scope changes (`with`, `each`, custom blocks) make paths
+      // context-dependent. Gateway mediation intentionally refuses them.
+      valid = false;
+    }
+    if (record.type === 'PathExpression' && typeof record.original === 'string') {
+      const original = record.original;
+      const exact = /^user\.env\.([A-Za-z_][A-Za-z0-9_]*)$/.exec(original);
+      const isCallee =
+        parentKey === 'path' &&
+        (parent?.type === 'MustacheStatement' || parent?.type === 'SubExpression') &&
+        ((Array.isArray(parent.params) && parent.params.length > 0) ||
+          (parent.hash &&
+            typeof parent.hash === 'object' &&
+            Array.isArray((parent.hash as Record<string, unknown>).pairs) &&
+            ((parent.hash as Record<string, unknown>).pairs as unknown[]).length > 0));
+      if (exact && record.data !== true && record.depth === 0 && !isCallee) {
+        keys.add(exact[1]!);
+        mightReferenceUserEnv = true;
+      } else if (isCallee && MCP_TEMPLATE_HELPERS.has(original)) {
+        // Static helper names are safe: their arguments are walked below and
+        // therefore bind every user.env dependency used by nested/fallback
+        // expressions.
+      } else if (
+        original === 'lookup' ||
+        original.includes('user.env') ||
+        original.includes('user/env') ||
+        original.startsWith('@root') ||
+        original.startsWith('this.') ||
+        original.startsWith('./') ||
+        (typeof record.depth === 'number' && record.depth > 0)
+      ) {
+        valid = false;
+        mightReferenceUserEnv = true;
+      } else {
+        // The gateway grammar contains only literals, the registered static
+        // helpers above, and absolute user.env.KEY values. Unknown/dynamic
+        // paths may render today but are deliberately not mediable.
+        valid = false;
+      }
+    }
+    for (const [key, value] of Object.entries(record)) {
+      if (Array.isArray(value))
+        value.forEach((item) => {
+          walk(item, record, key);
+        });
+      else walk(value, record, key);
+    }
+  };
+  for (const value of values) {
+    if (typeof value !== 'string' || !hasTemplateMarker(value)) continue;
+    if (/user[./]env|@root|\blookup\b|{{[#/]?(?:with|each)\b/.test(value)) {
+      mightReferenceUserEnv = true;
+    }
+    if (/{{[^}]*?(?:@root|\bthis\.|\.\/|\blookup\b)|{{[#/]?(?:with|each)\b/.test(value)) {
+      valid = false;
+    }
+    try {
+      walk(Handlebars.parse(value));
+    } catch {
+      valid = false;
+    }
+  }
+  return { keys, valid, mightReferenceUserEnv };
 }
 
 /**

--- a/packages/core/src/tools/mcp/jwt-auth.ts
+++ b/packages/core/src/tools/mcp/jwt-auth.ts
@@ -32,7 +32,9 @@ export interface JWTTokenFetchOptions {
   /** PostgreSQL/hosted callers disable process-local bearer caching. */
   cache?: boolean;
   /** Optional live request authority for secret-bearing provider work. */
-  assertCurrent?: () => void;
+  assertCurrent?: () => void | Promise<void>;
+  /** Optional narrower fence invoked by safeOutboundFetch only at physical dispatch. */
+  assertBeforeDispatch?: () => void | Promise<void>;
   /** Injectable DNS boundary for deterministic authority-race tests. */
   resolveDns?: OutboundDnsLookup;
 }
@@ -68,7 +70,7 @@ export async function fetchJWTToken(
   config: JWTConfig,
   options: JWTTokenFetchOptions = {}
 ): Promise<string> {
-  options.assertCurrent?.();
+  await options.assertCurrent?.();
   const { api_url, api_token, api_secret } = config;
   const shouldCache = options.cache !== false;
   const cacheKey = getCacheKey(config, options.cacheNamespace ?? '<standalone>');
@@ -76,7 +78,7 @@ export async function fetchJWTToken(
   // Check cache first
   const cached = shouldCache ? tokenCache.get(cacheKey) : undefined;
   if (cached && cached.expiresAt > Date.now()) {
-    options.assertCurrent?.();
+    await options.assertCurrent?.();
     return cached.token;
   }
 
@@ -96,13 +98,13 @@ export async function fetchJWTToken(
         name: api_token,
         secret: api_secret,
       }),
-      assertCurrent: options.assertCurrent,
+      assertCurrent: options.assertBeforeDispatch ?? options.assertCurrent,
       resolveDns: options.resolveDns,
     });
   } catch (error) {
     // Network/TLS libraries may reflect the endpoint or request values. Keep
     // their exception entirely behind the closed MCP error boundary.
-    options.assertCurrent?.();
+    await options.assertCurrent?.();
     throw asMCPExternalError(error, { stage: 'jwt' });
   }
 
@@ -116,10 +118,10 @@ export async function fetchJWTToken(
   try {
     data = (await response.json()) as typeof data;
   } catch {
-    options.assertCurrent?.();
+    await options.assertCurrent?.();
     throw asMCPExternalError(undefined, { stage: 'jwt', category: 'invalid_response' });
   }
-  options.assertCurrent?.();
+  await options.assertCurrent?.();
 
   // Handle different response formats
   const token = data.access_token || data.payload?.access_token;

--- a/packages/core/src/tools/mcp/oauth-refresh.postgres.test.ts
+++ b/packages/core/src/tools/mcp/oauth-refresh.postgres.test.ts
@@ -24,6 +24,7 @@ import {
   AmbiguousRefreshError,
   FailedRefreshError,
   GrantConfigurationChangedError,
+  OAuthRefreshAuthorityCancelledError,
   OAuthRefreshExchangeError,
   refreshAndPersistToken,
 } from './oauth-refresh';
@@ -433,6 +434,62 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
         refresh_generation: 1,
         refresh_success_generation: 0,
       });
+    });
+
+    it('releases an authority-cancelled pre-dispatch claim without quarantining the grant', async () => {
+      const tokenProvider = await provider((_body, response) => {
+        response.writeHead(500);
+        response.end();
+      });
+      const bound = await seed(
+        'authority-cancel',
+        tokenProvider.url.replace('127.0.0.1', 'localhost')
+      );
+      let dnsStarted!: () => void;
+      let releaseDns!: () => void;
+      const dnsObserved = new Promise<void>((resolve) => (dnsStarted = resolve));
+      const dnsGate = new Promise<void>((resolve) => (releaseDns = resolve));
+      let current = true;
+      const refresh = refreshAndPersistToken({
+        db: dbA,
+        tenantId: bound.tenantId,
+        userId: bound.userId,
+        mcpServerId: bound.serverId,
+        validateGrant: async () => true,
+        observedRefreshVersion: initialRefreshVersion(bound),
+        allowLocalhostHttpDevelopment: true,
+        resolveDns: async () => {
+          dnsStarted();
+          await dnsGate;
+          return [{ address: '127.0.0.1', family: 4 }];
+        },
+        assertCurrent: () => {
+          if (!current) throw new Error('gateway task authority changed');
+        },
+      });
+      await dnsObserved;
+      current = false;
+      releaseDns();
+
+      const error = await refresh.catch((reason: unknown) => reason);
+      expect(error).toBeInstanceOf(OAuthRefreshAuthorityCancelledError);
+      expect(error).toMatchObject({
+        code: 'oauth_refresh_authority_cancelled',
+        authorityCause: { message: 'gateway task authority changed' },
+      });
+      expect(tokenProvider.calls()).toBe(0);
+      const retained = await runWithTenantDatabaseScope(dbA, bound.tenantId, (scoped) =>
+        new UserMCPOAuthTokenRepository(scoped, masterSecret).getToken(bound.userId, bound.serverId)
+      );
+      expect(retained).toMatchObject({
+        oauth_access_token: 'expired-access-authority-cancel',
+        oauth_refresh_token: 'refresh-authority-cancel-0',
+        refresh_status: 'idle',
+        refresh_generation: 1,
+        refresh_success_generation: 0,
+      });
+      expect(retained?.refresh_claim_id).toBeUndefined();
+      expect(retained?.refresh_claimed_at).toBeUndefined();
     });
 
     it('marks a stale refresh owner ambiguous and never replays its rotating token', async () => {

--- a/packages/core/src/tools/mcp/oauth-refresh.test.ts
+++ b/packages/core/src/tools/mcp/oauth-refresh.test.ts
@@ -8,15 +8,39 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+const { MockOutboundPreDispatchAuthorityError } = vi.hoisted(() => ({
+  MockOutboundPreDispatchAuthorityError: class OutboundPreDispatchAuthorityError extends Error {
+    readonly code = 'outbound_pre_dispatch_authority_rejected';
+    readonly authorityCause: unknown;
+    constructor(cause: unknown) {
+      super('Outbound request authority changed before dispatch');
+      this.authorityCause = cause;
+    }
+  },
+}));
+
 vi.mock('../../utils/safe-outbound-fetch', () => ({
-  safeOutboundFetch: (input: string | URL, options: Record<string, unknown> = {}) => {
+  OutboundPreDispatchAuthorityError: MockOutboundPreDispatchAuthorityError,
+  safeOutboundFetch: async (input: string | URL, options: Record<string, unknown> = {}) => {
     const {
       timeoutMs: _timeout,
       maxRedirects: _max,
       maxResponseBytes: _bytes,
       allowLocalhostHttp: _local,
+      assertCurrent,
+      resolveDns,
       ...init
     } = options;
+    if (typeof resolveDns === 'function') {
+      await resolveDns(new URL(input).hostname, { all: true, verbatim: true });
+    }
+    if (typeof assertCurrent === 'function') {
+      try {
+        await assertCurrent();
+      } catch (error) {
+        throw new MockOutboundPreDispatchAuthorityError(error);
+      }
+    }
     return globalThis.fetch(input, init as RequestInit);
   },
 }));
@@ -31,6 +55,7 @@ import {
   MissingRefreshTokenError,
   MissingTokenEndpointError,
   needsRefresh,
+  OAuthRefreshAuthorityCancelledError,
   REFRESH_BUFFER_MS,
   refreshAndPersistToken,
   refreshMCPToken,
@@ -252,6 +277,40 @@ describe('refreshMCPToken', () => {
     });
 
     expect(result.expires_in).toBe(3600);
+  });
+
+  it('rechecks task authority after token-endpoint DNS and before credential dispatch', async () => {
+    let releaseDns!: () => void;
+    let dnsStarted!: () => void;
+    const dnsGate = new Promise<void>((resolve) => (releaseDns = resolve));
+    const dnsObserved = new Promise<void>((resolve) => (dnsStarted = resolve));
+    let current = true;
+    globalThis.fetch = vi.fn() as typeof globalThis.fetch;
+
+    const pending = refreshMCPToken({
+      tokenEndpoint: 'https://auth.example.com/token',
+      refreshToken: 'refresh-secret',
+      clientId: 'client-id',
+      resolveDns: async () => {
+        dnsStarted();
+        await dnsGate;
+        return [{ address: '203.0.113.10', family: 4 }];
+      },
+      assertCurrent: () => {
+        if (!current) throw new Error('task authority changed');
+      },
+    });
+    await dnsObserved;
+    current = false;
+    releaseDns();
+
+    const error = await pending.catch((reason: unknown) => reason);
+    expect(error).toBeInstanceOf(OAuthRefreshAuthorityCancelledError);
+    expect(error).toMatchObject({
+      code: 'oauth_refresh_authority_cancelled',
+      authorityCause: { message: 'task authority changed' },
+    });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/core/src/tools/mcp/oauth-refresh.ts
+++ b/packages/core/src/tools/mcp/oauth-refresh.ts
@@ -9,7 +9,11 @@ import {
   UserMCPOAuthTokenRepository,
 } from '../../db/repositories';
 import type { MCPServerID, UserID } from '../../types';
-import { safeOutboundFetch } from '../../utils/safe-outbound-fetch';
+import {
+  type OutboundDnsLookup,
+  OutboundPreDispatchAuthorityError,
+  safeOutboundFetch,
+} from '../../utils/safe-outbound-fetch';
 import { assertMcpGrantSubjectEntitled } from './grant-entitlement';
 import { inferOAuthTokenUrl } from './oauth-auth';
 import { resolveTokenExpiry } from './oauth-token-expiry';
@@ -84,6 +88,16 @@ export class OAuthRefreshExchangeError extends Error {
   }
 }
 
+/** No refresh credential was dispatched because caller authority changed. */
+export class OAuthRefreshAuthorityCancelledError extends Error {
+  readonly code = 'oauth_refresh_authority_cancelled';
+
+  constructor(readonly authorityCause: unknown) {
+    super('OAuth refresh authority changed before dispatch');
+    this.name = 'OAuthRefreshAuthorityCancelledError';
+  }
+}
+
 export interface RefreshMCPTokenOptions {
   tokenEndpoint: string;
   refreshToken: string;
@@ -92,6 +106,9 @@ export interface RefreshMCPTokenOptions {
   resourceUri?: string;
   /** Exact loopback HTTP exception for standalone development/tests only. */
   allowLocalhostHttp?: boolean;
+  /** Task/session/rollout fence checked immediately before credential dispatch. */
+  assertCurrent?: () => void | Promise<void>;
+  resolveDns?: OutboundDnsLookup;
 }
 
 export interface RefreshMCPTokenResult {
@@ -139,8 +156,13 @@ export async function refreshMCPToken(
       redirect: 'error',
       timeoutMs: 15_000,
       allowLocalhostHttp: opts.allowLocalhostHttp,
+      assertCurrent: opts.assertCurrent,
+      resolveDns: opts.resolveDns,
     });
-  } catch {
+  } catch (error) {
+    if (error instanceof OutboundPreDispatchAuthorityError) {
+      throw new OAuthRefreshAuthorityCancelledError(error.authorityCause);
+    }
     throw new OAuthRefreshExchangeError('transport_ambiguous', true);
   }
 
@@ -204,6 +226,9 @@ export interface RefreshAndPersistDeps {
   onInvalidGrant?: (info: { userId: UserID | null; mcpServerId: MCPServerID }) => void;
   /** Internal test/development seam; daemon PostgreSQL callers leave this false. */
   allowLocalhostHttpDevelopment?: boolean;
+  assertCurrent?: () => void | Promise<void>;
+  /** Deterministic DNS seam used by pre-dispatch authority race tests. */
+  resolveDns?: OutboundDnsLookup;
 }
 
 function exactGrantMatches(
@@ -378,6 +403,8 @@ async function refreshPostgres(deps: RefreshAndPersistDeps): Promise<string> {
       clientSecret: row.oauth_client_secret,
       resourceUri: row.oauth_resource_uri,
       allowLocalhostHttp: deps.allowLocalhostHttpDevelopment,
+      assertCurrent: deps.assertCurrent,
+      resolveDns: deps.resolveDns,
     });
     const expiry = resolveTokenExpiry(result, result.access_token);
     const committed = await tenantWork(deps, async (db) => {
@@ -413,6 +440,18 @@ async function refreshPostgres(deps: RefreshAndPersistDeps): Promise<string> {
       if (!deleted) return observeCommittedRefresh(deps, fence);
       console.warn('[MCP OAuth Refresh] refresh_failed category=invalid_grant');
       notifyInvalidGrant(deps);
+      throw error;
+    }
+    if (error instanceof OAuthRefreshAuthorityCancelledError) {
+      await tenantWork(deps, (db) =>
+        new UserMCPOAuthTokenRepository(db).finishRefreshClaim(
+          deps.userId,
+          deps.mcpServerId,
+          fence,
+          'idle'
+        )
+      );
+      console.warn('[MCP OAuth Refresh] refresh_cancelled category=authority_pre_dispatch');
       throw error;
     }
     const ambiguous = !(error instanceof OAuthRefreshExchangeError) || error.ambiguous;
@@ -489,6 +528,8 @@ async function refreshStandalone(
       clientSecret: row.oauth_client_secret ?? server?.auth?.oauth_client_secret,
       resourceUri: row.oauth_resource_uri,
       allowLocalhostHttp: true,
+      assertCurrent: deps.assertCurrent,
+      resolveDns: deps.resolveDns,
     });
     const expiry = resolveTokenExpiry(result, result.access_token);
     await assertGrantSubjectForRefresh(deps, deps.db);

--- a/packages/core/src/types/mcp.ts
+++ b/packages/core/src/types/mcp.ts
@@ -554,6 +554,9 @@ export interface MCPServerFilters {
   ownerless?: boolean;
   /** Exact materialized catalog identity; never a substring search. */
   catalogEntryName?: string;
+  /** Bounded diagnostic/list reads; callers should request one extra row for truncation. */
+  limit?: number;
+  offset?: number;
 }
 
 /**
@@ -646,6 +649,41 @@ export type MCPServersConfig = Record<
     env?: Record<string, string>;
   }
 >;
+
+// ============================================================================
+// Authoritative MCP egress gateway
+// ============================================================================
+
+/** Tenant rollout for the daemon-owned, HTTP-only MCP proxy. */
+export const MCP_EGRESS_GATEWAY_MODES = ['off', 'observe', 'compatibility', 'enforced'] as const;
+export type MCPEgressGatewayMode = (typeof MCP_EGRESS_GATEWAY_MODES)[number];
+
+export interface MCPEgressGatewayStatus {
+  mode: MCPEgressGatewayMode;
+  supported_transports: Array<'streamable-http-buffered'>;
+  unsupported_transports: string[];
+  /** Total local work consuming gateway capacity, including credential/admission reservations. */
+  in_flight_requests: number;
+  /** Requests whose provider transport has started. */
+  provider_in_flight_requests: number;
+  /** Requests still resolving credentials or awaiting final provider admission. */
+  reserved_requests: number;
+  oldest_request_ms: number;
+  excluded_servers: Array<{
+    mcp_server_id: MCPServerID;
+    name: string;
+    reason:
+      | 'transport_not_mediated'
+      | 'approval_not_mediated'
+      | 'template_configuration'
+      | 'oauth_reauth_required';
+    recovery: string;
+  }>;
+  excluded_servers_truncated: boolean;
+  admission_available: boolean | null;
+  operator: boolean;
+  guarantee: string;
+}
 
 // ============================================================================
 // MCP Session Tokens (daemon ↔ MCP server channel)

--- a/packages/core/src/utils/safe-outbound-fetch.test.ts
+++ b/packages/core/src/utils/safe-outbound-fetch.test.ts
@@ -2,6 +2,7 @@ import http from 'node:http';
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   assertSafeOAuthUrl,
+  OutboundPreDispatchAuthorityError,
   safeOutboundFetch,
   UnsafeOutboundUrlError,
 } from './safe-outbound-fetch';
@@ -216,7 +217,11 @@ describe('safe OAuth outbound URL policy', () => {
     current = false;
     releaseFirstHop();
 
-    await expect(request).rejects.toThrow('request authority replaced');
+    const error = await request.catch((reason: unknown) => reason);
+    expect(error).toBeInstanceOf(OutboundPreDispatchAuthorityError);
+    expect((error as OutboundPreDispatchAuthorityError).authorityCause).toMatchObject({
+      message: 'request authority replaced',
+    });
     expect(targetReached).toBe(false);
   });
 

--- a/packages/core/src/utils/safe-outbound-fetch.ts
+++ b/packages/core/src/utils/safe-outbound-fetch.ts
@@ -56,6 +56,20 @@ export class UnsafeOutboundUrlError extends Error {
   }
 }
 
+/**
+ * The caller-owned authority/cancellation fence rejected before a socket was
+ * constructed. This is deliberately distinct from a transport failure after
+ * dispatch: no request bytes could have reached the destination.
+ */
+export class OutboundPreDispatchAuthorityError extends Error {
+  readonly code = 'outbound_pre_dispatch_authority_rejected';
+
+  constructor(readonly authorityCause: unknown) {
+    super('Outbound request authority changed before dispatch');
+    this.name = 'OutboundPreDispatchAuthorityError';
+  }
+}
+
 export interface SafeOutboundFetchOptions extends Omit<RequestInit, 'redirect' | 'signal'> {
   redirect?: 'error' | 'follow';
   timeoutMs?: number;
@@ -65,9 +79,12 @@ export interface SafeOutboundFetchOptions extends Omit<RequestInit, 'redirect' |
   allowLocalhostHttp?: boolean;
   /**
    * Optional caller-owned authority fence for credential-bearing requests.
-   * Checked around every physical dispatch, response/error, and redirect hop.
+   * Checked once immediately before every physical dispatch. Redirects are
+   * separate dispatches and therefore receive a separate check.
    */
-  assertCurrent?: () => void;
+  assertCurrent?: () => void | Promise<void>;
+  /** Abort an already-admitted provider request as an availability accelerator. */
+  signal?: AbortSignal;
   /** Injectable DNS boundary for deterministic authority-race tests. */
   resolveDns?: OutboundDnsLookup;
 }
@@ -224,14 +241,26 @@ async function requestOnce(
   options: SafeOutboundFetchOptions,
   signal: AbortSignal
 ): Promise<Response> {
-  throwIfAborted(signal);
-  assertSafeParsedUrl(url, options.allowLocalhostHttp === true);
-  const pinned = await resolvePinnedAddress(
-    url,
-    options.allowLocalhostHttp === true,
-    signal,
-    options.resolveDns ?? lookup
-  );
+  let pinned: { address: string; family: 4 | 6 };
+  try {
+    throwIfAborted(signal);
+    assertSafeParsedUrl(url, options.allowLocalhostHttp === true);
+    pinned = await resolvePinnedAddress(
+      url,
+      options.allowLocalhostHttp === true,
+      signal,
+      options.resolveDns ?? lookup
+    );
+  } catch (error) {
+    // A caller cancellation while validating DNS is known to precede socket
+    // construction. Preserve that fact instead of classifying it as an
+    // ambiguous transport failure. The deadline signal is intentionally not
+    // included: only the explicit caller-owned authority signal qualifies.
+    if (options.signal?.aborted) {
+      throw new OutboundPreDispatchAuthorityError(options.signal.reason ?? error);
+    }
+    throw error;
+  }
   const body = requestBody(options.body);
   const headers = new Headers(options.headers);
   if (body != null && !headers.has('content-length')) {
@@ -244,7 +273,11 @@ async function requestOnce(
   // DNS validation may itself have awaited. Re-ask immediately before opening
   // the socket so a caller cannot lose authority during lookup and still send
   // the captured headers/body.
-  options.assertCurrent?.();
+  try {
+    await options.assertCurrent?.();
+  } catch (error) {
+    throw new OutboundPreDispatchAuthorityError(error);
+  }
   return new Promise<Response>((resolve, reject) => {
     let settled = false;
     let responseStream: http.IncomingMessage | undefined;
@@ -331,26 +364,20 @@ export async function safeOutboundFetch(
   }
   const deadline = new AbortController();
   const timer = setTimeout(() => deadline.abort(outboundTimeoutError()), timeoutMs);
+  const signal = options.signal
+    ? AbortSignal.any([deadline.signal, options.signal])
+    : deadline.signal;
   try {
     let url = new URL(input);
     const callerHeadersPresent = hasCallerHeaders(options.headers);
     const redirectMode = options.redirect ?? 'error';
     const maxRedirects = options.maxRedirects ?? 3;
     for (let hop = 0; ; hop += 1) {
-      // This assertion is intentionally per hop rather than only around the
-      // aggregate fetch. Redirect handling is an internal request loop, and
-      // each destination is a distinct external side effect.
-      options.assertCurrent?.();
-      let response: Response;
-      try {
-        response = await requestOnce(url, options, deadline.signal);
-      } catch (error) {
-        // Authority/expiry wins over a simultaneous network error and prevents
-        // callers from treating it as a retryable provider failure.
-        options.assertCurrent?.();
-        throw error;
-      }
-      options.assertCurrent?.();
+      // requestOnce performs the single authority check immediately after DNS
+      // validation and before it constructs the socket. Do not add checks on
+      // response/error paths: they do not fence another outbound side effect
+      // and would multiply admission queries for every call.
+      const response = await requestOnce(url, options, signal);
       if (![301, 302, 303, 307, 308].includes(response.status)) return response;
       if (redirectMode !== 'follow' || hop >= maxRedirects) {
         throw new UnsafeOutboundUrlError('Outbound OAuth redirect is not allowed');


### PR DESCRIPTION
## Summary

Implements the independently reviewed authoritative MCP egress gateway phase of #2500.

Executors receive only opaque capabilities scoped to the task, principal, session, and MCP server. The daemon owns final credential resolution, OAuth/JWT materialization, and the outbound proxy/send authority; reusable bearer, JWT, OAuth, header, and environment secrets are not projected to executors.

Independent review status: correctness **zero P0–P3 / MERGEABLE**; architecture **SHIP**.

## Mediated transport surface

This phase deliberately supports only bounded **POST** and **DELETE** Streamable HTTP operations.

The gateway fails closed, before provider dispatch, for:

- stdio
- GET server-stream channels
- legacy SSE handoff
- WebSocket
- redirects
- ask-policy servers
- any transport or template configuration whose authority cannot be mediated safely

This PR does not claim strict revocation or transparent compatibility for an unmediated transport.

## Authority and revocation guarantee

Final admission uses one consistent authority snapshot:

- SQLite: immediate transaction
- PostgreSQL: repeatable-read transaction

The admitted destination, server configuration, attachment, task/session authority, rollout mode, and durable credential/grant identity all come from that same snapshot. A final authority assertion occurs immediately before each credential-bearing socket hop, including OAuth refresh/token egress.

**Exact guarantee:** no credential-bearing hop is admitted after the relevant authority mutation commits. A hop admitted earlier may complete, and the provider may observe it. In-process aborts and tenant/server coordination accelerate cancellation but are not presented as proof of physical revocation.

## Security and boundedness

- Strict AST-limited template dependency grammar aligned with rendering.
- Indeterminate/dynamic/relative/lookup template forms are ineligible; affected user environment keys are scrubbed rather than leaked to executors.
- Durable OAuth material identity excludes routine token/expiry projection while binding grant identity, generation, and server configuration.
- Decoded MCP JSON values are scanned and SSE output is reconstructed only from validated fields.
- Streaming bytes, duration, sockets, requests, and per-process/tenant/task/server reservations are bounded.
- OAuth refresh distinguishes typed, known-no-send authority cancellation from genuine post-send ambiguity. Pre-dispatch cancellation releases the refresh claim safely and preserves the prior grant.
- Abort acceleration is tenant- and server-scoped; rollout changes do not disrupt unrelated tenants.
- Compatibility/observe/enforced rollout, truthful local active/reserved status, operator diagnostics, and accessible UI recovery/status are included.

The implementation intentionally has **no durable lease, outbox, quarantine state machine, or database migration**. Authority versions plus consistent snapshots provide the narrower, honest guarantee above without retaining unproven teardown machinery.

## Validation

Run with source workspace mocks where applicable using **AGOR_MANAGED_AGENTIC_TOOLS=0**:

- Core gateway/OAuth/safe-fetch suites: **211 passed**
- Daemon gateway/OAuth/coordination suites: **187 passed, 1 skipped**
- UI gateway/settings/load-stabilization suites: **71 passed**
- Executor projection suites: **121 passed**
- Workspace source-mode typecheck: **21/21 tasks passed**
- Final daemon source-mode typecheck passed
- Biome lint passed
- Frontend design-system validation: **330 fixtures passed**
- Multitenancy, daemon-filesystem, and realtime boundary checks passed

PostgreSQL conditional suites were invoked, but the environment had no PostgreSQL URL:

- Gateway PostgreSQL: **3 skipped**
- OAuth refresh PostgreSQL: **9 skipped**

No managed HA or Playwright MCP server was attached to the review session. Puppeteer was not substituted. The PR therefore makes no measured HA/99.99% availability claim.

## Stack

This PR targets finalized **mcp-auth-recovery-hot-reload** at **18c120cc**:

1. #2480 — 5232d8d
2. #2530 — 711aedb
3. #2553 — 18c120cc
4. This authoritative egress gateway PR

#2501 is explicitly excluded.

## Follow-ups

- Make capacity limits configurable through the established configuration surface.
- Keep the gateway template-helper allowlist synchronized with renderer evolution.
- Add an explicit daemon shutdown close hook for gateway-local reservations/sockets.
