### PR TITLE
Improve MCP server read performance

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/mcp-servers.oauth-hooks.integration.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/mcp-servers.oauth-hooks.integration.test.ts
@@ -209,8 +209,8 @@ describe('MCP OAuth status through Feathers response hooks', () => {
       baseServiceParams,
     };
 
-    // Prove the actual Feathers boundary handed the tool an enriched/redacted
-    // projection which cannot itself reproduce the v4 fingerprint.
+    // Generic reads never hydrate the per-user grant. External reads retain
+    // the existing secret-redaction boundary.
     const projected = await app
       .service('mcp-servers')
       .get(server.mcp_server_id, baseServiceParams as never);
@@ -218,9 +218,6 @@ describe('MCP OAuth status through Feathers response hooks', () => {
     expect(JSON.stringify(projected)).not.toContain('configured-client-secret');
     expect(JSON.stringify(projected)).not.toContain('durable-grant-access');
 
-    // Exercise the production after-hook projection used by an in-process
-    // executor lookup. Runtime token and expiry enrichment must not change the
-    // durable gateway material identity used by first admission.
     const executorProjected = await app.service('mcp-servers').get(server.mcp_server_id, {
       authenticated: true,
       provider: undefined,
@@ -229,8 +226,13 @@ describe('MCP OAuth status through Feathers response hooks', () => {
       authentication: { payload: { type: 'internal' } },
       tenant: { tenant_id: 'default', source: 'static' },
     } as never);
-    expect(executorProjected.auth?.oauth_access_token).toBe('durable-grant-access');
-    expect(executorProjected.auth?.oauth_token_expires_at).toEqual(expect.any(Number));
+    // Trusted in-process reads retain their existing access to credentials
+    // stored on the server row, but must not receive the user's durable grant.
+    expect(executorProjected.auth?.oauth_access_token).toBe('configured-static-access');
+    expect(executorProjected.auth?.oauth_access_token).not.toBe('durable-grant-access');
+    expect(executorProjected.auth?.oauth_token_expires_at).toBe(
+      server.auth?.oauth_token_expires_at
+    );
     expect(mcpEgressMaterialHash(executorProjected, {}, 'projection-hash-key')).toBe(
       mcpEgressMaterialHash(savedServer!, {}, 'projection-hash-key')
     );

--- a/apps/agor-daemon/src/register-hooks.mcp-headers-redaction.test.ts
+++ b/apps/agor-daemon/src/register-hooks.mcp-headers-redaction.test.ts
@@ -13,11 +13,18 @@ describe('register-hooks MCP server secret redaction', () => {
     expect(source).toContain('redactMCPServerSecretFields');
     expect(source).toContain('redactMCPServerSecrets');
     expect(utilSource).toContain('redactMCPAuthSecrets(server.auth)');
-    expect(source).toMatch(/find:\s*\[injectPerUserOAuthTokens,\s*redactMCPServerSecretFields\]/);
-    // Ownership hooks may run ahead of these; redaction must still be last.
     expect(source).toMatch(
-      /get:\s*\[[\s\S]*?injectPerUserOAuthTokens,\s*redactMCPServerSecretFields[\s\S]*?\]/
+      /find:\s*\[presentMcpOAuthPolicies,\s*redactMCPServerSecretFieldsForGatewayMode\]/
     );
+    // Ownership hooks may run ahead of these; redaction must still be last.
+    expect(source).toMatch(/get:\s*\[[\s\S]*?redactMCPServerSecretFieldsForGatewayMode[\s\S]*?\]/);
+  });
+
+  it('keeps ordinary MCP server reads free of OAuth grant lookups', () => {
+    const block = source.slice(source.indexOf("safeService('mcp-servers')?.hooks({"));
+    const readHooks = block.slice(0, block.indexOf("safeService('mcp-catalog')"));
+    expect(readHooks).not.toContain('UserMCPOAuthTokenRepository');
+    expect(readHooks).not.toContain('injectPerUserOAuthTokens');
   });
 
   it('redacts every mcp-servers method that returns a row, remove included', () => {

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -30,7 +30,6 @@ import {
   type BranchRepository,
   CardRepository,
   getMCPEgressGatewayMode,
-  isPostgresDatabaseHandle,
   requireCurrentTenantId,
   runWithTenantDatabaseScope,
   ScheduleRepository,
@@ -39,7 +38,6 @@ import {
   TaskRepository,
   type TenantScopeAwareDatabase,
   TenantWriteGateActiveError,
-  UserMCPOAuthTokenRepository,
   type UsersRepository,
 } from '@agor/core/db';
 import {
@@ -117,7 +115,6 @@ import {
 import { gatewayRouteHook } from './hooks/gateway-route.js';
 import { validateMessageCreate } from './hooks/validate-message-create.js';
 import { coordinateMCPServerMutationAfterWrite } from './mcp-egress/coordination.js';
-import { resolveForUserIdWithGate } from './oauth-auth-helpers.js';
 import { protectExternalPermissionMessageWrites } from './permissions/permission-message-boundary.js';
 import type { RedisRealtimeRuntime } from './realtime/redis-realtime.js';
 import type { ArtifactsService } from './services/artifacts.js';
@@ -129,14 +126,7 @@ import {
 import { CODEX_AUTH_DEFER_USER_REALTIME } from './services/codex-auth-shared.js';
 import type { GatewayService } from './services/gateway.js';
 import { groupMembershipsHooks, groupsHooks } from './services/groups.js';
-import {
-  presentMCPOAuthCompatibilityPolicy,
-  resolveMCPOAuthCompatibilityPolicy,
-} from './services/mcp-oauth-compatibility.js';
-import {
-  isMCPOAuthGrantBoundToServer,
-  shouldVerifyMCPOAuthGrantBinding,
-} from './services/mcp-oauth-grant-binding.js';
+import { presentMCPServerOAuthPolicies } from './services/mcp-server-presentation.js';
 import {
   isRemoteRelationshipsEnrichedResult,
   markRemoteRelationshipsEnrichedResult,
@@ -2317,104 +2307,17 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   });
 
   // ============================================================================
-  // MCP servers hooks (with per-user OAuth token injection)
+  // MCP servers hooks
   // ============================================================================
 
-  // Hook to inject per-user OAuth tokens into MCP server responses
-  const injectPerUserOAuthTokens = async (context: HookContext) => {
-    // Try multiple sources for user ID:
-    // 1. params.user (from socket authentication)
-    // 2. query.forUserId (explicitly passed from executor for per-user OAuth)
-    const queryForUserId = (context.params?.query as Record<string, unknown>)?.forUserId as
-      | string
-      | undefined;
-    const userId = resolveForUserIdWithGate({
-      queryForUserId,
-      isServiceAccount: context.params?.user?._isServiceAccount,
-      callerUserId: context.params?.user?.user_id,
-    });
-    const injectToken = async (server: MCPServer) => {
-      if (server.auth?.type !== 'oauth') {
-        return server;
-      }
-
-      const compatibilityPolicy = await resolveMCPOAuthCompatibilityPolicy(server);
-      const serverWithPolicy: MCPServer = {
-        ...server,
-        oauth_compatibility_policy: presentMCPOAuthCompatibilityPolicy(compatibilityPolicy),
-      };
-      if (!userId) return serverWithPolicy;
-
-      // Tokens for both modes live in user_mcp_oauth_tokens:
-      //   - per_user  → row keyed by (userId, serverId)
-      //   - shared    → row keyed by (NULL, serverId)
-      const mode = server.auth.oauth_mode ?? 'per_user';
-      const tokenUserId: import('@agor/core/types').UserID | null =
-        mode === 'per_user' ? (userId as import('@agor/core/types').UserID) : null;
-
-      try {
-        const userTokenRepo = new UserMCPOAuthTokenRepository(db);
-        const row = await userTokenRepo.getToken(tokenUserId, server.mcp_server_id);
-
-        if (!row) {
-          return serverWithPolicy;
-        }
-        const compatibilityMode = compatibilityPolicy.mode;
-        if (
-          shouldVerifyMCPOAuthGrantBinding(
-            isPostgresDatabaseHandle(db),
-            row.grant_binding_version
-          ) &&
-          !isMCPOAuthGrantBoundToServer(
-            process.env.AGOR_MASTER_SECRET!,
-            server,
-            row,
-            compatibilityMode
-          )
-        ) {
-          console.warn('[MCP OAuth] grant_rejected category=binding_mismatch');
-          return serverWithPolicy;
-        }
-
-        // Response enrichment is a durable read only. Refresh is coordinated
-        // by oauth-auth-headers/manual refresh, never from an after hook that
-        // may hold an unrelated tenant transaction.
-        if (
-          row.refresh_status !== 'idle' ||
-          (row.oauth_token_expires_at && row.oauth_token_expires_at <= new Date())
-        ) {
-          return serverWithPolicy;
-        }
-        const accessToken = row.oauth_access_token;
-        const expiresAt = row.oauth_token_expires_at;
-
-        return {
-          ...serverWithPolicy,
-          auth: {
-            ...server.auth,
-            oauth_access_token: accessToken,
-            // Surface expiry so the UI can render "expires in X" tooltips.
-            // Stored as Date in the repo, emitted as ms epoch to match MCPAuth.
-            oauth_token_expires_at:
-              expiresAt instanceof Date ? expiresAt.getTime() : (expiresAt ?? undefined),
-          },
-        };
-      } catch {
-        console.warn('[MCP OAuth] grant_resolution_failed category=local_error');
-      }
-
-      return serverWithPolicy;
-    };
-
-    // Handle both single result and array/paginated results
+  const presentMcpOAuthPolicies = async (context: HookContext): Promise<HookContext> => {
     if (Array.isArray(context.result)) {
-      context.result = await Promise.all(context.result.map(injectToken));
+      context.result = await presentMCPServerOAuthPolicies(context.result);
     } else if (context.result?.data && Array.isArray(context.result.data)) {
-      context.result.data = await Promise.all(context.result.data.map(injectToken));
+      context.result.data = await presentMCPServerOAuthPolicies(context.result.data);
     } else if (context.result?.mcp_server_id) {
-      context.result = await injectToken(context.result);
+      [context.result] = await presentMCPServerOAuthPolicies([context.result]);
     }
-
     return context;
   };
 
@@ -2499,10 +2402,10 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       remove: [authorizeMcpServerWriteHook],
     },
     after: {
-      find: [injectPerUserOAuthTokens, redactMCPServerSecretFieldsForGatewayMode],
+      find: [presentMcpOAuthPolicies, redactMCPServerSecretFieldsForGatewayMode],
       get: [
         denyMcpServerGetOfAnotherUsersPrivate,
-        injectPerUserOAuthTokens,
+        presentMcpOAuthPolicies,
         redactMCPServerSecretFieldsForGatewayMode,
       ],
       create: [redactMCPServerSecretFieldsForGatewayMode],
@@ -2543,7 +2446,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       ],
     },
     after: {
-      find: [injectPerUserOAuthTokens, redactMCPServerSecretFields],
+      find: [redactMCPServerSecretFields],
     },
   });
 

--- a/apps/agor-daemon/src/services/mcp-catalog-connect.postgres.test.ts
+++ b/apps/agor-daemon/src/services/mcp-catalog-connect.postgres.test.ts
@@ -31,7 +31,11 @@ const { probeRemoteAuthType, probeRemoteBearerToken } = vi.hoisted(() => ({
   probeRemoteAuthType: vi.fn(),
   probeRemoteBearerToken: vi.fn(),
 }));
-vi.mock('@agor/core/mcp-catalog', () => ({ probeRemoteAuthType, probeRemoteBearerToken }));
+vi.mock('@agor/core/mcp-catalog', () => ({
+  loadCatalog: vi.fn().mockResolvedValue([]),
+  probeRemoteAuthType,
+  probeRemoteBearerToken,
+}));
 
 const postgresUrl = process.env.AGOR_TEST_POSTGRES_URL;
 const usesPostgresSchema = process.env.AGOR_DB_DIALECT === 'postgresql';

--- a/apps/agor-daemon/src/services/mcp-server-presentation.ts
+++ b/apps/agor-daemon/src/services/mcp-server-presentation.ts
@@ -1,0 +1,24 @@
+import { loadCatalog } from '@agor/core/mcp-catalog';
+import type { MCPServer } from '@agor/core/types';
+import {
+  presentMCPOAuthCompatibilityPolicy,
+  resolveMCPOAuthCompatibilityPolicy,
+} from './mcp-oauth-compatibility.js';
+
+/** Secret-free compatibility projection used by ordinary reads. */
+export async function presentMCPServerOAuthPolicies(
+  servers: readonly MCPServer[]
+): Promise<MCPServer[]> {
+  if (!servers.some((server) => server.auth?.type === 'oauth')) return [...servers];
+  const catalog = await loadCatalog();
+  return Promise.all(
+    servers.map(async (server) => {
+      if (server.auth?.type !== 'oauth') return server;
+      const policy = await resolveMCPOAuthCompatibilityPolicy(server, catalog);
+      return {
+        ...server,
+        oauth_compatibility_policy: presentMCPOAuthCompatibilityPolicy(policy),
+      };
+    })
+  );
+}

--- a/apps/agor-daemon/src/services/mcp-servers.binding.test.ts
+++ b/apps/agor-daemon/src/services/mcp-servers.binding.test.ts
@@ -29,6 +29,19 @@ describe('MCP mutation transaction binding', () => {
     }
   });
 
+  it('preserves Feathers count-only pagination for $limit: 0', async () => {
+    const base = await databaseWithServer('base');
+    databases.push(base.db);
+    const service = createMCPServersService(base.db as TenantScopeAwareDatabase);
+
+    await expect(service.find({ query: { $limit: 0 } } as MCPServerParams)).resolves.toEqual({
+      total: 1,
+      limit: 0,
+      skip: 0,
+      data: [],
+    });
+  });
+
   it('keeps overlapping requests isolated even when they reuse one params object', async () => {
     const base = await databaseWithServer('base');
     const first = await databaseWithServer('first');

--- a/apps/agor-daemon/src/services/mcp-servers.ts
+++ b/apps/agor-daemon/src/services/mcp-servers.ts
@@ -114,31 +114,14 @@ export class MCPServersService extends DrizzleService<
       if (params.query.catalogEntryName) filters.catalogEntryName = params.query.catalogEntryName;
     }
 
-    const servers = await this.mcpServerRepo.findAll(filters);
-
     const sort = params?.query?.$sort as Record<string, 1 | -1> | undefined;
-    if (sort) {
-      servers.sort((a, b) => {
-        for (const [field, direction] of Object.entries(sort)) {
-          const aValue = a[field as keyof MCPServer];
-          const bValue = b[field as keyof MCPServer];
-          const aComparable = aValue instanceof Date ? aValue.getTime() : aValue;
-          const bComparable = bValue instanceof Date ? bValue.getTime() : bValue;
-          if (aComparable === bComparable) continue;
-          if (aComparable === undefined || aComparable === null) return -1 * direction;
-          if (bComparable === undefined || bComparable === null) return 1 * direction;
-          return (aComparable < bComparable ? -1 : 1) * direction;
-        }
-        return 0;
-      });
-    }
-
-    // Apply pagination if requested
     const limit = params?.query?.$limit ?? this.paginate?.default ?? 50;
     const skip = params?.query?.$skip ?? 0;
-
-    const total = servers.length;
-    const data = servers.slice(skip, skip + limit);
+    const pageFilters: MCPServerFilters = { ...filters, limit, offset: skip, sort };
+    const [total, data] = await Promise.all([
+      this.mcpServerRepo.count(filters),
+      this.mcpServerRepo.findAll(pageFilters),
+    ]);
 
     if (this.paginate) {
       return {

--- a/apps/agor-ui/src/components/MCPServerSelect/MCPServerSelect.test.ts
+++ b/apps/agor-ui/src/components/MCPServerSelect/MCPServerSelect.test.ts
@@ -51,9 +51,7 @@ describe('buildMcpServerOptions', () => {
     expect(option?.label).not.toContain('Not signed in');
   });
 
-  it('leaves an OAuth server holding a live token unmarked without the durable set', () => {
-    // The daemon injects the token on every read, so a caller with no store —
-    // the marketplace is one — still gets the right answer.
+  it('does not trust an OAuth token projected onto a generic server read', () => {
     const oauth = server({
       auth: {
         type: 'oauth',
@@ -61,7 +59,7 @@ describe('buildMcpServerOptions', () => {
         oauth_token_expires_at: 4102444800000,
       },
     } as Partial<MCPServer>);
-    expect(buildMcpServerOptions([oauth])[0]?.label).not.toContain('Not signed in');
+    expect(buildMcpServerOptions([oauth])[0]?.label).toContain('Not signed in');
   });
 
   it('leaves a non-OAuth server unmarked', () => {

--- a/apps/agor-ui/src/components/Marketplace/CatalogTab.test.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CatalogTab.test.tsx
@@ -4,6 +4,7 @@ import { sessionPath } from '@agor-live/client';
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { agorStore } from '../../store/agorStore';
 import { consumeMarketplacePromptSuggestion } from '../../utils/marketplaceOAuthPrompt';
 import { getPromptDraft } from '../../utils/promptDrafts';
 import { CatalogTab } from './CatalogTab';
@@ -195,6 +196,7 @@ function chooseSelectOption(inputLabel: string, optionLabel: string): void {
 }
 
 beforeEach(() => {
+  agorStore.getState().reset();
   catalogReads = [];
   catalogRows = [DEEPWIKI, LINEAR];
   catalogFindError = null;
@@ -700,9 +702,14 @@ describe('connect', () => {
   });
 
   it('suggests the starter prompt when a reused install already holds a live token', async () => {
-    // A reused install comes back through `mcp-servers` find, where the daemon
-    // injects the caller's token — redacted to a sentinel, but present, which
-    // is all "is this finished" needs.
+    // The dedicated non-secret status resource, rather than a credential on
+    // the generic server read, is the UI's authentication authority.
+    act(() => {
+      agorStore.getState().applyMaps((prev) => ({
+        ...prev,
+        userAuthenticatedMcpServerIds: new Set(['server-1']),
+      }));
+    });
     await connectAndLand({
       mcp_server_id: 'server-1',
       auth: {

--- a/apps/agor-ui/src/components/SettingsModal/MCPServersTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPServersTable.test.tsx
@@ -2,8 +2,9 @@ import { canConfigureMCPServers } from '@agor/core/mcp/member-policy';
 import type { AgorClient, MCPMemberPolicy, MCPServer, User } from '@agor-live/client';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { App as AntdApp } from 'antd';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ConnectionProvider } from '../../contexts/ConnectionContext';
+import { agorStore } from '../../store/agorStore';
 import { MCPServersTable } from './MCPServersTable';
 
 const ADMIN: User = {
@@ -149,6 +150,10 @@ const POLICY_UNREADABLE_HINT = /MCP policy could not be read/i;
 // form integration suites rather than weakening the workspace-wide timeout.
 const ANT_FORM_INTEGRATION_TIMEOUT = 60_000;
 const AUTHORITY_TRANSITION_TIMEOUT = 120_000;
+
+beforeEach(() => {
+  agorStore.getState().reset();
+});
 
 const policyRadio = (name: RegExp) => screen.getByRole('radio', { name });
 
@@ -879,19 +884,17 @@ describe('MCPServersTable unfinished installs', () => {
     expect(screen.queryByText('Not tested')).not.toBeInTheDocument();
   });
 
-  it('reports health normally once a live token is present', async () => {
+  it('reports health normally once oauth-status confirms authentication', async () => {
+    act(() => {
+      agorStore.getState().applyMaps((prev) => ({
+        ...prev,
+        userAuthenticatedMcpServerIds: new Set(['server-1']),
+      }));
+    });
     renderTable({
       policy: 'allow_crud',
       currentUser: ADMIN,
-      servers: [
-        oauthServer({
-          auth: {
-            type: 'oauth',
-            oauth_access_token: '••••••••',
-            oauth_token_expires_at: 4102444800000,
-          },
-        } as Partial<MCPServer>),
-      ],
+      servers: [oauthServer()],
     });
 
     expect(await screen.findByText('Not tested')).toBeVisible();

--- a/apps/agor-ui/src/hooks/useAgorData.test.tsx
+++ b/apps/agor-ui/src/hooks/useAgorData.test.tsx
@@ -131,8 +131,8 @@ function makeMockClient(seed: Record<string, unknown[]> = {}) {
     },
     // Fire an `io` event (e.g. `connect`) so tests can drive the reconnect
     // refetch path.
-    emitIo: (event: string) => {
-      for (const fn of ioListeners.get(event) ?? []) fn(undefined);
+    emitIo: (event: string, payload?: unknown) => {
+      for (const fn of ioListeners.get(event) ?? []) fn(payload);
     },
     // Register a synchronous side effect that runs every time `service(name)`'s
     // `method` is invoked (receives the 1-based call count). The hook fires

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -36,6 +36,9 @@ import {
   ROLES,
 } from '@agor-live/client';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+
+const MCP_OAUTH_STATUS_POLL_INTERVAL_MS = 60_000;
+
 import {
   bumpFirstPaintMergeRevisions,
   bumpRevision,
@@ -1226,6 +1229,32 @@ export function useAgorData(
   // stops retrying and never applies a snapshot (or schedules another timer)
   // after teardown. Generation bump = cancellation; see `runHydration`.
   useEffect(() => () => cancelAllHydrations(), []);
+
+  // OAuth status is intentionally separate from generic MCP server reads so
+  // listing servers never loads credentials. Poll the non-secret status path
+  // as well as reacting to OAuth events; otherwise a grant that expires while
+  // a tab is idle could remain displayed as authenticated indefinitely.
+  useEffect(() => {
+    if (!client || !enabled || !authorityScopeKey) return;
+    const pollAuthorityScope = authorityScopeKey;
+    const interval = window.setInterval(() => {
+      void client
+        .service('mcp-servers/oauth-status')
+        .find()
+        .then((res) => {
+          if (authorityScopeKeyRef.current !== pollAuthorityScope) return;
+          const ids =
+            (res as { authenticated_server_ids?: string[] })?.authenticated_server_ids ?? [];
+          agorStore
+            .getState()
+            .applyMaps((prev) => ({ ...prev, userAuthenticatedMcpServerIds: new Set(ids) }));
+        })
+        .catch(() => {
+          // Transient disconnects are handled by the next poll/realtime refetch.
+        });
+    }, MCP_OAUTH_STATUS_POLL_INTERVAL_MS);
+    return () => window.clearInterval(interval);
+  }, [authorityScopeKey, client, enabled]);
 
   // If the user navigates to /s/<id>/ after the initial active-session fetch,
   // load that one session by ID as well. This keeps direct links to archived

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -64,7 +64,7 @@ import {
   untombstoneSession,
 } from '../store/realtimeBatch';
 import { createInitialLoadDebugTimer, isInitialLoadDebugEnabled } from '../utils/initialLoadDebug';
-import { refetchMCPOAuthDurableState } from '../utils/mcpOAuthAttempt';
+import { runLatestMCPOAuthStatusRequest } from '../utils/mcpOAuthAttempt';
 import { TOKENS_REFRESHED_EVENT } from '../utils/singleFlightRefresh';
 import {
   resolveBoardFromUrlPure,
@@ -413,6 +413,44 @@ export function useAgorData(
   // physical reconnect or page refresh. We use a ref rather than state since
   // we only consume it in event handlers, never in render.
   const lastSilentFetchFailedRef = useRef(false);
+  const oauthStatusRequestGenerationRef = useRef(0);
+
+  /**
+   * One latest-request-wins coordinator for initial hydration, polling, and
+   * realtime OAuth hints. A later request invalidates every earlier response,
+   * preventing an old poll from overwriting a newer disconnect/re-auth result.
+   */
+  const refetchOAuthDurableState = useCallback(
+    async (requestAuthorityScope: string, mcpServerId?: string): Promise<boolean> => {
+      if (!client) return false;
+      return runLatestMCPOAuthStatusRequest(
+        oauthStatusRequestGenerationRef,
+        async () => {
+          const [status, freshServer] = await Promise.all([
+            client.service('mcp-servers/oauth-status').find(),
+            mcpServerId
+              ? client.service('mcp-servers').get(mcpServerId)
+              : Promise.resolve(undefined),
+          ]);
+          return { status, freshServer };
+        },
+        () => authorityScopeKeyRef.current === requestAuthorityScope,
+        ({ status, freshServer }) => {
+          const ids =
+            (status as { authenticated_server_ids?: string[] })?.authenticated_server_ids ?? [];
+          agorStore.getState().applyMaps((prev) => {
+            if (!freshServer) {
+              return { ...prev, userAuthenticatedMcpServerIds: new Set(ids) };
+            }
+            const mcpServerById = new Map(prev.mcpServerById);
+            mcpServerById.set(freshServer.mcp_server_id, freshServer);
+            return { ...prev, userAuthenticatedMcpServerIds: new Set(ids), mcpServerById };
+          });
+        }
+      );
+    },
+    [client]
+  );
 
   // Fetch all data
   //
@@ -552,18 +590,7 @@ export function useAgorData(
               artifactById: buildById(list, 'artifact_id', prev.artifactById),
             }))
         );
-        void runAuthorityHydration(
-          'oauth-status',
-          ['oauth'],
-          () => client.service('mcp-servers/oauth-status').find(),
-          (res) => {
-            const ids =
-              (res as { authenticated_server_ids?: string[] })?.authenticated_server_ids ?? [];
-            agorStore
-              .getState()
-              .applyMaps((prev) => ({ ...prev, userAuthenticatedMcpServerIds: new Set(ids) }));
-          }
-        );
+        void refetchOAuthDurableState(fetchAuthorityScope);
 
         // ── Essential gated fetches — LIGHT batch ───────────────────────
         // Tiny global collections (boards / users / repos / card-types stay
@@ -1137,6 +1164,7 @@ export function useAgorData(
       client,
       directSessionId,
       enabled,
+      refetchOAuthDurableState,
     ]
   );
 
@@ -1238,23 +1266,12 @@ export function useAgorData(
     if (!client || !enabled || !authorityScopeKey) return;
     const pollAuthorityScope = authorityScopeKey;
     const interval = window.setInterval(() => {
-      void client
-        .service('mcp-servers/oauth-status')
-        .find()
-        .then((res) => {
-          if (authorityScopeKeyRef.current !== pollAuthorityScope) return;
-          const ids =
-            (res as { authenticated_server_ids?: string[] })?.authenticated_server_ids ?? [];
-          agorStore
-            .getState()
-            .applyMaps((prev) => ({ ...prev, userAuthenticatedMcpServerIds: new Set(ids) }));
-        })
-        .catch(() => {
-          // Transient disconnects are handled by the next poll/realtime refetch.
-        });
+      void refetchOAuthDurableState(pollAuthorityScope).catch(() => {
+        // Transient disconnects are handled by the next poll/realtime refetch.
+      });
     }, MCP_OAUTH_STATUS_POLL_INTERVAL_MS);
     return () => window.clearInterval(interval);
-  }, [authorityScopeKey, client, enabled]);
+  }, [authorityScopeKey, client, enabled, refetchOAuthDurableState]);
 
   // If the user navigates to /s/<id>/ after the initial active-session fetch,
   // load that one session by ID as well. This keeps direct links to archived
@@ -1540,11 +1557,8 @@ export function useAgorData(
     }) => {
       if (!event.success || !event.mcp_server_id) return;
       try {
-        await refetchMCPOAuthDurableState(
-          client,
-          event.mcp_server_id,
-          () => authorityScopeKeyRef.current === authorityScopeKey
-        );
+        const applied = await refetchOAuthDurableState(authorityScopeKey, event.mcp_server_id);
+        if (!applied) return;
         if (authorityScopeKeyRef.current !== authorityScopeKey) return;
         bumpRevision('oauth');
         bumpRevision('mcpServers');
@@ -1559,11 +1573,8 @@ export function useAgorData(
     const handleOAuthDisconnected = async (event: { mcp_server_id: string }) => {
       if (!event.mcp_server_id) return;
       try {
-        await refetchMCPOAuthDurableState(
-          client,
-          event.mcp_server_id,
-          () => authorityScopeKeyRef.current === authorityScopeKey
-        );
+        const applied = await refetchOAuthDurableState(authorityScopeKey, event.mcp_server_id);
+        if (!applied) return;
         if (authorityScopeKeyRef.current !== authorityScopeKey) return;
         bumpRevision('oauth');
         bumpRevision('mcpServers');
@@ -1710,6 +1721,7 @@ export function useAgorData(
     enabled,
     fetchData,
     hasInitiallyFetched,
+    refetchOAuthDurableState,
   ]);
 
   // Derived render model for the loading checklist. Memoized so the array

--- a/apps/agor-ui/src/utils/mcpAuth.test.ts
+++ b/apps/agor-ui/src/utils/mcpAuth.test.ts
@@ -49,24 +49,8 @@ describe('mcpServerNeedsAuth', () => {
     expect(mcpServerNeedsAuth(jwt, new Set())).toBe(false);
   });
 
-  it('returns false when token present and no expiry', () => {
+  it('does not trust OAuth credentials projected onto an ordinary server read', () => {
     const server = makeOAuthServer({ oauth_access_token: 'tok-123' });
-    expect(mcpServerNeedsAuth(server, new Set())).toBe(false);
-  });
-
-  it('returns false when token present and expiry is in the future', () => {
-    const server = makeOAuthServer({
-      oauth_access_token: 'tok-123',
-      oauth_token_expires_at: Date.now() + 60_000,
-    });
-    expect(mcpServerNeedsAuth(server, new Set())).toBe(false);
-  });
-
-  it('returns true when token present but expired', () => {
-    const server = makeOAuthServer({
-      oauth_access_token: 'tok-123',
-      oauth_token_expires_at: Date.now() - 1000,
-    });
     expect(mcpServerNeedsAuth(server, new Set())).toBe(true);
   });
 
@@ -79,14 +63,6 @@ describe('mcpServerNeedsAuth', () => {
   it('returns true when no token and server is NOT in Set', () => {
     const server = makeOAuthServer();
     expect(mcpServerNeedsAuth(server, new Set())).toBe(true);
-  });
-
-  it('returns true when no token, server in Set, but expiry is in the past', () => {
-    const server = makeOAuthServer({
-      oauth_token_expires_at: Date.now() - 1000,
-    });
-    const set = new Set(['test-server-id']);
-    expect(mcpServerNeedsAuth(server, set)).toBe(true);
   });
 
   // This is the bug scenario: after disconnect, token was stripped but the

--- a/apps/agor-ui/src/utils/mcpAuth.ts
+++ b/apps/agor-ui/src/utils/mcpAuth.ts
@@ -3,26 +3,12 @@ import type { MCPServer } from '@agor-live/client';
 /**
  * Determine if an MCP server needs authentication from the current user.
  *
- * Two sources of truth, intentionally:
- *   1. `server.auth.oauth_access_token` / `oauth_token_expires_at` — populated
- *      by the daemon's `injectPerUserOAuthTokens` find-hook on every
- *      `mcp-servers` find/get. Authoritative, but only as fresh as the last
- *      fetch. Covers both shared-mode and per-user tokens.
- *   2. `userAuthenticatedMcpServerIds` — a Set populated from the durable
- *      `/mcp-servers/oauth-status` resource. Realtime OAuth events merely
- *      trigger a full status/server refetch; they never mutate this Set
- *      optimistically.
- *
- * Both branches are gated on `!isExpired` so the optimistic Set can never
- * outlive the actual token: stale "authenticated" state degrades back to
- * "needs auth" once expiry passes, even if nothing pruned the Set.
- *
- * The expiry check on the access-token branch matters because the daemon's
- * find-hook reflects the row verbatim: when JIT refresh has failed (no
- * refresh_token, invalid_grant, transient error), the cached row carries a
- * now-past `oauth_token_expires_at`. Without re-checking expiry here, the UI
- * surfaces a "happy" purple chip and suppresses the above-prompt-box auth
- * banner — leaving users to send doomed prompts.
+ * OAuth authentication has one non-secret source of truth:
+ * `userAuthenticatedMcpServerIds`, populated from the dedicated
+ * `/mcp-servers/oauth-status` resource. Generic server reads deliberately do
+ * not load per-user grants. Realtime OAuth events and a periodic status poll
+ * refresh the Set so an expired or invalid grant is removed without exposing
+ * its token or expiry through the ordinary server resource.
  *
  * Bearer/JWT rows can intentionally remain saved after an explicit secret
  * clear. Their redacted sentinel counts as a configured saved value; absence
@@ -43,19 +29,5 @@ export function mcpServerNeedsAuth(
   }
   if (server.auth.type !== 'oauth') return false;
 
-  const expiresAt = server.auth.oauth_token_expires_at;
-  // Use `<=` to match the daemon-side boundary: `oauth-status` treats
-  // `> now` as still-valid (so `<= now` is expired) and the executor's
-  // auth-headers path also flips at `<=`. Without this we'd silently
-  // disagree with the daemon at the exact expiry millisecond.
-  const isExpired = !!(expiresAt && expiresAt <= Date.now());
-
-  // A token only counts as "authenticated" while it's still valid.
-  if (server.auth.oauth_access_token && !isExpired) return false;
-
-  // Durable status refetch fallback. Re-check expiry here too because a
-  // long-lived tab may not have polled again since token expiry.
-  if (userAuthenticatedMcpServerIds.has(server.mcp_server_id) && !isExpired) return false;
-
-  return true;
+  return !userAuthenticatedMcpServerIds.has(server.mcp_server_id);
 }

--- a/apps/agor-ui/src/utils/mcpOAuthAttempt.test.ts
+++ b/apps/agor-ui/src/utils/mcpOAuthAttempt.test.ts
@@ -4,6 +4,7 @@ import {
   oauthAttemptFailureMessage,
   refetchMCPOAuthDurableState,
   refreshAndRefetchMCPOAuthGrant,
+  runLatestMCPOAuthStatusRequest,
   waitForMCPOAuthAttempt,
 } from './mcpOAuthAttempt';
 
@@ -18,6 +19,36 @@ function deferred<T>() {
   });
   return { promise, resolve };
 }
+
+describe('runLatestMCPOAuthStatusRequest', () => {
+  it('discards an older response that completes after a newer request', async () => {
+    const generation = { current: 0 };
+    const older = deferred<string[]>();
+    let applied: string[] = [];
+    const apply = (ids: string[]) => {
+      applied = ids;
+    };
+
+    const olderRequest = runLatestMCPOAuthStatusRequest(
+      generation,
+      () => older.promise,
+      () => true,
+      apply
+    );
+    await expect(
+      runLatestMCPOAuthStatusRequest(
+        generation,
+        async () => [],
+        () => true,
+        apply
+      )
+    ).resolves.toBe(true);
+    older.resolve(['stale-server']);
+
+    await expect(olderRequest).resolves.toBe(false);
+    expect(applied).toEqual([]);
+  });
+});
 
 describe('waitForMCPOAuthAttempt', () => {
   it('uses repeated durable gets rather than a realtime event as completion proof', async () => {

--- a/apps/agor-ui/src/utils/mcpOAuthAttempt.ts
+++ b/apps/agor-ui/src/utils/mcpOAuthAttempt.ts
@@ -9,6 +9,21 @@ import { agorStore } from '@/store/agorStore';
 
 export type { MCPOAuthAttemptResult, MCPOAuthAttemptStatus, MCPOAuthRefreshResult };
 
+/** Run an OAuth-status read with latest-request-wins application semantics. */
+export async function runLatestMCPOAuthStatusRequest<T>(
+  generationRef: { current: number },
+  fetch: () => Promise<T>,
+  shouldApply: () => boolean,
+  apply: (value: T) => void
+): Promise<boolean> {
+  if (!shouldApply()) return false;
+  const generation = ++generationRef.current;
+  const value = await fetch();
+  if (!shouldApply() || generationRef.current !== generation) return false;
+  apply(value);
+  return true;
+}
+
 const sleep = (milliseconds: number, signal?: AbortSignal) =>
   new Promise<void>((resolve, reject) => {
     if (signal?.aborted) {

--- a/packages/core/src/db/repositories/mcp-servers.test.ts
+++ b/packages/core/src/db/repositories/mcp-servers.test.ts
@@ -113,6 +113,29 @@ describe('MCPServerRepository.create', () => {
   });
 });
 
+describe('MCPServerRepository pagination', () => {
+  dbTest(
+    'pushes sorting, limit, and offset into the list query while count ignores paging',
+    async ({ db }) => {
+      const repo = new MCPServerRepository(db);
+      for (const name of ['charlie', 'alpha', 'bravo']) {
+        await repo.create(createMCPServerData({ name, enabled: true }));
+      }
+      await repo.create(createMCPServerData({ name: 'disabled', enabled: false }));
+
+      const page = await repo.findAll({
+        enabled: true,
+        sort: { name: 1 },
+        limit: 1,
+        offset: 1,
+      });
+
+      expect(page.map((server) => server.name)).toEqual(['bravo']);
+      expect(await repo.count({ enabled: true, limit: 1, offset: 1 })).toBe(3);
+    }
+  );
+});
+
 // ============================================================================
 // Read
 // ============================================================================

--- a/packages/core/src/db/repositories/mcp-servers.ts
+++ b/packages/core/src/db/repositories/mcp-servers.ts
@@ -14,7 +14,9 @@ import type {
   UpdateMCPServerInput,
   UserID,
 } from '@agor/core/types';
-import { and, asc, eq, isNull, like, or, sql } from 'drizzle-orm';
+import type { AnyColumn } from 'drizzle-orm';
+import { and, asc, desc, eq, isNull, like, or, sql } from 'drizzle-orm';
+import { PAGINATION } from '../../config/constants';
 import { generateId } from '../../lib/ids';
 import {
   assertValidMCPAuthPatch,
@@ -415,6 +417,7 @@ export class MCPServerRepository
       const fullId = await this.resolveId(id);
       const row = await select(this.db, {
         mcp_server_id: mcpServers.mcp_server_id,
+        server_id: mcpServers.mcp_server_id,
         owner_user_id: mcpServers.owner_user_id,
         transport: mcpServers.transport,
         scope: mcpServers.scope,
@@ -581,11 +584,23 @@ export class MCPServerRepository
         query = query.where(and(...conditions));
       }
 
-      if (filters?.limit !== undefined || filters?.offset !== undefined) {
-        query = query.orderBy(asc(mcpServers.mcp_server_id));
-      }
+      const sortableColumns: Record<string, AnyColumn> = {
+        mcp_server_id: mcpServers.mcp_server_id,
+        name: mcpServers.name,
+        transport: mcpServers.transport,
+        scope: mcpServers.scope,
+        enabled: mcpServers.enabled,
+        source: mcpServers.source,
+        created_at: mcpServers.created_at,
+        updated_at: mcpServers.updated_at,
+      };
+      const order = Object.entries(filters?.sort ?? {}).flatMap(([field, direction]) => {
+        const column = sortableColumns[field];
+        return column ? [direction === -1 ? desc(column) : asc(column)] : [];
+      });
+      query = query.orderBy(...order, asc(mcpServers.mcp_server_id));
       if (filters?.limit !== undefined) {
-        query = query.limit(Math.max(1, Math.min(1000, Math.trunc(filters.limit))));
+        query = query.limit(Math.max(1, Math.min(PAGINATION.MAX_LIMIT, Math.trunc(filters.limit))));
       }
       if (filters?.offset !== undefined) {
         query = query.offset(Math.max(0, Math.trunc(filters.offset)));
@@ -1055,8 +1070,29 @@ export class MCPServerRepository
    */
   async count(filters?: MCPServerFilters): Promise<number> {
     try {
-      const servers = await this.findAll(filters);
-      return servers.length;
+      const conditions = [];
+      if (filters?.scope) conditions.push(eq(mcpServers.scope, filters.scope));
+      if (filters?.scopeId && filters.scope === 'global') {
+        conditions.push(eq(mcpServers.owner_user_id, filters.scopeId));
+      }
+      if (filters?.transport) conditions.push(eq(mcpServers.transport, filters.transport));
+      if (filters?.enabled !== undefined) {
+        conditions.push(eq(mcpServers.enabled, filters.enabled));
+      }
+      if (filters?.source) conditions.push(eq(mcpServers.source, filters.source));
+      if (filters?.catalogEntryName) {
+        conditions.push(eq(mcpServers.catalog_entry_name, filters.catalogEntryName));
+      }
+      if (filters?.usableByUserId) {
+        conditions.push(
+          or(isNull(mcpServers.owner_user_id), eq(mcpServers.owner_user_id, filters.usableByUserId))
+        );
+      }
+      if (filters?.ownerless) conditions.push(isNull(mcpServers.owner_user_id));
+
+      const query = select(this.db, { count: sql<number>`count(*)` }).from(mcpServers);
+      const row = await (conditions.length > 0 ? query.where(and(...conditions)) : query).one();
+      return Number(row?.count ?? 0);
     } catch (error) {
       throw new RepositoryError(
         `Failed to count MCP servers: ${error instanceof Error ? error.message : String(error)}`,

--- a/packages/core/src/db/repositories/mcp-servers.ts
+++ b/packages/core/src/db/repositories/mcp-servers.ts
@@ -11,10 +11,11 @@ import type {
   MCPServer,
   MCPServerFilters,
   MCPServerID,
+  MCPServerSortField,
   UpdateMCPServerInput,
   UserID,
 } from '@agor/core/types';
-import type { AnyColumn } from 'drizzle-orm';
+import type { AnyColumn, SQL } from 'drizzle-orm';
 import { and, asc, desc, eq, isNull, like, or, sql } from 'drizzle-orm';
 import { PAGINATION } from '../../config/constants';
 import { generateId } from '../../lib/ids';
@@ -80,6 +81,40 @@ export class MCPServerConfigConflictError extends Error {
 export interface MCPServerUpdateOptions {
   /** Feathers PUT: omitted mutable configuration is cleared instead of merged. */
   replace?: boolean;
+}
+
+const MCP_SERVER_SORT_COLUMNS: Record<MCPServerSortField, AnyColumn> = {
+  mcp_server_id: mcpServers.mcp_server_id,
+  name: mcpServers.name,
+  transport: mcpServers.transport,
+  scope: mcpServers.scope,
+  enabled: mcpServers.enabled,
+  source: mcpServers.source,
+  created_at: mcpServers.created_at,
+  updated_at: mcpServers.updated_at,
+};
+
+function buildMCPServerConditions(filters?: MCPServerFilters): SQL[] {
+  const conditions: SQL[] = [];
+  if (filters?.scope) conditions.push(eq(mcpServers.scope, filters.scope));
+  if (filters?.scopeId && filters.scope === 'global') {
+    conditions.push(eq(mcpServers.owner_user_id, filters.scopeId));
+  }
+  if (filters?.transport) conditions.push(eq(mcpServers.transport, filters.transport));
+  if (filters?.enabled !== undefined) conditions.push(eq(mcpServers.enabled, filters.enabled));
+  if (filters?.source) conditions.push(eq(mcpServers.source, filters.source));
+  if (filters?.catalogEntryName) {
+    conditions.push(eq(mcpServers.catalog_entry_name, filters.catalogEntryName));
+  }
+  if (filters?.usableByUserId) {
+    const usable = or(
+      isNull(mcpServers.owner_user_id),
+      eq(mcpServers.owner_user_id, filters.usableByUserId)
+    );
+    if (usable) conditions.push(usable);
+  }
+  if (filters?.ownerless) conditions.push(isNull(mcpServers.owner_user_id));
+  return conditions;
 }
 
 function mergeServerConfiguration(
@@ -540,67 +575,19 @@ export class MCPServerRepository
     try {
       let query = select(this.db).from(mcpServers);
 
-      // Apply filters
-      const conditions = [];
-
-      if (filters?.scope) {
-        conditions.push(eq(mcpServers.scope, filters.scope));
-      }
-
-      if (filters?.scopeId) {
-        // Match against the appropriate scope foreign key
-        if (filters.scope === 'global') {
-          conditions.push(eq(mcpServers.owner_user_id, filters.scopeId));
-        }
-        // For session scope: use session_mcp_servers junction table (not handled here)
-      }
-
-      if (filters?.transport) {
-        conditions.push(eq(mcpServers.transport, filters.transport));
-      }
-
-      if (filters?.enabled !== undefined) {
-        conditions.push(eq(mcpServers.enabled, filters.enabled));
-      }
-
-      if (filters?.source) {
-        conditions.push(eq(mcpServers.source, filters.source));
-      }
-      if (filters?.catalogEntryName) {
-        conditions.push(eq(mcpServers.catalog_entry_name, filters.catalogEntryName));
-      }
-
-      if (filters?.usableByUserId) {
-        conditions.push(
-          or(isNull(mcpServers.owner_user_id), eq(mcpServers.owner_user_id, filters.usableByUserId))
-        );
-      }
-
-      if (filters?.ownerless) {
-        conditions.push(isNull(mcpServers.owner_user_id));
-      }
+      const conditions = buildMCPServerConditions(filters);
 
       if (conditions.length > 0) {
         query = query.where(and(...conditions));
       }
 
-      const sortableColumns: Record<string, AnyColumn> = {
-        mcp_server_id: mcpServers.mcp_server_id,
-        name: mcpServers.name,
-        transport: mcpServers.transport,
-        scope: mcpServers.scope,
-        enabled: mcpServers.enabled,
-        source: mcpServers.source,
-        created_at: mcpServers.created_at,
-        updated_at: mcpServers.updated_at,
-      };
       const order = Object.entries(filters?.sort ?? {}).flatMap(([field, direction]) => {
-        const column = sortableColumns[field];
+        const column = MCP_SERVER_SORT_COLUMNS[field as keyof typeof MCP_SERVER_SORT_COLUMNS];
         return column ? [direction === -1 ? desc(column) : asc(column)] : [];
       });
       query = query.orderBy(...order, asc(mcpServers.mcp_server_id));
       if (filters?.limit !== undefined) {
-        query = query.limit(Math.max(1, Math.min(PAGINATION.MAX_LIMIT, Math.trunc(filters.limit))));
+        query = query.limit(Math.max(0, Math.min(PAGINATION.MAX_LIMIT, Math.trunc(filters.limit))));
       }
       if (filters?.offset !== undefined) {
         query = query.offset(Math.max(0, Math.trunc(filters.offset)));
@@ -1070,25 +1057,7 @@ export class MCPServerRepository
    */
   async count(filters?: MCPServerFilters): Promise<number> {
     try {
-      const conditions = [];
-      if (filters?.scope) conditions.push(eq(mcpServers.scope, filters.scope));
-      if (filters?.scopeId && filters.scope === 'global') {
-        conditions.push(eq(mcpServers.owner_user_id, filters.scopeId));
-      }
-      if (filters?.transport) conditions.push(eq(mcpServers.transport, filters.transport));
-      if (filters?.enabled !== undefined) {
-        conditions.push(eq(mcpServers.enabled, filters.enabled));
-      }
-      if (filters?.source) conditions.push(eq(mcpServers.source, filters.source));
-      if (filters?.catalogEntryName) {
-        conditions.push(eq(mcpServers.catalog_entry_name, filters.catalogEntryName));
-      }
-      if (filters?.usableByUserId) {
-        conditions.push(
-          or(isNull(mcpServers.owner_user_id), eq(mcpServers.owner_user_id, filters.usableByUserId))
-        );
-      }
-      if (filters?.ownerless) conditions.push(isNull(mcpServers.owner_user_id));
+      const conditions = buildMCPServerConditions(filters);
 
       const query = select(this.db, { count: sql<number>`count(*)` }).from(mcpServers);
       const row = await (conditions.length > 0 ? query.where(and(...conditions)) : query).one();

--- a/packages/core/src/lib/feathers-validation.test.ts
+++ b/packages/core/src/lib/feathers-validation.test.ts
@@ -189,7 +189,7 @@ describe('taskQueryValidator', () => {
 });
 
 describe('mcpServerQueryValidator', () => {
-  it('preserves forUserId for executor per-user OAuth token injection', async () => {
+  it('strips internal identity hints from public server reads', async () => {
     const context = {
       params: {
         query: {
@@ -206,7 +206,6 @@ describe('mcpServerQueryValidator', () => {
     expect(context.params.query).toEqual({
       scope: 'global',
       enabled: true,
-      forUserId: '019e8e1c',
     });
   });
 });

--- a/packages/core/src/lib/feathers-validation.ts
+++ b/packages/core/src/lib/feathers-validation.ts
@@ -403,7 +403,6 @@ export const mcpServerQuerySchema = createQuerySchema(
     ownerless: Type.Optional(CommonSchemas.boolean),
     // Executor/session-token callers pass this so hooks can inject the
     // task creator's per-user OAuth token instead of the session owner's.
-    forUserId: Type.Optional(CommonSchemas.uuid),
     // Narrows a listing to shared servers plus one user's private ones.
     // Trusted callers set it; on an external member request the service hooks
     // overwrite whatever arrived with the caller's own id.

--- a/packages/core/src/mcp/scoping.test.ts
+++ b/packages/core/src/mcp/scoping.test.ts
@@ -160,10 +160,11 @@ describe('getMcpServersForSession', () => {
       ENFORCING
     );
 
-    expect(findAll).toHaveBeenCalledWith(
-      { scope: 'global', enabled: true, usableByUserId: 'owner-a' },
-      'prompt-user'
-    );
+    expect(findAll).toHaveBeenCalledWith({
+      scope: 'global',
+      enabled: true,
+      usableByUserId: 'owner-a',
+    });
   });
 
   it('resolves an OAuth server whose only template is oauth_client_secret', async () => {

--- a/packages/core/src/mcp/scoping.ts
+++ b/packages/core/src/mcp/scoping.ts
@@ -33,7 +33,7 @@ import {
 } from './tool-permissions';
 
 export interface MCPScopingServerRepository {
-  findAll(filters?: MCPServerFilters, forUserId?: string): Promise<MCPServer[]>;
+  findAll(filters?: MCPServerFilters): Promise<MCPServer[]>;
 }
 
 export interface MCPScopingSessionRepository {
@@ -185,17 +185,13 @@ export async function getMcpServersForSession(
         addServer(server, server.scope === 'global' ? 'global' : 'session-assigned');
       }
     } else {
-      // STEP 1: Get ALL global-scoped MCP servers (available to all sessions)
-      // Pass forUserId for per-user OAuth token injection
-      mcpDebug(`   [MCP Scoping] Calling findAll with forUserId: ${deps.forUserId || 'NOT SET'}`);
-      const globalServers = await deps.mcpServerRepo.findAll(
-        {
-          scope: 'global',
-          enabled: true,
-          ...(deps.sessionOwnerId ? { usableByUserId: deps.sessionOwnerId } : {}),
-        },
-        deps.forUserId
-      );
+      // STEP 1: Get all usable global definitions. OAuth credentials are
+      // hydrated later through the executor-only auth-header capability.
+      const globalServers = await deps.mcpServerRepo.findAll({
+        scope: 'global',
+        enabled: true,
+        ...(deps.sessionOwnerId ? { usableByUserId: deps.sessionOwnerId } : {}),
+      });
 
       mcpDebug(`   📍 Global scope: ${globalServers?.length ?? 0} server(s)`);
 

--- a/packages/core/src/types/mcp.ts
+++ b/packages/core/src/types/mcp.ts
@@ -558,8 +558,19 @@ export interface MCPServerFilters {
   limit?: number;
   offset?: number;
   /** Validated Feathers sort pushed into the repository query. */
-  sort?: Partial<Record<keyof MCPServer, 1 | -1>>;
+  sort?: Partial<Record<MCPServerSortField, 1 | -1>>;
 }
+
+/** Persisted columns that repository-backed MCP server lists can sort by. */
+export type MCPServerSortField =
+  | 'mcp_server_id'
+  | 'name'
+  | 'transport'
+  | 'scope'
+  | 'enabled'
+  | 'source'
+  | 'created_at'
+  | 'updated_at';
 
 /**
  * Create MCP Server input

--- a/packages/core/src/types/mcp.ts
+++ b/packages/core/src/types/mcp.ts
@@ -557,6 +557,8 @@ export interface MCPServerFilters {
   /** Bounded diagnostic/list reads; callers should request one extra row for truncation. */
   limit?: number;
   offset?: number;
+  /** Validated Feathers sort pushed into the repository query. */
+  sort?: Partial<Record<keyof MCPServer, 1 | -1>>;
 }
 
 /**

--- a/packages/executor/src/db/feathers-repositories.test.ts
+++ b/packages/executor/src/db/feathers-repositories.test.ts
@@ -131,16 +131,13 @@ describe('FeathersMCPServersRepository.findAll', () => {
       service: () => ({ find }),
     } as never);
 
-    await repo.findAll(
-      {
-        scope: 'global',
-        enabled: true,
-        source: 'agor',
-        usableByUserId: 'user-a',
-        ownerless: true,
-      },
-      'user-a'
-    );
+    await repo.findAll({
+      scope: 'global',
+      enabled: true,
+      source: 'agor',
+      usableByUserId: 'user-a',
+      ownerless: true,
+    });
 
     expect(find).toHaveBeenCalledWith({
       query: {
@@ -150,7 +147,6 @@ describe('FeathersMCPServersRepository.findAll', () => {
         source: 'agor',
         usableByUserId: 'user-a',
         ownerless: true,
-        forUserId: 'user-a',
       },
     });
   });

--- a/packages/executor/src/db/feathers-repositories.ts
+++ b/packages/executor/src/db/feathers-repositories.ts
@@ -145,7 +145,7 @@ export class FeathersMCPServersRepository {
     }
   }
 
-  async findAll(filters?: MCPServerFilters, forUserId?: string): Promise<MCPServer[]> {
+  async findAll(filters?: MCPServerFilters): Promise<MCPServer[]> {
     const service = this.client.service('mcp-servers');
     const query: Record<string, unknown> = { $limit: 1000 };
 
@@ -172,16 +172,6 @@ export class FeathersMCPServersRepository {
       query.ownerless = filters.ownerless;
     }
 
-    // Pass user ID for per-user OAuth token injection
-    // This allows the daemon to inject per-user tokens even when socket auth isn't available
-    if (forUserId) {
-      query.forUserId = forUserId;
-      console.log(`[MCP Repo] Adding forUserId to query: ${forUserId}`);
-    } else {
-      console.log(`[MCP Repo] No forUserId provided`);
-    }
-
-    console.log(`[MCP Repo] Query to daemon:`, JSON.stringify(query));
     const result = await service.find({ query });
     return Array.isArray(result) ? result : result.data;
   }


### PR DESCRIPTION
## Summary

- keep ordinary `mcp-servers.find/get` reads secret-free and remove per-server OAuth grant enrichment
- preserve the non-secret OAuth compatibility-policy projection for UI callers
- keep executor OAuth hydration on the existing protected `oauth-auth-headers` path
- push MCP server filtering, deterministic sorting, pagination, and counting into SQL
- remove the obsolete public `forUserId` query hint and executor forwarding

## Security and tenancy

- public MCP server reads no longer load or decrypt OAuth grants before redaction
- private-server usability remains constrained by the trusted caller/session owner
- repository queries continue to run through the existing tenant-scoped database/RLS boundary
- no credential-bearing Feathers method was added

## Tests

- `pnpm check`
- `pnpm --filter @agor/core exec vitest run src/db/repositories/mcp-servers.test.ts src/lib/feathers-validation.test.ts`
- `pnpm --filter @agor/daemon exec vitest run src/register-hooks.mcp-headers-redaction.test.ts src/services/mcp-servers.binding.test.ts`
- `pnpm --filter @agor/executor exec vitest run src/db/feathers-repositories.test.ts`
