### PR TITLE
chore(agor-live): raise package-content budget to 98 MiB / 24 MiB

### DIFF
--- a/packages/agor-live/scripts/check-package-content.mjs
+++ b/packages/agor-live/scripts/check-package-content.mjs
@@ -5,8 +5,8 @@ import { join, resolve } from 'node:path';
 
 const limits = {
   files: 2600,
-  unpackedBytes: 96 * 1024 * 1024,
-  packedBytes: 23 * 1024 * 1024,
+  unpackedBytes: 98 * 1024 * 1024,
+  packedBytes: 24 * 1024 * 1024,
 };
 
 function measureDirectory(directory) {


### PR DESCRIPTION
## What

The `0.25.2` build tripped the `agor-live` package-content guardrail (`scripts/check-package-content.mjs`) by a hair:

- `unpackedBytes: 100684592 > 100663296` (~21 KiB over 96 MiB)
- `packedBytes: 24165494 > 24117248` (~48 KiB over 23 MiB)

Bumps the caps to **98 MiB unpacked / 24 MiB packed** (~2 MiB / ~1 MiB headroom). `files` left at 2600 (2596 actual).

## Why bump, not trim

The Marketplace PR (#2530) legitimately grew the bundle — new MCP tools + four-tab UI. This is a soft guardrail that's been nudged up before (2400→2600 files; 95→96 MiB earlier the same day). Adding a little headroom so the next PR doesn't re-trip immediately.

## Real fat, for a follow-up (not safe mid-deploy)

- `dist/daemon` inlines shared deps into **every** entry point — 26 files >900 KB = **38.6 MiB**. Daemon code-splitting / shared chunks is the biggest lever.
- `@agor/core` ships both `.cjs` and `.js` (~**11 MiB** duplicated). Dropping one format if the consumer only needs one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)