### PR TITLE
fix(ui): validate branch-to-board moves before they 403

### DIFF
--- a/apps/agor-ui/src/components/BranchModal/BranchModal.tsx
+++ b/apps/agor-ui/src/components/BranchModal/BranchModal.tsx
@@ -210,6 +210,8 @@ export const BranchModal: React.FC<BranchModalProps> = ({
           state={form.general}
           setField={form.setGeneral}
           onArchiveOrDelete={onArchiveOrDelete}
+          boardAttachChecking={form.boardAttachChecking}
+          boardAttachError={form.boardAttachError}
         />
       ),
     },
@@ -316,7 +318,11 @@ export const BranchModal: React.FC<BranchModalProps> = ({
   // (General, Teammate, Permissions). Tabs like Environment / Sessions /
   // Files / Schedules have their own actions outside the form.
   const canSave =
-    (form.canEditGeneral || form.canEditPermissions) && form.hasChanges && !form.saving;
+    (form.canEditGeneral || form.canEditPermissions) &&
+    form.hasChanges &&
+    !form.saving &&
+    !form.boardAttachError &&
+    !form.boardAttachChecking;
 
   const footer = (
     <Space>

--- a/apps/agor-ui/src/components/BranchModal/tabs/GeneralTab.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/GeneralTab.tsx
@@ -35,6 +35,10 @@ interface GeneralTabProps {
   state: GeneralFormState;
   setField: <K extends keyof GeneralFormState>(key: K, value: GeneralFormState[K]) => void;
   onArchiveOrDelete?: (branchId: string, options: BranchArchiveOrDeleteOptions) => void;
+  /** Verifying `board.attach_branch` on a newly-picked target board. */
+  boardAttachChecking?: boolean;
+  /** Set once verification finds the caller can't move a branch onto the picked board. */
+  boardAttachError?: string | null;
 }
 
 export const GeneralTab: React.FC<GeneralTabProps> = ({
@@ -47,6 +51,8 @@ export const GeneralTab: React.FC<GeneralTabProps> = ({
   state,
   setField,
   onArchiveOrDelete,
+  boardAttachChecking = false,
+  boardAttachError = null,
 }) => {
   const [archiveDeleteModalOpen, setArchiveDeleteModalOpen] = useState(false);
   const branchById = useAgorStore(selectBranchById);
@@ -117,13 +123,23 @@ export const GeneralTab: React.FC<GeneralTabProps> = ({
             Work Context
           </Typography.Text>
           <Form layout="horizontal" colon={false}>
-            <Form.Item label="Board" labelCol={{ span: 6 }} wrapperCol={{ span: 18 }}>
+            <Form.Item
+              label="Board"
+              labelCol={{ span: 6 }}
+              wrapperCol={{ span: 18 }}
+              validateStatus={boardAttachError ? 'error' : undefined}
+              help={
+                boardAttachError ||
+                (boardAttachChecking ? 'Checking access to that board…' : undefined)
+              }
+            >
               <Select
                 value={state.boardId}
                 onChange={(value) => setField('boardId', value)}
                 placeholder="Select board (optional)..."
                 allowClear
                 disabled={!canEdit}
+                loading={boardAttachChecking}
                 options={boardSelectOptions(boards, branchById)}
               />
             </Form.Item>

--- a/apps/agor-ui/src/components/BranchModal/testUtils.tsx
+++ b/apps/agor-ui/src/components/BranchModal/testUtils.tsx
@@ -42,6 +42,8 @@ export interface StubClientOptions {
   capabilityPolicy?: BranchCapabilityPolicy;
   failPermissionsFind?: boolean;
   workspacePreferences?: { personal_session_sharing_enabled: boolean };
+  /** Response for `boards/:id/effective-access`, keyed by the requested board id. */
+  boardEffectiveAccessById?: Record<string, unknown>;
 }
 
 export function makeStubClient(opts: StubClientOptions = {}): {
@@ -83,6 +85,19 @@ export function makeStubClient(opts: StubClientOptions = {}): {
           }
           if (path === 'branches/:id/effective-access') {
             return opts.effectiveAccess ?? { can: 'session', is_owner: false, source: 'others' };
+          }
+          if (path === 'boards/:id/effective-access') {
+            const boardId = (args as { route?: { id?: string } } | undefined)?.route?.id;
+            const configured = boardId ? opts.boardEffectiveAccessById?.[boardId] : undefined;
+            return (
+              configured ?? {
+                capabilities: ['board.view', 'board.edit', 'board.attach_branch'],
+                fs_access: 'none',
+                source: 'primary_owner',
+                group_ids: [],
+                is_primary_owner: true,
+              }
+            );
           }
           if (path === 'branches/:id/permissions') {
             if (opts.failPermissionsFind) throw new Error('permission package unavailable');

--- a/apps/agor-ui/src/components/BranchModal/useBranchModalForm.test.tsx
+++ b/apps/agor-ui/src/components/BranchModal/useBranchModalForm.test.tsx
@@ -1,3 +1,4 @@
+import type { Branch } from '@agor-live/client';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { __resetAuthConfigForTests, __setAuthConfigForTests } from '../../hooks/useAuthConfig';
@@ -157,5 +158,100 @@ describe('useBranchModalForm normalized permission package', () => {
     act(() => result.current.reset());
     expect(result.current.capabilityPolicy?.binding_mode).toBe('override');
     expect(result.current.permissionsChanged).toBe(false);
+  });
+});
+
+describe('useBranchModalForm board-move validation', () => {
+  beforeEach(() => {
+    __setAuthConfigForTests({ requireAuth: true }, { branchRbac: true });
+  });
+
+  afterEach(() => {
+    __resetAuthConfigForTests();
+  });
+
+  it('blocks the move and reports why when the caller lacks board.attach_branch on the target board', async () => {
+    const owner = makeUser({ user_id: 'user-1', role: 'member' });
+    const branch = makeBranch();
+    const { client } = makeStubClient({
+      users: [owner],
+      boardEffectiveAccessById: {
+        'board-no-attach': {
+          capabilities: ['board.view'],
+          fs_access: 'none',
+          source: 'others',
+          group_ids: [],
+          is_primary_owner: false,
+        },
+      },
+    });
+    const { result } = renderHook(
+      () => useBranchModalForm({ branch, client, currentUser: owner, open: true }),
+      { wrapper }
+    );
+    await waitFor(() => expect(result.current.permissionsLoading).toBe(false));
+
+    act(() => result.current.setGeneral('boardId', 'board-no-attach'));
+    await waitFor(() => expect(result.current.boardAttachChecking).toBe(false));
+
+    expect(result.current.boardAttachError).toContain('Board Editor or Manager access');
+
+    let saved: Awaited<ReturnType<typeof result.current.save>> | undefined;
+    await act(async () => {
+      saved = await result.current.save();
+    });
+    expect(saved?.ok).toBe(false);
+  });
+
+  it('allows the move once the caller has board.attach_branch on the target board', async () => {
+    const owner = makeUser({ user_id: 'user-1', role: 'member' });
+    const branch = makeBranch();
+    const { client, calls } = makeStubClient({
+      users: [owner],
+      boardEffectiveAccessById: {
+        'board-allowed': {
+          capabilities: ['board.view', 'board.edit', 'board.attach_branch'],
+          fs_access: 'none',
+          source: 'direct_user',
+          group_ids: [],
+          is_primary_owner: false,
+        },
+      },
+    });
+    const { result } = renderHook(
+      () => useBranchModalForm({ branch, client, currentUser: owner, open: true }),
+      { wrapper }
+    );
+    await waitFor(() => expect(result.current.permissionsLoading).toBe(false));
+
+    act(() => result.current.setGeneral('boardId', 'board-allowed'));
+    await waitFor(() => expect(result.current.boardAttachChecking).toBe(false));
+    expect(result.current.boardAttachError).toBeNull();
+
+    let saved: Awaited<ReturnType<typeof result.current.save>> | undefined;
+    await act(async () => {
+      saved = await result.current.save();
+    });
+    expect(saved).toEqual({ ok: true });
+    expect(
+      calls.some((call) => call.service === 'boards/:id/effective-access' && call.method === 'find')
+    ).toBe(true);
+  });
+
+  it('does not check effective-access when the board selection is unchanged', async () => {
+    const owner = makeUser({ user_id: 'user-1', role: 'member' });
+    const branch = makeBranch({ board_id: 'board-1' as Branch['board_id'] });
+    const { client, calls } = makeStubClient({ users: [owner] });
+    const { result } = renderHook(
+      () => useBranchModalForm({ branch, client, currentUser: owner, open: true }),
+      { wrapper }
+    );
+    await waitFor(() => expect(result.current.permissionsLoading).toBe(false));
+
+    act(() => result.current.setGeneral('notes', 'unrelated change'));
+    await waitFor(() => expect(result.current.generalChanged).toBe(true));
+
+    expect(result.current.boardAttachError).toBeNull();
+    expect(calls.some((call) => call.service === 'boards/:id/effective-access')).toBe(false);
   });
 });

--- a/apps/agor-ui/src/components/BranchModal/useBranchModalForm.ts
+++ b/apps/agor-ui/src/components/BranchModal/useBranchModalForm.ts
@@ -23,6 +23,7 @@ import type {
   BranchCapabilityPolicy,
   CapabilityPolicyWorkspacePreferences,
   EffectiveBranchAccess,
+  EffectiveCapabilityPolicyAccess,
   Group,
   TeammateConfig,
   User,
@@ -86,6 +87,13 @@ export interface BranchModalFormApi {
   canEditPermissions: boolean;
   canControlEnvironment: boolean;
 
+  // Board-move validation: `board_id` is a Select of every board the caller
+  // can VIEW, not just the ones they can attach a branch to, so a selection
+  // can't be pre-filtered the way other fields are disabled outright. This
+  // is checked reactively once a target board is actually picked.
+  boardAttachChecking: boolean;
+  boardAttachError: string | null;
+
   // Aggregate state
   hasChanges: boolean;
   saving: boolean;
@@ -141,6 +149,8 @@ export function useBranchModalForm({
   const [workspacePreferences, setWorkspacePreferences] =
     useState<CapabilityPolicyWorkspacePreferences>({ personal_session_sharing_enabled: false });
   const [permissionsLoadError, setPermissionsLoadError] = useState<Error | null>(null);
+  const [boardAttachChecking, setBoardAttachChecking] = useState(false);
+  const [boardAttachError, setBoardAttachError] = useState<string | null>(null);
 
   const [saving, setSaving] = useState(false);
 
@@ -275,6 +285,51 @@ export function useBranchModalForm({
     };
   }, [open, client, branchId, branchRbacEnabled]);
 
+  // Validate a newly-selected target board once it's actually picked, rather
+  // than trying to pre-filter the Select's options: the board list is scoped
+  // to "boards I can VIEW", and knowing which of those the caller can also
+  // attach a branch to would mean an effective-access call per board. The
+  // daemon rejects a move to a board without `board.attach_branch` (or away
+  // from the current board without `board.edit`), so this mirrors that one
+  // check for the one board actually chosen.
+  const targetBoardId = general.boardId;
+  useEffect(() => {
+    if (!open || !client || !branchRbacEnabled) {
+      setBoardAttachError(null);
+      return;
+    }
+    const originalBoardId = branch?.board_id || undefined;
+    if (!targetBoardId || targetBoardId === originalBoardId) {
+      setBoardAttachError(null);
+      return;
+    }
+    let cancelled = false;
+    setBoardAttachChecking(true);
+    setBoardAttachError(null);
+    client
+      .service('boards/:id/effective-access')
+      .find({ route: { id: targetBoardId } })
+      .then((access: unknown) => {
+        if (cancelled) return;
+        const capabilities = (access as EffectiveCapabilityPolicyAccess).capabilities;
+        if (!capabilities.includes('board.attach_branch')) {
+          setBoardAttachError('You need Board Editor or Manager access to move a branch here.');
+        }
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        setBoardAttachError(
+          error instanceof Error ? error.message : 'Could not verify access to that board.'
+        );
+      })
+      .finally(() => {
+        if (!cancelled) setBoardAttachChecking(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, client, branchRbacEnabled, branch?.board_id, targetBoardId]);
+
   // Change detection per slice
   const isTeammateBranch = branch ? isTeammate(branch) : false;
   const generalChanged = useMemo(() => {
@@ -345,6 +400,9 @@ export function useBranchModalForm({
 
   const save = useCallback(async (): Promise<{ ok: true } | { ok: false; error: Error }> => {
     if (!branch || !client) return { ok: false, error: new Error('Modal not ready') };
+    // Belt-and-suspenders: the Save button is already disabled while this is
+    // set, but save() is also exported directly, so re-check here too.
+    if (boardAttachError) return { ok: false, error: new Error(boardAttachError) };
     setSaving(true);
     try {
       const updates: BranchUpdate = {};
@@ -396,6 +454,7 @@ export function useBranchModalForm({
   }, [
     branch,
     client,
+    boardAttachError,
     generalChanged,
     canEditGeneral,
     general,
@@ -426,6 +485,8 @@ export function useBranchModalForm({
     canManagePolicy,
     canEditPermissions,
     canControlEnvironment,
+    boardAttachChecking,
+    boardAttachError,
     hasChanges,
     saving,
     save,


### PR DESCRIPTION
## Summary

Follow-up in the permission-gating series (#2578, #2577's field-level pattern). This one's shaped differently from Cards/Boards, worth reading before the diff.

`BranchModal`'s board picker (General tab) lists every board the caller can **view**, via `boardSelectOptions(boards, branchById)` — not filtered by which of those boards they can actually attach a branch to. Moving a branch onto a board requires `board.attach_branch` capability on that specific board (`ensureCanChangeBranchBoard`, `apps/agor-daemon/src/register-hooks.ts:2111-2147`), a separate per-board check distinct from the branch-level `all` tier already required just to reach this screen (`ensureBranchPermission('all', ...)`). So a user with full authority over their own branch can easily lack Editor/Manager access on some *other* team's board (they can see it, they just can't edit it) — pick it from the dropdown, hit Save, get a 403 with no warning.

**Why this isn't a straight field-disabling PR like Cards/Boards:** pre-filtering which dropdown *options* are valid would mean an effective-access call per board in the list, which doesn't scale to a workspace with many boards. Instead this validates reactively, once a target is actually picked:

- `useBranchModalForm` fetches `boards/:id/effective-access` (the endpoint added in #2578) for the newly-selected board only, when it differs from the branch's current board.
- On a miss, `boardAttachError` is set with a clear message and surfaced as inline validation under the Board field (`validateStatus="error"` + `help`), with a loading state while the check is in flight.
- The Save button is blocked while checking or while an error is set — `save()` also re-checks defensively, since it's exported and callable directly.
- Selecting the board back to its original value (or a board that does pass) clears the error automatically; no board selected at all skips the check entirely.

Level 1 (inline validation) and Level 2 (Save gating) ship together here since neither works cleanly alone for this field — there's no "always render disabled options" affordance without the N-call cost above.

**Not in scope:** the mirror case (needing `board.edit` on the *previous* board to detach/move away from it) is a real, distinct check the daemon also enforces, but is far less likely to be hit in practice (it'd require branch-level `all` authority without board-level edit authority on your own branch's *current* board, an unusual RBAC configuration) — left as a known gap rather than folded in here to keep this PR's shape simple.

## Test plan

- [x] New tests in `useBranchModalForm.test.tsx`: blocks + explains when the caller lacks `board.attach_branch` on the target (and `save()` returns `ok: false`); allows the move and fires the effective-access call once capability is present; does **not** fire the check at all when the board selection is unchanged (e.g. editing an unrelated field).
- [x] `pnpm typecheck` — clean across all 21 workspace tasks.
- [x] `pnpm biome check` — clean (pre-commit hook also passed).
- [x] Full `BranchModal` suite — 30/30 passing, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)