### PR TITLE
feat(apm): trace FeathersJS service methods for APM

### DIFF
--- a/apps/agor-daemon/src/metrics/feathers.ts
+++ b/apps/agor-daemon/src/metrics/feathers.ts
@@ -1,30 +1,17 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { performance } from 'node:perf_hooks';
 import type { HookContext } from '@agor/core/types';
+import {
+  type FeathersInstrumentationOptions,
+  normalizeFeathersMethod as normalizeMethod,
+  normalizeFeathersService as normalizeService,
+  normalizeFeathersTransport as normalizeTransport,
+} from '../utils/feathers-instrumentation.js';
 import type { DaemonMetrics } from './types.js';
 
 type AroundNext = () => Promise<void>;
 
-interface FeathersMetricsOptions {
-  excludedServicePaths?: readonly string[];
-  isInternalCall?: (context: HookContext) => boolean;
-}
-
-function normalizeTransport(provider: unknown): 'rest' | 'socketio' | 'mcp' | 'other' | undefined {
-  if (provider === undefined || provider === null) return undefined;
-  if (provider === 'rest' || provider === 'socketio' || provider === 'mcp') return provider;
-  return 'other';
-}
-
-function normalizeMethod(method: string): string {
-  return ['create', 'find', 'get', 'patch', 'remove', 'update'].includes(method)
-    ? method
-    : 'custom';
-}
-
-function normalizeService(path: string): string {
-  return /^[a-zA-Z0-9_/-]{1,100}$/.test(path) ? path : 'other';
-}
+type FeathersMetricsOptions = FeathersInstrumentationOptions;
 
 function errorStatus(error: unknown): string | number {
   if (!error || typeof error !== 'object') return 'error';

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -184,6 +184,7 @@ import {
 } from './services/users.js';
 import { resolveWebTerminalCapability } from './terminal-capability.js';
 import { forceFailUnverifiedTask } from './termination-coordinator.js';
+import { createFeathersTracingHook } from './tracing/feathers.js';
 import {
   REMOVED_AGENTIC_TOOL_RUNTIME_MESSAGE,
   requireActiveAgenticTool,
@@ -5421,6 +5422,10 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   app.hooks({
     around: {
       all: [
+        // Outermost: open the APM span first so it encloses the metrics timing
+        // and every child (Postgres, Redis) span. No-op unless
+        // metrics.apm.trace_services is enabled and dd-trace is loaded.
+        createFeathersTracingHook(config.metrics?.apm?.trace_services ?? 'off'),
         createFeathersMetricsHook(getDaemonMetrics(app), {
           // Health probes already have HTTP metrics; avoid doubling their
           // high-frequency signal at the Feathers boundary.

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -5419,22 +5419,29 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
   // Global app hooks + error handler
   // ============================================================================
 
+  // Health probes already have HTTP metrics/spans; auth strategies preserve the
+  // provider for the serialized-entity lookup even though it is framework work.
+  // Both instrumentation hooks skip the same set for a consistent boundary.
+  const feathersInstrumentationOptions = {
+    excludedServicePaths: ['health'],
+    isInternalCall: (context: HookContext) => isAuthenticationUserLookup(context.params),
+  };
+
+  // Outermost: open the APM span first so it encloses the metrics timing and
+  // every child (Postgres, Redis) span. Registered only when enabled, so
+  // metrics.apm.trace_services=off adds nothing to the hook chain.
+  const apmTraceDepth = config.metrics?.apm?.trace_services ?? 'off';
+  const aroundAll =
+    apmTraceDepth === 'off'
+      ? [createFeathersMetricsHook(getDaemonMetrics(app), feathersInstrumentationOptions)]
+      : [
+          createFeathersTracingHook(apmTraceDepth, feathersInstrumentationOptions),
+          createFeathersMetricsHook(getDaemonMetrics(app), feathersInstrumentationOptions),
+        ];
+
   app.hooks({
     around: {
-      all: [
-        // Outermost: open the APM span first so it encloses the metrics timing
-        // and every child (Postgres, Redis) span. No-op unless
-        // metrics.apm.trace_services is enabled and dd-trace is loaded.
-        createFeathersTracingHook(config.metrics?.apm?.trace_services ?? 'off'),
-        createFeathersMetricsHook(getDaemonMetrics(app), {
-          // Health probes already have HTTP metrics; avoid doubling their
-          // high-frequency signal at the Feathers boundary.
-          excludedServicePaths: ['health'],
-          // JWT/local strategies preserve provider for the serialized entity
-          // lookup even though it is authentication framework work.
-          isInternalCall: (context) => isAuthenticationUserLookup(context.params),
-        }),
-      ],
+      all: aroundAll,
     },
     before: {
       all: [enforcePasswordChange],

--- a/apps/agor-daemon/src/tracing/feathers.test.ts
+++ b/apps/agor-daemon/src/tracing/feathers.test.ts
@@ -1,5 +1,5 @@
 import type { HookContext } from '@agor/core/types';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { createFeathersTracingHook, type DatadogTracer } from './feathers.js';
 
 interface TracedCall {
@@ -8,21 +8,51 @@ interface TracedCall {
   tags?: Record<string, unknown>;
 }
 
-/** Records trace() invocations and runs the wrapped fn, like dd-trace would. */
+interface FakeSpan {
+  finished: boolean;
+  error?: unknown;
+}
+
+/**
+ * Models dd-trace's documented `trace()` contract: it awaits the promise-backed
+ * callback, finishes the span, and tags a rejected error onto it. Encoding that
+ * lifecycle here (rather than a bare recorder) means the hook's reliance on
+ * dd-trace to finish/tag — instead of doing it manually — is actually asserted.
+ */
 class RecordingTracer implements DatadogTracer {
   readonly calls: TracedCall[] = [];
+  readonly spans: FakeSpan[] = [];
   async trace<T>(
     name: string,
     options: { resource?: string; tags?: Record<string, unknown> },
     fn: () => Promise<T>
   ): Promise<T> {
     this.calls.push({ name, resource: options.resource, tags: options.tags });
-    return fn();
+    const span: FakeSpan = { finished: false };
+    this.spans.push(span);
+    try {
+      const result = await fn();
+      span.finished = true;
+      return result;
+    } catch (error) {
+      span.error = error;
+      span.finished = true;
+      throw error;
+    }
   }
 }
 
 function ctx(path: string, method: string, provider?: string): HookContext {
   return { path, method, params: provider ? { provider } : {} } as unknown as HookContext;
+}
+
+/** Deferred promise for interleaving concurrent requests deterministically. */
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
 }
 
 describe('Feathers tracing hook', () => {
@@ -37,7 +67,7 @@ describe('Feathers tracing hook', () => {
     expect(tracer.calls).toHaveLength(0);
   });
 
-  it('is a passthrough when dd-trace is not loaded', async () => {
+  it('is a passthrough when a null tracer is injected', async () => {
     const hook = createFeathersTracingHook('full', { tracer: null });
     let ran = false;
     await hook(ctx('sessions', 'find', 'socketio'), async () => {
@@ -46,7 +76,25 @@ describe('Feathers tracing hook', () => {
     expect(ran).toBe(true);
   });
 
-  it('names the span <service>.<method> and tags service/method/transport', async () => {
+  it('warns once and no-ops when enabled but no tracer is installed', async () => {
+    // dd-trace / dd-trace-api are optional peers, absent in the test env, so the
+    // real resolver path returns null — the enabled-but-unresolved case.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const hook = createFeathersTracingHook('full');
+      let ran = false;
+      await hook(ctx('sessions', 'find', 'socketio'), async () => {
+        ran = true;
+      });
+      expect(ran).toBe(true);
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(String(warn.mock.calls[0]?.[0])).toContain('no APM tracer is loaded');
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('names the span resource <service>.<method> and tags service/method/transport', async () => {
     const tracer = new RecordingTracer();
     const hook = createFeathersTracingHook('full', { tracer });
     await hook(ctx('sessions', 'find', 'socketio'), async () => undefined);
@@ -72,10 +120,27 @@ describe('Feathers tracing hook', () => {
     expect(tracer.calls[0]?.tags?.['feathers.transport']).toBe('internal');
   });
 
-  it('skips the high-frequency health probe at every depth', async () => {
+  it('skips the high-frequency health probe by default at every depth', async () => {
     const tracer = new RecordingTracer();
     const hook = createFeathersTracingHook('full', { tracer });
     await hook(ctx('health', 'find', 'rest'), async () => undefined);
+    expect(tracer.calls).toHaveLength(0);
+  });
+
+  it('honors a custom excludedServicePaths list', async () => {
+    const tracer = new RecordingTracer();
+    const hook = createFeathersTracingHook('full', { tracer, excludedServicePaths: ['boards'] });
+    await hook(ctx('boards', 'find', 'socketio'), async () => undefined);
+    expect(tracer.calls).toHaveLength(0);
+  });
+
+  it('skips calls classified internal via isInternalCall (auth-lookup parity)', async () => {
+    const tracer = new RecordingTracer();
+    const hook = createFeathersTracingHook('full', {
+      tracer,
+      isInternalCall: (context) => context.path === 'users',
+    });
+    await hook(ctx('users', 'get', 'socketio'), async () => undefined);
     expect(tracer.calls).toHaveLength(0);
   });
 
@@ -89,25 +154,60 @@ describe('Feathers tracing hook', () => {
     expect(tracer.calls.map((c) => c.resource)).toEqual(['branches.find', 'sessions.get']);
   });
 
-  it('entrypoint mode suppresses nested fan-out to one span per request', async () => {
+  it('entrypoint mode suppresses sequential nested fan-out to one span', async () => {
     const tracer = new RecordingTracer();
     const hook = createFeathersTracingHook('entrypoint', { tracer });
     await hook(ctx('branches', 'find', 'socketio'), async () => {
-      // Nested internal calls inherit the request scope and are not traced.
       await hook(ctx('sessions', 'get'), async () => undefined);
       await hook(ctx('messages', 'find'), async () => undefined);
     });
     expect(tracer.calls.map((c) => c.resource)).toEqual(['branches.find']);
   });
 
-  it('propagates errors while still opening the span', async () => {
+  it('entrypoint mode suppresses parallel nested fan-out (Promise.all)', async () => {
+    const tracer = new RecordingTracer();
+    const hook = createFeathersTracingHook('entrypoint', { tracer });
+    await hook(ctx('branches', 'find', 'socketio'), async () => {
+      await Promise.all([
+        hook(ctx('sessions', 'get'), async () => undefined),
+        hook(ctx('messages', 'find'), async () => undefined),
+      ]);
+    });
+    expect(tracer.calls.map((c) => c.resource)).toEqual(['branches.find']);
+  });
+
+  it('entrypoint mode isolates two concurrent independent requests', async () => {
+    const tracer = new RecordingTracer();
+    const hook = createFeathersTracingHook('entrypoint', { tracer });
+    const gate = deferred();
+
+    // Request A stays open (awaiting the gate) while request B runs its own
+    // nested call — proving AsyncLocalStorage keeps the two scopes separate.
+    const reqA = hook(ctx('branches', 'find', 'socketio'), async () => {
+      await gate.promise;
+      await hook(ctx('sessions', 'get'), async () => undefined); // nested in A → suppressed
+    });
+    const reqB = hook(ctx('boards', 'find', 'socketio'), async () => {
+      await hook(ctx('cards', 'find'), async () => undefined); // nested in B → suppressed
+      gate.resolve();
+    });
+    await Promise.all([reqA, reqB]);
+
+    // Exactly the two top-level requests are traced; neither nested call leaks.
+    expect(tracer.calls.map((c) => c.resource).sort()).toEqual(['boards.find', 'branches.find']);
+  });
+
+  it('propagates errors while finishing and tagging the span', async () => {
     const tracer = new RecordingTracer();
     const hook = createFeathersTracingHook('full', { tracer });
+    const boom = new Error('boom');
     await expect(
       hook(ctx('sessions', 'find', 'socketio'), async () => {
-        throw new Error('boom');
+        throw boom;
       })
     ).rejects.toThrow('boom');
-    expect(tracer.calls).toHaveLength(1);
+    expect(tracer.spans).toHaveLength(1);
+    expect(tracer.spans[0]?.finished).toBe(true);
+    expect(tracer.spans[0]?.error).toBe(boom);
   });
 });

--- a/apps/agor-daemon/src/tracing/feathers.test.ts
+++ b/apps/agor-daemon/src/tracing/feathers.test.ts
@@ -1,0 +1,113 @@
+import type { HookContext } from '@agor/core/types';
+import { describe, expect, it } from 'vitest';
+import { createFeathersTracingHook, type DatadogTracer } from './feathers.js';
+
+interface TracedCall {
+  name: string;
+  resource?: string;
+  tags?: Record<string, unknown>;
+}
+
+/** Records trace() invocations and runs the wrapped fn, like dd-trace would. */
+class RecordingTracer implements DatadogTracer {
+  readonly calls: TracedCall[] = [];
+  async trace<T>(
+    name: string,
+    options: { resource?: string; tags?: Record<string, unknown> },
+    fn: () => Promise<T>
+  ): Promise<T> {
+    this.calls.push({ name, resource: options.resource, tags: options.tags });
+    return fn();
+  }
+}
+
+function ctx(path: string, method: string, provider?: string): HookContext {
+  return { path, method, params: provider ? { provider } : {} } as unknown as HookContext;
+}
+
+describe('Feathers tracing hook', () => {
+  it('is a passthrough when depth is off (never touches the tracer)', async () => {
+    const tracer = new RecordingTracer();
+    const hook = createFeathersTracingHook('off', { tracer });
+    let ran = false;
+    await hook(ctx('sessions', 'find', 'socketio'), async () => {
+      ran = true;
+    });
+    expect(ran).toBe(true);
+    expect(tracer.calls).toHaveLength(0);
+  });
+
+  it('is a passthrough when dd-trace is not loaded', async () => {
+    const hook = createFeathersTracingHook('full', { tracer: null });
+    let ran = false;
+    await hook(ctx('sessions', 'find', 'socketio'), async () => {
+      ran = true;
+    });
+    expect(ran).toBe(true);
+  });
+
+  it('names the span <service>.<method> and tags service/method/transport', async () => {
+    const tracer = new RecordingTracer();
+    const hook = createFeathersTracingHook('full', { tracer });
+    await hook(ctx('sessions', 'find', 'socketio'), async () => undefined);
+    expect(tracer.calls).toEqual([
+      {
+        name: 'feathers.request',
+        resource: 'sessions.find',
+        tags: {
+          'feathers.service': 'sessions',
+          'feathers.method': 'find',
+          'feathers.transport': 'socketio',
+          'span.kind': 'server',
+        },
+      },
+    ]);
+  });
+
+  it('normalizes unknown methods to custom and internal (no-provider) transport', async () => {
+    const tracer = new RecordingTracer();
+    const hook = createFeathersTracingHook('full', { tracer });
+    await hook(ctx('sessions', 'archive'), async () => undefined);
+    expect(tracer.calls[0]?.resource).toBe('sessions.custom');
+    expect(tracer.calls[0]?.tags?.['feathers.transport']).toBe('internal');
+  });
+
+  it('skips the high-frequency health probe at every depth', async () => {
+    const tracer = new RecordingTracer();
+    const hook = createFeathersTracingHook('full', { tracer });
+    await hook(ctx('health', 'find', 'rest'), async () => undefined);
+    expect(tracer.calls).toHaveLength(0);
+  });
+
+  it('full mode traces nested service-to-service calls as child spans', async () => {
+    const tracer = new RecordingTracer();
+    const hook = createFeathersTracingHook('full', { tracer });
+    // Simulate branches.find fanning out to a nested sessions.get.
+    await hook(ctx('branches', 'find', 'socketio'), async () => {
+      await hook(ctx('sessions', 'get'), async () => undefined);
+    });
+    expect(tracer.calls.map((c) => c.resource)).toEqual(['branches.find', 'sessions.get']);
+  });
+
+  it('entrypoint mode suppresses nested fan-out to one span per request', async () => {
+    const tracer = new RecordingTracer();
+    const hook = createFeathersTracingHook('entrypoint', { tracer });
+    await hook(ctx('branches', 'find', 'socketio'), async () => {
+      // Nested internal calls inherit the request scope and are not traced.
+      await hook(ctx('sessions', 'get'), async () => undefined);
+      await hook(ctx('messages', 'find'), async () => undefined);
+    });
+    expect(tracer.calls.map((c) => c.resource)).toEqual(['branches.find']);
+  });
+
+  it('propagates errors while still opening the span', async () => {
+    const tracer = new RecordingTracer();
+    const hook = createFeathersTracingHook('full', { tracer });
+    await expect(
+      hook(ctx('sessions', 'find', 'socketio'), async () => {
+        throw new Error('boom');
+      })
+    ).rejects.toThrow('boom');
+    expect(tracer.calls).toHaveLength(1);
+  });
+});

--- a/apps/agor-daemon/src/tracing/feathers.test.ts
+++ b/apps/agor-daemon/src/tracing/feathers.test.ts
@@ -1,6 +1,6 @@
 import type { HookContext } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
-import { createFeathersTracingHook, type DatadogTracer } from './feathers.js';
+import { createFeathersTracingHook, type DatadogTracer, resolveTracerModule } from './feathers.js';
 
 interface TracedCall {
   name: string;
@@ -76,12 +76,12 @@ describe('Feathers tracing hook', () => {
     expect(ran).toBe(true);
   });
 
-  it('warns once and no-ops when enabled but no tracer is installed', async () => {
-    // dd-trace / dd-trace-api are optional peers, absent in the test env, so the
-    // real resolver path returns null — the enabled-but-unresolved case.
+  it('warns once and no-ops when enabled but no tracer resolves', async () => {
+    // Inject a resolver that returns null so the enabled-but-unresolved path is
+    // deterministic regardless of whether dd-trace is installed in the workspace.
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     try {
-      const hook = createFeathersTracingHook('full');
+      const hook = createFeathersTracingHook('full', { resolveTracer: () => null });
       let ran = false;
       await hook(ctx('sessions', 'find', 'socketio'), async () => {
         ran = true;
@@ -89,6 +89,19 @@ describe('Feathers tracing hook', () => {
       expect(ran).toBe(true);
       expect(warn).toHaveBeenCalledTimes(1);
       expect(String(warn.mock.calls[0]?.[0])).toContain('no APM tracer is loaded');
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('does not warn when a resolver supplies a tracer', async () => {
+    const tracer = new RecordingTracer();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const hook = createFeathersTracingHook('full', { resolveTracer: () => tracer });
+      await hook(ctx('sessions', 'find', 'socketio'), async () => undefined);
+      expect(warn).not.toHaveBeenCalled();
+      expect(tracer.calls).toHaveLength(1);
     } finally {
       warn.mockRestore();
     }
@@ -209,5 +222,40 @@ describe('Feathers tracing hook', () => {
     expect(tracer.spans).toHaveLength(1);
     expect(tracer.spans[0]?.finished).toBe(true);
     expect(tracer.spans[0]?.error).toBe(boom);
+  });
+});
+
+describe('resolveTracerModule', () => {
+  const validTracer = { trace: () => Promise.resolve() };
+  const notFound = (id: string) => {
+    throw Object.assign(new Error(`Cannot find module '${id}'`), { code: 'MODULE_NOT_FOUND' });
+  };
+
+  it('returns dd-trace-api when present, without consulting dd-trace', () => {
+    const seen: string[] = [];
+    const resolved = resolveTracerModule((id) => {
+      seen.push(id);
+      if (id === 'dd-trace-api') return validTracer;
+      throw new Error('should not be reached');
+    });
+    expect(resolved).toBe(validTracer);
+    expect(seen).toEqual(['dd-trace-api']);
+  });
+
+  it('falls back to dd-trace when dd-trace-api is absent', () => {
+    const resolved = resolveTracerModule((id) => (id === 'dd-trace' ? validTracer : notFound(id)));
+    expect(resolved).toBe(validTracer);
+  });
+
+  it('unwraps a default export', () => {
+    const resolved = resolveTracerModule((id) =>
+      id === 'dd-trace-api' ? { default: validTracer } : notFound(id)
+    );
+    expect(resolved).toBe(validTracer);
+  });
+
+  it('skips a module without a callable trace() and returns null when both absent', () => {
+    expect(resolveTracerModule(() => ({}))).toBeNull();
+    expect(resolveTracerModule(notFound)).toBeNull();
   });
 });

--- a/apps/agor-daemon/src/tracing/feathers.ts
+++ b/apps/agor-daemon/src/tracing/feathers.ts
@@ -2,6 +2,12 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import { createRequire } from 'node:module';
 import type { ApmTraceServiceDepth } from '@agor/core/config';
 import type { HookContext } from '@agor/core/types';
+import {
+  type FeathersInstrumentationOptions,
+  normalizeFeathersMethod,
+  normalizeFeathersService,
+  normalizeFeathersTransport,
+} from '../utils/feathers-instrumentation.js';
 
 type AroundNext = () => Promise<void>;
 
@@ -17,7 +23,7 @@ export interface DatadogTracer {
   ): Promise<T>;
 }
 
-export interface FeathersTracingOptions {
+export interface FeathersTracingOptions extends FeathersInstrumentationOptions {
   /**
    * Inject the tracer (or `null` to force the passthrough) instead of resolving
    * the process-wide dd-trace singleton. Intended for tests.
@@ -25,60 +31,64 @@ export interface FeathersTracingOptions {
   tracer?: DatadogTracer | null;
 }
 
-const KNOWN_METHODS = ['create', 'find', 'get', 'patch', 'remove', 'update'];
-
 /**
  * Feathers `health` is a high-frequency probe whose latency is already captured
  * by the auto-instrumented `GET /health` Express span. A Feathers-layer span
- * adds cost without adding insight, so it is skipped at every depth.
+ * adds cost without insight, so it is excluded by default at every depth.
  */
-const EXCLUDED_SERVICE_PATHS = new Set(['health']);
+export const DEFAULT_EXCLUDED_SERVICE_PATHS = ['health'] as const;
 
 const requireFromDaemon = createRequire(import.meta.url);
 
 /**
- * Resolve the process-wide dd-trace singleton without initializing it.
+ * Resolve the process-wide APM tracer without initializing it.
  *
- * The tracer is loaded ahead of application code by Datadog single-step
- * instrumentation (`NODE_OPTIONS`), so importing `dd-trace` here returns the
- * already-initialized instance. It is treated as an optional peer — exactly
- * like `hot-shots` for StatsD — so the daemon runs unchanged when APM is not
- * installed.
+ * The tracer is preloaded ahead of application code by Datadog single-step
+ * instrumentation (`NODE_OPTIONS`). It is an OPTIONAL runtime dependency that
+ * Agor never declares as a hard dep or bundles (declaring it as a peer makes
+ * pnpm auto-install its native modules, defeating the point). So this returns
+ * `null` unless the operator has installed `dd-trace` — or the lightweight
+ * `dd-trace-api` bridge — into the daemon's module tree, or single-step
+ * provides it. `dd-trace-api` is tried first because it is Datadog's supported
+ * entry point for custom instrumentation under single-step; both expose the
+ * same `tracer.trace()` surface. Treated like `hot-shots` for StatsD: present →
+ * used, absent → no-op (loudly, at registration).
  */
 function loadTracer(): DatadogTracer | null {
-  try {
-    const mod = requireFromDaemon('dd-trace') as { default?: DatadogTracer } & DatadogTracer;
-    return mod.default ?? mod ?? null;
-  } catch {
-    return null;
+  for (const moduleName of ['dd-trace-api', 'dd-trace']) {
+    try {
+      const mod = requireFromDaemon(moduleName) as { default?: DatadogTracer } & DatadogTracer;
+      const tracer = mod.default ?? mod;
+      if (tracer && typeof tracer.trace === 'function') return tracer;
+    } catch {
+      // Not installed under this name; try the next.
+    }
   }
-}
-
-function normalizeMethod(method: string): string {
-  return KNOWN_METHODS.includes(method) ? method : 'custom';
+  return null;
 }
 
 /**
  * App-level `around` hook that wraps every Feathers service method in a
- * `feathers.request` APM span, named `<service>.<method>` (e.g.
- * `sessions.find`). dd-trace has no FeathersJS plugin, so without this the
- * service calls that ride socket.io are invisible to APM even though HTTP,
- * Express, and Postgres are auto-instrumented.
+ * `feathers.request` APM span whose RESOURCE name is `<service>.<method>` (e.g.
+ * `sessions.find`; the operation name is `feathers.request`). dd-trace has no
+ * FeathersJS plugin, so without this the service calls that ride socket.io are
+ * invisible to APM even though HTTP, Express, and Postgres are
+ * auto-instrumented.
  *
  * The span inherits the ambient `agor-daemon` service and nests under the
  * active HTTP span, so child Postgres queries appear directly beneath the
- * service method that issued them — which is what surfaces N+1s and full
- * scans.
+ * service method that issued them — which is what surfaces N+1s and full scans.
  *
  * Depth controls cost vs. visibility:
- * - `off`     — returns a passthrough; nothing is registered.
+ * - `off`        — returns a passthrough (callers should skip registering it).
  * - `entrypoint` — one span per external request; nested service-to-service
  *   fan-out is suppressed via a request-local scope (mirrors the metrics hook).
- * - `full`    — a span per invocation including nested calls; reveals the full
- *   fan-out at the cost of much higher span volume.
+ * - `full`       — a span per invocation including nested calls; reveals the
+ *   full fan-out at the cost of much higher span volume.
  *
- * Falls back to a passthrough when dd-trace is not loaded, so it is safe to
- * register unconditionally.
+ * Falls back to a passthrough when no tracer is loaded, warning once (unless a
+ * tracer was explicitly injected) so an enabled-but-unresolved deployment is
+ * loud rather than silently emitting nothing.
  */
 export function createFeathersTracingHook(
   depth: ApmTraceServiceDepth,
@@ -88,26 +98,41 @@ export function createFeathersTracingHook(
   if (depth === 'off') return passthrough;
 
   const tracer = options.tracer !== undefined ? options.tracer : loadTracer();
-  if (!tracer) return passthrough;
+  if (!tracer) {
+    // Only warn when we attempted real resolution (options.tracer === undefined),
+    // never for tests that explicitly inject `null`.
+    if (options.tracer === undefined) {
+      console.warn(
+        `[apm] metrics.apm.trace_services="${depth}" but no APM tracer is loaded ` +
+          '(dd-trace / dd-trace-api not installed); Feathers service tracing is disabled.'
+      );
+    }
+    return passthrough;
+  }
 
+  const excluded = new Set(options.excludedServicePaths ?? DEFAULT_EXCLUDED_SERVICE_PATHS);
+  const { isInternalCall } = options;
   // Only `entrypoint` needs nesting suppression; `full` traces every call.
   const requestScope = depth === 'entrypoint' ? new AsyncLocalStorage<true>() : null;
 
   return async (context: HookContext, next: AroundNext): Promise<void> => {
-    if (requestScope?.getStore() || EXCLUDED_SERVICE_PATHS.has(context.path)) {
+    if (requestScope?.getStore() || excluded.has(context.path) || isInternalCall?.(context)) {
       await next();
       return;
     }
 
+    const service = normalizeFeathersService(context.path);
+    const method = normalizeFeathersMethod(context.method);
     const runTraced = () =>
       tracer.trace(
         'feathers.request',
         {
-          resource: `${context.path}.${normalizeMethod(context.method)}`,
+          resource: `${service}.${method}`,
           tags: {
-            'feathers.service': context.path,
-            'feathers.method': context.method,
-            'feathers.transport': context.params?.provider ?? 'internal',
+            'feathers.service': service,
+            'feathers.method': method,
+            'feathers.transport':
+              normalizeFeathersTransport(context.params?.provider) ?? 'internal',
             'span.kind': 'server',
           },
         },

--- a/apps/agor-daemon/src/tracing/feathers.ts
+++ b/apps/agor-daemon/src/tracing/feathers.ts
@@ -29,6 +29,12 @@ export interface FeathersTracingOptions extends FeathersInstrumentationOptions {
    * the process-wide dd-trace singleton. Intended for tests.
    */
   tracer?: DatadogTracer | null;
+  /**
+   * Override tracer resolution (defaults to {@link resolveTracerModule}). Lets
+   * tests exercise the enabled-but-unresolved warning path deterministically,
+   * independent of whether dd-trace happens to be installed in the workspace.
+   */
+  resolveTracer?: () => DatadogTracer | null;
 }
 
 /**
@@ -54,11 +60,13 @@ const requireFromDaemon = createRequire(import.meta.url);
  * same `tracer.trace()` surface. Treated like `hot-shots` for StatsD: present →
  * used, absent → no-op (loudly, at registration).
  */
-function loadTracer(): DatadogTracer | null {
+export function resolveTracerModule(
+  requireFn: (id: string) => unknown = requireFromDaemon
+): DatadogTracer | null {
   for (const moduleName of ['dd-trace-api', 'dd-trace']) {
     try {
-      const mod = requireFromDaemon(moduleName) as { default?: DatadogTracer } & DatadogTracer;
-      const tracer = mod.default ?? mod;
+      const mod = requireFn(moduleName) as { default?: DatadogTracer } & DatadogTracer;
+      const tracer = mod?.default ?? mod;
       if (tracer && typeof tracer.trace === 'function') return tracer;
     } catch {
       // Not installed under this name; try the next.
@@ -97,7 +105,10 @@ export function createFeathersTracingHook(
   const passthrough = async (_context: HookContext, next: AroundNext): Promise<void> => next();
   if (depth === 'off') return passthrough;
 
-  const tracer = options.tracer !== undefined ? options.tracer : loadTracer();
+  const tracer =
+    options.tracer !== undefined
+      ? options.tracer
+      : (options.resolveTracer ?? resolveTracerModule)();
   if (!tracer) {
     // Only warn when we attempted real resolution (options.tracer === undefined),
     // never for tests that explicitly inject `null`.

--- a/apps/agor-daemon/src/tracing/feathers.ts
+++ b/apps/agor-daemon/src/tracing/feathers.ts
@@ -1,0 +1,124 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { createRequire } from 'node:module';
+import type { ApmTraceServiceDepth } from '@agor/core/config';
+import type { HookContext } from '@agor/core/types';
+
+type AroundNext = () => Promise<void>;
+
+/** Minimal surface of the dd-trace singleton we depend on. */
+export interface DatadogTracer {
+  trace<T>(
+    name: string,
+    options: {
+      resource?: string;
+      tags?: Record<string, unknown>;
+    },
+    fn: () => Promise<T>
+  ): Promise<T>;
+}
+
+export interface FeathersTracingOptions {
+  /**
+   * Inject the tracer (or `null` to force the passthrough) instead of resolving
+   * the process-wide dd-trace singleton. Intended for tests.
+   */
+  tracer?: DatadogTracer | null;
+}
+
+const KNOWN_METHODS = ['create', 'find', 'get', 'patch', 'remove', 'update'];
+
+/**
+ * Feathers `health` is a high-frequency probe whose latency is already captured
+ * by the auto-instrumented `GET /health` Express span. A Feathers-layer span
+ * adds cost without adding insight, so it is skipped at every depth.
+ */
+const EXCLUDED_SERVICE_PATHS = new Set(['health']);
+
+const requireFromDaemon = createRequire(import.meta.url);
+
+/**
+ * Resolve the process-wide dd-trace singleton without initializing it.
+ *
+ * The tracer is loaded ahead of application code by Datadog single-step
+ * instrumentation (`NODE_OPTIONS`), so importing `dd-trace` here returns the
+ * already-initialized instance. It is treated as an optional peer — exactly
+ * like `hot-shots` for StatsD — so the daemon runs unchanged when APM is not
+ * installed.
+ */
+function loadTracer(): DatadogTracer | null {
+  try {
+    const mod = requireFromDaemon('dd-trace') as { default?: DatadogTracer } & DatadogTracer;
+    return mod.default ?? mod ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeMethod(method: string): string {
+  return KNOWN_METHODS.includes(method) ? method : 'custom';
+}
+
+/**
+ * App-level `around` hook that wraps every Feathers service method in a
+ * `feathers.request` APM span, named `<service>.<method>` (e.g.
+ * `sessions.find`). dd-trace has no FeathersJS plugin, so without this the
+ * service calls that ride socket.io are invisible to APM even though HTTP,
+ * Express, and Postgres are auto-instrumented.
+ *
+ * The span inherits the ambient `agor-daemon` service and nests under the
+ * active HTTP span, so child Postgres queries appear directly beneath the
+ * service method that issued them — which is what surfaces N+1s and full
+ * scans.
+ *
+ * Depth controls cost vs. visibility:
+ * - `off`     — returns a passthrough; nothing is registered.
+ * - `entrypoint` — one span per external request; nested service-to-service
+ *   fan-out is suppressed via a request-local scope (mirrors the metrics hook).
+ * - `full`    — a span per invocation including nested calls; reveals the full
+ *   fan-out at the cost of much higher span volume.
+ *
+ * Falls back to a passthrough when dd-trace is not loaded, so it is safe to
+ * register unconditionally.
+ */
+export function createFeathersTracingHook(
+  depth: ApmTraceServiceDepth,
+  options: FeathersTracingOptions = {}
+) {
+  const passthrough = async (_context: HookContext, next: AroundNext): Promise<void> => next();
+  if (depth === 'off') return passthrough;
+
+  const tracer = options.tracer !== undefined ? options.tracer : loadTracer();
+  if (!tracer) return passthrough;
+
+  // Only `entrypoint` needs nesting suppression; `full` traces every call.
+  const requestScope = depth === 'entrypoint' ? new AsyncLocalStorage<true>() : null;
+
+  return async (context: HookContext, next: AroundNext): Promise<void> => {
+    if (requestScope?.getStore() || EXCLUDED_SERVICE_PATHS.has(context.path)) {
+      await next();
+      return;
+    }
+
+    const runTraced = () =>
+      tracer.trace(
+        'feathers.request',
+        {
+          resource: `${context.path}.${normalizeMethod(context.method)}`,
+          tags: {
+            'feathers.service': context.path,
+            'feathers.method': context.method,
+            'feathers.transport': context.params?.provider ?? 'internal',
+            'span.kind': 'server',
+          },
+        },
+        // dd-trace finishes the span and tags any thrown/rejected error itself.
+        () => next()
+      );
+
+    if (requestScope) {
+      await requestScope.run(true, runTraced);
+    } else {
+      await runTraced();
+    }
+  };
+}

--- a/apps/agor-daemon/src/utils/feathers-instrumentation.ts
+++ b/apps/agor-daemon/src/utils/feathers-instrumentation.ts
@@ -1,0 +1,50 @@
+import type { HookContext } from '@agor/core/types';
+
+/**
+ * Shared classification/normalization for Feathers service-call instrumentation.
+ *
+ * Both the StatsD metrics hook (`metrics/feathers.ts`) and the APM tracing hook
+ * (`tracing/feathers.ts`) wrap every service method and need identical answers
+ * for "which transport / method / service is this, and should it be
+ * instrumented at all". Keeping that logic here stops the two hooks from
+ * drifting (e.g. one bounding tag cardinality while the other emits raw values).
+ */
+
+export type FeathersTransport = 'rest' | 'socketio' | 'mcp' | 'other';
+
+const KNOWN_METHODS = ['create', 'find', 'get', 'patch', 'remove', 'update'];
+
+/**
+ * Map a Feathers `params.provider` to a bounded transport label. Returns
+ * `undefined` for internal (no-provider) calls; callers decide whether to skip
+ * them (metrics) or label them `internal` (tracing).
+ */
+export function normalizeFeathersTransport(provider: unknown): FeathersTransport | undefined {
+  if (provider === undefined || provider === null) return undefined;
+  if (provider === 'rest' || provider === 'socketio' || provider === 'mcp') return provider;
+  return 'other';
+}
+
+/** Bound method names to the known Feathers set, collapsing custom methods. */
+export function normalizeFeathersMethod(method: string): string {
+  return KNOWN_METHODS.includes(method) ? method : 'custom';
+}
+
+/** Bound the service path to a safe, low-cardinality identifier. */
+export function normalizeFeathersService(path: string): string {
+  return /^[a-zA-Z0-9_/-]{1,100}$/.test(path) ? path : 'other';
+}
+
+/**
+ * Options shared by the Feathers instrumentation hooks for deciding which calls
+ * to skip entirely.
+ */
+export interface FeathersInstrumentationOptions {
+  /** Service paths never instrumented (e.g. the high-frequency `health` probe). */
+  excludedServicePaths?: readonly string[];
+  /**
+   * Classify framework-internal calls that enter with an external provider (e.g.
+   * the authentication serialized-entity lookup) so they can be skipped.
+   */
+  isInternalCall?: (context: HookContext) => boolean;
+}

--- a/apps/agor-docs/content/guide/config-yaml.mdx
+++ b/apps/agor-docs/content/guide/config-yaml.mdx
@@ -288,3 +288,50 @@ signals.
 Older Agor versions reject the unknown top-level `metrics` key. During a
 mixed-version rollout, upgrade every daemon first, then add the block and
 restart the fleet.
+
+## Datadog APM (dd-trace) tracing
+
+When the daemon runs under a Datadog APM tracer — typically loaded process-wide
+by [single-step instrumentation](https://docs.datadoghq.com/tracing/trace_collection/automatic_instrumentation/single-step-apm/)
+via `NODE_OPTIONS` — HTTP, Express, Postgres, and Redis are auto-instrumented.
+FeathersJS is not: dd-trace ships no Feathers plugin, so service-method calls
+that ride socket.io are invisible to APM. This setting adds an app-level hook
+that wraps each service method in a `feathers.request` span whose **resource**
+name is `<service>.<method>` (for example `sessions.find`), nested under the
+active HTTP span so child Postgres queries appear beneath the method that
+issued them:
+
+```yaml
+metrics:
+  apm:
+    trace_services: off # off | entrypoint | full
+```
+
+- **`off`** (default) — the hook is not registered; zero overhead.
+- **`entrypoint`** — one span per top-level request; nested service-to-service
+  fan-out is suppressed. Cheap and bounded — safe to leave on in production.
+- **`full`** — a span per service-method invocation including nested calls, so
+  the full fan-out and its child queries are visible. Highest span volume (and
+  ingestion cost) — intended for active investigation, not steady state.
+
+`AGOR_APM_TRACE_SERVICES` (`off`, `entrypoint`, or `full`) overrides the YAML
+value so depth can be changed without editing config. Like all metrics
+settings, this is resolved into the daemon's immutable startup snapshot and
+takes effect on restart.
+
+The tracer is an **optional runtime dependency** that Agor never declares or
+bundles: the hook resolves `dd-trace-api` (Datadog's supported bridge for
+custom instrumentation under single-step) or `dd-trace` at runtime and no-ops
+if neither is installed. Note that single-step instrumentation does not
+necessarily make these packages resolvable from Agor's own module tree, so on
+deployments that enable `entrypoint`/`full` you may need to install one
+alongside `agor-live`:
+
+```bash
+npm install -g --ignore-scripts dd-trace-api
+```
+
+If `trace_services` is enabled but no tracer resolves, the daemon logs a
+one-time warning at startup and continues with Feathers tracing disabled — it
+never fails closed or blocks requests. This setting carries no credentials; span
+delivery is handled entirely by the ambient Datadog tracer/Agent.

--- a/apps/agor-docs/content/guide/mcp-egress-gateway.mdx
+++ b/apps/agor-docs/content/guide/mcp-egress-gateway.mdx
@@ -144,7 +144,7 @@ and oldest local request. Useful metrics are:
 - rejected gateway requests by stable, secret-free reason in logs;
 - database health/latency from the normal daemon health path.
 
-The target budgets remain <=5 ms p95 and <=25 ms p99 admission and <=20 ms p95
+The target budgets remain `<=5 ms` p95 and `<=25 ms` p99 admission and `<=20 ms` p95
 forwarding overhead. This phase has no measured HA/99.99% availability evidence. It performs one
 initial authority/material load and one final durable authority check per
 physical hop; it does not maintain lease, mutation, quarantine, or outbox rows.

--- a/packages/core/src/config/config-manager.test.ts
+++ b/packages/core/src/config/config-manager.test.ts
@@ -856,6 +856,54 @@ describe('loadConfig', () => {
     await expect(loadConfig()).rejects.toThrow(/metrics must be an object/);
   });
 
+  it('defaults APM service tracing to off and validates the depth knob', async () => {
+    const agorDir = path.join(tempDir, '.agor');
+    const configPath = path.join(agorDir, 'config.yaml');
+    await fs.mkdir(agorDir, { recursive: true });
+
+    // Default: off, present so callers can read it without optional-chaining.
+    expect(getDefaultConfig().metrics?.apm).toEqual({ trace_services: 'off' });
+
+    // Env override wins over file config, for flipping depth without a redeploy.
+    expect(
+      resolveEffectiveConfig(
+        { metrics: { apm: { trace_services: 'off' } } },
+        { AGOR_APM_TRACE_SERVICES: 'full' }
+      ).metrics?.apm?.trace_services
+    ).toBe('full');
+    expect(() => resolveEffectiveConfig({}, { AGOR_APM_TRACE_SERVICES: 'loud' })).toThrow(
+      /AGOR_APM_TRACE_SERVICES must be one of/
+    );
+
+    for (const depth of ['off', 'entrypoint', 'full'] as const) {
+      __resetConfigCacheForTests();
+      await fs.writeFile(
+        configPath,
+        yaml.dump({ metrics: { apm: { trace_services: depth } } }),
+        'utf-8'
+      );
+      await expect(loadConfig()).resolves.toMatchObject({
+        metrics: { apm: { trace_services: depth } },
+      });
+    }
+
+    __resetConfigCacheForTests();
+    await fs.writeFile(
+      configPath,
+      yaml.dump({ metrics: { apm: { trace_services: 'verbose' } } }),
+      'utf-8'
+    );
+    await expect(loadConfig()).rejects.toThrow(/metrics\.apm\.trace_services must be one of/);
+
+    __resetConfigCacheForTests();
+    await fs.writeFile(configPath, yaml.dump({ metrics: { apm: { surprise: true } } }), 'utf-8');
+    await expect(loadConfig()).rejects.toThrow(/metrics\.apm\.surprise/);
+
+    __resetConfigCacheForTests();
+    await fs.writeFile(configPath, yaml.dump({ metrics: { apm: [] } }), 'utf-8');
+    await expect(loadConfig()).rejects.toThrow(/metrics\.apm must be an object/);
+  });
+
   it('accepts a deployment-owned agentic tool package list', async () => {
     const agorDir = path.join(tempDir, '.agor');
     const configPath = path.join(agorDir, 'config.yaml');

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -32,6 +32,7 @@ import { assertValidMultiTenancyConfig } from './multitenancy';
 import { AgorPasswordPolicyProfile } from './password-policy';
 import { isPlainConfigRecord } from './plain-record';
 import {
+  type AgorApmSettings,
   type AgorConfig,
   AgorExternalIdentityProvider,
   AgorExternalIdentityProvisioning,
@@ -39,6 +40,7 @@ import {
   AgorRoleAuthority,
   type AgorStatsDSettings,
   AgorUserLifecycleAuthority,
+  APM_TRACE_SERVICE_DEPTHS,
   BRANCH_STORAGE_MODES,
   type BranchStorageMode,
   DEFAULT_BRANCH_STORAGE_MODE,
@@ -343,6 +345,18 @@ function validateStatsDConfig(statsd: AgorStatsDSettings | undefined): void {
   }
 }
 
+function validateApmConfig(apm: AgorApmSettings | undefined): void {
+  if (apm === undefined) return;
+  if (!apm || typeof apm !== 'object' || Array.isArray(apm)) {
+    throw new Error('Config error: metrics.apm must be an object');
+  }
+  if (apm.trace_services !== undefined && !APM_TRACE_SERVICE_DEPTHS.includes(apm.trace_services)) {
+    throw new Error(
+      `Config error: metrics.apm.trace_services must be one of: ${APM_TRACE_SERVICE_DEPTHS.join(', ')}`
+    );
+  }
+}
+
 function parseOptionalBooleanEnvironmentValue(
   value: string | undefined,
   name: string
@@ -351,6 +365,18 @@ function parseOptionalBooleanEnvironmentValue(
   if (value === '1' || value === 'true') return true;
   if (value === '0' || value === 'false') return false;
   throw new Error(`Config error: ${name} must be one of: true, false, 1, 0`);
+}
+
+function parseOptionalApmTraceDepthEnvironmentValue(
+  value: string | undefined
+): AgorApmSettings['trace_services'] | undefined {
+  if (value === undefined || value === '') return undefined;
+  if (!APM_TRACE_SERVICE_DEPTHS.includes(value as never)) {
+    throw new Error(
+      `Config error: AGOR_APM_TRACE_SERVICES must be one of: ${APM_TRACE_SERVICE_DEPTHS.join(', ')}`
+    );
+  }
+  return value as AgorApmSettings['trace_services'];
 }
 
 function parseOptionalPortEnvironmentValue(
@@ -979,7 +1005,7 @@ function validateConfig(config: AgorConfig): void {
   ) {
     throw new Error('Config error: metrics must be an object');
   }
-  only(config.metrics, 'metrics', ['statsd']);
+  only(config.metrics, 'metrics', ['statsd', 'apm']);
   only(config.metrics?.statsd, 'metrics.statsd', [
     'enabled',
     'host',
@@ -987,7 +1013,9 @@ function validateConfig(config: AgorConfig): void {
     'prefix',
     'global_tags',
   ]);
+  only(config.metrics?.apm, 'metrics.apm', ['trace_services']);
   validateStatsDConfig(config.metrics?.statsd);
+  validateApmConfig(config.metrics?.apm);
   only(legacyConfig.onboarding, 'onboarding', [
     ...RETIRED_CONFIG_KEYS.onboarding,
     'frameworkRepoUrl',
@@ -1380,6 +1408,9 @@ export function getDefaultConfig(): AgorConfig {
         prefix: 'agor.daemon.',
         global_tags: {},
       },
+      apm: {
+        trace_services: 'off',
+      },
     },
     multi_tenancy: {
       filesystem_isolation_enabled: false,
@@ -1411,6 +1442,7 @@ export function resolveEffectiveConfig(
     'AGOR_STATSD_ENABLED'
   );
   const statsdPort = parseOptionalPortEnvironmentValue(env.AGOR_STATSD_PORT, 'AGOR_STATSD_PORT');
+  const apmTraceServices = parseOptionalApmTraceDepthEnvironmentValue(env.AGOR_APM_TRACE_SERVICES);
   const externalLaunch = resolveEffectiveExternalLaunchConfig(config.external_launch, env);
 
   // Resolve the effective Unix isolation mode (env override wins) so the
@@ -1532,11 +1564,17 @@ export function resolveEffectiveConfig(
         ...(statsdPort !== undefined ? { port: statsdPort } : {}),
         ...(env.AGOR_STATSD_PREFIX ? { prefix: env.AGOR_STATSD_PREFIX } : {}),
       },
+      apm: {
+        ...defaults.metrics?.apm,
+        ...config.metrics?.apm,
+        ...(apmTraceServices !== undefined ? { trace_services: apmTraceServices } : {}),
+      },
     },
     uploads: { ...defaults.uploads, ...config.uploads },
     multi_tenancy: { ...defaults.multi_tenancy, ...config.multi_tenancy },
   };
   validateStatsDConfig(resolved.metrics?.statsd);
+  validateApmConfig(resolved.metrics?.apm);
   return resolved;
 }
 

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -1196,6 +1196,10 @@ export interface AgorStatsDSettings {
   global_tags?: Record<string, string>;
 }
 
+/** Valid depths for FeathersJS service-method tracing, cheapest first. */
+export const APM_TRACE_SERVICE_DEPTHS = ['off', 'entrypoint', 'full'] as const;
+export type ApmTraceServiceDepth = (typeof APM_TRACE_SERVICE_DEPTHS)[number];
+
 /**
  * Datadog APM (dd-trace) tracing knobs for the daemon.
  *
@@ -1205,10 +1209,6 @@ export interface AgorStatsDSettings {
  * dd-trace has no native plugin for — the calls that ride socket.io are
  * otherwise invisible to APM.
  */
-/** Valid depths for FeathersJS service-method tracing, cheapest first. */
-export const APM_TRACE_SERVICE_DEPTHS = ['off', 'entrypoint', 'full'] as const;
-export type ApmTraceServiceDepth = (typeof APM_TRACE_SERVICE_DEPTHS)[number];
-
 export interface AgorApmSettings {
   /**
    * Depth of FeathersJS service-method span instrumentation. Defaults to `off`.

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -1196,9 +1196,41 @@ export interface AgorStatsDSettings {
   global_tags?: Record<string, string>;
 }
 
+/**
+ * Datadog APM (dd-trace) tracing knobs for the daemon.
+ *
+ * The tracer itself is loaded process-wide (single-step / `NODE_OPTIONS`
+ * injection), which already auto-instruments HTTP, Express, Postgres, and
+ * Redis. These settings only govern the FeathersJS service-method layer, which
+ * dd-trace has no native plugin for — the calls that ride socket.io are
+ * otherwise invisible to APM.
+ */
+/** Valid depths for FeathersJS service-method tracing, cheapest first. */
+export const APM_TRACE_SERVICE_DEPTHS = ['off', 'entrypoint', 'full'] as const;
+export type ApmTraceServiceDepth = (typeof APM_TRACE_SERVICE_DEPTHS)[number];
+
+export interface AgorApmSettings {
+  /**
+   * Depth of FeathersJS service-method span instrumentation. Defaults to `off`.
+   *
+   * - `off`: the Feathers tracing hook is not registered at all — zero overhead.
+   * - `entrypoint`: one span per top-level request; nested service-to-service
+   *   fan-out is suppressed (mirrors the StatsD metrics hook). Cheap and
+   *   bounded — safe to leave on in production.
+   * - `full`: a span per service-method invocation including nested calls, so
+   *   the fan-out and its child Postgres queries are visible in the flame
+   *   graph. Highest span volume (and ingestion cost) — intended for active
+   *   investigation, not steady state.
+   */
+  trace_services?: ApmTraceServiceDepth;
+}
+
 /** Optional daemon operational metrics exporters. */
 export interface AgorMetricsSettings {
   statsd?: AgorStatsDSettings;
+
+  /** Datadog APM (dd-trace) tracing knobs. */
+  apm?: AgorApmSettings;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds APM tracing for the FeathersJS service layer on `agor-daemon`.

Datadog APM is installed via single-step instrumentation (`NODE_OPTIONS`), which auto-instruments HTTP, Express, Postgres, and Redis. But **dd-trace has no FeathersJS plugin**, so service-method calls that ride socket.io (`sessions.find`, `branches.find`, `boards.find`, …) are invisible to APM. That's precisely the blind spot hiding the board/branch/session load paths we're investigating for event-loop stalls (health probes spiking to 1–2s while `runtime.node.event_loop.delay.max` peaks at ~2.3s, with GC pauses staying ~15–25ms → synchronous JS blocking, not GC).

This PR wraps every Feathers service method in a `feathers.request` span named `<service>.<method>`, nested under the active HTTP span so **child Postgres queries appear directly beneath the method that issued them** — which is what surfaces N+1s and full scans.

## The knob

Gated by a tri-state config setting so cost maps onto the setting:

```yaml
metrics:
  apm:
    trace_services: off        # off | entrypoint | full  (default: off)
```

| Depth | Behavior | Cost |
|---|---|---|
| `off` | hook not registered | zero |
| `entrypoint` | one span per top-level request; nested fan-out suppressed via `AsyncLocalStorage` (mirrors the StatsD metrics hook) | cheap, bounded — prod-safe |
| `full` | a span per invocation **including nested calls**; reveals full fan-out + child DB spans | high span volume — investigation mode |

An `AGOR_APM_TRACE_SERVICES` env override wins over file config, so depth can be flipped without editing config or redeploying.

## Design notes

- **Optional peer, like `hot-shots`:** the hook resolves the dd-trace singleton via `createRequire` and **no-ops when APM is not loaded**, so it's safe to register unconditionally.
- **Outermost hook:** registered before the existing metrics hook in `app.hooks({ around: { all: [...] } })`, so the span encloses the metrics timing and every child pg/redis span.
- **Inherits `agor-daemon` service** (no service override), so Feathers spans stay grouped under the daemon.
- **`health` is skipped** at every depth — its latency is already captured by the auto-instrumented `GET /health` Express span; a Feathers-layer span would add cost without insight.
- **Intentional overlap** with the existing StatsD `feathers.request.*` metrics is expected: StatsD is unsampled/cheap; APM adds the waterfall + child DB spans + profiler correlation. No behavior change when `trace_services: off` (the default).

## Overhead

- Hook per-span CPU is trivial (~µs) and mostly already paid via the tracer's existing `AsyncLocalStorage` propagation. The real variable is **span volume** in `full` mode (fan-out) → ingestion cost, which is why the default is `off` and `entrypoint` exists as the prod-safe middle.

## Files

- `packages/core/src/config/types.ts` — `AgorApmSettings`, `APM_TRACE_SERVICE_DEPTHS` const/type, `metrics.apm`
- `packages/core/src/config/config-manager.ts` — validation (`only()` allow-list + `validateApmConfig`), default `off`, resolve-merge, `AGOR_APM_TRACE_SERVICES` env override
- `apps/agor-daemon/src/tracing/feathers.ts` — the hook (new)
- `apps/agor-daemon/src/register-routes.ts` — wired into the global `around` hooks
- Tests: `config-manager.test.ts` (default / validation / env override) and `tracing/feathers.test.ts` (depth modes, nesting vs suppression, `health` exclusion, error propagation)

## Testing

- `pnpm check` — green (typecheck, lint, boundary checks, build; 15/15 turbo tasks)
- `packages/core` config-manager suite — 159/159
- `agor-daemon` tracing + metrics hook suites — 31/31

## How to use it to find offenders

1. Set `metrics.apm.trace_services: full` (or `AGOR_APM_TRACE_SERVICES=full`) and enable the profiler (`DD_PROFILING_ENABLED=true`, `DD_PROFILING_TIMELINE_ENABLED=true`).
2. Let ~an hour of real traffic flow.
3. Rank `feathers.request` by `SUM(@duration)` and p95; drill into the fattest — its child `pg` spans expose the N+1 / full-scan / heavy serialization, and the profiler flame graph names the exact JS function eating the event loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
