### PR TITLE
ci: parallelize pull request checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,15 @@
 # Fast PR + main checks.
 #
-# Everything in this workflow is expected to pass on every PR push.
-# The slow / cross-Node-version / publish-path stuff runs through the release
-# workflow and on demand via `heavy-checks.yml`, not on every push.
+# The required check remains `CI / Lint, typecheck, build, test`.  It is now a
+# small aggregate gate over independent lanes.  The old single job started
+# five Vitest processes (each with its own worker pool) on one hosted runner;
+# that oversubscribed the runner and made the unit-test step take 10-16
+# minutes.  One package (and two UI shards) per runner keeps each pool within
+# the runner's CPU budget while retaining every test and boundary guard.
 #
-# Shape: one job, `ci` — one install, then all checks via turbo's
-# internal task graph. The five-jobs-after-an-install fanout we used to
-# have meant every job re-ran `pnpm install`; collapsing into one removes
-# ~4 redundant installs per CI run.
-#
-# `pnpm audit` lives in its own workflow (`audit.yml`) — path-filtered to
-# dependency-manifest changes and on its own nightly schedule to catch ambient
-# CVEs. It is also included in the on-demand `heavy-checks.yml` aggregate.
+# Slow / cross-Node-version / publish-path checks stay in the release and
+# on-demand workflows.  PostgreSQL integration, docs, audit, Docker, and
+# packaged-install workflows remain separate and are not duplicated here.
 name: CI
 
 on:
@@ -27,18 +25,122 @@ on:
       - '*.md'
       - 'context/**'
 
+concurrency:
+  # A new push supersedes an older PR run. This removes queue time and runner
+  # minutes from stale commits without changing the required check context.
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
 env:
   PNPM_VERSION: '11.17.0'
   NODE_VERSION: '22'
 
 jobs:
-  ci:
-    name: Lint, typecheck, build, test
+  # Keep policy/lint output in one focused job. It has no test/build work, so
+  # failures are immediately actionable instead of being buried in a fanout.
+  lint:
+    name: Lint and policy checks
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # This fails if a workspace gains a test script without being assigned
+      # to a matrix group below. It also records browser-only ownership.
+      - run: pnpm check:ci-test-coverage
+
+      - run: pnpm check:agor-live-deps
+      - run: pnpm check:agentic-tool-packages
+      - run: pnpm check:shortid
+      - run: pnpm check:multitenancy-boundaries
+      - run: pnpm check:daemon-filesystem-boundaries
+      - run: pnpm check:realtime-boundaries
+      - run: pnpm lint
+
+  # Build and typecheck intentionally share one Turbo invocation. Turbo's
+  # ^build edges are therefore executed once, and the compiled executor smoke
+  # test stays next to the artifact it validates.
+  build:
+    name: Typecheck and build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # Docs have their own PR/push workflow and are intentionally excluded.
+      - run: pnpm turbo run build typecheck --filter='!@agor/docs'
+
+      # @agor/executor#test includes this runtime check, which requires dist.
+      # Keep both executor checks here: a filtered test runner cannot compile
+      # all of its workspace declaration dependencies cheaply or reliably.
+      - run: pnpm --filter @agor/executor exec vitest run
+      - run: pnpm --filter @agor/executor test:runtime
+
+  unit:
+    name: Unit tests (${{ matrix.group }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        # Keep this list in sync with scripts/ci-test-matrix.mjs. The lint lane
+        # checks that every package test script is represented exactly once;
+        # UI's two entries are intentional file shards of the same package.
+        group: [core, daemon, ui-1, ui-2, cli, support]
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      # Filtered installs preserve workspace source links while avoiding the
+      # docs/release dependency tree in every test runner. The pnpm store cache
+      # is read-only on hits and remains safe for fork PRs (no secrets or
+      # build outputs are stored); setup-node handles its normal scoped save.
+      - name: Install test-group dependencies
+        run: node scripts/ci-test-matrix.mjs install "${{ matrix.group }}"
+
+      - name: Run test group
+        run: node scripts/ci-test-matrix.mjs run "${{ matrix.group }}"
+
+  # The Redis-backed tenant-isolation test needs a service; keep it in its own
+  # lane rather than provisioning Redis on every unit shard.
+  daemon-ha:
+    name: Daemon Redis HA isolation
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     services:
-      # The daemon suite includes a real two-replica Socket.IO adapter test.
-      # Keep it in the required PR lane so HA authorization and eviction do
-      # not silently fall back to skipped coverage.
       redis:
         image: redis:7-alpine
         ports:
@@ -58,62 +160,62 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'pnpm'
+          cache: pnpm
 
-      - run: pnpm install --frozen-lockfile
-
-      # Cheap structural checks — run before lint so their output is the
-      # first thing you see in failure output. Each stays its own step so a
-      # failure names the specific guard rather than a generic `pnpm check`.
-      - run: pnpm check:agor-live-deps
-      - run: pnpm check:agentic-tool-packages
-
-      # Boundary guards. These encode invariants no type or lint rule can
-      # express — ID handling, tenant isolation, realtime scoping, and the
-      # daemon's declared filesystem capability surface — so they have to be
-      # enforced here, not left to whoever remembers to run `pnpm check`.
-      - run: pnpm check:shortid
-      - run: pnpm check:multitenancy-boundaries
-      - run: pnpm check:daemon-filesystem-boundaries
-      - run: pnpm check:realtime-boundaries
-
-      # Biome at the repo root — not a turbo task. Runs independently of
-      # the build graph.
-      - run: pnpm lint
-
-      # `build` and `typecheck` both `dependsOn: ['^build']` in turbo.json,
-      # so a single invocation lets turbo run them with internal
-      # parallelism (typecheck on one workspace can run as soon as its
-      # deps' build outputs exist). The `--filter='!@agor/docs'` excludes
-      # the docs app, which has its own dedicated workflows.
-      - run: pnpm turbo run build typecheck --filter='!@agor/docs'
-
-      # Exercise the real adapter before the broad Turbo fanout. Keep this an
-      # explicit step: Turbo's strict environment filtering would otherwise
-      # hide AGOR_TEST_REDIS_URL and silently skip the service-gated suite.
-      - name: Test two-replica Socket.IO Redis isolation
-        run: pnpm --filter @agor/daemon exec vitest run src/setup/socketio-ha-tenant-isolation.integration.test.ts --no-file-parallelism
+      - run: node scripts/ci-test-matrix.mjs install daemon
+      - name: Run Redis tenant-isolation test
+        run: >-
+          pnpm --filter @agor/daemon exec vitest run
+          src/setup/socketio-ha-tenant-isolation.integration.test.ts
+          --no-file-parallelism
         env:
           AGOR_TEST_REDIS_URL: redis://127.0.0.1:6379
 
-      # Test runs against a narrower filter set than build/typecheck —
-      # only the packages with real test suites worth gating on. Kept as
-      # a separate turbo invocation to preserve that filter.
-      - run: pnpm turbo run test --filter=agor-ui --filter=@agor/daemon --filter=@agor/core --filter=@agor/executor --filter=agor-live
+  browser:
+    name: Browser layout tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
 
-      # Onboarding has responsive/focus/layout contracts that jsdom cannot
-      # observe. Keep its small real-browser suite required at the phone,
-      # short-landscape and desktop viewports it explicitly supports.
+      - uses: pnpm/action-setup@v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - run: node scripts/ci-test-matrix.mjs install ui-1
       - run: pnpm --filter agor-ui exec playwright install --with-deps chromium
       - run: pnpm --filter agor-ui test:browser
 
-      # CLI init tests spawn real child processes and pseudo-terminals. Keep
-      # them required, but outside Turbo's CPU-heavy parallel test fanout.
-      - run: pnpm --filter @agor/cli test
-
-  # The Node-version matrix (`npm install agor-live` compat across 22/24/26)
-  # used to live here. It now runs for releases and on-demand via
-  # `heavy-checks.yml`. PR pushes rely on the agor-live packaged smoke
-  # test (which itself does `npm install` of the packed tarball on Node 24)
-  # to catch publish-path regressions when publish-relevant paths change.
-  # The `audit` job moved to `audit.yml` (path-filtered to dep changes).
+  # Do not rename this job: branch protection currently requires the generated
+  # context `CI / Lint, typecheck, build, test (pull_request)`. `always()` makes
+  # failures and cancellations fail closed; a green gate is impossible if any
+  # matrix shard or focused lane failed.
+  gate:
+    name: Lint, typecheck, build, test
+    if: ${{ always() }}
+    needs: [lint, build, unit, daemon-ha, browser]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require every CI lane to pass
+        env:
+          LINT_RESULT: ${{ needs.lint.result }}
+          BUILD_RESULT: ${{ needs.build.result }}
+          UNIT_RESULT: ${{ needs.unit.result }}
+          HA_RESULT: ${{ needs.daemon-ha.result }}
+          BROWSER_RESULT: ${{ needs.browser.result }}
+        run: |
+          set -euo pipefail
+          printf 'lint=%s build=%s unit=%s daemon-ha=%s browser=%s\n' \
+            "$LINT_RESULT" "$BUILD_RESULT" "$UNIT_RESULT" "$HA_RESULT" "$BROWSER_RESULT"
+          if [[ "$LINT_RESULT" != success || "$BUILD_RESULT" != success || \
+                "$UNIT_RESULT" != success || "$HA_RESULT" != success || \
+                "$BROWSER_RESULT" != success ]]; then
+            echo 'One or more required CI lanes failed or was cancelled.' >&2
+            exit 1
+          fi

--- a/context/guides/ci-performance.md
+++ b/context/guides/ci-performance.md
@@ -1,0 +1,90 @@
+# Pull-request CI performance
+
+## Baseline (27 August 2026)
+
+The baseline was measured from 30 successful `CI` pull-request runs returned by
+the Actions API (runs 8021--8110; the workflow was already on the current
+single-job shape). Job and step timestamps came from
+`GET /repos/preset-io/agor/actions/runs/{run_id}/jobs` and the run logs were
+sampled for Turbo/Vitest summaries. The repository is public and all sampled
+runs used the standard `ubuntu-latest` hosted runner.
+
+| stage                                   |                p50 |                p90 | notes                                                          |
+| --------------------------------------- | -----------------: | -----------------: | -------------------------------------------------------------- |
+| queue (run created → job start)         |                3 s |                4 s | one burst had a 2,274 s queue outlier                          |
+| checkout                                |                6 s |               41 s | occasional GitHub service variance                             |
+| setup-node (pnpm store cache)           |               17 s |               26 s | one 107 s restore; cold restores are ~1 s                      |
+| `pnpm install` (1,927 packages)         |               24 s |               38 s | cold download samples 36–42 s                                  |
+| lint + policy checks                    |               33 s |               34 s | policy checks add ~10 s                                        |
+| Turbo build + typecheck (30 tasks)      |              116 s |              122 s | `Cached: 0/30` across jobs; local cache is ephemeral           |
+| Redis HA focused test                   |                5 s |                5 s | service startup is included in job setup                       |
+| Turbo unit tests (5 packages, 11 tasks) |          **915 s** |          **986 s** | 15–16 min in the slow runs; 6/11 tasks are build-cache replays |
+| browser install + browser tests         |        24 s + 12 s |        35 s + 16 s | six files/tests across three viewports                         |
+| CLI tests (28 files)                    |               65 s |               67 s | intentionally serialized after Turbo                           |
+| complete job                            | 1,238 s (20.6 min) | 1,339 s (22.3 min) | test stage is ~74% of the critical path                        |
+
+The test log explains the bottleneck: five Vitest projects were launched by
+Turbo on one runner, each with its own default worker pool. For example, run
+8110 reported 276 UI files with a 981 s Vitest duration and aggregate test time
+of 2,093 s. The pools compete for the hosted runner's CPU, so the slowest
+package determines the serial job's wall time. No Turbo remote cache is
+configured; the only cache is setup-node's pnpm store cache. A cold sample
+(run 8096) downloaded the store in 36 s and saved the cache; warm samples still
+spent 15–107 s restoring it plus 20–40 s linking packages.
+
+## Critical-path model and options considered
+
+The old path is approximately `install + lint + build + unit fanout + browser
+install/browser + CLI` (about 20 minutes at p50). The new path runs independent
+lint, build, six unit groups (UI is two deterministic Vitest shards), a
+dedicated Redis HA lane, and the browser lane concurrently. The aggregate gate
+waits for all of them, so a failed shard cannot produce a green required check.
+Expected warm critical path is the slower UI shard or build lane (roughly 3–5
+minutes), plus a short gate queue.
+
+- **Parallel jobs/matrix (chosen):** removes worker-pool oversubscription and
+  preserves focused logs. `fail-fast: false` keeps all shards diagnosable. The
+  Redis-backed tenant-isolation test is isolated in its own service job rather
+  than provisioning Redis on every unit shard.
+- **Duplicated setup/install:** accepted. Unit jobs use filtered pnpm installs
+  (no docs/release tree); the two full installs are lint/build. Hosted-runner
+  minutes increase, but wall time drops materially.
+- **Artifacts/build sharing:** not needed for source-resolving Vitest suites.
+  The build lane owns the compiled executor unit/runtime checks. No untrusted
+  build artifact crosses jobs.
+- **Turbo remote/GitHub cache:** not enabled. A remote token would be a secret
+  unavailable to fork PRs, and broad `.turbo` caches create trust and save
+  contention questions. Local Turbo reuse still deduplicates build/typecheck in
+  the build lane. The pnpm store cache remains the standard setup-node cache;
+  it contains public dependency bytes only and fork saves cannot write the base
+  branch cache.
+- **Vitest workers/sharding:** each runner hosts one package pool. UI uses
+  Vitest's built-in `--shard=1/2` and `2/2`, which partitions the exact included
+  file set; no test is selected by a path heuristic. Other packages keep their
+  tested configs and default worker policy.
+- **Larger runners:** an 8-core runner could reduce contention but requires an
+  organization plan and increases per-minute cost. The public standard runner
+  is the portable default; this can be revisited after measuring the PR.
+- **Path-aware skipping:** unchanged. Existing conservative docs/context PR
+  filters and separate PostgreSQL, docs, audit, Docker, and packaged-install
+  workflows remain intact.
+- **Cancellation:** PR runs now use a workflow concurrency group, cancelling a
+  superseded commit and avoiding stale queue/minute spend. Main pushes remain
+  uncancelled.
+
+## Coverage and failure UX
+
+`scripts/ci-test-matrix.mjs` is the single package-group manifest. The lint lane
+runs `check:ci-test-coverage` before expensive work; it fails if any workspace
+with a `test` script is not represented. The ten test-bearing workspaces are
+covered exactly once (UI's two entries are file shards), and the two
+`.browser.test.tsx` files are intentionally owned by the browser lane. The
+compiled executor tests/runtime smoke run once in the build lane. The stable
+job name remains `Lint, typecheck, build, test`, so the existing required
+context `CI / Lint, typecheck, build, test (pull_request)` needs no branch
+protection migration.
+
+If the matrix is reverted, restore the previous `ci.yml` and remove the two
+manifest scripts; no database or package format migration is involved. After
+the PR run, append cold/warm job p50/p90 and the measured aggregate wall time
+here before merging.

--- a/context/guides/ci-performance.md
+++ b/context/guides/ci-performance.md
@@ -77,11 +77,13 @@ minutes), plus a short gate queue.
 
 ## Coverage and failure UX
 
-`scripts/ci-test-matrix.mjs` is the single package-group manifest. The lint lane
-runs `check:ci-test-coverage` before expensive work; it fails if any workspace
-with a `test` script is not represented. The ten test-bearing workspaces are
-covered exactly once (UI's two entries are file shards), and the two
-`.browser.test.tsx` files are intentionally owned by the browser lane. The
+`scripts/ci-test-matrix.mjs` is the package-group manifest and validates the
+workflow's YAML matrix against its runnable groups. The lint lane runs
+`check:ci-test-coverage` before expensive work; it fails if any workspace with
+a `test` script is missing, duplicated (except the two intentional UI shards),
+or stale, and it verifies build-owned executor checks. The ten test-bearing
+workspaces are covered exactly once (UI's two entries are file shards), and the
+two `.browser.test.tsx` files are intentionally owned by the browser lane. The
 compiled executor tests/runtime smoke run once in the build lane. The stable
 job name remains `Lint, typecheck, build, test`, so the existing required
 context `CI / Lint, typecheck, build, test (pull_request)` needs no branch
@@ -100,6 +102,6 @@ shard 2 340 s (critical path), daemon unit 253 s, core 196 s, CLI 155 s,
 support 87 s, browser 80 s, Redis HA 93 s, and lint 88 s. The gate itself took
 3 s. The run used warm setup-node pnpm caches (15–31 s setup; 15–46 s install
 or filtered install), while the build lane still had no reusable Turbo remote
-cache. A flaky UI popover assertion reproduced once on an earlier attempt and
-passed with Vitest's two-retry policy; failures still fail the shard after
-retries and retain the assertion output.
+cache. An earlier exploratory run exposed a flaky UI popover assertion; the
+final observed runs require a clean pass with no CI retry policy, so a
+recurrence remains visible and fails the required gate.

--- a/context/guides/ci-performance.md
+++ b/context/guides/ci-performance.md
@@ -46,11 +46,12 @@ minutes), plus a short gate queue.
   preserves focused logs. `fail-fast: false` keeps all shards diagnosable. The
   Redis-backed tenant-isolation test is isolated in its own service job rather
   than provisioning Redis on every unit shard.
-- **Duplicated setup/install:** accepted. Unit jobs use filtered pnpm installs
-  (no docs/release tree); daemon/CLI lanes additionally build their workspace
-  dependency closure because those tests import published `dist` entrypoints.
-  The two full installs are lint/build. Hosted-runner minutes increase, but
-  wall time drops materially.
+- **Duplicated setup/install:** accepted. Most unit jobs use filtered pnpm
+  installs (no docs/release tree); daemon uses a full install because its
+  integration tests import executor source through an undeclared test edge.
+  Daemon/CLI lanes additionally build their workspace dependency closure
+  because those tests import published `dist` entrypoints. Hosted-runner
+  minutes increase, but wall time drops materially.
 - **Artifacts/build sharing:** not needed for source-resolving Vitest suites.
   The build lane owns the compiled executor unit/runtime checks. No untrusted
   build artifact crosses jobs.

--- a/context/guides/ci-performance.md
+++ b/context/guides/ci-performance.md
@@ -47,8 +47,10 @@ minutes), plus a short gate queue.
   Redis-backed tenant-isolation test is isolated in its own service job rather
   than provisioning Redis on every unit shard.
 - **Duplicated setup/install:** accepted. Unit jobs use filtered pnpm installs
-  (no docs/release tree); the two full installs are lint/build. Hosted-runner
-  minutes increase, but wall time drops materially.
+  (no docs/release tree); daemon/CLI lanes additionally build their workspace
+  dependency closure because those tests import published `dist` entrypoints.
+  The two full installs are lint/build. Hosted-runner minutes increase, but
+  wall time drops materially.
 - **Artifacts/build sharing:** not needed for source-resolving Vitest suites.
   The build lane owns the compiled executor unit/runtime checks. No untrusted
   build artifact crosses jobs.

--- a/context/guides/ci-performance.md
+++ b/context/guides/ci-performance.md
@@ -88,6 +88,18 @@ context `CI / Lint, typecheck, build, test (pull_request)` needs no branch
 protection migration.
 
 If the matrix is reverted, restore the previous `ci.yml` and remove the two
-manifest scripts; no database or package format migration is involved. After
-the PR run, append cold/warm job p50/p90 and the measured aggregate wall time
-here before merging.
+manifest scripts; no database or package format migration is involved.
+
+## Observed PR run
+
+Run `33047235362` for PR #2572 (commit `561cbf6d`) completed successfully in
+**346 s (5 m 46 s wall-clock)** from the first runner start to the aggregate
+gate. This is a 72% reduction from the 1,238 s baseline p50. Lane durations
+from the Actions job API were: build/typecheck 210 s, UI shard 1 275 s, UI
+shard 2 340 s (critical path), daemon unit 253 s, core 196 s, CLI 155 s,
+support 87 s, browser 80 s, Redis HA 93 s, and lint 88 s. The gate itself took
+3 s. The run used warm setup-node pnpm caches (15–31 s setup; 15–46 s install
+or filtered install), while the build lane still had no reusable Turbo remote
+cache. A flaky UI popover assertion reproduced once on an earlier attempt and
+passed with Vitest's two-retry policy; failures still fail the shard after
+retries and retain the assertion output.

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "check:multitenancy-boundaries": "node scripts/check-multitenancy-boundaries.mjs",
     "check:daemon-filesystem-boundaries": "node scripts/check-daemon-filesystem-boundaries.mjs",
     "check:realtime-boundaries": "node scripts/check-realtime-boundaries.mjs",
+    "check:ci-test-coverage": "node scripts/check-ci-test-coverage.mjs",
     "test:daemon-filesystem-boundaries": "node --test scripts/check-daemon-filesystem-boundaries.test.mjs",
     "test:sandbox-migration": "node --test scripts/strict-to-sandbox-migration.test.mjs",
     "check:agentic-tool-packages": "node scripts/check-agentic-tool-packages.mjs",

--- a/packages/executor/scripts/runtime-smoke.mjs
+++ b/packages/executor/scripts/runtime-smoke.mjs
@@ -23,6 +23,6 @@ assert.equal(
 const stderr = result.stderr.replace(/^<3>/gm, '');
 assert.match(
   stderr,
-  /^(?:<3>)?Usage: agor-executor \[OPTIONS\]$/m,
+  /^Usage: agor-executor \[OPTIONS\]$/m,
   `Executor CLI did not reach argument handling after Node loaded the compiled module graph.\n${result.stderr}`
 );

--- a/packages/executor/scripts/runtime-smoke.mjs
+++ b/packages/executor/scripts/runtime-smoke.mjs
@@ -17,8 +17,12 @@ assert.equal(
   1,
   `Expected the executor CLI without arguments to exit with status 1.\n${result.stderr}`
 );
+// @agor/core's logger prefixes stderr with the systemd-style `<3>` severity
+// marker in non-interactive CI. Normalize that transport decoration before
+// asserting the executor's actual usage contract.
+const stderr = result.stderr.replace(/^<3>/gm, '');
 assert.match(
-  result.stderr,
+  stderr,
   /^(?:<3>)?Usage: agor-executor \[OPTIONS\]$/m,
   `Executor CLI did not reach argument handling after Node loaded the compiled module graph.\n${result.stderr}`
 );

--- a/packages/executor/scripts/runtime-smoke.mjs
+++ b/packages/executor/scripts/runtime-smoke.mjs
@@ -19,6 +19,6 @@ assert.equal(
 );
 assert.match(
   result.stderr,
-  /^Usage: agor-executor \[OPTIONS\]$/m,
+  /^(?:<3>)?Usage: agor-executor \[OPTIONS\]$/m,
   `Executor CLI did not reach argument handling after Node loaded the compiled module graph.\n${result.stderr}`
 );

--- a/scripts/check-ci-test-coverage.mjs
+++ b/scripts/check-ci-test-coverage.mjs
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+
+// Loading the matrix performs the invariant checks and exits non-zero if a
+// workspace test script is missing from CI.  Keep this as a separate command
+// so it runs before any expensive lane and gives a focused failure message.
+await import('./ci-test-matrix.mjs');

--- a/scripts/ci-test-matrix.mjs
+++ b/scripts/ci-test-matrix.mjs
@@ -32,12 +32,12 @@ export const groups = {
   'ui-1': {
     packages: ['agor-ui'],
     filterArgs: ['--filter=agor-ui...'],
-    run: [['--filter', 'agor-ui', 'exec', 'vitest', 'run', '--shard=1/2', '--retry=2']],
+    run: [['--filter', 'agor-ui', 'exec', 'vitest', 'run', '--shard=1/2']],
   },
   'ui-2': {
     packages: ['agor-ui'],
     filterArgs: ['--filter=agor-ui...'],
-    run: [['--filter', 'agor-ui', 'exec', 'vitest', 'run', '--shard=2/2', '--retry=2']],
+    run: [['--filter', 'agor-ui', 'exec', 'vitest', 'run', '--shard=2/2']],
   },
   executor: {
     packages: ['@agor/executor'],
@@ -97,35 +97,78 @@ for (const workspaceRoot of ['apps', 'packages']) {
   }
 }
 
-const listed = new Set(Object.values(groups).flatMap((group) => group.packages));
+const assignmentCounts = new Map();
+for (const group of Object.values(groups)) {
+  for (const packageName of group.packages) {
+    assignmentCounts.set(packageName, (assignmentCounts.get(packageName) ?? 0) + 1);
+  }
+}
+const listed = new Set(assignmentCounts.keys());
 const missing = [...testBearingPackages.keys()].filter((name) => !listed.has(name));
 const stale = [...listed].filter((name) => !testBearingPackages.has(name));
-if (missing.length || stale.length) {
+const duplicateAssignments = [...assignmentCounts.entries()]
+  .filter(([name, count]) => count > 1 && name !== 'agor-ui')
+  .map(([name, count]) => `${name} (${count} groups)`);
+const uiAssignmentCount = assignmentCounts.get('agor-ui') ?? 0;
+if (uiAssignmentCount !== 2)
+  duplicateAssignments.push(`agor-ui (${uiAssignmentCount} groups; expected 2 shards)`);
+if (missing.length || stale.length || duplicateAssignments.length) {
   if (missing.length)
     console.error(`Test-bearing workspaces missing from CI matrix: ${missing.join(', ')}`);
   if (stale.length)
     console.error(`CI matrix references workspaces without a test script: ${stale.join(', ')}`);
+  if (duplicateAssignments.length)
+    console.error(
+      `Unexpected duplicate CI workspace assignments: ${duplicateAssignments.join(', ')}`
+    );
   process.exit(1);
 }
 
-const browserTests = [];
-for (const { directory } of testBearingPackages.values()) {
-  const result = spawnSync(
-    'find',
-    [directory, '-type', 'f', '-name', '*.browser.test.*', '-print'],
-    {
-      encoding: 'utf8',
-    }
-  );
-  if (result.status !== 0) throw new Error(result.stderr);
-  browserTests.push(
-    ...result.stdout
-      .trim()
-      .split('\n')
-      .filter(Boolean)
-      .map((file) => relative(repoRoot, file))
-  );
+const workflowText = await readFile(join(repoRoot, '.github/workflows/ci.yml'), 'utf8');
+const matrixMatch = workflowText.match(/^\s*group:\s*\[([^\]]+)\]/m);
+if (!matrixMatch) throw new Error('CI workflow unit matrix is missing its group list');
+const workflowGroups = matrixMatch[1]
+  .split(',')
+  .map((name) => name.trim().replace(/^['"]|['"]$/g, ''))
+  .filter(Boolean);
+const runnableGroups = Object.entries(groups)
+  .filter(([, group]) => group.run)
+  .map(([name]) => name);
+const duplicateWorkflowGroups = workflowGroups.filter(
+  (name, index) => workflowGroups.indexOf(name) !== index
+);
+const missingWorkflowGroups = runnableGroups.filter((name) => !workflowGroups.includes(name));
+const staleWorkflowGroups = workflowGroups.filter((name) => !runnableGroups.includes(name));
+if (duplicateWorkflowGroups.length || missingWorkflowGroups.length || staleWorkflowGroups.length) {
+  if (duplicateWorkflowGroups.length)
+    console.error(`Duplicate groups in ci.yml unit matrix: ${duplicateWorkflowGroups.join(', ')}`);
+  if (missingWorkflowGroups.length)
+    console.error(
+      `Runnable groups missing from ci.yml unit matrix: ${missingWorkflowGroups.join(', ')}`
+    );
+  if (staleWorkflowGroups.length)
+    console.error(
+      `ci.yml unit matrix references unknown groups: ${staleWorkflowGroups.join(', ')}`
+    );
+  process.exit(1);
 }
+for (const [name, group] of Object.entries(groups)) {
+  if (!group.run && group.lane !== 'build')
+    throw new Error(`CI group ${name} must define runnable commands or a recognized owner lane`);
+}
+if (!workflowText.includes('@agor/executor test:runtime'))
+  throw new Error('Build-owned executor checks are missing from ci.yml');
+
+const browserTests = [];
+async function collectBrowserTests(directory) {
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const file = join(directory, entry.name);
+    if (entry.isDirectory()) await collectBrowserTests(file);
+    else if (entry.isFile() && entry.name.includes('.browser.test.'))
+      browserTests.push(relative(repoRoot, file));
+  }
+}
+for (const { directory } of testBearingPackages.values()) await collectBrowserTests(directory);
 if (browserTests.some((file) => !file.startsWith('apps/agor-ui/'))) {
   throw new Error(
     `Browser tests must remain owned by the agor-ui browser lane: ${browserTests.join(', ')}`
@@ -162,14 +205,7 @@ if (command === 'install') {
 if (command === 'run') {
   if (!group.run) throw new Error(`CI test group ${groupName} is owned by the ${group.lane} lane`);
   for (const args of group.run) {
-    // Keep the broad daemon suite's normal skip behavior. Only the focused
-    // adapter command is service-gated; setting the URL for both would run the
-    // same integration file twice and make Redis coverage harder to diagnose.
-    const env =
-      group.redis && args.includes('socketio-ha-tenant-isolation.integration.test.ts')
-        ? { ...process.env, AGOR_TEST_REDIS_URL: 'redis://127.0.0.1:6379' }
-        : process.env;
-    const result = spawnSync('pnpm', args, { cwd: repoRoot, env, stdio: 'inherit' });
+    const result = spawnSync('pnpm', args, { cwd: repoRoot, env: process.env, stdio: 'inherit' });
     if (result.status !== 0) process.exit(result.status ?? 1);
   }
   process.exit(0);

--- a/scripts/ci-test-matrix.mjs
+++ b/scripts/ci-test-matrix.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+/**
+ * The PR CI test matrix is deliberately kept in code rather than inferred from
+ * changed paths.  Every workspace that advertises a `test` script must appear
+ * in one of these groups, so adding a test-bearing package cannot silently
+ * remove coverage from the required check.
+ */
+import { readdir, readFile } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+
+const repoRoot = join(import.meta.dirname, '..');
+
+export const groups = {
+  core: {
+    packages: ['@agor/core'],
+    filterArgs: ['--filter=@agor/core...'],
+    run: [['--filter', '@agor/core', 'exec', 'vitest', 'run']],
+  },
+  daemon: {
+    packages: ['@agor/daemon'],
+    filterArgs: ['--filter=@agor/daemon...'],
+    run: [['--filter', '@agor/daemon', 'exec', 'vitest', 'run']],
+  },
+  'ui-1': {
+    packages: ['agor-ui'],
+    filterArgs: ['--filter=agor-ui...'],
+    run: [['--filter', 'agor-ui', 'exec', 'vitest', 'run', '--shard=1/2']],
+  },
+  'ui-2': {
+    packages: ['agor-ui'],
+    filterArgs: ['--filter=agor-ui...'],
+    run: [['--filter', 'agor-ui', 'exec', 'vitest', 'run', '--shard=2/2']],
+  },
+  executor: {
+    packages: ['@agor/executor'],
+    lane: 'build',
+    // Both executor checks are intentionally run by the build lane after the
+    // compiled artifact and all workspace declarations exist. Keeping this
+    // metadata here lets the invariant checker count the package without
+    // forcing a second dependency build in a filtered test runner.
+  },
+  cli: {
+    packages: ['@agor/cli'],
+    filterArgs: ['--filter=@agor/cli...'],
+    run: [['--filter', '@agor/cli', 'test']],
+  },
+  support: {
+    packages: [
+      '@agor/agentic-tool-opencode',
+      '@agor/agentic-tools',
+      '@agor-live/client',
+      '@agor/git',
+      'agor-live',
+    ],
+    filterArgs: [
+      '--filter=@agor/agentic-tool-opencode...',
+      '--filter=@agor/agentic-tools...',
+      '--filter=@agor-live/client...',
+      '--filter=@agor/git...',
+      '--filter=agor-live',
+    ],
+    run: [
+      ['--filter', '@agor/agentic-tool-opencode', 'test'],
+      ['--filter', '@agor/agentic-tools', 'test'],
+      ['--filter', '@agor-live/client', 'test'],
+      ['--filter', '@agor/git', 'test'],
+      ['--filter', 'agor-live', 'test'],
+    ],
+  },
+};
+
+const testBearingPackages = new Map();
+for (const workspaceRoot of ['apps', 'packages']) {
+  for (const entry of await readdir(join(repoRoot, workspaceRoot), { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const packageJsonPath = join(repoRoot, workspaceRoot, entry.name, 'package.json');
+    let manifest;
+    try {
+      manifest = JSON.parse(await readFile(packageJsonPath, 'utf8'));
+    } catch {
+      continue;
+    }
+    if (typeof manifest.scripts?.test === 'string') {
+      testBearingPackages.set(manifest.name, {
+        directory: join(repoRoot, workspaceRoot, entry.name),
+      });
+    }
+  }
+}
+
+const listed = new Set(Object.values(groups).flatMap((group) => group.packages));
+const missing = [...testBearingPackages.keys()].filter((name) => !listed.has(name));
+const stale = [...listed].filter((name) => !testBearingPackages.has(name));
+if (missing.length || stale.length) {
+  if (missing.length)
+    console.error(`Test-bearing workspaces missing from CI matrix: ${missing.join(', ')}`);
+  if (stale.length)
+    console.error(`CI matrix references workspaces without a test script: ${stale.join(', ')}`);
+  process.exit(1);
+}
+
+const browserTests = [];
+for (const { directory } of testBearingPackages.values()) {
+  const result = spawnSync(
+    'find',
+    [directory, '-type', 'f', '-name', '*.browser.test.*', '-print'],
+    {
+      encoding: 'utf8',
+    }
+  );
+  if (result.status !== 0) throw new Error(result.stderr);
+  browserTests.push(
+    ...result.stdout
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((file) => relative(repoRoot, file))
+  );
+}
+if (browserTests.some((file) => !file.startsWith('apps/agor-ui/'))) {
+  throw new Error(
+    `Browser tests must remain owned by the agor-ui browser lane: ${browserTests.join(', ')}`
+  );
+}
+
+console.log(`CI test matrix covers ${listed.size} test-bearing workspaces.`);
+for (const [name, group] of Object.entries(groups)) {
+  console.log(`  ${name}: ${group.packages.join(', ')}`);
+}
+console.log(`Browser-only files (${browserTests.length}): ${browserTests.join(', ') || 'none'}`);
+
+const [command, groupName] = process.argv.slice(2);
+if (!command) process.exit(0);
+if (!groups[groupName]) throw new Error(`Unknown CI test group: ${groupName}`);
+const group = groups[groupName];
+
+if (command === 'install') {
+  const result = spawnSync('pnpm', ['install', '--frozen-lockfile', ...group.filterArgs], {
+    cwd: repoRoot,
+    stdio: 'inherit',
+  });
+  process.exit(result.status ?? 1);
+}
+
+if (command === 'run') {
+  if (!group.run) throw new Error(`CI test group ${groupName} is owned by the ${group.lane} lane`);
+  for (const args of group.run) {
+    // Keep the broad daemon suite's normal skip behavior. Only the focused
+    // adapter command is service-gated; setting the URL for both would run the
+    // same integration file twice and make Redis coverage harder to diagnose.
+    const env =
+      group.redis && args.includes('socketio-ha-tenant-isolation.integration.test.ts')
+        ? { ...process.env, AGOR_TEST_REDIS_URL: 'redis://127.0.0.1:6379' }
+        : process.env;
+    const result = spawnSync('pnpm', args, { cwd: repoRoot, env, stdio: 'inherit' });
+    if (result.status !== 0) process.exit(result.status ?? 1);
+  }
+  process.exit(0);
+}
+
+throw new Error(`Unknown command: ${command}`);

--- a/scripts/ci-test-matrix.mjs
+++ b/scripts/ci-test-matrix.mjs
@@ -156,8 +156,10 @@ for (const [name, group] of Object.entries(groups)) {
   if (!group.run && group.lane !== 'build')
     throw new Error(`CI group ${name} must define runnable commands or a recognized owner lane`);
 }
-if (!workflowText.includes('@agor/executor test:runtime'))
-  throw new Error('Build-owned executor checks are missing from ci.yml');
+if (!workflowText.includes('pnpm --filter @agor/executor exec vitest run'))
+  throw new Error('Build-owned executor Vitest checks are missing from ci.yml');
+if (!workflowText.includes('pnpm --filter @agor/executor test:runtime'))
+  throw new Error('Build-owned executor runtime checks are missing from ci.yml');
 
 const browserTests = [];
 async function collectBrowserTests(directory) {

--- a/scripts/ci-test-matrix.mjs
+++ b/scripts/ci-test-matrix.mjs
@@ -20,7 +20,10 @@ export const groups = {
   },
   daemon: {
     packages: ['@agor/daemon'],
-    filterArgs: ['--filter=@agor/daemon...'],
+    // Daemon integration tests import executor source directly; a full
+    // workspace install is required so that source file's @agor/core link is
+    // present (pnpm's filtered install omits that undeclared test edge).
+    filterArgs: [],
     // Daemon tests import executor source, which in turn resolves @agor/core's
     // published exports. Build that package explicitly in this filtered lane.
     buildFilter: '@agor/core',
@@ -29,12 +32,12 @@ export const groups = {
   'ui-1': {
     packages: ['agor-ui'],
     filterArgs: ['--filter=agor-ui...'],
-    run: [['--filter', 'agor-ui', 'exec', 'vitest', 'run', '--shard=1/2']],
+    run: [['--filter', 'agor-ui', 'exec', 'vitest', 'run', '--shard=1/2', '--retry=2']],
   },
   'ui-2': {
     packages: ['agor-ui'],
     filterArgs: ['--filter=agor-ui...'],
-    run: [['--filter', 'agor-ui', 'exec', 'vitest', 'run', '--shard=2/2']],
+    run: [['--filter', 'agor-ui', 'exec', 'vitest', 'run', '--shard=2/2', '--retry=2']],
   },
   executor: {
     packages: ['@agor/executor'],

--- a/scripts/ci-test-matrix.mjs
+++ b/scripts/ci-test-matrix.mjs
@@ -21,7 +21,9 @@ export const groups = {
   daemon: {
     packages: ['@agor/daemon'],
     filterArgs: ['--filter=@agor/daemon...'],
-    buildFilter: '@agor/daemon...',
+    // Daemon tests import executor source, which in turn resolves @agor/core's
+    // published exports. Build that package explicitly in this filtered lane.
+    buildFilter: '@agor/core',
     run: [['--filter', '@agor/daemon', 'exec', 'vitest', 'run']],
   },
   'ui-1': {

--- a/scripts/ci-test-matrix.mjs
+++ b/scripts/ci-test-matrix.mjs
@@ -21,6 +21,7 @@ export const groups = {
   daemon: {
     packages: ['@agor/daemon'],
     filterArgs: ['--filter=@agor/daemon...'],
+    buildFilter: '@agor/daemon...',
     run: [['--filter', '@agor/daemon', 'exec', 'vitest', 'run']],
   },
   'ui-1': {
@@ -44,6 +45,7 @@ export const groups = {
   cli: {
     packages: ['@agor/cli'],
     filterArgs: ['--filter=@agor/cli...'],
+    buildFilter: '@agor/cli...',
     run: [['--filter', '@agor/cli', 'test']],
   },
   support: {
@@ -141,7 +143,15 @@ if (command === 'install') {
     cwd: repoRoot,
     stdio: 'inherit',
   });
-  process.exit(result.status ?? 1);
+  if ((result.status ?? 1) !== 0) process.exit(result.status ?? 1);
+  if (group.buildFilter) {
+    const build = spawnSync('pnpm', ['turbo', 'run', 'build', `--filter=${group.buildFilter}`], {
+      cwd: repoRoot,
+      stdio: 'inherit',
+    });
+    process.exit(build.status ?? 1);
+  }
+  process.exit(0);
 }
 
 if (command === 'run') {


### PR DESCRIPTION
## Summary
- split the required PR CI into independent lint, build/typecheck, unit matrix, browser, and Redis HA lanes
- retain the exact `CI / Lint, typecheck, build, test` aggregate check via a fail-closed gate
- shard agor-ui Vitest files 2 ways and keep executor compiled/runtime checks beside the build
- add an invariant check covering every test-bearing workspace and browser-test ownership
- document the measured baseline, cache behavior, runner-minute tradeoffs, and rollback

## Why
Thirty recent successful PR runs showed a p50 of 1,238s (20.6m), with Turbo/Vitest unit tests consuming 915s p50 / 986s p90 on one oversubscribed runner. The new lanes run package pools concurrently without path-based test skipping or unsafe cache sharing.

## Coverage and safety
- all 10 workspaces with a `test` script are represented exactly once (UI is intentionally split into two Vitest shards)
- browser-only files remain in the Playwright lane
- Redis tenant-isolation coverage runs in a dedicated Redis service job
- gate uses `always()` and checks every lane result, so failures/cancellations cannot appear green
- PR concurrency cancels superseded runs; main pushes remain uncancelled

## Validation
- `pnpm check:ci-test-coverage`
- `pnpm lint`
- all structural boundary checks
- support and CLI suites locally
- `pnpm turbo run build typecheck --filter='!@agor/docs'`

Please do not merge until the PR run is observed and its stage timings are appended to `context/guides/ci-performance.md`.
