### PR TITLE
fix(ui): sanitize whitespace from pasted secrets across credential inputs

### DIFF
--- a/apps/agor-ui/src/components/ApiKeyFields.tsx
+++ b/apps/agor-ui/src/components/ApiKeyFields.tsx
@@ -8,6 +8,7 @@ import {
 import { Button, Input, Space, Tooltip, Typography, theme } from 'antd';
 import { useLayoutEffect, useState } from 'react';
 import { useAuthorityOperationGuard } from '@/hooks/useAuthorityOperationGuard';
+import { sanitizeSecretValue } from '@/utils/sanitizeSecret';
 import { ClaudeSubscriptionTokenInstructions } from './ClaudeSubscriptionTokenInstructions';
 import { Tag } from './Tag';
 
@@ -203,7 +204,13 @@ export const ApiKeyFields: React.FC<ApiKeyFieldsProps> = ({
 
   const handleSave = async (field: AgenticToolConfigField) => {
     const operation = operationGuard.begin();
-    const value = inputValues[field]?.trim();
+    const raw = inputValues[field];
+    // Non-secret fields (base URLs) only need outer whitespace trimmed.
+    // Secret fields (API keys, OAuth tokens) can pick up an embedded space
+    // or newline when pasted from a terminal that soft-wrapped the value
+    // (e.g. `claude setup-token` output), so strip whitespace everywhere.
+    const config = configs.find((c) => c.field === field);
+    const value = raw ? (config?.type === 'text' ? raw.trim() : sanitizeSecretValue(raw)) : '';
     if (!value || !operation.isCurrent()) return;
 
     await onSave(field, value);

--- a/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.tsx
@@ -22,6 +22,7 @@ import {
 import { useState } from 'react';
 import { useAuthorityOperationGuard } from '@/hooks/useAuthorityOperationGuard';
 import { useThemedMessage } from '@/utils/message';
+import { sanitizeSecretValue } from '@/utils/sanitizeSecret';
 import { MCPOAuthRecoveryAlert } from './MCPOAuthRecoveryAlert';
 import { describeMissingForOAuth, missingMCPFieldLabels } from './mcp-form-requirements';
 import { extractOAuthConfigForTesting, validateHeadersJSON } from './mcp-oauth-utils';
@@ -249,8 +250,14 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
     try {
       if (currentAuthType === 'jwt') {
         const apiUrl = values.jwt_api_url;
-        const apiToken = values.jwt_api_token;
-        const apiSecret = values.jwt_api_secret;
+        const apiToken =
+          typeof values.jwt_api_token === 'string'
+            ? sanitizeSecretValue(values.jwt_api_token)
+            : values.jwt_api_token;
+        const apiSecret =
+          typeof values.jwt_api_secret === 'string'
+            ? sanitizeSecretValue(values.jwt_api_secret)
+            : values.jwt_api_secret;
 
         if (!apiUrl || !apiToken || !apiSecret) {
           showError('Please fill in all JWT authentication fields');

--- a/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.ts
+++ b/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.ts
@@ -4,6 +4,7 @@ import {
   isValidMCPHeaderName,
 } from '@agor/core/tools/mcp/http-headers';
 import type { MCPAuthPatch, MCPOAuthDCRMode } from '@agor-live/client';
+import { sanitizeSecretValue } from '@/utils/sanitizeSecret';
 
 /**
  * OAuth utility functions extracted from MCPServersTable for testability.
@@ -54,9 +55,13 @@ export function extractOAuthConfig(values: Record<string, unknown>): OAuthConfig
     config.oauth_client_id = values.oauth_client_id;
   }
 
-  // Only include client secret if it's provided
+  // Only include client secret if it's provided. Template expressions (e.g.
+  // `{{ user.env.VAR }}`) are left untouched; only a real pasted secret gets
+  // whitespace-sanitized.
   if (values.oauth_client_secret && typeof values.oauth_client_secret === 'string') {
-    config.oauth_client_secret = values.oauth_client_secret;
+    config.oauth_client_secret = isTemplateValue(values.oauth_client_secret)
+      ? values.oauth_client_secret
+      : sanitizeSecretValue(values.oauth_client_secret);
   }
 
   // Only include scope if it's provided
@@ -131,7 +136,7 @@ export function extractOAuthConfigForTesting(values: Record<string, unknown>): T
     typeof values.oauth_client_secret === 'string' &&
     !isTemplateValue(values.oauth_client_secret)
   ) {
-    config.client_secret = values.oauth_client_secret;
+    config.client_secret = sanitizeSecretValue(values.oauth_client_secret);
   }
 
   // Include scope if provided
@@ -219,11 +224,15 @@ export function buildAuthFromValues(
 
   const auth: BuiltAuth = { type: authType };
   if (authType === 'bearer') {
-    if (typeof values.auth_token === 'string') auth.token = values.auth_token;
+    if (typeof values.auth_token === 'string') auth.token = sanitizeSecretValue(values.auth_token);
   } else if (authType === 'jwt') {
     if (typeof values.jwt_api_url === 'string') auth.api_url = values.jwt_api_url;
-    if (typeof values.jwt_api_token === 'string') auth.api_token = values.jwt_api_token;
-    if (typeof values.jwt_api_secret === 'string') auth.api_secret = values.jwt_api_secret;
+    if (typeof values.jwt_api_token === 'string') {
+      auth.api_token = sanitizeSecretValue(values.jwt_api_token);
+    }
+    if (typeof values.jwt_api_secret === 'string') {
+      auth.api_secret = sanitizeSecretValue(values.jwt_api_secret);
+    }
   } else {
     Object.assign(auth, extractOAuthConfig(values));
     if (options.preserveAbsentDcrMode && values.oauth_dcr_mode === 'advertised') {

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.test.tsx
@@ -503,6 +503,32 @@ describe('OnboardingWizard', () => {
     });
   });
 
+  it('strips whitespace picked up from a wrapped terminal paste before saving a subscription token', async () => {
+    // `claude setup-token` prints a long token that a narrow terminal soft-wraps
+    // across lines; copying the wrapped output can carry an embedded newline.
+    const onUpdateUser = vi.fn(async () => undefined);
+    renderWizard({ initialStep: 'llm', onUpdateUser });
+
+    clickButton('Claude');
+    clickButton('Subscription token');
+
+    fireEvent.change(screen.getByLabelText('Claude subscription token'), {
+      target: { value: 'sk-ant-oat01-abc\n123-def456' },
+    });
+    clickButton(/^connect →/i);
+
+    await waitFor(() => {
+      expect(onUpdateUser).toHaveBeenCalledWith(
+        'user-1',
+        expect.objectContaining({
+          agentic_tools: {
+            'claude-code': { CLAUDE_CODE_OAUTH_TOKEN: 'sk-ant-oat01-abc123-def456' },
+          },
+        })
+      );
+    });
+  });
+
   it('shows a previously connected provider as verified and lets the user continue without re-entering a key', async () => {
     const onCheckAuth = vi.fn(async () => ({ authenticated: true }));
     const onUpdateUser = vi.fn(async () => undefined);

--- a/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
+++ b/apps/agor-ui/src/components/OnboardingWizard/OnboardingWizard.tsx
@@ -29,6 +29,7 @@ import {
 import { Alert, Button, Input, Modal, Spin, Tag, Tooltip, Typography, theme } from 'antd';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { VISUALLY_HIDDEN_STYLE } from '@/utils/accessibility';
+import { sanitizeSecretValue } from '@/utils/sanitizeSecret';
 import { useAuthenticatedAuthorityScope } from '../../hooks/useAuthorityOperationGuard';
 import { useAgorStore } from '../../store/agorStore';
 import {
@@ -156,7 +157,7 @@ const LLM_OPTIONS: LlmOption[] = [
 const GOAL_CAP_HINT = 'Deselect one to swap it for this.';
 
 function validateLlmKeyPattern(agent: AgenticToolName, key: string): string | null {
-  const k = key.trim();
+  const k = sanitizeSecretValue(key);
   if (!k) return null;
   switch (agent) {
     case 'claude-code':
@@ -657,11 +658,11 @@ export function OnboardingWizard({
         // Key stored, check still in progress — keep enabled so user isn't stuck
         if (agentHasKey(selectedAgent) && llmAuthVerified[selectedAgent] === undefined) return true;
         // Require a new key with valid format (stored key absent or broken)
-        if (!apiKey.trim()) return false;
+        if (!sanitizeSecretValue(apiKey)) return false;
         // Subscription tokens have no fixed format — any non-empty string is
         // accepted (the daemon validates the token).
         if (authMethod === 'claude-subscription-token') return true;
-        return validateLlmKeyPattern(selectedAgent, apiKey.trim()) === null;
+        return validateLlmKeyPattern(selectedAgent, sanitizeSecretValue(apiKey)) === null;
       }
       case 'workspace':
         // A teammate name is required — it names the new board we always create.
@@ -698,10 +699,10 @@ export function OnboardingWizard({
           return llmAuthVerified.codex === true ? null : 'Import your Codex login to continue';
         }
         if (agentHasKey(selectedAgent) && llmAuthVerified[selectedAgent] === undefined) return null;
-        if (!apiKey.trim()) {
+        if (!sanitizeSecretValue(apiKey)) {
           return 'Enter your API key to continue';
         }
-        const err = validateLlmKeyPattern(selectedAgent, apiKey.trim());
+        const err = validateLlmKeyPattern(selectedAgent, sanitizeSecretValue(apiKey));
         return err ?? null;
       }
       case 'workspace':
@@ -869,11 +870,11 @@ export function OnboardingWizard({
           goToStep('done');
           return;
         }
-        if (!user || !apiKey.trim()) return;
+        if (!user || !sanitizeSecretValue(apiKey)) return;
         // Subscription tokens have no fixed format (see primaryEnabled/disabledReason
         // above, which already treat them as exempt) — only pattern-validate API keys.
         if (authMethod !== 'claude-subscription-token') {
-          const patternErr = validateLlmKeyPattern(selectedAgent, apiKey.trim());
+          const patternErr = validateLlmKeyPattern(selectedAgent, sanitizeSecretValue(apiKey));
           if (patternErr) {
             setLlmError(patternErr);
             return;
@@ -883,7 +884,7 @@ export function OnboardingWizard({
         setLlmError(null);
         if (onCheckAuth) {
           try {
-            const authResult = await onCheckAuth(selectedAgent, apiKey.trim());
+            const authResult = await onCheckAuth(selectedAgent, sanitizeSecretValue(apiKey));
             if (!isCurrent()) return;
             // Only block on a definitive rejection; 'unknown' (transient/transport
             // failure) proceeds to save rather than rejecting a possibly-valid key.
@@ -904,7 +905,7 @@ export function OnboardingWizard({
         try {
           await onUpdateUser(user.user_id, {
             agentic_tools: {
-              [selectedAgent]: { [keyName]: apiKey.trim() },
+              [selectedAgent]: { [keyName]: sanitizeSecretValue(apiKey) },
             } as UpdateUserInput['agentic_tools'],
           });
           if (!isCurrent()) return;

--- a/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/GatewayChannelsTable.tsx
@@ -100,6 +100,7 @@ import {
 } from '@/hooks/useAuthorityOperationGuard';
 import { mapToSortedArray } from '@/utils/mapHelpers';
 import { useThemedMessage } from '@/utils/message';
+import { sanitizeSecretValue } from '@/utils/sanitizeSecret';
 import { filterBySettingsSearch } from '@/utils/settingsSearch';
 import { ACCESS_TOKEN_KEY } from '@/utils/tokenRefresh';
 import { buildModelConfigFromFormValues, getFormValuesFromConfig } from '../AgenticToolConfigForm';
@@ -2003,7 +2004,7 @@ function discordConfigFromFormValues(values: Record<string, unknown>): Record<st
   const botToken = readFormString(values.discord_bot_token);
   return {
     ...artifact.draft.config,
-    ...(botToken ? { bot_token: botToken } : {}),
+    ...(botToken ? { bot_token: sanitizeSecretValue(botToken) } : {}),
   };
 }
 
@@ -3901,8 +3902,8 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
   const handleSlackTest = useCallback(async () => {
     const values = createForm.getFieldsValue(true);
     await runConnectionProbe('slack', {
-      bot_token: values.bot_token,
-      app_token: values.app_token,
+      bot_token: values.bot_token ? sanitizeSecretValue(values.bot_token) : values.bot_token,
+      app_token: values.app_token ? sanitizeSecretValue(values.app_token) : values.app_token,
       enable_channels: values.enable_channels ?? false,
       enable_groups: values.enable_groups ?? false,
       enable_mpim: values.enable_mpim ?? false,
@@ -3928,7 +3929,8 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
     const form = editModalOpen ? editForm : createForm;
     const values = form.getFieldsValue(true);
     const config: Record<string, unknown> = {};
-    if (values.shortcut_api_token) config.api_token = values.shortcut_api_token;
+    if (values.shortcut_api_token)
+      config.api_token = sanitizeSecretValue(values.shortcut_api_token);
     if (values.shortcut_agent_member_id) config.agent_member_id = values.shortcut_agent_member_id;
     if (values.shortcut_mention_name) config.mention_name = values.shortcut_mention_name;
     await runConnectionProbe(
@@ -4023,13 +4025,17 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
       }
     } else if (values.channel_type === 'teams') {
       if (values.teams_app_id) config.app_id = values.teams_app_id;
-      if (values.teams_app_password) config.app_password = values.teams_app_password;
+      if (values.teams_app_password) {
+        config.app_password = sanitizeSecretValue(values.teams_app_password as string);
+      }
       config.tenant_id = values.teams_tenant_id;
       config.webhook_port = (values.teams_webhook_port as number) ?? 3978;
       config.webhook_path = (values.teams_webhook_path as string) || '/api/messages';
       config.require_mention = values.teams_require_mention ?? true;
     } else if (values.channel_type === 'shortcut') {
-      if (values.shortcut_api_token) config.api_token = values.shortcut_api_token;
+      if (values.shortcut_api_token) {
+        config.api_token = sanitizeSecretValue(values.shortcut_api_token as string);
+      }
       if (values.shortcut_agent_member_id) {
         config.agent_member_id = values.shortcut_agent_member_id;
       } else {
@@ -4056,8 +4062,8 @@ export const GatewayChannelsTable: React.FC<GatewayChannelsTableProps> = ({
         }
       }
     } else if (values.channel_type === 'slack') {
-      if (values.bot_token) config.bot_token = values.bot_token;
-      if (values.app_token) config.app_token = values.app_token;
+      if (values.bot_token) config.bot_token = sanitizeSecretValue(values.bot_token as string);
+      if (values.app_token) config.app_token = sanitizeSecretValue(values.app_token as string);
       // The Slack wizard only creates inbound/Socket-Mode channels (bot + app
       // token, Socket Mode required), so record that intent by default. This
       // makes getRequiredSecretFields require app_token for UI-created inbound

--- a/apps/agor-ui/src/components/Widgets/GatewayTokenWidget.tsx
+++ b/apps/agor-ui/src/components/Widgets/GatewayTokenWidget.tsx
@@ -35,6 +35,7 @@ import { useMemo, useRef, useState } from 'react';
 import { useAuth } from '@/hooks';
 import { useAgorStore } from '@/store/agorStore';
 import { useThemedMessage } from '@/utils/message';
+import { sanitizeSecretValue } from '@/utils/sanitizeSecret';
 import { registerWidgetComponent, type WidgetComponentProps } from '../MessageBlock/WidgetBlock';
 
 const { Text } = Typography;
@@ -71,6 +72,17 @@ function presentationFor(channelType: string, field: string): FieldPresentation 
     ...getGatewayCredentialPresentation(channelType as ChannelType, field),
     textarea: field === 'private_key',
   };
+}
+
+/**
+ * Normalize a field's raw input before validating/submitting. Single-line
+ * opaque secrets (bot tokens, app passwords, signing secrets) can pick up
+ * a stray space or newline from a wrapped terminal/clipboard paste, so
+ * strip whitespace everywhere. PEM keys (`textarea: true`) have structurally
+ * meaningful newlines, so those only get outer whitespace trimmed.
+ */
+function normalizeFieldValue(channelType: string, field: string, value: string): string {
+  return presentationFor(channelType, field).textarea ? value.trim() : sanitizeSecretValue(value);
 }
 
 function readParams(widget: WidgetMessageMetadata): GatewayTokenParams {
@@ -259,7 +271,9 @@ const PendingForm: React.FC<PendingFormProps> = ({ widgetId, params, client }) =
   const validate = (): Record<string, string> => {
     const errors: Record<string, string> = {};
     for (const field of fields) {
-      const value = values[field]?.trim() ?? '';
+      const value = values[field]
+        ? normalizeFieldValue(params.channelType, field, values[field])
+        : '';
       if (!value) {
         errors[field] = 'Enter a value.';
         continue;
@@ -292,7 +306,11 @@ const PendingForm: React.FC<PendingFormProps> = ({ widgetId, params, client }) =
     setValidationMessage(null);
     setFieldErrors({});
     const tokens: Record<string, string> = {};
-    for (const field of fields) tokens[field] = values[field]?.trim() ?? '';
+    for (const field of fields) {
+      tokens[field] = values[field]
+        ? normalizeFieldValue(params.channelType, field, values[field])
+        : '';
+    }
     try {
       await post('submit', { tokens });
       setLocalResolution('submitted');

--- a/apps/agor-ui/src/pages/knowledgeSemanticSettings.test.ts
+++ b/apps/agor-ui/src/pages/knowledgeSemanticSettings.test.ts
@@ -55,4 +55,13 @@ describe('Knowledge semantic settings UI helpers', () => {
 
     expect(patch.indexing).toEqual({ paused: true, batch_size: 32 });
   });
+
+  it('strips whitespace embedded mid-key from a wrapped terminal/clipboard paste', () => {
+    const patch = buildKnowledgeSemanticSettingsPatch(
+      DEFAULT_KNOWLEDGE_SEMANTIC_SETTINGS,
+      'sk-proj-abc\n123-def456',
+      false
+    );
+    expect(patch.api_key).toBe('sk-proj-abc123-def456');
+  });
 });

--- a/apps/agor-ui/src/pages/knowledgeSemanticSettings.ts
+++ b/apps/agor-ui/src/pages/knowledgeSemanticSettings.ts
@@ -3,6 +3,7 @@ import type {
   KnowledgeSemanticSettingsPublic,
 } from '@agor/core/types';
 import { DEFAULT_KNOWLEDGE_SEMANTIC_POLICY } from '@agor/core/types';
+import { sanitizeSecretValue } from '@/utils/sanitizeSecret';
 
 export const DEFAULT_KNOWLEDGE_SEMANTIC_SETTINGS: KnowledgeSemanticSettingsPublic = {
   ...DEFAULT_KNOWLEDGE_SEMANTIC_POLICY,
@@ -34,7 +35,7 @@ export function buildKnowledgeSemanticSettingsPatch(
   clearApiKey: boolean
 ): KnowledgeSemanticSettingsPatch {
   const settings = normalizeKnowledgeSemanticSettings(values);
-  const trimmedApiKey = apiKeyDraft.trim();
+  const sanitizedApiKey = sanitizeSecretValue(apiKeyDraft);
   return {
     enabled: settings.enabled,
     provider: settings.provider,
@@ -42,6 +43,6 @@ export function buildKnowledgeSemanticSettingsPatch(
     dimensions: settings.dimensions,
     chunking: { ...settings.chunking },
     indexing: { ...settings.indexing },
-    ...(clearApiKey ? { api_key: null } : trimmedApiKey ? { api_key: trimmedApiKey } : {}),
+    ...(clearApiKey ? { api_key: null } : sanitizedApiKey ? { api_key: sanitizedApiKey } : {}),
   };
 }

--- a/apps/agor-ui/src/utils/sanitizeSecret.test.ts
+++ b/apps/agor-ui/src/utils/sanitizeSecret.test.ts
@@ -25,4 +25,26 @@ describe('sanitizeSecretValue', () => {
   it('reduces a whitespace-only string to empty', () => {
     expect(sanitizeSecretValue('   \n\t  ')).toBe('');
   });
+
+  it('strips zero-width and invisible characters a rich-text paste can leave behind', () => {
+    const zeroWidthSpace = String.fromCodePoint(0x200b);
+    const zwnj = String.fromCodePoint(0x200c);
+    const zwj = String.fromCodePoint(0x200d);
+    const wordJoiner = String.fromCodePoint(0x2060);
+    const bom = String.fromCodePoint(0xfeff);
+
+    expect(sanitizeSecretValue(`sk-ant-oat01-abc${zeroWidthSpace}123-def456`)).toBe(
+      'sk-ant-oat01-abc123-def456'
+    );
+    expect(sanitizeSecretValue(`sk-ant-oat01-abc${zwnj}123-def456`)).toBe(
+      'sk-ant-oat01-abc123-def456'
+    );
+    expect(sanitizeSecretValue(`sk-ant-oat01-abc${zwj}123-def456`)).toBe(
+      'sk-ant-oat01-abc123-def456'
+    );
+    expect(sanitizeSecretValue(`sk-ant-oat01-abc${wordJoiner}123-def456`)).toBe(
+      'sk-ant-oat01-abc123-def456'
+    );
+    expect(sanitizeSecretValue(`${bom}sk-ant-api03-clean`)).toBe('sk-ant-api03-clean');
+  });
 });

--- a/apps/agor-ui/src/utils/sanitizeSecret.test.ts
+++ b/apps/agor-ui/src/utils/sanitizeSecret.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeSecretValue } from './sanitizeSecret';
+
+describe('sanitizeSecretValue', () => {
+  it('strips leading and trailing whitespace', () => {
+    expect(sanitizeSecretValue('  sk-ant-oat01-abc123  ')).toBe('sk-ant-oat01-abc123');
+  });
+
+  it('strips whitespace embedded mid-string, e.g. from a wrapped terminal paste', () => {
+    expect(sanitizeSecretValue('sk-ant-oat01-abc\n123-def456')).toBe('sk-ant-oat01-abc123-def456');
+  });
+
+  it('strips tabs and runs of consecutive whitespace characters', () => {
+    expect(sanitizeSecretValue('sk-ant\t\t-oat01   -abc123')).toBe('sk-ant-oat01-abc123');
+  });
+
+  it('leaves an already-clean token unchanged', () => {
+    expect(sanitizeSecretValue('sk-ant-oat01-abc123')).toBe('sk-ant-oat01-abc123');
+  });
+
+  it('returns an empty string unchanged', () => {
+    expect(sanitizeSecretValue('')).toBe('');
+  });
+
+  it('reduces a whitespace-only string to empty', () => {
+    expect(sanitizeSecretValue('   \n\t  ')).toBe('');
+  });
+});

--- a/apps/agor-ui/src/utils/sanitizeSecret.ts
+++ b/apps/agor-ui/src/utils/sanitizeSecret.ts
@@ -1,13 +1,24 @@
+// Invisible/zero-width characters a paste can carry without anything showing
+// up in the input: zero-width space (U+200B), ZWNJ (U+200C), ZWJ (U+200D),
+// word joiner (U+2060), BOM (U+FEFF). Written as \u-escapes (never a literal
+// invisible byte in source, which would be unreviewable) and as an
+// alternation rather than a character class — a ZWJ in a char class trips
+// biome's noMisleadingCharacterClass even when it's an escape, not a literal.
+const ZERO_WIDTH_CHARS = /\u200b|\u200c|\u200d|\u2060|\ufeff/g;
+
 /**
  * Sanitize a pasted secret (API key, OAuth/subscription token, bot token,
- * JWT secret, etc.) by stripping every whitespace character, not just
- * leading/trailing.
+ * JWT secret, etc.) by stripping every whitespace character (not just
+ * leading/trailing) and invisible/zero-width characters.
  *
  * Terminals soft-wrap long tokens (e.g. `claude setup-token` output) across
  * display lines. A copy-paste of the wrapped output can carry an embedded
  * newline or space at the wrap point that a plain `.trim()` won't catch,
- * silently corrupting the token. These values never legitimately contain
- * whitespace, so stripping it entirely — anywhere in the string — is safe.
+ * silently corrupting the token. Rich-text sources (docs, chat apps, some
+ * browsers) can likewise leave a zero-width character or a BOM in a paste
+ * with nothing visibly different about it. These values never legitimately
+ * contain whitespace or zero-width characters, so stripping both — anywhere
+ * in the string — is safe.
  *
  * Do NOT use this for values where internal whitespace can be meaningful:
  * human account passwords, PEM-formatted keys (newlines are structural),
@@ -15,5 +26,5 @@
  * values that aren't known to be opaque tokens.
  */
 export function sanitizeSecretValue(value: string): string {
-  return value.replace(/\s+/g, '');
+  return value.replace(ZERO_WIDTH_CHARS, '').replace(/\s+/g, '');
 }

--- a/apps/agor-ui/src/utils/sanitizeSecret.ts
+++ b/apps/agor-ui/src/utils/sanitizeSecret.ts
@@ -1,0 +1,19 @@
+/**
+ * Sanitize a pasted secret (API key, OAuth/subscription token, bot token,
+ * JWT secret, etc.) by stripping every whitespace character, not just
+ * leading/trailing.
+ *
+ * Terminals soft-wrap long tokens (e.g. `claude setup-token` output) across
+ * display lines. A copy-paste of the wrapped output can carry an embedded
+ * newline or space at the wrap point that a plain `.trim()` won't catch,
+ * silently corrupting the token. These values never legitimately contain
+ * whitespace, so stripping it entirely — anywhere in the string — is safe.
+ *
+ * Do NOT use this for values where internal whitespace can be meaningful:
+ * human account passwords, PEM-formatted keys (newlines are structural),
+ * template expressions (e.g. `{{ user.env.VAR }}`), or generic env-var
+ * values that aren't known to be opaque tokens.
+ */
+export function sanitizeSecretValue(value: string): string {
+  return value.replace(/\s+/g, '');
+}


### PR DESCRIPTION
## Summary

- Terminals soft-wrap long tokens (e.g. `claude setup-token` output), so a copy-paste of one can pick up an embedded newline/space at the wrap point. A plain `.trim()` only catches leading/trailing whitespace and misses this — reported bug: pasting a Claude Code subscription token this way broke the saved credential.
- Adds a shared `sanitizeSecretValue()` (`apps/agor-ui/src/utils/sanitizeSecret.ts`) that strips whitespace everywhere in the value, and wires it into every opaque credential input across the UI:
  - Agentic tool settings (`ApiKeyFields.tsx`): Anthropic API key, Claude subscription (OAuth) token, Anthropic auth token, OpenAI/Gemini/Cursor API keys, Copilot GitHub token.
  - MCP server auth (`mcp-oauth-utils.ts`, `MCPServerFormFields.tsx`): bearer token, JWT api token/secret, OAuth client secret (both the save path and the "Test connection" probe path).
  - Gateway channels (`GatewayChannelsTable.tsx`): Slack bot/app tokens, Teams app password, Shortcut API token, Discord bot token — both the create/edit save path and the connection-test probes.
  - The in-conversation `GatewayTokenWidget` (agent-requested token capture) — same field set as above, reached via a different UI surface.
  - Knowledge semantic search embedding provider API key (`knowledgeSemanticSettings.ts`).

## Deliberately excluded (audited, not overlooked)

- **PEM-formatted private keys** (GitHub App `private_key`) — internal newlines are structurally meaningful; only outer whitespace is trimmed.
- **Template expressions** (e.g. `{{ user.env.VAR }}` for MCP OAuth client secret) — left untouched via the existing `isTemplateValue` check; only a real pasted secret gets sanitized.
- **Human account passwords** (login, force-password-change, admin reset) — internal whitespace can be meaningful/intentional; not touched.
- **Generic env-var editors** (`EnvVarEditor`, `EnvVarRequestWidget`) — these hold arbitrary agent-requested values, not known to always be opaque tokens, so they keep their existing leading/trailing-only `.trim()` rather than risk corrupting a legitimate multi-word value.

## Test plan

- [x] New unit tests for `sanitizeSecretValue` (leading/trailing, mid-string, tabs/runs, empty, whitespace-only).
- [x] New regression test in `knowledgeSemanticSettings.test.ts` for a mid-string-whitespace API key.
- [x] `pnpm typecheck` — clean.
- [x] `pnpm biome check` — clean (pre-commit hook also passed).
- [x] Full affected test suites (sanitizeSecret, knowledgeSemanticSettings, GatewayChannelsTable, MCPServer, GatewayTokenWidget) — 160/160 passing.
- [x] Full `agor-ui` suite run for regressions — the only failures are in `CapabilityPolicyEditor` (unrelated RBAC remodel, #2555), confirmed pre-existing/flaky by passing cleanly in isolation (21/21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)