### PR TITLE
fix(gateway): overlap Shortcut mention polling

### DIFF
--- a/packages/core/src/gateway/connectors/shortcut.test.ts
+++ b/packages/core/src/gateway/connectors/shortcut.test.ts
@@ -241,6 +241,51 @@ describe('polling', () => {
     );
     expect(decodeURIComponent(searchUrl)).not.toContain('comment:agorithm');
   });
+
+  it('processes a mention that appears in search after its timestamp watermark passed', async () => {
+    const delayedCommentTime = new Date(Date.now() - 1_000).toISOString();
+    let searchCalls = 0;
+    const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const value = String(url);
+      if (value.endsWith('/member')) return json({ id: 'agent-1' });
+      if (value.endsWith('/members/agent-1')) {
+        return json({ id: 'agent-1', profile: { mention_name: 'agorithm' } });
+      }
+      if (value.includes('/search/stories')) {
+        searchCalls += 1;
+        return json({ data: searchCalls === 1 ? [] : [{ id: 1 }], next: null });
+      }
+      if (init?.method === 'POST') return json({ id: 900 }, 201);
+      return json({
+        id: 1,
+        comments: [
+          {
+            id: 10,
+            author_id: 'author-1',
+            text: '@agorithm help',
+            member_mention_ids: ['agent-1'],
+            created_at: delayedCommentTime,
+          },
+        ],
+      });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const connector = new ShortcutConnector({ api_token: 'tok' });
+    const callback = vi.fn();
+    try {
+      // Shortcut search is eventually consistent: the first poll misses the
+      // story, then the next poll returns its already-older comment.
+      await connector.startListening(callback);
+      await connector.stopListening();
+      await connector.startListening(callback);
+    } finally {
+      await connector.stopListening();
+    }
+
+    expect(callback).toHaveBeenCalledOnce();
+    expect(callback.mock.calls[0]?.[0].metadata.shortcut_story_id).toBe(1);
+  });
 });
 
 describe('sendMessage', () => {

--- a/packages/core/src/gateway/connectors/shortcut.ts
+++ b/packages/core/src/gateway/connectors/shortcut.ts
@@ -126,6 +126,10 @@ const SHORTCUT_API_BASE = 'https://api.app.shortcut.com/api/v3';
 const DEFAULT_POLL_INTERVAL_MS = 15_000;
 const DEFAULT_SEARCH_PAGE_SIZE = 25;
 const DEFAULT_STARTUP_LOOKBACK_MS = 5 * 60_000;
+// Shortcut story search is eventually consistent. Re-scan a bounded window so
+// a comment that becomes searchable after its own timestamp is still admitted;
+// processed ids and the gateway's durable provider-event claim absorb repeats.
+const DEFAULT_POLL_OVERLAP_MS = 5 * 60_000;
 
 class ShortcutHttpError extends Error {
   constructor(readonly status: number) {
@@ -206,6 +210,11 @@ export function stripAgentMention(
 /** ISO timestamp → `YYYY-MM-DD` for the Shortcut `updated:` range operator. */
 function toSearchDate(iso: string): string {
   return iso.slice(0, 10);
+}
+
+function withLookback(iso: string, lookbackMs: number): string {
+  const timestamp = Date.parse(iso);
+  return Number.isFinite(timestamp) ? new Date(timestamp - lookbackMs).toISOString() : iso;
 }
 
 /**
@@ -474,8 +483,11 @@ export class ShortcutConnector implements GatewayConnector {
 
     const requireMention = this.config.require_mention ?? true;
     const messages: InboundMessage[] = [];
-    // Snapshot the watermark up front so concurrent edits don't move it.
-    const cutoff = this.state.lastPollAt;
+    // Snapshot the watermark up front so concurrent edits don't move it. Scan
+    // with overlap because Shortcut search can index a comment after the poll
+    // that advanced past its created/updated timestamp.
+    const watermark = this.state.lastPollAt;
+    const cutoff = withLookback(watermark, DEFAULT_POLL_OVERLAP_MS);
     const nextWatermark = new Date().toISOString();
 
     // ── Stage 1: discover candidate stories ──────────────────


### PR DESCRIPTION
## Summary

- Re-scan a five-minute overlap behind the saved Shortcut poll watermark.
- Keep the checkpoint monotonic and use the existing processed-comment ring plus durable provider-event claim for deduplication.
- Add a regression for a comment that becomes searchable only after its own timestamp has passed the watermark.

## Why

Shortcut story search is eventually consistent. Previously a poll could advance the timestamp watermark before a new mention appeared in search; later polls found the story but permanently skipped its older comment.

## Test evidence

- Regression test failed before the connector change: expected one callback, observed zero.
- `shortcut.test.ts`: 32/32 passing after the change.