### PR TITLE
feat(ui): disable board-edit fields the caller can't save

### DIFF
--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -23,6 +23,7 @@ import {
 import {
   AmbiguousIdError,
   and,
+  BoardRepository,
   BranchRepository,
   DiscordMessageDeliveryRepository,
   EntityNotFoundError,
@@ -175,6 +176,7 @@ import {
   GROUP_MEMBERSHIPS_SERVICE_TRANSPORT_METHODS,
   GROUPS_SERVICE_TRANSPORT_METHODS,
   setupBoardAlignedBranchesService,
+  setupBoardEffectiveAccessService,
   setupBranchEffectiveAccessService,
   setupBranchFsAccessUsersService,
 } from './services/groups.js';
@@ -583,6 +585,7 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
     methods: [...GROUP_MEMBERSHIPS_SERVICE_TRANSPORT_METHODS],
   });
   setupBranchEffectiveAccessService(app, new BranchRepository(db), { allowSuperadmin });
+  setupBoardEffectiveAccessService(app, new BoardRepository(db), { allowSuperadmin });
   setupBoardAlignedBranchesService(app, new BranchRepository(db));
   setupBranchFsAccessUsersService(app, new BranchRepository(db));
   setupCapabilityPolicyServices(app, db, { allowSuperadmin });

--- a/apps/agor-daemon/src/services/groups.test.ts
+++ b/apps/agor-daemon/src/services/groups.test.ts
@@ -1,9 +1,15 @@
 import {
+  type BoardRepository,
   type BranchRepository,
   GroupRepository,
   getCurrentTenantDatabaseScope,
 } from '@agor/core/db';
-import type { AuthenticatedParams, HookContext, User } from '@agor/core/types';
+import type {
+  AuthenticatedParams,
+  EffectiveCapabilityPolicyAccess,
+  HookContext,
+  User,
+} from '@agor/core/types';
 import { ROLES } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
 import { dbTest } from '../../../../packages/core/src/db/test-helpers';
@@ -12,6 +18,7 @@ import {
   createGroupsService,
   groupMembershipsHooks,
   groupsHooks,
+  setupBoardEffectiveAccessService,
   setupBranchEffectiveAccessService,
 } from './groups';
 import { UsersService } from './users';
@@ -278,6 +285,101 @@ describe('normalized branch effective-access service', () => {
       service.find({
         provider: 'rest',
         route: { id: branchId },
+        user: undefined as never,
+      })
+    ).rejects.toThrow(/authentication required/i);
+  });
+});
+
+describe('normalized board effective-access service', () => {
+  const boardId = '019f0000-0000-7000-8000-00000000c0de';
+  const userId = '019f0000-0000-7000-8000-00000000abcd';
+
+  function install(access: EffectiveCapabilityPolicyAccess) {
+    let service:
+      | {
+          find(params: {
+            route: { id: string };
+            user: { user_id: string; role: string };
+          }): Promise<unknown>;
+        }
+      | undefined;
+    const app = {
+      use: vi.fn((_path: string, value: typeof service) => {
+        service = value;
+      }),
+    };
+    const repo = {
+      findById: vi.fn(async () => ({ board_id: boardId })),
+      resolveUserAccess: vi.fn(async () => access),
+    } as unknown as BoardRepository;
+    setupBoardEffectiveAccessService(app as never, repo);
+    if (!service) throw new Error('effective-access service was not registered');
+    return { service, repo };
+  }
+
+  function params(role: string) {
+    return {
+      route: { id: boardId },
+      user: {
+        user_id: userId,
+        role,
+      },
+    };
+  }
+
+  it('returns the normalized resolver result, including group and filesystem access', async () => {
+    const effective: EffectiveCapabilityPolicyAccess = {
+      capabilities: ['board.view', 'board.edit'],
+      fs_access: 'none',
+      source: 'group',
+      group_ids: ['019f0000-0000-7000-8000-00000000f00d' as never],
+      is_primary_owner: false,
+    };
+    const { service, repo } = install(effective);
+
+    await expect(service.find(params(ROLES.MEMBER))).resolves.toEqual(effective);
+    expect(repo.resolveUserAccess).toHaveBeenCalledOnce();
+  });
+
+  it('fails closed when the normalized policy grants no view capability', async () => {
+    const { service } = install({
+      capabilities: [],
+      fs_access: 'none',
+      source: 'others',
+      group_ids: [],
+      is_primary_owner: false,
+    });
+    await expect(service.find(params(ROLES.MEMBER))).rejects.toThrow(/view permission/i);
+  });
+
+  it('retains the configured superadmin bypass without consulting policy rows', async () => {
+    const { service, repo } = install({
+      capabilities: [],
+      fs_access: 'none',
+      source: 'others',
+      group_ids: [],
+      is_primary_owner: false,
+    });
+    await expect(service.find(params(ROLES.SUPERADMIN))).resolves.toMatchObject({
+      capabilities: expect.arrayContaining(['board.view', 'board.edit']),
+      source: 'primary_owner',
+    });
+    expect(repo.resolveUserAccess).not.toHaveBeenCalled();
+  });
+
+  it('requires an authenticated principal', async () => {
+    const { service } = install({
+      capabilities: ['board.view'],
+      fs_access: 'none',
+      source: 'others',
+      group_ids: [],
+      is_primary_owner: false,
+    });
+    await expect(
+      service.find({
+        provider: 'rest',
+        route: { id: boardId },
         user: undefined as never,
       })
     ).rejects.toThrow(/authentication required/i);

--- a/apps/agor-daemon/src/services/groups.ts
+++ b/apps/agor-daemon/src/services/groups.ts
@@ -4,7 +4,7 @@
  * Admin-managed groups and memberships used by group-aware Branch RBAC.
  */
 
-import type { BranchRepository } from '@agor/core/db';
+import type { BoardRepository, BranchRepository } from '@agor/core/db';
 import {
   eq,
   GroupRepository,
@@ -21,6 +21,7 @@ import type {
   Branch,
   BranchID,
   EffectiveBranchAccess,
+  EffectiveCapabilityPolicyAccess,
   Group,
   GroupMembership,
   HookContext,
@@ -28,7 +29,12 @@ import type {
   User,
   UserID,
 } from '@agor/core/types';
-import { hasMinimumRole, hasRoleAuthorityOver, ROLES } from '@agor/core/types';
+import {
+  BOARD_POLICY_CAPABILITIES,
+  hasMinimumRole,
+  hasRoleAuthorityOver,
+  ROLES,
+} from '@agor/core/types';
 import { isSuperAdmin, PERMISSION_RANK } from '../utils/branch-authorization.js';
 import {
   lockTenantAuthorizationFence,
@@ -262,6 +268,63 @@ export function setupBranchEffectiveAccessService(
 
         if (PERMISSION_RANK[can] < PERMISSION_RANK.view) {
           throw new Forbidden('You need view permission to see branch access');
+        }
+
+        return effective;
+      },
+    },
+    { methods: ['find'] }
+  );
+}
+
+const SUPERADMIN_BOARD_ACCESS: EffectiveCapabilityPolicyAccess = {
+  capabilities: [...BOARD_POLICY_CAPABILITIES],
+  fs_access: 'none',
+  source: 'primary_owner',
+  group_ids: [],
+  is_primary_owner: false,
+};
+
+/**
+ * Board analog of `setupBranchEffectiveAccessService`. Boards were the
+ * newer resource in the capability-policy remodel, so their effective
+ * access is already the normalized `EffectiveCapabilityPolicyAccess` shape
+ * (no legacy `others_can`-tier translation needed).
+ */
+export function setupBoardEffectiveAccessService(
+  app: import('@agor/core/feathers').Application,
+  boardRepo: BoardRepository,
+  options: { allowSuperadmin?: boolean } = {}
+) {
+  app.use(
+    'boards/:id/effective-access',
+    {
+      async find(params?: Params): Promise<EffectiveCapabilityPolicyAccess> {
+        const authParams = params as
+          | (Params & { user?: { user_id: string; role: string; _isServiceAccount?: boolean } })
+          | undefined;
+        if (authParams?.provider && authParams.user?._isServiceAccount) {
+          return SUPERADMIN_BOARD_ACCESS;
+        }
+
+        const user = authParams?.user;
+        if (!user) throw new NotAuthenticated('Authentication required');
+
+        const boardId = paramsRoute(params)?.id;
+        if (!boardId) throw new BadRequest('Board ID is required');
+
+        const board = await boardRepo.findById(boardId);
+        if (!board) throw new BadRequest(`Board not found: ${boardId}`);
+
+        if (isSuperAdmin(user.role, options.allowSuperadmin ?? true)) {
+          return SUPERADMIN_BOARD_ACCESS;
+        }
+
+        const userId = user.user_id as UserID;
+        const effective = await boardRepo.resolveUserAccess(board, userId);
+
+        if (!effective.capabilities.includes('board.view')) {
+          throw new Forbidden('You need view permission to see board access');
         }
 
         return effective;

--- a/apps/agor-daemon/src/utils/realtime-publish-policy.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish-policy.ts
@@ -329,6 +329,7 @@ export const REALTIME_PUBLISH_POLICY = {
   'cursor-models': { audience: 'none', why: 'Per-caller model list.' },
   health: { audience: 'none', why: 'Liveness probe.' },
   'boards/:id/aligned-branches': { audience: 'none', why: 'Query route.' },
+  'boards/:id/effective-access': { audience: 'none', why: 'Query route.' },
   'branches/:id/effective-access': { audience: 'none', why: 'Query route.' },
   'branches/:id/fs-access-users': { audience: 'none', why: 'Query route.' },
   'me/artifact-trust-grants': { audience: 'none', why: 'Trust grants belonging to the caller.' },

--- a/apps/agor-ui/src/components/BoardEditModal/BoardEditModal.test.tsx
+++ b/apps/agor-ui/src/components/BoardEditModal/BoardEditModal.test.tsx
@@ -18,15 +18,18 @@ vi.mock('../forms/BoardFormFields', () => ({
     capabilityPolicyEditor,
     allGroups,
     rbacEnabled,
+    canEditGeneral,
   }: {
     capabilityPolicyEditor?: React.ReactNode;
     allGroups?: Array<{ name: string }>;
     rbacEnabled?: boolean;
+    canEditGeneral?: boolean;
   }) => (
     <>
       <Form.Item name="name" label="Name" rules={[{ required: true }]}>
         <Input />
       </Form.Item>
+      <div data-testid="board-modal-can-edit-general" data-value={String(canEditGeneral)} />
       {capabilityPolicyEditor && (
         <div
           data-testid="board-modal-policy-editor"
@@ -97,6 +100,17 @@ function makeClient(metadataError: { code?: number; message?: string } = { code:
         if (name === 'workspace-preferences') {
           return { find: vi.fn().mockResolvedValue({ personal_session_sharing_enabled: false }) };
         }
+        if (name === 'boards/:id/effective-access') {
+          return {
+            find: vi.fn().mockResolvedValue({
+              capabilities: ['board.view', 'board.edit', 'board.attach_branch'],
+              fs_access: 'none',
+              source: 'primary_owner',
+              group_ids: [],
+              is_primary_owner: true,
+            }),
+          };
+        }
         return { findAll: vi.fn().mockResolvedValue([]) };
       },
     } as unknown as AgorClient,
@@ -126,6 +140,73 @@ describe('BoardEditModal', () => {
     expect(await screen.findByDisplayValue('Fresh name')).toBeInTheDocument();
     expect(screen.queryByTestId('board-modal-policy-editor')).not.toBeInTheDocument();
     expect(permissionsFind).not.toHaveBeenCalled();
+  });
+
+  it('defaults canEditGeneral to true when RBAC is disabled, without fetching effective-access', async () => {
+    __setAuthConfigForTests({ requireAuth: true }, { branchRbac: false });
+    const { client } = makeClient();
+
+    render(
+      <BoardEditModal
+        board={listedBoard}
+        client={client}
+        open
+        onClose={vi.fn()}
+        onUpdate={vi.fn()}
+      />
+    );
+
+    await screen.findByDisplayValue('Fresh name');
+    expect(screen.getByTestId('board-modal-can-edit-general')).toHaveAttribute(
+      'data-value',
+      'true'
+    );
+  });
+
+  it('passes canEditGeneral=false through to BoardFormFields when the caller lacks board.edit', async () => {
+    const get = vi.fn().mockResolvedValue(freshBoard);
+    const client = {
+      service: (name: string) => {
+        if (name === 'boards') return { get };
+        if (name === 'boards/:id/permissions') {
+          return {
+            find: vi.fn().mockResolvedValue(policy),
+            patch: vi.fn().mockImplementation(async (_id: unknown, value: unknown) => value),
+          };
+        }
+        if (name === 'workspace-preferences') {
+          return { find: vi.fn().mockResolvedValue({ personal_session_sharing_enabled: false }) };
+        }
+        if (name === 'boards/:id/effective-access') {
+          return {
+            find: vi.fn().mockResolvedValue({
+              capabilities: ['board.view'],
+              fs_access: 'none',
+              source: 'others',
+              group_ids: [],
+              is_primary_owner: false,
+            }),
+          };
+        }
+        return { findAll: vi.fn().mockResolvedValue([]) };
+      },
+    } as unknown as AgorClient;
+
+    render(
+      <BoardEditModal
+        board={listedBoard}
+        client={client}
+        open
+        onClose={vi.fn()}
+        onUpdate={vi.fn()}
+      />
+    );
+
+    await screen.findByDisplayValue('Fresh name');
+    expect(screen.getByTestId('board-modal-can-edit-general')).toHaveAttribute(
+      'data-value',
+      'false'
+    );
   });
 
   it('loads the latest board and normalized permission package before saving', async () => {
@@ -175,6 +256,17 @@ describe('BoardEditModal', () => {
         }
         if (name === 'workspace-preferences') {
           return { find: vi.fn().mockResolvedValue({ personal_session_sharing_enabled: false }) };
+        }
+        if (name === 'boards/:id/effective-access') {
+          return {
+            find: vi.fn().mockResolvedValue({
+              capabilities: ['board.view', 'board.edit', 'board.attach_branch'],
+              fs_access: 'none',
+              source: 'primary_owner',
+              group_ids: [],
+              is_primary_owner: true,
+            }),
+          };
         }
         throw new Error(`Unexpected service: ${name}`);
       },

--- a/apps/agor-ui/src/components/BoardEditModal/BoardEditModal.tsx
+++ b/apps/agor-ui/src/components/BoardEditModal/BoardEditModal.tsx
@@ -3,6 +3,7 @@ import type {
   Board,
   BoardCapabilityPolicies,
   CapabilityPolicyWorkspacePreferences,
+  EffectiveCapabilityPolicyAccess,
   Group,
   User,
 } from '@agor-live/client';
@@ -48,6 +49,9 @@ export function BoardEditModal({
   const [policy, setPolicy] = useState<BoardCapabilityPolicies | null>(null);
   const [workspacePreferences, setWorkspacePreferences] =
     useState<CapabilityPolicyWorkspacePreferences>({ personal_session_sharing_enabled: false });
+  const [effectiveAccess, setEffectiveAccess] = useState<EffectiveCapabilityPolicyAccess | null>(
+    null
+  );
   const [loadedBoard, setLoadedBoard] = useState<Board | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
@@ -64,6 +68,7 @@ export function BoardEditModal({
     setLoadError(null);
     setLoadedBoard(null);
     setPolicy(null);
+    setEffectiveAccess(null);
 
     // Re-read the board as the modal opens. The selector uses a lean board list,
     // while this form must always start from the full, latest representation.
@@ -94,9 +99,10 @@ export function BoardEditModal({
         }
 
         if (branchRbacEnabled) {
-          const [policyResult, preferencesResult] = await Promise.allSettled([
+          const [policyResult, preferencesResult, accessResult] = await Promise.allSettled([
             client.service('boards/:id/permissions').find({ route: { id: board.board_id } }),
             client.service('workspace-preferences').find(),
+            client.service('boards/:id/effective-access').find({ route: { id: board.board_id } }),
           ]);
           if (cancelled) return;
           if (policyResult.status === 'fulfilled') {
@@ -107,9 +113,18 @@ export function BoardEditModal({
           if (preferencesResult.status === 'fulfilled') {
             setWorkspacePreferences(preferencesResult.value);
           }
+          // A failed fetch here fails closed: canEditGeneral (below) treats a
+          // null effectiveAccess as "no board.edit capability", same as an
+          // explicit denial.
+          setEffectiveAccess(
+            accessResult.status === 'fulfilled'
+              ? (accessResult.value as unknown as EffectiveCapabilityPolicyAccess)
+              : null
+          );
         } else {
           setPolicy(null);
           setWorkspacePreferences({ personal_session_sharing_enabled: false });
+          setEffectiveAccess(null);
         }
         if (cancelled) return;
         // Populate the form BEFORE exposing loadedBoard so the background
@@ -148,6 +163,16 @@ export function BoardEditModal({
       cancelled = true;
     };
   }, [board, branchRbacEnabled, client, form, open]);
+
+  // Preserve the legacy open-RBAC behavior while the normalized policy
+  // feature is disabled: every board mutator has always been allowed to
+  // save general settings there, and the daemon-side authorization hook
+  // is a no-op in that mode too. The server remains authoritative for
+  // every write either way — this only prevents typing into fields that
+  // are certain to 403.
+  const canEditGeneral = branchRbacEnabled
+    ? Boolean(effectiveAccess?.capabilities.includes('board.edit'))
+    : true;
 
   const syncPermissions = async () => {
     if (!branchRbacEnabled || !client || !board || !policy) return;
@@ -210,6 +235,7 @@ export function BoardEditModal({
             rbacEnabled={branchRbacEnabled}
             allUsers={allUsers}
             allGroups={allGroups}
+            canEditGeneral={canEditGeneral}
             capabilityPolicyEditor={
               branchRbacEnabled ? (
                 policy ? (
@@ -234,7 +260,11 @@ export function BoardEditModal({
                 help="Add custom fields for use in zone trigger templates (e.g., {{ board.context.yourField }})"
                 rules={[{ validator: validateJSON }]}
               >
-                <JSONEditor placeholder='{"team": "Backend", "sprint": 42}' rows={4} />
+                <JSONEditor
+                  placeholder='{"team": "Backend", "sprint": 42}'
+                  rows={4}
+                  disabled={!canEditGeneral}
+                />
               </Form.Item>
             }
           />

--- a/apps/agor-ui/src/components/EmojiPickerInput/EmojiPickerInput.tsx
+++ b/apps/agor-ui/src/components/EmojiPickerInput/EmojiPickerInput.tsx
@@ -94,10 +94,11 @@ export const EmojiPickerInput: React.FC<EmojiPickerInputProps> = ({
 export const FormEmojiPickerInput: React.FC<{
   fieldName: string;
   defaultEmoji?: string;
-}> = ({ fieldName, defaultEmoji }) => {
+  disabled?: boolean;
+}> = ({ fieldName, defaultEmoji, disabled }) => {
   return (
     <Form.Item name={fieldName} noStyle initialValue={defaultEmoji}>
-      <EmojiPickerInput defaultEmoji={defaultEmoji} />
+      <EmojiPickerInput defaultEmoji={defaultEmoji} disabled={disabled} />
     </Form.Item>
   );
 };

--- a/apps/agor-ui/src/components/JSONEditor/JSONEditor.tsx
+++ b/apps/agor-ui/src/components/JSONEditor/JSONEditor.tsx
@@ -6,6 +6,7 @@ export interface JSONEditorProps {
   onChange?: (value: string) => void;
   placeholder?: string;
   rows?: number;
+  disabled?: boolean;
 }
 
 /**
@@ -23,6 +24,7 @@ export const JSONEditor: React.FC<JSONEditorProps> = ({
   onChange,
   placeholder = '{"key": "value"}',
   rows = 4,
+  disabled = false,
 }) => (
   <CodeEditor
     value={value ?? ''}
@@ -30,6 +32,7 @@ export const JSONEditor: React.FC<JSONEditorProps> = ({
     language="json"
     placeholder={placeholder}
     rows={rows}
+    readOnly={disabled}
   />
 );
 

--- a/apps/agor-ui/src/components/forms/BoardFormFields.test.tsx
+++ b/apps/agor-ui/src/components/forms/BoardFormFields.test.tsx
@@ -6,8 +6,10 @@ import { BoardFormFields, extractBoardFormValues } from './BoardFormFields';
 
 function BoardFormHarness({
   onRead,
+  canEditGeneral,
 }: {
   onRead: (values: ReturnType<typeof extractBoardFormValues>) => void;
+  canEditGeneral?: boolean;
 }) {
   const [form] = Form.useForm();
   return (
@@ -20,7 +22,7 @@ function BoardFormHarness({
         owner_ids: ['user-1'],
       }}
     >
-      <BoardFormFields form={form} rbacEnabled />
+      <BoardFormFields form={form} rbacEnabled canEditGeneral={canEditGeneral} />
       <button type="button" onClick={() => onRead(extractBoardFormValues(form))}>
         Read values
       </button>
@@ -50,5 +52,32 @@ describe('BoardFormFields permissions', () => {
     expect(onRead).toHaveBeenLastCalledWith(
       expect.objectContaining({ default_others_can: 'view' })
     );
+  });
+});
+
+describe('BoardFormFields general-settings permission gating', () => {
+  it('disables name and description when the caller lacks board.edit', () => {
+    renderWithApp(<BoardFormHarness onRead={vi.fn()} canEditGeneral={false} />);
+
+    expect(screen.getByPlaceholderText('My Board')).toBeDisabled();
+    expect(screen.getByPlaceholderText('Optional description...')).toBeDisabled();
+    expect(screen.getByText("You don't have permission to edit this board.")).toBeInTheDocument();
+  });
+
+  it('swaps the appearance tab for a read-only notice instead of leaving live controls that bypass disabling', () => {
+    renderWithApp(<BoardFormHarness onRead={vi.fn()} canEditGeneral={false} />);
+    fireEvent.click(screen.getByRole('tab', { name: 'CSS' }));
+
+    expect(
+      screen.getByText("You don't have permission to edit this board's appearance.")
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText('Background mode')).not.toBeInTheDocument();
+  });
+
+  it('leaves name and description editable by default (legacy/non-RBAC path)', () => {
+    renderWithApp(<BoardFormHarness onRead={vi.fn()} />);
+
+    expect(screen.getByPlaceholderText('My Board')).not.toBeDisabled();
+    expect(screen.getByPlaceholderText('Optional description...')).not.toBeDisabled();
   });
 });

--- a/apps/agor-ui/src/components/forms/BoardFormFields.tsx
+++ b/apps/agor-ui/src/components/forms/BoardFormFields.tsx
@@ -1,4 +1,5 @@
 import type { Board, Group, User } from '@agor-live/client';
+import { LockOutlined } from '@ant-design/icons';
 import type { FormInstance } from 'antd';
 import { Alert, Form, Input, Space, Tabs, Typography } from 'antd';
 import { FormEmojiPickerInput } from '../EmojiPickerInput';
@@ -91,6 +92,14 @@ export interface BoardFormFieldsProps {
   allGroups?: Group[];
   /** Normalized permission editor mounted by BoardEditModal and persisted separately. */
   capabilityPolicyEditor?: React.ReactNode;
+  /**
+   * Whether the caller may edit the board's general settings (name,
+   * description, appearance). Defaults to `true` for the legacy/non-RBAC
+   * path, where every board mutator has always been allowed to save.
+   * `board.edit` is a single capability covering all of these fields
+   * together, so they're gated uniformly rather than field-by-field.
+   */
+  canEditGeneral?: boolean;
 }
 
 /**
@@ -109,24 +118,42 @@ export const BoardFormFields: React.FC<BoardFormFieldsProps> = ({
   allUsers = [],
   allGroups = [],
   capabilityPolicyEditor,
+  canEditGeneral = true,
 }) => {
   const generalFields = (
     <>
-      <Form.Item label="Name" required style={{ marginBottom: 24 }}>
+      <Form.Item
+        label="Name"
+        required
+        style={{ marginBottom: 24 }}
+        help={
+          canEditGeneral ? undefined : (
+            <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+              <LockOutlined style={{ marginRight: 4 }} />
+              You don't have permission to edit this board.
+            </Typography.Text>
+          )
+        }
+      >
         <Space.Compact style={{ display: 'flex' }}>
-          <FormEmojiPickerInput fieldName="icon" defaultEmoji="📋" />
+          <FormEmojiPickerInput fieldName="icon" defaultEmoji="📋" disabled={!canEditGeneral} />
           <Form.Item
             name="name"
             noStyle
             rules={[{ required: true, message: 'Please enter a board name' }]}
           >
-            <Input placeholder="My Board" style={{ flex: 1 }} autoFocus={autoFocus} />
+            <Input
+              placeholder="My Board"
+              style={{ flex: 1 }}
+              autoFocus={autoFocus}
+              disabled={!canEditGeneral}
+            />
           </Form.Item>
         </Space.Compact>
       </Form.Item>
 
       <Form.Item label="Description" name="description">
-        <Input.TextArea placeholder="Optional description..." rows={3} />
+        <Input.TextArea placeholder="Optional description..." rows={3} disabled={!canEditGeneral} />
       </Form.Item>
     </>
   );
@@ -200,7 +227,21 @@ export const BoardFormFields: React.FC<BoardFormFieldsProps> = ({
 
   const permissionsFields = capabilityPolicyEditor ?? legacyPermissionsFields;
 
-  const cssFields = <BoardBackgroundEditor form={form} resetSignal={backgroundResetSignal} />;
+  // The background editor has several controls (preset gallery, gradient
+  // helper) that write to the form directly rather than through a masked
+  // input, so disabling its individual fields wouldn't actually stop an
+  // edit. Swap in a read-only notice instead of fighting to disable every
+  // control inside it.
+  const cssFields = canEditGeneral ? (
+    <BoardBackgroundEditor form={form} resetSignal={backgroundResetSignal} />
+  ) : (
+    <Alert
+      type="info"
+      showIcon
+      icon={<LockOutlined />}
+      message="You don't have permission to edit this board's appearance."
+    />
+  );
 
   return (
     <Tabs

--- a/packages/core/src/db/repositories/boards.test.ts
+++ b/packages/core/src/db/repositories/boards.test.ts
@@ -1890,4 +1890,40 @@ describe('BoardRepository normalized permission boundary', () => {
       repo.update(board.board_id, { primary_owner_user_id: generateId() })
     ).rejects.toThrow('Primary ownership is immutable');
   });
+
+  dbTest(
+    'resolveUserAccess grants full capabilities to the primary owner and none to an unrelated member on a private board',
+    async ({ db }) => {
+      const repo = new BoardRepository(db);
+      const creatorId = generateId() as UUID;
+      const otherId = generateId() as UUID;
+      await new UsersRepository(db).create({
+        user_id: creatorId,
+        email: `owner-${creatorId}@agor.test`,
+        role: 'member',
+      });
+      await new UsersRepository(db).create({
+        user_id: otherId,
+        email: `other-${otherId}@agor.test`,
+        role: 'member',
+      });
+      const board = await repo.create(
+        createBoardData({
+          name: 'Effective Access Board',
+          created_by: creatorId,
+          access_mode: 'private',
+        })
+      );
+
+      const ownerAccess = await repo.resolveUserAccess(board, creatorId);
+      expect(ownerAccess.is_primary_owner).toBe(true);
+      expect(ownerAccess.capabilities).toEqual(
+        expect.arrayContaining(['board.view', 'board.edit'])
+      );
+
+      const otherAccess = await repo.resolveUserAccess(board, otherId);
+      expect(otherAccess.is_primary_owner).toBe(false);
+      expect(otherAccess.capabilities).toEqual([]);
+    }
+  );
 });

--- a/packages/core/src/db/repositories/boards.ts
+++ b/packages/core/src/db/repositories/boards.ts
@@ -12,6 +12,7 @@ import type {
   BoardObject,
   Branch,
   BranchPermissionLevel,
+  EffectiveCapabilityPolicyAccess,
   UserID,
   UUID,
 } from '@agor/core/types';
@@ -577,6 +578,20 @@ export class BoardRepository implements BaseRepository<Board, Partial<Board>> {
       userId as UserID
     );
     return access.capabilities.includes('board.view');
+  }
+
+  /**
+   * Resolve a user's effective capability-policy access to a board.
+   *
+   * Mirrors `BranchRepository.resolveUserAccess` — the central app-layer
+   * resolver for point checks. Callers that need the full effective-access
+   * payload (not just a single boolean like `canMutate`/`canView`) use this.
+   */
+  async resolveUserAccess(board: Board, userId: UUID): Promise<EffectiveCapabilityPolicyAccess> {
+    return new CapabilityPolicyRepository(this.db).resolveBoardAccess(
+      board.board_id,
+      userId as UserID
+    );
   }
 
   /** Resolve a board only when the caller can currently view it. */


### PR DESCRIPTION
## Summary

Follow-up to a permissions-affordance audit: `BoardEditModal` was the one capability-policy resource still letting a user type into every general setting (name, description, appearance, custom context) and only discover they can't save on a 403. Users and MCP servers already do this correctly (`UserSettingsModal`'s `canWriteX` pattern, `MCPServersTable`'s `canEditMcpServer`); `BranchModal` already does the same for branches via a dedicated `branches/:id/effective-access` endpoint. Boards were missing the equivalent.

(A parallel candidate, `GatewayChannelsTable`, turned out to be a non-issue — that entire settings tab is already admin-gated at the navigation level, with no partial-permission scenario to fix.)

- Adds `boards/:id/effective-access` (`apps/agor-daemon/src/services/groups.ts`), mirroring the existing `branches/:id/effective-access` service almost exactly. Boards already carry the normalized `EffectiveCapabilityPolicyAccess` shape natively (`capabilities`/`fs_access`/`source`/`is_primary_owner`) — no legacy `others_can`-tier translation needed, unlike branches.
- Adds `BoardRepository.resolveUserAccess(board, userId)`, mirroring `BranchRepository.resolveUserAccess`, backing the new endpoint with the same `CapabilityPolicyRepository.resolveBoardAccess` used by the existing `canMutate`/`canView` checks — so the offered UI state and the accepted write can't drift apart.
- `BoardEditModal` fetches the new endpoint alongside its existing policy load and computes `canEditGeneral = branchRbacEnabled ? capabilities.includes('board.edit') : true` (preserves the legacy open-RBAC behavior when the feature flag is off — server stays authoritative either way).
- `BoardFormFields` disables Name, Description, and the emoji picker when `!canEditGeneral`, with a "You don't have permission to edit this board." help note (same convention as `UserSettingsModal`).
- The Custom Context (JSON) field is disabled the same way — added a `disabled` prop to `JSONEditor`/`CodeEditor` (`readOnly` under the hood), reusable by its other call sites (CardsTable, GatewayChannelsTable, AdvancedSettingsForm, ThemeEditorModal).
- The appearance (background/CSS) tab is swapped for a read-only notice instead of disabled field-by-field: its preset gallery and gradient helper write to the form directly (`form.setFieldsValue(...)`) rather than through a masked input, so disabling just the two textareas wouldn't actually stop an edit — a plain Alert avoids that half-measure.
- The Permissions tab is untouched — `CapabilityPolicyModalEditor` already computes its own `canManageAccess` independently (a different capability, `board.policy.manage`).

## Deliberately out of scope (staged separately)

- **Save-button gating.** `canEditGeneral` already exists and wiring it into `okButtonProps.disabled` (matching `BranchModal`'s `canSave`) is a near-zero-cost follow-up, but this PR is field-level disabling only, kept separate on purpose.
- **Hiding the edit screen entirely** for boards with zero editable capabilities — more case-by-case, not attempted here.

## Test plan

- [x] New daemon tests for `boards/:id/effective-access`: normalized resolver result, fails closed with no `board.view`, superadmin bypass without consulting policy rows, requires authentication (mirrors the existing branch endpoint's test shape).
- [x] New `BoardRepository.resolveUserAccess` DB-backed test: full capabilities for the primary owner, none for an unrelated member on a private board.
- [x] New `BoardFormFields` tests: Name/Description disabled + help text shown when `canEditGeneral=false`; appearance tab shows the read-only notice instead of live controls; fields stay editable by default (legacy/non-RBAC path).
- [x] New `BoardEditModal` tests: `canEditGeneral` defaults to `true` (and skips the effective-access fetch) when RBAC is disabled; `canEditGeneral=false` propagates correctly from a denying effective-access response.
- [x] `pnpm typecheck` — clean across all 21 workspace tasks.
- [x] `pnpm biome check` — clean (pre-commit hook also passed).
- [x] Full affected suites: `packages/core` boards repository (104/104), daemon groups + realtime-publish-policy (153/153), UI BoardEditModal/BoardFormFields/EmojiPickerInput/JSONEditor (19/19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)