### PR TITLE
perf: reduce branch and board point-read amplification

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/branches.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.test.ts
@@ -830,6 +830,7 @@ describe('agor_branches_set_zone', () => {
     const result = await setZone({ branchId: 'branch-1', zoneId: null });
     const parsed = JSON.parse(result.content[0].text);
 
+    expect(branchesGet).toHaveBeenCalledOnce();
     expect(branchesGet).toHaveBeenCalledWith('branch-1', baseServiceParams);
     expect(findByBranchId).toHaveBeenCalledWith('branch-1', baseServiceParams);
     expect(boardObjectsPatch).toHaveBeenCalledWith(
@@ -963,6 +964,7 @@ describe('agor_branches_set_zone', () => {
     });
     const parsed = JSON.parse(result.content[0].text);
 
+    expect(branchesGet).toHaveBeenCalledOnce();
     expect(sessionsGet).toHaveBeenCalledWith('session-1', baseServiceParams);
     expect(boardObjectsPatch).toHaveBeenCalledWith(
       'obj-branch-1',

--- a/apps/agor-daemon/src/mcp/tools/branches.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.ts
@@ -1099,7 +1099,7 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
       }),
     },
     async (args) => {
-      const branchId = await resolveBranchId(ctx, coerceString(args.branchId)!);
+      const branchIdInput = coerceString(args.branchId)!;
       const zoneId = args.zoneId === null ? null : coerceString(args.zoneId)!;
       const rawTargetSessionId = coerceString(args.targetSessionId);
       const triggerTemplate = args.triggerTemplate === true;
@@ -1110,6 +1110,11 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
         );
       }
 
+      // branches.get resolves short IDs and returns the canonical authorized
+      // entity. Keep it for the rest of this operation instead of resolving
+      // with one get and reading the same branch again below.
+      const branch = await ctx.app.service('branches').get(branchIdInput, ctx.baseServiceParams);
+      const branchId = branch.branch_id;
       const targetSession = rawTargetSessionId
         ? ((await ctx.app
             .service('sessions')
@@ -1125,9 +1130,6 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
           ? `📍 MCP clearing zone pin for branch ${shortId(branchId)}`
           : `📍 MCP pinning branch ${shortId(branchId)} to zone ${zoneId}`
       );
-
-      // Get branch to find its board
-      const branch = await ctx.app.service('branches').get(branchId, ctx.baseServiceParams);
 
       if (triggerTemplate && targetSession && targetSession.branch_id !== branch.branch_id) {
         throw new Error(

--- a/apps/agor-daemon/src/mcp/tools/cards.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/cards.test.ts
@@ -213,6 +213,7 @@ describe('card MCP realtime events', () => {
     await captureHandler('agor_cards_move', ctx)({ cardId: 'card-1', zoneId: null });
     await captureHandler('agor_cards_archive', ctx)({ cardId: 'card-1' });
 
+    expect(boardsGet).toHaveBeenCalledOnce();
     expect(createWithPlacement).toHaveBeenCalledWith(expect.any(Object), params);
     expect(moveToZone).toHaveBeenCalledWith('card-1', null, undefined);
     expect(archive).toHaveBeenCalledWith('card-1');

--- a/apps/agor-daemon/src/mcp/tools/cards.ts
+++ b/apps/agor-daemon/src/mcp/tools/cards.ts
@@ -40,14 +40,19 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
       }),
     },
     async (args) => {
-      const boardId = await resolveBoardId(ctx, coerceString(args.boardId)!);
       const title = coerceString(args.title)!;
-      const board = await ctx.app.service('boards').get(boardId, ctx.baseServiceParams);
+      // boards.get already resolves exact and short IDs. Reuse the authorized
+      // canonical entity instead of resolving it with one get and immediately
+      // reading the same board again.
+      const board = await ctx.app
+        .service('boards')
+        .get(coerceString(args.boardId)!, ctx.baseServiceParams);
       let zoneData: ZoneBoardObject | undefined;
       const zoneId = coerceString(args.zoneId);
       if (zoneId) {
         const zone = board.objects?.[zoneId];
-        if (zone?.type !== 'zone') throw new Error(`Zone ${zoneId} not found on board ${boardId}`);
+        if (zone?.type !== 'zone')
+          throw new Error(`Zone ${zoneId} not found on board ${board.board_id}`);
         zoneData = zone;
       }
 
@@ -356,12 +361,15 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
       }),
     },
     async (args) => {
-      const boardId = await resolveBoardId(ctx, coerceString(args.boardId)!);
       const cardsArr = args.cards;
       if (!Array.isArray(cardsArr) || cardsArr.length === 0)
         throw new Error('non-empty cards array is required');
 
-      const board = await ctx.app.service('boards').get(boardId, ctx.baseServiceParams);
+      // Preserve the same short-ID resolution and authorization boundary while
+      // avoiding resolveBoardId() + boards.get() for the same entity.
+      const board = await ctx.app
+        .service('boards')
+        .get(coerceString(args.boardId)!, ctx.baseServiceParams);
       const cardsService = ctx.app.service('cards') as unknown as CardsService;
 
       const results = [];

--- a/apps/agor-daemon/src/mcp/tools/schedules.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/schedules.test.ts
@@ -1,3 +1,4 @@
+import { PAGINATION } from '@agor/core/config';
 import {
   AGENTIC_TOOL_NAMES,
   type ScheduleCreateData,
@@ -285,5 +286,58 @@ describe('schedule MCP input schemas', () => {
       provider: 'mcp',
     });
     expect(JSON.parse(response.content[0].text).data).toHaveLength(2);
+  });
+
+  it('chunks branch authorization at the service pagination cap', async () => {
+    const handlers = new Map<string, ToolHandler>();
+    const fakeServer = {
+      registerTool: (name: string, _cfg: unknown, cb: ToolHandler) => handlers.set(name, cb),
+    } as unknown as McpServer;
+    const schedules = Array.from({ length: PAGINATION.MAX_LIMIT + 1 }, (_, index) => ({
+      schedule_id: `schedule-${index}`,
+      branch_id: `branch-${index}`,
+    }));
+    const branchesFind = vi.fn(async (params: { query: { branch_id: { $in: string[] } } }) =>
+      params.query.branch_id.$in.map((branch_id) => ({
+        branch_id,
+        board_id: 'board-target',
+      }))
+    );
+    const boardsGet = vi.fn(async () => ({ board_id: 'board-target' }));
+
+    registerScheduleTools(fakeServer, {
+      app: {
+        service(path: string) {
+          if (path === 'schedules') return { find: vi.fn(async () => schedules) };
+          if (path === 'branches') return { find: branchesFind };
+          if (path === 'boards') return { get: boardsGet };
+          throw new Error(`Unexpected service: ${path}`);
+        },
+      } as any,
+      db: {} as any,
+      userId: 'user-1' as any,
+      sessionId: undefined,
+      authenticatedUser: { user_id: 'user-1', email: 'user@example.com', role: 'member' } as any,
+      baseServiceParams: { provider: 'mcp' },
+    });
+
+    const response = (await handlers.get('agor_schedules_list')?.({
+      boardId: 'board-target',
+      limit: 25,
+      offset: 0,
+    })) as { content: Array<{ text: string }> };
+    const body = JSON.parse(response.content[0].text) as {
+      total: number;
+      data: unknown[];
+    };
+
+    expect(boardsGet).toHaveBeenCalledOnce();
+    expect(branchesFind).toHaveBeenCalledTimes(2);
+    expect(branchesFind.mock.calls.map(([params]) => params.query.branch_id.$in.length)).toEqual([
+      PAGINATION.MAX_LIMIT,
+      1,
+    ]);
+    expect(body.total).toBe(PAGINATION.MAX_LIMIT + 1);
+    expect(body.data).toHaveLength(25);
   });
 });

--- a/apps/agor-daemon/src/mcp/tools/schedules.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/schedules.test.ts
@@ -234,4 +234,56 @@ describe('schedule MCP input schemas', () => {
       {}
     );
   });
+
+  it('bulk-loads unique branches when filtering schedules by board', async () => {
+    const handlers = new Map<string, ToolHandler>();
+    const fakeServer = {
+      registerTool: (name: string, _cfg: unknown, cb: ToolHandler) => handlers.set(name, cb),
+    } as unknown as McpServer;
+    const schedules = [
+      { schedule_id: 'schedule-1', branch_id: 'branch-a' },
+      { schedule_id: 'schedule-2', branch_id: 'branch-a' },
+      { schedule_id: 'schedule-3', branch_id: 'branch-b' },
+    ];
+    const branchesFind = vi.fn(async () => [
+      { branch_id: 'branch-a', board_id: 'board-target' },
+      { branch_id: 'branch-b', board_id: 'board-other' },
+    ]);
+    const branchesGet = vi.fn();
+    const boardsGet = vi.fn(async () => ({ board_id: 'board-target' }));
+
+    registerScheduleTools(fakeServer, {
+      app: {
+        service(path: string) {
+          if (path === 'schedules') return { find: vi.fn(async () => schedules) };
+          if (path === 'branches') return { find: branchesFind, get: branchesGet };
+          if (path === 'boards') return { get: boardsGet };
+          throw new Error(`Unexpected service: ${path}`);
+        },
+      } as any,
+      db: {} as any,
+      userId: 'user-1' as any,
+      sessionId: undefined,
+      authenticatedUser: { user_id: 'user-1', email: 'user@example.com', role: 'member' } as any,
+      baseServiceParams: { provider: 'mcp' },
+    });
+
+    const response = (await handlers.get('agor_schedules_list')?.({
+      boardId: 'board-target',
+      limit: 25,
+      offset: 0,
+    })) as { content: Array<{ text: string }> };
+
+    expect(boardsGet).toHaveBeenCalledOnce();
+    expect(branchesGet).not.toHaveBeenCalled();
+    expect(branchesFind).toHaveBeenCalledWith({
+      query: {
+        branch_id: { $in: ['branch-a', 'branch-b'] },
+        $limit: 2,
+      },
+      paginate: false,
+      provider: 'mcp',
+    });
+    expect(JSON.parse(response.content[0].text).data).toHaveLength(2);
+  });
 });

--- a/apps/agor-daemon/src/mcp/tools/schedules.ts
+++ b/apps/agor-daemon/src/mcp/tools/schedules.ts
@@ -4,6 +4,7 @@
  * design doc.
  */
 
+import { PAGINATION } from '@agor/core/config';
 import { BadRequest } from '@agor/core/feathers';
 import {
   AGENTIC_TOOL_NAMES,
@@ -132,19 +133,25 @@ export function registerScheduleTools(server: McpServer, ctx: McpContext): void 
         const boardId = await resolveBoardId(ctx, args.boardId);
         const allData: Schedule[] = Array.isArray(result) ? result : result.data;
         const branchIds = [...new Set(allData.map((schedule) => schedule.branch_id))];
-        const branchesResult = branchIds.length
-          ? await ctx.app.service('branches').find({
-              query: {
-                branch_id: { $in: branchIds },
-                $limit: branchIds.length,
-              },
-              paginate: false,
-              ...ctx.baseServiceParams,
-            })
-          : [];
-        const branches = (
-          Array.isArray(branchesResult) ? branchesResult : branchesResult.data
-        ) as Branch[];
+        const branches: Branch[] = [];
+        // BranchesService clamps every `$limit` to PAGINATION.MAX_LIMIT even
+        // for non-paginated calls. Keep each authorization batch below that
+        // boundary so large schedule sets are complete rather than silently
+        // dropping branches above the cap.
+        for (let offset = 0; offset < branchIds.length; offset += PAGINATION.MAX_LIMIT) {
+          const batch = branchIds.slice(offset, offset + PAGINATION.MAX_LIMIT);
+          const branchesResult = await ctx.app.service('branches').find({
+            query: {
+              branch_id: { $in: batch },
+              $limit: batch.length,
+            },
+            paginate: false,
+            ...ctx.baseServiceParams,
+          });
+          branches.push(
+            ...((Array.isArray(branchesResult) ? branchesResult : branchesResult.data) as Branch[])
+          );
+        }
         const matchingBranchIds = new Set(
           branches.filter((branch) => branch.board_id === boardId).map((branch) => branch.branch_id)
         );

--- a/apps/agor-daemon/src/mcp/tools/schedules.ts
+++ b/apps/agor-daemon/src/mcp/tools/schedules.ts
@@ -7,6 +7,7 @@
 import { BadRequest } from '@agor/core/feathers';
 import {
   AGENTIC_TOOL_NAMES,
+  type Branch,
   type Schedule,
   type ScheduleAgenticToolConfig,
   type ScheduleCreateData,
@@ -123,16 +124,31 @@ export function registerScheduleTools(server: McpServer, ctx: McpContext): void 
         ...ctx.baseServiceParams,
       });
 
-      // boardId filter is post-query (we'd need a JOIN to do it in SQL);
-      // keep it simple — schedule counts per board are small. Resolve
-      // short IDs first so a caller can pass either form.
+      // boardId filter is post-query (we'd need a JOIN to do it in SQL).
+      // Resolve short IDs first so a caller can pass either form, then bulk
+      // authorize the unique referenced branches rather than issuing one
+      // branches.get request per schedule.
       if (args.boardId) {
         const boardId = await resolveBoardId(ctx, args.boardId);
         const allData: Schedule[] = Array.isArray(result) ? result : result.data;
-        const branches = await Promise.all(
-          allData.map((s) => ctx.app.service('branches').get(s.branch_id, ctx.baseServiceParams))
+        const branchIds = [...new Set(allData.map((schedule) => schedule.branch_id))];
+        const branchesResult = branchIds.length
+          ? await ctx.app.service('branches').find({
+              query: {
+                branch_id: { $in: branchIds },
+                $limit: branchIds.length,
+              },
+              paginate: false,
+              ...ctx.baseServiceParams,
+            })
+          : [];
+        const branches = (
+          Array.isArray(branchesResult) ? branchesResult : branchesResult.data
+        ) as Branch[];
+        const matchingBranchIds = new Set(
+          branches.filter((branch) => branch.board_id === boardId).map((branch) => branch.branch_id)
         );
-        const filtered = allData.filter((_, i) => branches[i]?.board_id === boardId);
+        const filtered = allData.filter((schedule) => matchingBranchIds.has(schedule.branch_id));
         const data = filtered.slice(args.offset, args.offset + args.limit);
         return textResult(mcpPageResult({ total: filtered.length, data }, args.limit, args.offset));
       }

--- a/apps/agor-daemon/src/register-hooks.test.ts
+++ b/apps/agor-daemon/src/register-hooks.test.ts
@@ -1522,6 +1522,12 @@ describe('registered file service RBAC database preload', () => {
           return { session_id: 'session-1', branch_id: 'branch-1' };
         }),
       };
+      const sessionsRepository = {
+        findById: vi.fn(async () => {
+          assertTenantScope();
+          return { session_id: 'session-1', branch_id: 'branch-1' };
+        }),
+      };
       const app = {
         service(servicePath: string) {
           return {
@@ -1551,7 +1557,8 @@ describe('registered file service RBAC database preload', () => {
         boardsService: undefined,
         branchRepository: branchRepository as RegisterHooksContext['branchRepository'],
         usersRepository: {} as RegisterHooksContext['usersRepository'],
-        sessionsRepository: {} as RegisterHooksContext['sessionsRepository'],
+        sessionsRepository:
+          sessionsRepository as unknown as RegisterHooksContext['sessionsRepository'],
         deployment: { mode: 'standalone' },
       });
 
@@ -1574,8 +1581,10 @@ describe('registered file service RBAC database preload', () => {
 
       expect(context.params.branch?.branch_id).toBe('branch-1');
       expect(getCurrentTenantDatabaseScope()).toBeUndefined();
-      if (path === 'files') expect(sessionsService.get).toHaveBeenCalledOnce();
-      else expect(branchRepository.findById).toHaveBeenCalledOnce();
+      if (path === 'files') {
+        expect(sessionsRepository.findById).toHaveBeenCalledOnce();
+        expect(sessionsService.get).not.toHaveBeenCalled();
+      } else expect(branchRepository.findById).toHaveBeenCalledOnce();
     }
   );
 });

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -442,6 +442,8 @@ export interface RegisterHooksContext {
   sessionsService: SessionsServiceImpl;
   messagesService: MessagesServiceImpl;
   boardsService: BoardsServiceImpl | undefined;
+  /** Test seam; production constructs one repository over the trusted scoped DB. */
+  boardRepository?: BoardRepository & RealtimeAccessBoardRepository;
   branchRepository: BranchRepository;
   usersRepository: UsersRepository;
   sessionsRepository: SessionRepository;
@@ -1229,8 +1231,9 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     sessionsRepository: sessionsRepository as unknown as RealtimeAccessSessionRepository,
   });
   bindRealtimeAccessCacheInvalidation(app, realtimeAccessCache);
-  const boardRepository = new BoardRepository(db) as BoardRepository &
-    RealtimeAccessBoardRepository;
+  const boardRepository =
+    ctx.boardRepository ??
+    (new BoardRepository(db) as BoardRepository & RealtimeAccessBoardRepository);
   const boardCommentsRepository = new BoardCommentsRepository(db);
   const boardObjectsRepository = new BoardObjectRepository(db);
   const cardRepository = new CardRepository(db);
@@ -3399,14 +3402,36 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       if (!board) throw new Forbidden(`Board not found: ${id}`);
       const allowed =
         mode === 'view'
-          ? await boardRepository.canView(board.board_id, user.user_id as UserID)
-          : await boardRepository.canMutate(board.board_id, user.user_id as UserID);
+          ? await boardRepository.canViewResolved(board, user.user_id as UserID)
+          : await boardRepository.canMutateResolved(board, user.user_id as UserID);
       if (!allowed) {
         throw new Forbidden(
           mode === 'view'
             ? `You need board access to ${action}`
             : `You need Board Editor or Manager access to ${action}`
         );
+      }
+      if (context.path === 'boards' && context.method === 'get' && context.id) {
+        // The same tenant transaction and caller authority immediately enter
+        // BoardsService.get after this hook. Canonicalize short/slug IDs and
+        // pass the just-authorized row through the generic adapter's bounded
+        // request params instead of reading it a third time. This is neither a
+        // cross-request nor cross-principal cache; policy resolution above is
+        // still performed on every call, preserving immediate revocation.
+        context.id = board.board_id;
+        (
+          context.params as typeof context.params & {
+            _agorPrefetchedRecord?: {
+              id: string;
+              idField: string;
+              record: Board;
+            };
+          }
+        )._agorPrefetchedRecord = {
+          id: board.board_id,
+          idField: 'board_id',
+          record: board,
+        };
       }
       return context;
     };

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -1580,7 +1580,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
    */
   const promptWriteGuards = [
     ...(executionMode.appRbacEnabled || executionMode.requiresExecutionHomeKey
-      ? [resolveSessionContext(), loadSession(sessionsService)]
+      ? [resolveSessionContext(), loadSession(sessionsRepository)]
       : []),
     ...(executionMode.requiresExecutionHomeKey
       ? [validateSessionUnixUsername(usersRepository)]
@@ -1620,7 +1620,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         ...(executionMode.appRbacEnabled
           ? [
               resolveSessionContext(),
-              loadSession(sessionsService),
+              loadSession(sessionsRepository),
               loadBranchFromSession(branchRepository),
               ensureCanView(superadminOpts), // Require 'view' permission
             ]
@@ -1653,7 +1653,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         ...(executionMode.appRbacEnabled
           ? [
               resolveSessionContext(),
-              loadSession(sessionsService),
+              loadSession(sessionsRepository),
               loadBranchFromSession(branchRepository),
               ensureCanPromptInSession({ ...superadminOpts, branchRepository }), // Require 'prompt' (or 'session' for own sessions)
             ]
@@ -1666,7 +1666,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         ...(executionMode.appRbacEnabled
           ? [
               resolveSessionContext(),
-              loadSession(sessionsService),
+              loadSession(sessionsRepository),
               loadBranchFromSession(branchRepository),
               ensureCanPromptInSession({ ...superadminOpts, branchRepository }), // Require 'prompt' (or 'session' for own sessions)
             ]
@@ -2684,7 +2684,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
                 if (!sessionId) return context;
                 context.params.sessionId = sessionId;
                 // Delegate to the existing chain now that sessionId is primed.
-                await loadSession(sessionsService)(context);
+                await loadSession(sessionsRepository)(context);
                 await loadBranchFromSession(branchRepository)(context);
                 await ensureCanView(superadminOpts)(context);
                 return context;
@@ -2973,7 +2973,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     ...(executionMode.appRbacEnabled
       ? [
           resolveSessionContext(),
-          loadSession(sessionsService),
+          loadSession(sessionsRepository),
           loadBranchFromSession(branchRepository),
           // Branch permission by patch type:
           //   - Prompt-flow patches (tasks, archived, status, …) are bookkeeping
@@ -3029,7 +3029,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         ...(executionMode.appRbacEnabled
           ? [
               // Load session's branch and check permissions
-              loadSessionBranch(sessionsService, branchRepository),
+              loadSessionBranch(sessionsRepository, branchRepository),
               ensureCanView(superadminOpts), // Require 'view' permission on branch
             ]
           : []),
@@ -3117,7 +3117,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         ...(executionMode.appRbacEnabled
           ? [
               resolveSessionContext(),
-              loadSession(sessionsService),
+              loadSession(sessionsRepository),
               loadBranchFromSession(branchRepository),
               ensureBranchPermission('all', 'delete sessions', superadminOpts), // Require 'all' permission
             ]
@@ -3315,7 +3315,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         ...(executionMode.appRbacEnabled
           ? [
               resolveSessionContext(),
-              loadSession(sessionsService),
+              loadSession(sessionsRepository),
               loadBranchFromSession(branchRepository),
               ensureCanView(superadminOpts), // Require 'view' permission
             ]
@@ -3333,7 +3333,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         ...(executionMode.appRbacEnabled
           ? [
               resolveSessionContext(),
-              loadSession(sessionsService),
+              loadSession(sessionsRepository),
               loadBranchFromSession(branchRepository),
               ensureCanPromptInSession({ ...superadminOpts, branchRepository }), // Require 'prompt' (or 'session' for own sessions)
             ]
@@ -3351,7 +3351,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
         ...(executionMode.appRbacEnabled
           ? [
               resolveSessionContext(),
-              loadSession(sessionsService),
+              loadSession(sessionsRepository),
               loadBranchFromSession(branchRepository),
               ensureBranchPermission('all', 'delete tasks', superadminOpts),
             ]

--- a/apps/agor-daemon/src/register-hooks.unix-identity-drift.test.ts
+++ b/apps/agor-daemon/src/register-hooks.unix-identity-drift.test.ts
@@ -67,6 +67,17 @@ const buildHarness = (options: {
 
   const sessionsService = {
     async get(sessionId: string) {
+      return {
+        session_id: sessionId,
+        branch_id: BRANCH_ID,
+        created_by: CREATOR_ID,
+        unix_username: 'alice',
+      };
+    },
+  };
+
+  const sessionsRepository = {
+    async findById(sessionId: string) {
       harness.sessionReads += 1;
       return {
         session_id: sessionId,
@@ -101,7 +112,7 @@ const buildHarness = (options: {
     boardsService: undefined,
     branchRepository: {} as RegisterHooksContext['branchRepository'],
     usersRepository: usersRepository as unknown as RegisterHooksContext['usersRepository'],
-    sessionsRepository: {} as RegisterHooksContext['sessionsRepository'],
+    sessionsRepository: sessionsRepository as unknown as RegisterHooksContext['sessionsRepository'],
   });
 
   return harness;

--- a/apps/agor-daemon/src/register-hooks.update-gating.test.ts
+++ b/apps/agor-daemon/src/register-hooks.update-gating.test.ts
@@ -42,7 +42,8 @@ type CapturedHooks = {
  */
 const captureRegisteredHooks = (
   branchRbacEnabled: boolean,
-  branchRepositoryOverride?: RegisterHooksContext['branchRepository']
+  branchRepositoryOverride?: RegisterHooksContext['branchRepository'],
+  boardRepositoryOverride?: RegisterHooksContext['boardRepository']
 ): Map<string, CapturedHooks> => {
   const captured = new Map<string, CapturedHooks>();
   const visibleBranch = {
@@ -90,6 +91,7 @@ const captureRegisteredHooks = (
     sessionsService: {} as RegisterHooksContext['sessionsService'],
     messagesService: {} as RegisterHooksContext['messagesService'],
     boardsService: undefined,
+    boardRepository: boardRepositoryOverride,
     branchRepository:
       branchRepositoryOverride ??
       ({
@@ -105,6 +107,54 @@ const captureRegisteredHooks = (
 
   return captured;
 };
+
+describe('board get authorization prefetch', () => {
+  it('passes one freshly authorized canonical row into the service method', async () => {
+    const board = {
+      board_id: '00000000-0000-7000-8000-000000000010',
+      name: 'Authorized board',
+    };
+    const findBySlugOrId = vi.fn(async () => board);
+    const canViewResolved = vi.fn(async () => true);
+    const canView = vi.fn(() => {
+      throw new Error('must not reload the authorized board');
+    });
+    const boardRepository = {
+      findBySlugOrId,
+      canViewResolved,
+      canView,
+    } as unknown as NonNullable<RegisterHooksContext['boardRepository']>;
+    const hooks = captureRegisteredHooks(true, undefined, boardRepository).get('boards')?.before;
+    if (!hooks) throw new Error('boards registers no before hooks');
+    const context = {
+      path: 'boards',
+      method: 'get',
+      id: '00000000',
+      params: {
+        provider: 'socketio',
+        query: {},
+        user: {
+          user_id: '00000000-0000-7000-8000-0000000000ff',
+          role: 'member',
+        },
+      },
+    } as unknown as HookContext;
+
+    for (const hook of [...(hooks.all ?? []), ...(hooks.get ?? [])]) await hook(context);
+
+    expect(findBySlugOrId).toHaveBeenCalledOnce();
+    expect(canViewResolved).toHaveBeenCalledWith(board, '00000000-0000-7000-8000-0000000000ff');
+    expect(canView).not.toHaveBeenCalled();
+    expect(context.id).toBe(board.board_id);
+    expect(context.params).toMatchObject({
+      _agorPrefetchedRecord: {
+        id: board.board_id,
+        idField: 'board_id',
+        record: board,
+      },
+    });
+  });
+});
 
 describe('branch hard-delete realtime hook', () => {
   it('captures current authorized recipients before the branch and ACL rows are removed', async () => {

--- a/apps/agor-daemon/src/services/branches.test.ts
+++ b/apps/agor-daemon/src/services/branches.test.ts
@@ -10,6 +10,7 @@ import {
   runWithTenantDatabaseScope,
   UsersRepository,
 } from '@agor/core/db';
+import { feathers } from '@agor/core/feathers';
 import {
   type Application,
   type BoardID,
@@ -2617,6 +2618,71 @@ describe('BranchesService environment health requests', () => {
     globalThis.fetch = originalFetch;
   });
 
+  dbTest(
+    'reduces a standalone automatic observation from three wrapped gets to zero',
+    async ({ db }) => {
+      const user = await new UsersRepository(db).create({
+        email: `${generateId()}@example.com`,
+        name: 'Automatic health hook receipt',
+      });
+      const repo = await new RepoRepository(db).create({
+        repo_id: generateId(),
+        slug: `automatic-health-hook-${generateId()}`,
+        name: 'Automatic health hook receipt',
+        repo_type: 'remote',
+        remote_url: 'https://example.invalid/automatic-health-hook.git',
+        local_path: `/tmp/${generateId()}`,
+        default_branch: 'main',
+      });
+      const branch = await new BranchRepository(db).create({
+        branch_id: generateId() as BranchID,
+        repo_id: repo.repo_id,
+        name: `automatic-health-hook-${generateId()}`,
+        ref: 'main',
+        branch_unique_id: 8_650_000,
+        path: `/tmp/${generateId()}`,
+        created_by: user.user_id,
+        environment_instance: { status: 'running' },
+      });
+      const app = feathers();
+      const service = new BranchesService(db as never, app as unknown as Application);
+      app.use('branches', service as never, { methods: ['get'] });
+      let wrappedGets = 0;
+      app.service('branches').hooks({
+        around: {
+          get: [
+            async (_context, next) => {
+              wrappedGets += 1;
+              await next();
+            },
+          ],
+        },
+      });
+
+      const registered = app.service('branches') as unknown as BranchesService;
+
+      // This is the deployed pre-fix shape: the standalone monitor first used
+      // the registered get, then its direct internal checkHealth call used
+      // this.get() for the initial and final canonical loads. Feathers wraps
+      // both nested standard-method calls even though checkHealth itself is not
+      // a transport method.
+      await app.service('branches').get(branch.branch_id);
+      await registered.checkHealth(branch.branch_id);
+      expect(wrappedGets).toBe(3);
+
+      wrappedGets = 0;
+      const result = await registered.checkHealth(branch.branch_id, undefined, {
+        intent: 'automatic',
+      });
+
+      expect(result).toMatchObject({
+        branch_id: branch.branch_id,
+        environment_instance: { status: 'running' },
+      });
+      expect(wrappedGets).toBe(0);
+    }
+  );
+
   it('reports a healthy errored environment without reviving or persisting it', async () => {
     const branch = {
       branch_id: 'wt-health-recover' as BranchID,
@@ -2686,7 +2752,12 @@ describe('BranchesService environment health requests', () => {
       },
     } as unknown as Application;
     const service = new BranchesService(createTenantScopeTestDb() as never, app);
-    vi.spyOn(service, 'get').mockResolvedValue(branch as never);
+    vi.spyOn(
+      service as unknown as {
+        getCanonicalBranch: (id: BranchID) => Promise<typeof branch>;
+      },
+      'getCanonicalBranch'
+    ).mockResolvedValue(branch);
     globalThis.fetch = vi.fn();
 
     await expect(

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -1235,11 +1235,15 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
   }
 
   /**
-   * Override get to enrich with zone information
-   *
-   * Session activity enrichment is opt-in via include_sessions query parameter
+   * Load the canonical branch shape without entering the Feathers method
+   * wrapper. Internal-only operations use this deliberately when their caller
+   * already owns the authority context and must not manufacture nested
+   * `branches.get` requests.
    */
-  async get(id: BranchID, params?: BranchParams): Promise<BranchWithZoneAndSessions> {
+  private async getCanonicalBranch(
+    id: BranchID,
+    params?: BranchParams
+  ): Promise<BranchWithZoneAndSessions> {
     // Check both query params and root-level params (root-level bypasses Feathers query filtering)
     const includeSessionsQuery = params?.query?.include_sessions;
     const includeSessionsRoot = params?._include_sessions;
@@ -1260,6 +1264,15 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     }
 
     return withZone as BranchWithZoneAndSessions;
+  }
+
+  /**
+   * Override get to enrich with zone information.
+   *
+   * Session activity enrichment is opt-in via include_sessions query parameter
+   */
+  async get(id: BranchID, params?: BranchParams): Promise<BranchWithZoneAndSessions> {
+    return this.getCanonicalBranch(id, params);
   }
 
   /**
@@ -2500,11 +2513,19 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     params?: BranchParams,
     internalOptions?: EnvironmentHealthCheckOptions
   ): Promise<BranchWithZoneAndSessions> {
-    const branch = await this.withTenantDatabase(params, () => this.get(id, params));
-    const _repo = await this.withTenantDatabase(
-      params,
-      () => this.app.service('repos').get(branch.repo_id, params) as Promise<Repo>
-    );
+    // `checkHealth` is intentionally not a transport method. Automatic calls
+    // originate only from the tenant-aware health monitor, so use the raw
+    // canonical loader for that path. Calling `this.get` from a registered
+    // Feathers service enters the standard get wrapper even though this custom
+    // method itself is invoked directly; a normal successful observation used
+    // to create two nested `branches.get` service requests in addition to the
+    // monitor's own preflight get. Explicit user/MCP status requests retain the
+    // wrapped get and its fail-closed authorization hooks.
+    const loadCurrent = () =>
+      internalOptions?.intent === 'automatic'
+        ? this.getCanonicalBranch(id, params)
+        : this.get(id, params);
+    const branch = await this.withTenantDatabase(params, loadCurrent);
 
     const currentStatus = branch.environment_instance?.status;
     if (
@@ -2556,7 +2577,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
       })
     );
     if (claimResult.outcome !== 'claimed') {
-      return this.withTenantDatabase(params, () => this.get(id, params));
+      return this.withTenantDatabase(params, loadCurrent);
     }
 
     try {
@@ -2565,7 +2586,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
         internalOptions?.signal
       );
       if (!observation) {
-        return this.withTenantDatabase(params, () => this.get(id, params));
+        return this.withTenantDatabase(params, loadCurrent);
       }
       const commitResult = await this.withTenantDatabase(params, () =>
         new EnvironmentHealthRepository(this.db).commit({
@@ -2575,7 +2596,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
           observation,
         })
       );
-      const current = await this.withTenantDatabase(params, () => this.get(id, params));
+      const current = await this.withTenantDatabase(params, loadCurrent);
       if (commitResult.outcome === 'committed' && commitResult.stateChanged) {
         emitServiceEvent(this.app, {
           path: 'branches',

--- a/apps/agor-daemon/src/services/health-monitor.test.ts
+++ b/apps/agor-daemon/src/services/health-monitor.test.ts
@@ -12,7 +12,10 @@ class BranchServiceMock extends EventEmitter {
   get = vi.fn(async (branchId: string) =>
     makeBranch({ branch_id: branchId, environment_instance: { status: 'running' } })
   );
-  checkHealth = vi.fn(async () => undefined);
+  checkHealth = vi.fn(
+    async (branchId: string): Promise<Branch | undefined> =>
+      makeBranch({ branch_id: branchId, environment_instance: { status: 'running' } })
+  );
 }
 
 function makeBranch(overrides: Partial<Branch> & { tenant_id?: string } = {}): Branch {
@@ -178,10 +181,7 @@ describe('HealthMonitor tenant context', () => {
 
     await vi.advanceTimersByTimeAsync(ENVIRONMENT.STARTUP_GRACE_PERIOD_MS);
 
-    await vi.waitFor(() => expect(branches.get).toHaveBeenCalled());
-    expect(branches.get).toHaveBeenCalledWith('branch-tenant-a', {
-      tenant: { tenant_id: 'tenant-a', source: 'auth_claim' },
-    });
+    expect(branches.get).not.toHaveBeenCalled();
     expect(branches.checkHealth).toHaveBeenCalledWith(
       'branch-tenant-a',
       { tenant: { tenant_id: 'tenant-a', source: 'auth_claim' } },
@@ -193,16 +193,13 @@ describe('HealthMonitor tenant context', () => {
   it('enters the branch tenant DB scope instead of inheriting stale timer scope', async () => {
     const branches = new BranchServiceMock();
     const ambientTenantIds: Array<string | undefined> = [];
-    branches.get.mockImplementation(async (branchId: string) => {
+    branches.checkHealth.mockImplementation(async (branchId: string) => {
       ambientTenantIds.push(getCurrentTenantId());
       return makeBranch({
         branch_id: branchId,
         tenant_id: 'tenant-a',
         environment_instance: { status: 'running' },
       });
-    });
-    branches.checkHealth.mockImplementation(async () => {
-      ambientTenantIds.push(getCurrentTenantId());
     });
 
     const monitor = new HealthMonitor(makeApp(branches) as never, {
@@ -224,7 +221,7 @@ describe('HealthMonitor tenant context', () => {
     await vi.advanceTimersByTimeAsync(ENVIRONMENT.STARTUP_GRACE_PERIOD_MS);
     await vi.waitFor(() => expect(branches.checkHealth).toHaveBeenCalledTimes(1));
 
-    expect(ambientTenantIds).toEqual(['tenant-a', 'tenant-a']);
+    expect(ambientTenantIds).toEqual(['tenant-a']);
     await monitor.cleanup();
   });
 
@@ -247,6 +244,51 @@ describe('HealthMonitor tenant context', () => {
 
     await vi.advanceTimersByTimeAsync(ENVIRONMENT.HEALTH_CHECK_INTERVAL_MS * 2);
     await vi.waitFor(() => expect(branches.checkHealth).toHaveBeenCalledTimes(3));
+    expect(branches.get).not.toHaveBeenCalled();
+    await monitor.cleanup();
+  });
+
+  it('performs no Feathers branch point reads during an hour of steady polling', async () => {
+    const branches = new BranchServiceMock();
+    const monitor = new HealthMonitor(makeApp(branches) as never);
+
+    branches.emit(
+      'patched',
+      makeBranch({ branch_id: 'steady-branch', environment_instance: { status: 'running' } })
+    );
+    await vi.advanceTimersByTimeAsync(ENVIRONMENT.STARTUP_GRACE_PERIOD_MS);
+    await vi.advanceTimersByTimeAsync(60 * 60_000);
+
+    // One immediate observation after the grace period plus 720 five-second
+    // interval observations. Before this fix the monitor also issued exactly
+    // 721 branches.get calls, each duplicating checkHealth's canonical load.
+    expect(branches.checkHealth).toHaveBeenCalledTimes(721);
+    expect(branches.get).not.toHaveBeenCalled();
+    await monitor.cleanup();
+  });
+
+  it('stops polling from the canonical checkHealth result when a lifecycle hint is missed', async () => {
+    const branches = new BranchServiceMock();
+    branches.checkHealth
+      .mockResolvedValueOnce(
+        makeBranch({ branch_id: 'stopping-branch', environment_instance: { status: 'stopped' } })
+      )
+      .mockResolvedValue(
+        makeBranch({ branch_id: 'stopping-branch', environment_instance: { status: 'running' } })
+      );
+    const monitor = new HealthMonitor(makeApp(branches) as never);
+
+    branches.emit(
+      'patched',
+      makeBranch({ branch_id: 'stopping-branch', environment_instance: { status: 'running' } })
+    );
+    await vi.advanceTimersByTimeAsync(ENVIRONMENT.STARTUP_GRACE_PERIOD_MS);
+    await vi.waitFor(() => expect(branches.checkHealth).toHaveBeenCalledOnce());
+    expect(monitor.getStatus().monitoringCount).toBe(0);
+
+    await vi.advanceTimersByTimeAsync(ENVIRONMENT.HEALTH_CHECK_INTERVAL_MS * 2);
+    expect(branches.checkHealth).toHaveBeenCalledOnce();
+    expect(branches.get).not.toHaveBeenCalled();
     await monitor.cleanup();
   });
 
@@ -304,7 +346,7 @@ describe('HealthMonitor tenant context', () => {
     await monitor.cleanup();
   });
 
-  it('stops monitoring when a real DrizzleService lookup misses a deleted branch', async () => {
+  it('stops monitoring when the canonical health check misses a deleted branch', async () => {
     const repository: Repository<Branch> = {
       create: vi.fn(),
       findById: vi.fn(async () => null),
@@ -312,13 +354,13 @@ describe('HealthMonitor tenant context', () => {
       update: vi.fn(),
       delete: vi.fn(),
     };
-    const branchAdapter = Object.assign(
-      new DrizzleService<Branch>(repository, {
-        id: 'branch_id',
-        resourceType: 'Branch',
-      }),
-      { checkHealth: vi.fn() }
-    );
+    const branchAdapter = new DrizzleService<Branch>(repository, {
+      id: 'branch_id',
+      resourceType: 'Branch',
+    });
+    Object.assign(branchAdapter, {
+      checkHealth: vi.fn(async (branchId: string) => branchAdapter.get(branchId)),
+    });
     const app = feathers();
     app.use('branches', branchAdapter as never);
     const branches = app.service('branches') as unknown as BranchServiceMock;
@@ -332,7 +374,7 @@ describe('HealthMonitor tenant context', () => {
     await vi.waitFor(() => expect(repository.findById).toHaveBeenCalledOnce());
 
     expect(monitor.getStatus().monitoringCount).toBe(0);
-    expect(branches.checkHealth).not.toHaveBeenCalled();
+    expect(branches.checkHealth).toHaveBeenCalledOnce();
     await monitor.cleanup();
   });
 
@@ -373,8 +415,8 @@ describe('HealthMonitor tenant context', () => {
     let releaseCheck: (() => void) | undefined;
     branches.checkHealth.mockImplementation(
       () =>
-        new Promise<void>((resolve) => {
-          releaseCheck = resolve;
+        new Promise<Branch>((resolve) => {
+          releaseCheck = () => resolve(makeBranch({ environment_instance: { status: 'running' } }));
         })
     );
     const monitor = new HealthMonitor(makeApp(branches) as never);

--- a/apps/agor-daemon/src/services/health-monitor.ts
+++ b/apps/agor-daemon/src/services/health-monitor.ts
@@ -278,32 +278,40 @@ export class HealthMonitor {
       }
 
       const runCheck = async () => {
-        // Get current branch state
+        // Perform health check via the service method. `checkHealth` begins by
+        // loading and revalidating the current branch itself, so a separate
+        // `branches.get` here duplicated the same tenant-scoped point read (and
+        // its zone enrichment) on every five-second poll. Besides the database
+        // work, that preflight appeared as a top-level `branches.get` APM span
+        // because timer work has no enclosing Feathers request. The automatic
+        // check also uses the service's unwrapped canonical loader; explicit
+        // user/MCP status requests retain the normal authorization hooks.
+        //
+        // This direct custom service call bypasses Feathers around hooks, so
+        // when the monitor has a db handle and tenant params, enter the same
+        // tenant DB/ALS scope the scheduler uses before mutating branch
+        // environment state and emitting realtime patches.
         const branch =
           this.db && params?.tenant?.tenant_id
             ? await runWithTenantDatabaseScope(this.db, params.tenant.tenant_id, () =>
-                branchesService.get(branchId, params as never)
+                branchesService.checkHealth(branchId, params as never, {
+                  signal: controller.signal,
+                  intent: 'automatic',
+                })
               )
-            : await branchesService.get(branchId, params as never);
+            : await branchesService.checkHealth(branchId, params as never, {
+                signal: controller.signal,
+                intent: 'automatic',
+              });
 
-        // Only check if still running or starting
-        const status = branch.environment_instance?.status;
-        if (branch.archived || (status !== 'running' && status !== 'starting')) {
-          // Silently stop monitoring (not an error - expected when env stops)
-          // Start/stop logs are already handled in handleBranchUpdate()
+        // Keep the monitor's self-cleanup contract: a lifecycle change can
+        // commit without its realtime hint reaching this replica. The canonical
+        // result returned by checkHealth is the same live fact the removed
+        // preflight inspected, so stop locally when it is no longer eligible.
+        const status = branch?.environment_instance?.status;
+        if (!branch || branch.archived || (status !== 'running' && status !== 'starting')) {
           this.stopMonitoring(branchId);
-          return;
         }
-
-        // Perform health check via the service method. This direct custom
-        // service call bypasses Feathers around hooks, so when the monitor has
-        // a db handle and tenant params, enter the same tenant DB/ALS scope the
-        // scheduler uses before mutating branch environment state and emitting
-        // realtime patches.
-        await branchesService.checkHealth(branchId, params as never, {
-          signal: controller.signal,
-          intent: 'automatic',
-        });
       };
 
       const tenantId = params?.tenant?.tenant_id;

--- a/apps/agor-daemon/src/services/session-streams.test.ts
+++ b/apps/agor-daemon/src/services/session-streams.test.ts
@@ -1,6 +1,7 @@
 import type { Application } from '@agor/core/feathers';
 import { describe, expect, it, vi } from 'vitest';
 import { sessionStreamRoomName } from '../realtime/routing.js';
+import { readFeathersInstrumentationReason } from '../utils/feathers-instrumentation.js';
 import { SESSION_STREAMS_AWARE_FLAG } from '../utils/realtime-publish.js';
 import { createSessionStreamsService } from './session-streams.js';
 
@@ -52,6 +53,9 @@ describe('session-streams service', () => {
       } as never)
     ).resolves.toEqual({ session_id: 's1', subscribed: true });
     expect(get).toHaveBeenCalledWith('s1', expect.objectContaining({ query: {} }));
+    expect(readFeathersInstrumentationReason(get.mock.calls[0]?.[1])).toBe(
+      'session_stream_admission'
+    );
     expect(join).toHaveBeenCalledWith(connection);
   });
 

--- a/apps/agor-daemon/src/services/session-streams.ts
+++ b/apps/agor-daemon/src/services/session-streams.ts
@@ -3,6 +3,7 @@ import { resolveTenantContext } from '@agor/core/config';
 import type { Application } from '@agor/core/feathers';
 import { BadRequest, Forbidden } from '@agor/core/feathers';
 import type { Params } from '@agor/core/types';
+import { FEATHERS_INSTRUMENTATION_REASON } from '../utils/feathers-instrumentation.js';
 import {
   joinSessionStreamChannel,
   leaveSessionStreamChannel,
@@ -60,12 +61,14 @@ export function createSessionStreamsService(
     sessionId: string,
     params: Params
   ): Promise<string | null> => {
-    const session = (await app
-      .service('sessions')
-      .get(sessionId as never, { ...(params ?? {}), query: {} } as never)) as
-      | { session_id?: string }
-      | null
-      | undefined;
+    const session = (await app.service('sessions').get(
+      sessionId as never,
+      {
+        ...(params ?? {}),
+        query: {},
+        [FEATHERS_INSTRUMENTATION_REASON]: 'session_stream_admission',
+      } as never
+    )) as { session_id?: string } | null | undefined;
     return session?.session_id ?? null;
   };
 

--- a/apps/agor-daemon/src/services/sessions.get-auth.test.ts
+++ b/apps/agor-daemon/src/services/sessions.get-auth.test.ts
@@ -1,0 +1,135 @@
+import {
+  BranchRepository,
+  generateId,
+  RepoRepository,
+  SessionRepository,
+  UsersRepository,
+} from '@agor/core/db';
+import { feathers } from '@agor/core/feathers';
+import type { Application, HookContext, SessionID } from '@agor/core/types';
+import { ROLES, SessionStatus } from '@agor/core/types';
+import { afterEach, beforeEach, describe, expect, vi } from 'vitest';
+import { dbTest } from '../../../../packages/core/src/db/test-helpers';
+import { ensureCanView, loadSessionBranch } from '../utils/branch-authorization.js';
+import { SessionsService } from './sessions.js';
+
+describe('sessions.get authorization loading', () => {
+  beforeEach(() => vi.stubEnv('AGOR_BASE_URL', 'http://agor.test'));
+  afterEach(() => vi.unstubAllEnvs());
+
+  dbTest(
+    'reduces an external get from two Feathers invocations/relationship reads to one',
+    async ({ db }) => {
+      const user = await new UsersRepository(db).create({
+        email: `${generateId()}@example.invalid`,
+        name: 'Session get authorization receipt',
+      });
+      const repo = await new RepoRepository(db).create({
+        repo_id: generateId(),
+        slug: `session-get-auth-${generateId()}`,
+        name: 'Session get authorization receipt',
+        repo_type: 'remote',
+        remote_url: 'https://example.invalid/session-get-auth.git',
+        local_path: `/tmp/${generateId()}`,
+        default_branch: 'main',
+      });
+      const branch = await new BranchRepository(db).create({
+        branch_id: generateId(),
+        repo_id: repo.repo_id,
+        name: `session-get-auth-${generateId()}`,
+        ref: 'main',
+        branch_unique_id: 8_660_000,
+        path: `/tmp/${generateId()}`,
+        created_by: user.user_id,
+      });
+      const session = await new SessionRepository(db).create({
+        session_id: generateId(),
+        branch_id: branch.branch_id,
+        agentic_tool: 'claude-code',
+        status: SessionStatus.IDLE,
+        created_by: user.user_id,
+        tasks: [],
+        contextFiles: [],
+        genealogy: { children: [] },
+      });
+
+      const params = {
+        provider: 'rest',
+        user: { user_id: user.user_id, role: ROLES.MEMBER },
+      } as never;
+      const shortSessionId = session.session_id.slice(0, 8) as SessionID;
+
+      const createRegisteredService = () => {
+        const app = feathers();
+        const service = new SessionsService(db, app as unknown as Application);
+        app.use('sessions', service as never, { methods: ['get'] });
+        let wrappedGets = 0;
+        const relationshipReads = vi.spyOn(
+          (
+            service as unknown as {
+              sessionRelationshipRepo: { findForSessions(ids: SessionID[]): Promise<unknown[]> };
+            }
+          ).sessionRelationshipRepo,
+          'findForSessions'
+        );
+        app.service('sessions').hooks({
+          around: {
+            get: [
+              async (_context, next) => {
+                wrappedGets += 1;
+                await next();
+              },
+            ],
+          },
+        });
+        return { app, relationshipReads, wrappedGets: () => wrappedGets };
+      };
+
+      // Deployed pre-fix shape: the external authorization hook recursively
+      // called the registered sessions.get with provider undefined. The outer
+      // service reused that row, but both service bodies enriched relationships.
+      const before = createRegisteredService();
+      before.app.service('sessions').hooks({
+        before: {
+          get: [
+            async (context: HookContext) => {
+              if (!context.params.provider) return context;
+              const loaded = await context.service.get(context.id, { provider: undefined });
+              context.id = loaded.session_id;
+              (
+                context.params as typeof context.params & {
+                  _agorPrefetchedRecord?: unknown;
+                }
+              )._agorPrefetchedRecord = {
+                id: loaded.session_id,
+                idField: 'session_id',
+                record: loaded,
+              };
+              return context;
+            },
+          ],
+        },
+      });
+      await before.app.service('sessions').get(shortSessionId, params);
+      expect(before.wrappedGets()).toBe(2);
+      expect(before.relationshipReads).toHaveBeenCalledTimes(2);
+
+      // New shape: one tenant-scoped repository read authorizes the branch and
+      // is passed to the outer service, whose enrichment runs exactly once.
+      const after = createRegisteredService();
+      const authSessions = new SessionRepository(db);
+      const authFind = vi.spyOn(authSessions, 'findById');
+      after.app.service('sessions').hooks({
+        before: {
+          get: [loadSessionBranch(authSessions, new BranchRepository(db)), ensureCanView()],
+        },
+      });
+      const result = await after.app.service('sessions').get(shortSessionId, params);
+
+      expect(result.session_id).toBe(session.session_id);
+      expect(authFind).toHaveBeenCalledTimes(1);
+      expect(after.wrappedGets()).toBe(1);
+      expect(after.relationshipReads).toHaveBeenCalledTimes(1);
+    }
+  );
+});

--- a/apps/agor-daemon/src/services/sessions.get-auth.test.ts
+++ b/apps/agor-daemon/src/services/sessions.get-auth.test.ts
@@ -3,6 +3,7 @@ import {
   generateId,
   RepoRepository,
   SessionRepository,
+  shortId,
   UsersRepository,
 } from '@agor/core/db';
 import { feathers } from '@agor/core/feathers';
@@ -57,7 +58,7 @@ describe('sessions.get authorization loading', () => {
         provider: 'rest',
         user: { user_id: user.user_id, role: ROLES.MEMBER },
       } as never;
-      const shortSessionId = session.session_id.slice(0, 8) as SessionID;
+      const shortSessionId = shortId(session.session_id) as SessionID;
 
       const createRegisteredService = () => {
         const app = feathers();

--- a/apps/agor-daemon/src/services/tasks.executor-connection.test.ts
+++ b/apps/agor-daemon/src/services/tasks.executor-connection.test.ts
@@ -151,9 +151,9 @@ describe('TasksService runtime telemetry', () => {
     async ({ tenantId, expectedBranchId }) => {
       const service = Object.create(TasksService.prototype) as TasksService;
       const callbackRun = vi.fn();
-      const sessionGet = vi.fn(async () => {
+      const findHeartbeatBranchId = vi.fn(async () => {
         if (getCurrentTenantId() !== 'tenant-a') throw new Error('session not found');
-        return { session_id: task.session_id, branch_id: 'branch-a' };
+        return 'branch-a';
       });
       const emit = vi.fn();
       Reflect.set(service, 'taskRepo', {
@@ -163,9 +163,8 @@ describe('TasksService runtime telemetry', () => {
         isConfigured: () => true,
         run: callbackRun,
       });
-      Reflect.set(service, 'app', {
-        service: (path: string) => (path === 'sessions' ? { get: sessionGet } : { emit }),
-      });
+      Reflect.set(service, 'findHeartbeatBranchId', findHeartbeatBranchId);
+      Reflect.set(service, 'app', { service: () => ({ emit }) });
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
 
       await service.reportRuntimeTelemetry({ task_id: task.task_id }, {
@@ -173,7 +172,7 @@ describe('TasksService runtime telemetry', () => {
       } as never);
       await vi.waitFor(() => expect(callbackRun).toHaveBeenCalledOnce());
 
-      expect(sessionGet).toHaveBeenCalledWith(task.session_id);
+      expect(findHeartbeatBranchId).toHaveBeenCalledWith(task.session_id);
       expect(callbackRun).toHaveBeenCalledWith({
         event: 'executor_heartbeat',
         task_id: task.task_id,

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -20,6 +20,7 @@ import {
   enqueueTenantDatabasePostCommitCallback,
   getCurrentTenantId,
   runWithTenantDatabaseScope,
+  SessionRepository,
   shortId,
   type TaskDispatchClaimResult,
   TaskRepository,
@@ -35,6 +36,7 @@ import { type Application, BadRequest, Conflict } from '@agor/core/feathers';
 import { deriveTitleFromPrompt } from '@agor/core/sessions';
 import type {
   AuthenticatedParams,
+  BranchID,
   ContentBlock,
   ExecutorTerminationCompleteInput,
   MessageID,
@@ -573,10 +575,8 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
     };
 
     try {
-      const session = await this.app.service('sessions').get(task.session_id);
-      if (session?.branch_id) {
-        payload.branch_id = session.branch_id;
-      }
+      const branchId = await this.findHeartbeatBranchId(task.session_id);
+      if (branchId) payload.branch_id = branchId;
     } catch (error) {
       console.warn(
         `⚠️  [TasksService] Could not resolve branch_id for heartbeat task ${shortId(task.task_id)}:`,
@@ -585,6 +585,19 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
     }
 
     this.heartbeatCallbackRunner.run(payload);
+  }
+
+  /**
+   * The opt-in heartbeat callback needs only the Session's branch pointer.
+   * Re-enter a fresh tenant DB unit after the heartbeat request commits and
+   * avoid a fully enriched Feathers sessions.get on every ten-second tick.
+   */
+  private async findHeartbeatBranchId(sessionId: string): Promise<BranchID | null> {
+    const tenantId = getCurrentTenantId();
+    if (!tenantId) throw new Error('Missing tenant context for executor heartbeat callback');
+    return runWithTenantDatabaseScope(this.db, tenantId, (tenantDb) =>
+      new SessionRepository(tenantDb).findBranchIdBySessionId(sessionId)
+    );
   }
 
   private async runAfterTenantDatabaseCommit(
@@ -1510,9 +1523,9 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
     );
     if (this.heartbeatCallbackRunner.isConfigured()) {
       // Heartbeats arrive inside the request's tenant DB transaction. The
-      // optional callback enrichment performs a later sessions.get, so retain
-      // only the trusted tenant identity and re-enter after commit instead of
-      // inheriting a committed database scope into detached work.
+      // optional callback performs a later branch-pointer projection, so
+      // retain only the trusted tenant identity and re-enter after commit
+      // instead of inheriting a committed DB scope into detached work.
       deferWithTenantContext(
         params,
         () => this.handleExecutorHeartbeat(task, task.last_executor_heartbeat_at!),

--- a/apps/agor-daemon/src/setup/socketio.test.ts
+++ b/apps/agor-daemon/src/setup/socketio.test.ts
@@ -56,6 +56,7 @@ import {
 import { fingerprintExecutorSessionToken } from '../services/session-token-service';
 import type { TerminalAttachmentIdentity } from '../services/terminals';
 import { TERMINAL_REQUEST_JOIN_CHANNEL } from '../terminal-socket-connection';
+import { FEATHERS_INSTRUMENTATION_REASON } from '../utils/feathers-instrumentation';
 import { executorTaskChannelName } from '../utils/realtime-publish';
 import {
   configureChannels,
@@ -1994,10 +1995,24 @@ describe('terminal:* handler authorization', () => {
         expect.objectContaining({
           provider: 'socketio',
           tenant: expect.objectContaining({ tenant_id: 'default' }),
+          [FEATHERS_INSTRUMENTATION_REASON]: 'presence_cursor_admission',
         })
       );
       expect(getBoard).not.toHaveBeenCalledWith('over-bound', expect.anything());
       expect(socket.joined).toContain(boardPresenceRoomName('default', 'last-slot'));
+
+      // The UI emits on both Socket.IO connect and Feathers authentication.
+      // Once the first admission finishes, that duplicate event is an in-memory
+      // capability hit rather than a second boards.get authorization query.
+      await expect(
+        new Promise<{ ok: boolean }>((resolve) => {
+          void socket.handlers.get(PRESENCE_SOCKET_EVENTS.watchBoardCursors)?.(
+            'last-slot',
+            resolve
+          );
+        })
+      ).resolves.toEqual({ ok: true });
+      expect(getBoard).toHaveBeenCalledTimes(1);
     });
 
     it('invalidates a published board when a same-set synchronization is rate-limited', async () => {

--- a/apps/agor-daemon/src/setup/socketio.test.ts
+++ b/apps/agor-daemon/src/setup/socketio.test.ts
@@ -90,7 +90,10 @@ interface FakeSocket {
   disconnect(close?: boolean): void;
   broadcast: {
     emit: (event: string, data: unknown) => void;
-    to: (channel: string) => { emit: (event: string, data: unknown) => void };
+    to: (channel: string) => {
+      emit: (event: string, data: unknown) => void;
+      readonly volatile: { emit: (event: string, data: unknown) => void };
+    };
   };
   // socket.to(room) — broadcasts to a room EXCLUDING this socket. Mirrors the
   // real socket.io semantics used by the terminal:output relay.
@@ -103,6 +106,8 @@ interface FakeSocket {
 interface FakeIO {
   connectionHandler?: (socket: FakeSocket) => void;
   emitted: Array<{ channel: string; event: string; data: unknown }>;
+  /** Best-effort packets emitted through Socket.IO's volatile operator. */
+  volatileEmitted: Array<{ channel: string; event: string; data: unknown }>;
   /** Sender ids passed through the sender-excluding `socket.to` path. */
   excludedSenders: string[];
   sockets: { sockets: Map<string, FakeSocket> };
@@ -156,12 +161,23 @@ function makeSocket(id = 'sock1', io?: FakeIO): FakeSocket {
       emit: (event: string, data: unknown) => {
         io?.emitted.push({ channel: '*', event, data });
       },
-      to: (channel: string) => ({
-        emit: (event: string, data: unknown) => {
+      to: (channel: string) => {
+        const emit = (event: string, data: unknown) => {
           io?.emitted.push({ channel, event, data });
           deliverToRoom(io, channel, event, data, id);
-        },
-      }),
+        };
+        return {
+          emit,
+          get volatile() {
+            return {
+              emit: (event: string, data: unknown) => {
+                io?.volatileEmitted.push({ channel, event, data });
+                emit(event, data);
+              },
+            };
+          },
+        };
+      },
     },
     to: (channel: string) => ({
       emit: (event: string, data: unknown) => {
@@ -203,6 +219,7 @@ function deliverToRoom(
 function makeIO(): FakeIO {
   const io: FakeIO = {
     emitted: [],
+    volatileEmitted: [],
     excludedSenders: [],
     sockets: { sockets: new Map() },
     middlewares: [],
@@ -1726,6 +1743,12 @@ describe('terminal:* handler authorization', () => {
           timestamp: expect.any(Number),
         },
       });
+      expect(io.volatileEmitted).toContainEqual(
+        expect.objectContaining({
+          channel: boardPresenceRoomName('default', 'board-1'),
+          event: PRESENCE_SOCKET_EVENTS.cursorMoved,
+        })
+      );
 
       expect(io.emitted).toContainEqual({
         channel: tenantChannelName('default'),
@@ -1771,6 +1794,40 @@ describe('terminal:* handler authorization', () => {
             entry.channel === boardPresenceRoomName('default', 'board-1')
         )
       ).toHaveLength(2);
+    });
+
+    it('does no Feathers or database work for accepted cursor samples after admission', async () => {
+      const { app, io } = buildHarness();
+      const originalService = (app as any).service;
+      const boardGet = vi.fn(async (boardId: string) => ({ board_id: boardId, archived: false }));
+      const boardFind = vi.fn();
+      const service = vi.fn((path: string) =>
+        path === 'boards' ? { get: boardGet, find: boardFind } : originalService(path)
+      );
+      (app as any).service = service;
+      const publisher = makeSocket('cheap-cursor-publisher', io);
+      asUser(publisher, ALICE);
+      connect(io, publisher);
+
+      await publisher.handlers.get(PRESENCE_SOCKET_EVENTS.watchBoardCursors)?.('board-1');
+      expect(boardGet).toHaveBeenCalledOnce();
+      service.mockClear();
+      boardGet.mockClear();
+
+      for (let index = 0; index < 20; index++) {
+        publisher.handlers.get(PRESENCE_SOCKET_EVENTS.cursorMove)?.({
+          boardId: 'board-1',
+          x: index,
+          y: index,
+        });
+      }
+
+      expect(service).not.toHaveBeenCalled();
+      expect(boardGet).not.toHaveBeenCalled();
+      expect(boardFind).not.toHaveBeenCalled();
+      expect(
+        io.volatileEmitted.filter((entry) => entry.event === PRESENCE_SOCKET_EVENTS.cursorMoved)
+      ).toHaveLength(20);
     });
 
     it('never derives a navbar board association from cursor-only authorization', async () => {

--- a/apps/agor-daemon/src/setup/socketio.ts
+++ b/apps/agor-daemon/src/setup/socketio.ts
@@ -67,6 +67,7 @@ import {
   TERMINAL_REQUEST_JOIN_CHANNEL,
   type TerminalRequestConnection,
 } from '../terminal-socket-connection.js';
+import { FEATHERS_INSTRUMENTATION_REASON } from '../utils/feathers-instrumentation.js';
 import {
   joinExecutorTaskChannel,
   leaveAllExecutorTaskChannels,
@@ -1143,6 +1144,7 @@ export function createSocketIOConfig(
                 provider: 'socketio',
                 connection: fs.feathers,
                 tenant: auth.tenant,
+                [FEATHERS_INSTRUMENTATION_REASON]: 'presence_cursor_admission',
               } as never)) as Board;
               if (
                 board.archived ||

--- a/apps/agor-daemon/src/setup/socketio.ts
+++ b/apps/agor-daemon/src/setup/socketio.ts
@@ -964,11 +964,6 @@ export function createSocketIOConfig(
         );
       }
 
-      // Helper to get the user ID from immutable connection authority.
-      const getUserId = () => {
-        return getSocketAuthState(socket).userId ?? 'unknown';
-      };
-
       // A terminal-executor identity has zero non-terminal daemon visibility:
       // it must not watch board presence rooms or emit/receive cursor+presence
       // activity (it would otherwise spoof presence and observe collaborators).
@@ -1034,7 +1029,11 @@ export function createSocketIOConfig(
         delete presenceSocket.data.lastBoardPresenceEmitAt;
       };
 
-      const currentPresenceIdentity = () => {
+      const currentPresenceIdentity = (): {
+        userId: string;
+        tenantId: string;
+        presenceId: string;
+      } | null => {
         const auth = getSocketAuthState(socket);
         const tenantId = auth.tenant?.tenant_id;
         const presenceId = presenceSocket.data.presenceId;
@@ -1050,10 +1049,8 @@ export function createSocketIOConfig(
         return { userId: auth.userId, tenantId, presenceId };
       };
 
-      const publishTenantLiveness = () => {
-        const identity = currentPresenceIdentity();
+      const publishTenantLiveness = (identity = currentPresenceIdentity(), now = Date.now()) => {
         if (!identity) return;
-        const now = Date.now();
         if (
           presenceSocket.data.presenceActive &&
           presenceSocket.data.lastTenantPresenceEmitAt &&
@@ -1355,45 +1352,47 @@ export function createSocketIOConfig(
 
       // Handle cursor movement events
       socket.on(PRESENCE_SOCKET_EVENTS.cursorMove, (data: CursorMoveEvent) => {
-        if (isTerminalExecutorSocket()) return;
         if (!isCursorMoveEvent(data)) return;
         if (!allowCursorMove()) return;
-        const userId = getUserId();
+        // One immutable-authority projection plus the in-memory board grant is
+        // the entire per-sample authorization path. Never put a Feathers/DB
+        // lookup in this high-frequency handler: admission and revocation own
+        // that work at connection/room boundaries.
+        const identity = currentPresenceIdentity();
+        if (!identity) return;
         const fs = socket as FeathersSocket;
-        const tenantId = getTenantId();
-        if (!tenantId || !getSocketAuthState(socket).userId) return;
         if (!fs.data.authorizedBoardIds?.has(data.boardId)) return;
-        const presenceId = fs.data.presenceId;
-        if (!presenceId) return;
         const previousBoardId = fs.data.currentBoardId;
         const timestamp = Date.now();
 
         if (previousBoardId && previousBoardId !== data.boardId) {
           const left: CursorLeftEvent = {
-            userId,
-            presenceId,
+            userId: identity.userId,
+            presenceId: identity.presenceId,
             boardId: previousBoardId,
             timestamp,
           };
           emitHaNativeSocketEvent(
-            socket.broadcast.to(boardPresenceRoomName(tenantId, previousBoardId)),
+            socket.broadcast.to(boardPresenceRoomName(identity.tenantId, previousBoardId)),
             PRESENCE_SOCKET_EVENTS.cursorLeft,
             left
           );
         }
 
         const broadcastData: CursorMovedEvent = {
-          userId,
-          presenceId,
+          userId: identity.userId,
+          presenceId: identity.presenceId,
           boardId: data.boardId,
           x: data.x,
           y: data.y,
           timestamp,
         };
 
-        // Broadcast cursor position only to tabs actively watching this board.
+        // Cursor samples are lossy state, not an event log. Volatile fanout
+        // prevents a slow/recovering transport from buffering stale positions;
+        // leave/presence edge events intentionally remain reliable.
         emitHaNativeSocketEvent(
-          socket.broadcast.to(boardPresenceRoomName(tenantId, data.boardId)),
+          socket.broadcast.to(boardPresenceRoomName(identity.tenantId, data.boardId)).volatile,
           PRESENCE_SOCKET_EVENTS.cursorMoved,
           broadcastData
         );
@@ -1402,33 +1401,29 @@ export function createSocketIOConfig(
         // Cursor authorization and navbar association authorization are
         // intentionally separate. Cursor traffic refreshes only tenant-wide
         // liveness and can never assert a board association.
-        publishTenantLiveness();
+        publishTenantLiveness(identity, timestamp);
       });
 
       // Handle cursor leave events (user navigates away from board)
       socket.on(PRESENCE_SOCKET_EVENTS.cursorLeave, (data: CursorLeaveEvent) => {
-        if (isTerminalExecutorSocket()) return;
-        const userId = getUserId();
+        const identity = currentPresenceIdentity();
+        if (!identity) return;
         const fs = socket as FeathersSocket;
-        const tenantId = getTenantId();
-        if (!tenantId || !getSocketAuthState(socket).userId) return;
         if (!isBoundedBoardId(data?.boardId) || !fs.data.authorizedBoardIds?.has(data.boardId)) {
           return;
         }
         if (fs.data.currentBoardId !== data.boardId) return;
-        const presenceId = fs.data.presenceId;
-        if (!presenceId) return;
         // Make leave edge-triggered before fanout. Repeated caller packets can
         // no longer amplify one accepted, rate-limited cursor move into
         // unbounded Redis traffic.
         delete fs.data.currentBoardId;
 
         emitHaNativeSocketEvent(
-          socket.broadcast.to(boardPresenceRoomName(tenantId, data.boardId)),
+          socket.broadcast.to(boardPresenceRoomName(identity.tenantId, data.boardId)),
           PRESENCE_SOCKET_EVENTS.cursorLeft,
           {
-            userId,
-            presenceId,
+            userId: identity.userId,
+            presenceId: identity.presenceId,
             boardId: data.boardId,
             timestamp: Date.now(),
           }

--- a/apps/agor-daemon/src/tracing/feathers.test.ts
+++ b/apps/agor-daemon/src/tracing/feathers.test.ts
@@ -1,3 +1,4 @@
+import { feathers } from '@agor/core/feathers';
 import type { HookContext } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
 import { FEATHERS_INSTRUMENTATION_REASON } from '../utils/feathers-instrumentation.js';
@@ -151,6 +152,69 @@ describe('Feathers tracing hook', () => {
     await hook(ctx('sessions', 'archive'), async () => undefined);
     expect(tracer.calls[0]?.resource).toBe('sessions.custom');
     expect(tracer.calls[0]?.tags?.['feathers.transport']).toBe('internal');
+    expect(tracer.calls[0]?.tags).not.toHaveProperty('feathers.custom_method');
+  });
+
+  it.each([
+    'connectExecutor',
+    'reportTerminationComplete',
+    'reportRuntimeTelemetry',
+    'reportSdkHealthFailure',
+  ])(
+    'attributes the bounded tasks.custom method %s without changing its resource',
+    async (name) => {
+      const tracer = new RecordingTracer();
+      const hook = createFeathersTracingHook('full', { tracer });
+
+      await hook(ctx('tasks', name, 'socketio'), async () => undefined);
+
+      expect(tracer.calls[0]?.resource).toBe('tasks.custom');
+      expect(tracer.calls[0]?.tags).toMatchObject({
+        'feathers.method': 'custom',
+        'feathers.custom_method': name,
+      });
+    }
+  );
+
+  it('does not tag an unreviewed custom method', async () => {
+    const tracer = new RecordingTracer();
+    const hook = createFeathersTracingHook('full', { tracer });
+
+    await hook(ctx('tasks', 'callerSelectedMethod', 'socketio'), async () => undefined);
+
+    expect(tracer.calls[0]?.tags).not.toHaveProperty('feathers.custom_method');
+  });
+
+  it('receives the registered custom method name from a real Feathers invocation', async () => {
+    const tracer = new RecordingTracer();
+    const serviceApp = feathers();
+    serviceApp.use(
+      'tasks',
+      {
+        async reportRuntimeTelemetry() {
+          return { task_id: 'not-emitted' };
+        },
+      },
+      { methods: ['reportRuntimeTelemetry'] }
+    );
+    serviceApp.hooks({
+      around: { all: [createFeathersTracingHook('full', { tracer })] },
+    });
+
+    await (
+      serviceApp.service('tasks') as unknown as {
+        reportRuntimeTelemetry(data: unknown, params: unknown): Promise<unknown>;
+      }
+    ).reportRuntimeTelemetry({}, { provider: 'socketio' });
+
+    expect(tracer.calls).toHaveLength(1);
+    expect(tracer.calls[0]).toMatchObject({
+      resource: 'tasks.custom',
+      tags: {
+        'feathers.method': 'custom',
+        'feathers.custom_method': 'reportRuntimeTelemetry',
+      },
+    });
   });
 
   it('skips the high-frequency health probe by default at every depth', async () => {

--- a/apps/agor-daemon/src/tracing/feathers.test.ts
+++ b/apps/agor-daemon/src/tracing/feathers.test.ts
@@ -1,5 +1,6 @@
 import type { HookContext } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
+import { FEATHERS_INSTRUMENTATION_REASON } from '../utils/feathers-instrumentation.js';
 import { createFeathersTracingHook, type DatadogTracer, resolveTracerModule } from './feathers.js';
 
 interface TracedCall {
@@ -123,6 +124,25 @@ describe('Feathers tracing hook', () => {
         },
       },
     ]);
+  });
+
+  it('adds only a bounded server-authored reason tag when one is present', async () => {
+    const tracer = new RecordingTracer();
+    const hook = createFeathersTracingHook('full', { tracer });
+    const context = ctx('boards', 'get', 'socketio');
+    Object.assign(context.params, {
+      [FEATHERS_INSTRUMENTATION_REASON]: 'presence_cursor_admission',
+      // A wire/client string with the same description is deliberately inert;
+      // only the server-held symbol above is read.
+      feathersReason: 'unbounded-client-value',
+    });
+
+    await hook(context, async () => undefined);
+
+    expect(tracer.calls[0]?.tags).toMatchObject({
+      'feathers.transport': 'socketio',
+      'feathers.reason': 'presence_cursor_admission',
+    });
   });
 
   it('normalizes unknown methods to custom and internal (no-provider) transport', async () => {

--- a/apps/agor-daemon/src/tracing/feathers.ts
+++ b/apps/agor-daemon/src/tracing/feathers.ts
@@ -9,6 +9,7 @@ import {
   normalizeFeathersService,
   normalizeFeathersTransport,
   readFeathersInstrumentationReason,
+  readTaggedFeathersCustomMethod,
 } from '../utils/feathers-instrumentation.js';
 
 type AroundNext = () => Promise<void>;
@@ -118,6 +119,7 @@ export function createFeathersTracingHook(
     const service = normalizeFeathersService(context.path);
     const method = normalizeFeathersMethod(context.method);
     const reason = readFeathersInstrumentationReason(context.params);
+    const customMethod = readTaggedFeathersCustomMethod(context.path, context.method);
     const runTraced = () =>
       tracer.trace(
         'feathers.request',
@@ -129,6 +131,7 @@ export function createFeathersTracingHook(
             'feathers.transport':
               normalizeFeathersTransport(context.params?.provider) ?? 'internal',
             ...(reason ? { 'feathers.reason': reason } : {}),
+            ...(customMethod ? { 'feathers.custom_method': customMethod } : {}),
             'span.kind': 'server',
           },
         },

--- a/apps/agor-daemon/src/tracing/feathers.ts
+++ b/apps/agor-daemon/src/tracing/feathers.ts
@@ -8,6 +8,7 @@ import {
   normalizeFeathersMethod,
   normalizeFeathersService,
   normalizeFeathersTransport,
+  readFeathersInstrumentationReason,
 } from '../utils/feathers-instrumentation.js';
 
 type AroundNext = () => Promise<void>;
@@ -116,6 +117,7 @@ export function createFeathersTracingHook(
 
     const service = normalizeFeathersService(context.path);
     const method = normalizeFeathersMethod(context.method);
+    const reason = readFeathersInstrumentationReason(context.params);
     const runTraced = () =>
       tracer.trace(
         'feathers.request',
@@ -126,6 +128,7 @@ export function createFeathersTracingHook(
             'feathers.method': method,
             'feathers.transport':
               normalizeFeathersTransport(context.params?.provider) ?? 'internal',
+            ...(reason ? { 'feathers.reason': reason } : {}),
             'span.kind': 'server',
           },
         },

--- a/apps/agor-daemon/src/utils/branch-authorization.test.ts
+++ b/apps/agor-daemon/src/utils/branch-authorization.test.ts
@@ -327,7 +327,7 @@ describe('request-scoped RBAC loading', () => {
   }
 
   it('reuses a loaded session and branch across RBAC hooks in one request', async () => {
-    const sessionService = { get: vi.fn(async () => session) };
+    const sessionRepo = { findById: vi.fn(async () => session) };
     const branchRepo = makeBranchRepo();
     const ctx = {
       path: 'messages',
@@ -340,33 +340,34 @@ describe('request-scoped RBAC loading', () => {
       },
     } as unknown as HookContext;
 
-    await loadSession(sessionService)(ctx);
-    await loadSession(sessionService)(ctx);
+    await loadSession(sessionRepo)(ctx);
+    await loadSession(sessionRepo)(ctx);
     await loadBranchFromSession(branchRepo as never)(ctx);
     await loadBranchFromSession(branchRepo as never)(ctx);
 
-    expect(sessionService.get).toHaveBeenCalledTimes(1);
+    expect(sessionRepo.findById).toHaveBeenCalledTimes(1);
     expect(branchRepo.findById).toHaveBeenCalledTimes(1);
     expect(branchRepo.isOwner).toHaveBeenCalledTimes(1);
     expect(branchRepo.resolveUserPermission).toHaveBeenCalledTimes(1);
   });
 
-  it('marks sessions.get hook-loaded session as prefetched for the service get()', async () => {
-    const sessionService = { get: vi.fn(async () => session) };
+  it('canonicalizes and passes the repository-loaded session to the service get()', async () => {
+    const sessionRepo = { findById: vi.fn(async () => session) };
     const branchRepo = makeBranchRepo();
     const ctx = {
       path: 'sessions',
       method: 'get',
-      id: session.session_id,
+      id: 'session-c',
       params: {
         provider: 'rest',
         user: { user_id: USER_ID, role: ROLES.MEMBER },
       },
     } as unknown as HookContext;
 
-    await loadSessionBranch(sessionService, branchRepo as never)(ctx);
+    await loadSessionBranch(sessionRepo, branchRepo as never)(ctx);
 
-    expect(sessionService.get).toHaveBeenCalledTimes(1);
+    expect(sessionRepo.findById).toHaveBeenCalledWith('session-c');
+    expect(ctx.id).toBe(session.session_id);
     expect(ctx.params.session).toBe(session);
     expect(
       (ctx.params as { _agorPrefetchedRecord?: { record: unknown } })._agorPrefetchedRecord
@@ -375,6 +376,28 @@ describe('request-scoped RBAC loading', () => {
       idField: 'session_id',
       record: session,
     });
+  });
+
+  it('canonicalizes session IDs in the shared session authorization hook', async () => {
+    const sessionRepo = { findById: vi.fn(async () => session) };
+    const ctx = {
+      path: 'sessions',
+      method: 'patch',
+      id: 'session-c',
+      params: {
+        provider: 'rest',
+        user: { user_id: USER_ID, role: ROLES.MEMBER },
+        sessionId: 'session-c',
+      },
+    } as unknown as HookContext;
+
+    await loadSession(sessionRepo)(ctx);
+
+    expect(ctx.id).toBe(session.session_id);
+    expect(
+      (ctx.params as { _agorPrefetchedRecord?: { id: string; record: unknown } })
+        ._agorPrefetchedRecord
+    ).toEqual({ id: session.session_id, idField: 'session_id', record: session });
   });
 
   // Every id-addressed verb must resolve here. A verb missing from the branch

--- a/apps/agor-daemon/src/utils/branch-authorization.ts
+++ b/apps/agor-daemon/src/utils/branch-authorization.ts
@@ -134,8 +134,7 @@ function rememberPrefetchedRecord(
 
 async function loadCachedSession(
   params: AuthenticatedParams,
-  // biome-ignore lint/suspicious/noExplicitAny: FeathersJS service type not fully typed
-  sessionService: any,
+  sessionRepo: Pick<SessionRepository, 'findById'>,
   sessionId: string
 ): Promise<Session> {
   const cachedParamSession = (params as PrefetchParams).session as Session | undefined;
@@ -147,7 +146,7 @@ async function loadCachedSession(
   const cached = cache.sessions.get(sessionId);
   if (cached) return cached;
 
-  const session = (await sessionService.get(sessionId, { provider: undefined })) as Session | null;
+  const session = await sessionRepo.findById(sessionId);
   if (!session) {
     throw new Forbidden(`Session not found: ${sessionId}`);
   }
@@ -828,13 +827,12 @@ export function filterBranchesByPermission(branchRepo: BranchRepository) {
  * For session/task/message operations, we need to resolve the branch first.
  * This hook loads the session, then loads its branch.
  *
- * @param sessionService - FeathersJS sessions service
+ * @param sessionRepo - Tenant-scoped canonical session repository
  * @param branchRepo - BranchRepository instance
  * @returns Feathers hook
  */
 export function loadSessionBranch(
-  // biome-ignore lint/suspicious/noExplicitAny: FeathersJS service type not fully typed
-  sessionService: any, // Type as FeathersService if available
+  sessionRepo: Pick<SessionRepository, 'findById'>,
   branchRepo: BranchRepository
 ) {
   return async (context: HookContext) => {
@@ -892,9 +890,13 @@ export function loadSessionBranch(
       throw new Error('Cannot load session branch: session_id not found');
     }
 
-    const session = await loadCachedSession(context.params, sessionService, sessionId);
-    if (context.path === 'sessions' && context.id && String(context.id) === sessionId) {
-      rememberPrefetchedRecord(context, session, 'session_id', sessionId);
+    const session = await loadCachedSession(context.params, sessionRepo, sessionId);
+    if (context.path === 'sessions' && context.id) {
+      // Canonicalize short IDs once at the authorization boundary, then pass
+      // the exact tenant-scoped row through to the service body. This avoids a
+      // recursive Feathers sessions.get and lets DrizzleService reuse the row.
+      context.id = session.session_id;
+      rememberPrefetchedRecord(context, session, 'session_id', session.session_id);
     }
 
     const branch = await loadCachedBranch(context.params, branchRepo, session.branch_id);
@@ -995,12 +997,9 @@ export function resolveSessionContext() {
  *
  * This is Step 2 of the RBAC hook chain.
  *
- * @param sessionService - FeathersJS sessions service
+ * @param sessionRepo - Tenant-scoped canonical session repository
  */
-export function loadSession(
-  // biome-ignore lint/suspicious/noExplicitAny: FeathersJS service type
-  sessionService: any
-) {
+export function loadSession(sessionRepo: Pick<SessionRepository, 'findById'>) {
   return async (context: HookContext) => {
     // Skip for internal calls
     if (!context.params.provider) {
@@ -1013,9 +1012,10 @@ export function loadSession(
       throw new Error('resolveSessionContext hook must run before loadSession');
     }
 
-    const session = await loadCachedSession(context.params, sessionService, sessionId);
-    if (context.path === 'sessions' && context.id && String(context.id) === sessionId) {
-      rememberPrefetchedRecord(context, session, 'session_id', sessionId);
+    const session = await loadCachedSession(context.params, sessionRepo, sessionId);
+    if (context.path === 'sessions' && context.id) {
+      context.id = session.session_id;
+      rememberPrefetchedRecord(context, session, 'session_id', session.session_id);
     }
 
     // Cache on context for downstream hooks (type-safe via RBACParams)

--- a/apps/agor-daemon/src/utils/feathers-instrumentation.ts
+++ b/apps/agor-daemon/src/utils/feathers-instrumentation.ts
@@ -12,6 +12,34 @@ import type { HookContext } from '@agor/core/types';
 
 export type FeathersTransport = 'rest' | 'socketio' | 'mcp' | 'other';
 
+/**
+ * Server-authored, bounded reasons for service calls which otherwise look like
+ * anonymous transport entrypoints in APM. Keep this list deliberately small:
+ * values become Datadog tags, while resource IDs and user/tenant identifiers
+ * must never enter tracing dimensions.
+ */
+export const FEATHERS_INSTRUMENTATION_REASONS = ['presence_cursor_admission'] as const;
+export type FeathersInstrumentationReason = (typeof FEATHERS_INSTRUMENTATION_REASONS)[number];
+
+/**
+ * A symbol prevents a browser from forging an internal reason over REST or
+ * Socket.IO serialization. It remains available when server code spreads the
+ * params object into a nested Feathers call.
+ */
+export const FEATHERS_INSTRUMENTATION_REASON = Symbol('agor.feathersInstrumentationReason');
+
+export function readFeathersInstrumentationReason(
+  params: unknown
+): FeathersInstrumentationReason | undefined {
+  if (!params || typeof params !== 'object') return undefined;
+  const reason = (params as { [FEATHERS_INSTRUMENTATION_REASON]?: unknown })[
+    FEATHERS_INSTRUMENTATION_REASON
+  ];
+  return FEATHERS_INSTRUMENTATION_REASONS.includes(reason as FeathersInstrumentationReason)
+    ? (reason as FeathersInstrumentationReason)
+    : undefined;
+}
+
 const KNOWN_METHODS = ['create', 'find', 'get', 'patch', 'remove', 'update'];
 
 /**

--- a/apps/agor-daemon/src/utils/feathers-instrumentation.ts
+++ b/apps/agor-daemon/src/utils/feathers-instrumentation.ts
@@ -18,7 +18,10 @@ export type FeathersTransport = 'rest' | 'socketio' | 'mcp' | 'other';
  * values become Datadog tags, while resource IDs and user/tenant identifiers
  * must never enter tracing dimensions.
  */
-export const FEATHERS_INSTRUMENTATION_REASONS = ['presence_cursor_admission'] as const;
+export const FEATHERS_INSTRUMENTATION_REASONS = [
+  'presence_cursor_admission',
+  'session_stream_admission',
+] as const;
 export type FeathersInstrumentationReason = (typeof FEATHERS_INSTRUMENTATION_REASONS)[number];
 
 /**
@@ -41,6 +44,24 @@ export function readFeathersInstrumentationReason(
 }
 
 const KNOWN_METHODS = ['create', 'find', 'get', 'patch', 'remove', 'update'];
+
+/**
+ * Custom methods whose APM attribution is operationally useful and strictly
+ * bounded by a reviewed server registration. Do not accept arbitrary method
+ * strings here: values become Datadog tags.
+ */
+const TAGGED_CUSTOM_METHODS: Readonly<Record<string, readonly string[]>> = {
+  tasks: [
+    'connectExecutor',
+    'reportTerminationComplete',
+    'reportRuntimeTelemetry',
+    'reportSdkHealthFailure',
+  ],
+};
+
+export function readTaggedFeathersCustomMethod(path: string, method: string): string | undefined {
+  return TAGGED_CUSTOM_METHODS[path]?.includes(method) ? method : undefined;
+}
 
 /**
  * Map a Feathers `params.provider` to a bounded transport label. Returns

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.test.tsx
@@ -62,9 +62,20 @@ vi.mock('./SessionRunSettingsPopover', () => ({
   SessionRunSettingsPopover: () => null,
 }));
 
-const reactive = vi.hoisted(() => ({ tasks: [] as Task[] }));
+const reactive = vi.hoisted(() => {
+  const state = { tasks: [] as Task[] };
+  return {
+    get tasks() {
+      return state.tasks;
+    },
+    set tasks(tasks: Task[]) {
+      state.tasks = tasks;
+    },
+    useSharedReactiveSession: vi.fn(() => ({ state: { tasks: state.tasks } })),
+  };
+});
 vi.mock('../../hooks/useSharedReactiveSession', () => ({
-  useSharedReactiveSession: () => ({ state: { tasks: reactive.tasks } }),
+  useSharedReactiveSession: reactive.useSharedReactiveSession,
 }));
 
 const connected = {
@@ -240,6 +251,15 @@ describe('SessionPanel search control', () => {
 
     fireEvent.keyDown(searchInput, { key: 'Escape' });
     expect(getSearchRow()).toHaveStyle({ maxHeight: '0px' });
+  });
+
+  it('retains the same lazy reactive-session cache key as ConversationView', () => {
+    renderPanel();
+
+    expect(reactive.useSharedReactiveSession).toHaveBeenLastCalledWith(null, session.session_id, {
+      enabled: true,
+      reactiveOptions: { taskHydration: 'lazy' },
+    });
   });
 });
 

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -618,7 +618,10 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   const reactiveSessionId = session?.session_id ?? null;
   const { state: reactiveSessionState } = useSharedReactiveSession(client, reactiveSessionId, {
     enabled: open,
-    reactiveOptions: { taskHydration: 'none' },
+    // ConversationView retains the same lazy handle. Keeping the cache key
+    // identical collapses duplicate Session bootstrap/reconnect reads while
+    // preserving the transcript's latest-task hydration contract.
+    reactiveOptions: { taskHydration: 'lazy' },
   });
 
   const tasks = reactiveSessionState?.tasks || EMPTY_TASKS;

--- a/apps/agor-ui/src/hooks/useAgorData.test.tsx
+++ b/apps/agor-ui/src/hooks/useAgorData.test.tsx
@@ -34,7 +34,7 @@ const STANDALONE_AUTHORITY_SCOPE = '__standalone__:__standalone__:0';
  *     pre-seeded list for that service (default empty).
  *   - `service(name).on/removeListener` — wires up event handlers we
  *     dispatch from tests via `emit(name, event, payload)`.
- *   - `service(name).get(id)` — only used by the OAuth refetch path,
+ *   - `service(name).get(id)` — targeted deep-link / displayed-board reads,
  *     resolves with whatever the test stubbed.
  *   - `io.on/off` — captures connect / oauth listeners; tests don't
  *     trigger reconnect refetches.
@@ -86,7 +86,12 @@ function makeMockClient(seed: Record<string, unknown[]> = {}) {
   const service = (name: string) => ({
     findAll: vi.fn((args) => recordAndRespond(name, 'findAll', args)),
     find: vi.fn((args) => recordAndRespond(name, 'find', args)),
-    get: vi.fn().mockResolvedValue(seed[`${name}:get`] ?? null),
+    get: vi.fn((id: unknown) => {
+      const key = `${name}:get`;
+      fetchCounts.set(key, (fetchCounts.get(key) ?? 0) + 1);
+      fetchArguments.set(key, [...(fetchArguments.get(key) ?? []), id]);
+      return Promise.resolve(seed[key] ?? null);
+    }),
     on: (event: string, fn: Listener) => {
       let svc = serviceListeners.get(name);
       if (!svc) {
@@ -140,9 +145,9 @@ function makeMockClient(seed: Record<string, unknown[]> = {}) {
     // a write DURING the fetch window — exactly the race the hydration guards.
     onFetch: (name: string, method: 'findAll' | 'find', fn: (call: number) => unknown) =>
       fetchHooks.set(`${name}:${method}`, fn),
-    fetchCount: (name: string, method: 'findAll' | 'find') =>
+    fetchCount: (name: string, method: 'findAll' | 'find' | 'get') =>
       fetchCounts.get(`${name}:${method}`) ?? 0,
-    fetchArguments: (name: string, method: 'findAll' | 'find') =>
+    fetchArguments: (name: string, method: 'findAll' | 'find' | 'get') =>
       fetchArguments.get(`${name}:${method}`) ?? [],
   };
 }
@@ -1081,7 +1086,7 @@ describe('useAgorData — lean boards list + objects hydration', () => {
     };
     const seed: Record<string, unknown[]> = {};
     const gate = deferred();
-    const { client, onFetch } = makeMockClient(seed);
+    const { client, fetchCount, onFetch } = makeMockClient(seed);
     // Gated list (call 1) returns the lean board; hold the boards hydration
     // (call 2) open so the assertion sees the first-paint state — objects can
     // only have come from the targeted `boards.get`, never the hydration.
@@ -1100,6 +1105,8 @@ describe('useAgorData — lean boards list + objects hydration', () => {
       expect(board?.objects).toBeDefined();
       expect(Object.keys(board?.objects ?? {})).toContain('zone-1');
       expect(board?.custom_css).toBe('.x{}');
+      expect(fetchCount('boards', 'get')).toBe(1);
+      expect(fetchCount('branches', 'get')).toBe(0);
     } finally {
       gate.resolve();
       window.history.pushState({}, '', '/');
@@ -1122,7 +1129,7 @@ describe('useAgorData — lean boards list + objects hydration', () => {
     };
     const seed: Record<string, unknown[]> = {};
     const gate = deferred();
-    const { client, onFetch } = makeMockClient(seed);
+    const { client, fetchCount, onFetch } = makeMockClient(seed);
     // Hold the boards hydration (call 2) open so the assertion sees first-paint
     // state — objects can only have come from the targeted `boards.get`.
     seed['boards:get'] = fullBoard as never;
@@ -1139,6 +1146,8 @@ describe('useAgorData — lean boards list + objects hydration', () => {
       const board = agorStore.getState().boardById.get(boardId);
       expect(board?.objects).toBeDefined();
       expect(Object.keys(board?.objects ?? {})).toContain('zone-1');
+      expect(fetchCount('boards', 'get')).toBe(1);
+      expect(fetchCount('branches', 'get')).toBe(0);
       expect(board?.custom_css).toBe('.x{}');
     } finally {
       gate.resolve();
@@ -1158,7 +1167,7 @@ describe('useAgorData — lean boards list + objects hydration', () => {
       objects: { 'z-b': { type: 'zone', x: 0, y: 0, width: 1, height: 1 } },
     };
     const seed: Record<string, unknown[]> = {};
-    const { client, onFetch } = makeMockClient(seed);
+    const { client, fetchCount, onFetch } = makeMockClient(seed);
     // Home path (jsdom `/`): no board scope, no targeted get. The lean gated
     // fetch (call 1) carries no objects; the hydration (call 2) carries them.
     onFetch('boards', 'findAll', (call) => {
@@ -1169,5 +1178,39 @@ describe('useAgorData — lean boards list + objects hydration', () => {
     await flush();
     expect(agorStore.getState().boardById.get('board-A')?.objects).toBeDefined();
     expect(agorStore.getState().boardById.get('board-B')?.objects).toBeDefined();
+    expect(fetchCount('boards', 'get')).toBe(0);
+    expect(fetchCount('branches', 'get')).toBe(0);
+  });
+
+  it('does not repeat the displayed-board point read during reconnect resync', async () => {
+    window.history.pushState({}, '', '/b/displayed/');
+    const board = {
+      board_id: 'board-D',
+      slug: 'displayed',
+      name: 'Displayed',
+      objects: { 'zone-1': { type: 'zone', x: 0, y: 0, width: 1, height: 1 } },
+    };
+    const seed: Record<string, unknown[]> = {
+      boards: [board],
+      'boards:get': board as never,
+    };
+    const { client, emitIo, fetchCount } = makeMockClient(seed);
+    const { result } = renderHook(() => useAgorData(client));
+    try {
+      await waitForInitialLoad(result);
+      await flush();
+      expect(fetchCount('boards', 'get')).toBe(1);
+
+      act(() => emitIo('connect'));
+      await waitFor(() => expect(fetchCount('boards', 'findAll')).toBeGreaterThanOrEqual(3));
+      await flush();
+
+      // Silent reconnect uses the full boards.findAll snapshot. It deliberately
+      // skips the cold-load targeted get, so resync and idle do not poll boards.
+      expect(fetchCount('boards', 'get')).toBe(1);
+      expect(fetchCount('branches', 'get')).toBe(0);
+    } finally {
+      window.history.pushState({}, '', '/');
+    }
   });
 });

--- a/apps/agor-ui/src/hooks/useCursorTracking.test.tsx
+++ b/apps/agor-ui/src/hooks/useCursorTracking.test.tsx
@@ -1,0 +1,61 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useCursorTracking } from './useCursorTracking';
+
+describe('useCursorTracking', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('coalesces mousemove bursts and sends only volatile cursor samples', () => {
+    vi.useFakeTimers();
+    const volatileEmit = vi.fn();
+    const normalEmit = vi.fn();
+    const client = {
+      io: {
+        emit: normalEmit,
+        volatile: { emit: volatileEmit },
+      },
+    };
+    const reactFlowInstance = {
+      screenToFlowPosition: ({ x, y }: { x: number; y: number }) => ({ x, y }),
+    };
+    const { unmount } = renderHook(() =>
+      useCursorTracking({
+        client: client as never,
+        boardId: 'board-1' as never,
+        reactFlowInstance: reactFlowInstance as never,
+      })
+    );
+
+    act(() => {
+      window.dispatchEvent(new MouseEvent('mousemove', { clientX: 1, clientY: 2 }));
+      for (let index = 2; index <= 20; index++) {
+        window.dispatchEvent(new MouseEvent('mousemove', { clientX: index, clientY: index + 1 }));
+      }
+    });
+
+    // The first sample is immediate; the rest of the burst is one trailing,
+    // latest-position sample at the 100ms cadence (10/s steady state).
+    expect(volatileEmit).toHaveBeenCalledTimes(1);
+    expect(volatileEmit).toHaveBeenLastCalledWith('cursor-move', {
+      boardId: 'board-1',
+      x: 1,
+      y: 2,
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(volatileEmit).toHaveBeenCalledTimes(2);
+    expect(volatileEmit).toHaveBeenLastCalledWith('cursor-move', {
+      boardId: 'board-1',
+      x: 20,
+      y: 21,
+    });
+    expect(normalEmit).not.toHaveBeenCalled();
+
+    unmount();
+    expect(volatileEmit).toHaveBeenLastCalledWith('cursor-leave', { boardId: 'board-1' });
+  });
+});

--- a/docs/internal/branch-board-point-read-investigation-2026-08-28.md
+++ b/docs/internal/branch-board-point-read-investigation-2026-08-28.md
@@ -1,0 +1,462 @@
+# Branch and board point-read APM investigation (2026-08-28)
+
+## Scope and evidence boundary
+
+This investigation was opened for production APM rates of approximately
+30,000 `branches.get` resources/hour and 10,000 `boards.get` resources/hour.
+It covers the deployed source, every production call family, Feathers tracing
+semantics, deterministic UI and service call counts, RBAC/RLS boundaries, and
+bounded fixes.
+
+No Datadog API, Datadog MCP server, or read-only Datadog credential was
+available to this session. The deployed health endpoint was available, but it
+does not expose trace samples or the dashboard query definition. Consequently:
+
+- source and test statements below are **confirmed**;
+- arithmetic projections against the reported rates are marked **inference**;
+- no production tenant identifiers, resource identifiers, names, payloads,
+  trace headers, or secrets were read or recorded; and
+- the `boards.get` production split is deliberately left unattributed until the
+  low-cardinality tag added here is deployed or existing traces are queried.
+
+This is not a claim that all 30,000/10,000 reported hits are sampled spans,
+indexed spans, or APM trace-metric estimates. The exact Datadog graph measure
+and sampling/extrapolation settings must be captured with the follow-up query.
+
+## Exact revisions
+
+| Role                                              | Revision                                                                | Authored   | Subject                                                                 |
+| ------------------------------------------------- | ----------------------------------------------------------------------- | ---------- | ----------------------------------------------------------------------- |
+| Investigated `main` / `origin/main` / branch base | `5d19fbc6d72f36c9672010396510b35f1f8afbb9`                              | 2026-08-27 | `fix: allow HA Codex auth with delegated user homes (#2575)`            |
+| Deployed sandbox health response                  | `6a0074c1351f0a6d65540267dc7783b06cf7b258` (health reports `6a0074c13`) | 2026-08-26 | `feat(apm): trace postgres.js queries via Drizzle session shim (#2571)` |
+
+The deployed revision is an ancestor of investigated `main`. The health
+response reports Agor 0.25.2 and `realtime.required=false`, so this deployment
+uses the standalone `HealthMonitor`, not the distributed HA health observer.
+
+Relevant deployed changes are:
+
+- `21363788b...` / #2518 added fenced health observations and the final
+  canonical branch reload;
+- `e57798a47d54b50bccf19ae7386132688464af6e` / #2520 added tenant-isolated
+  realtime routing and repository-backed publication reauthorization;
+- `714ea498df84856a7e1f984fa4ff8bf96ebe5ce3` / #2567 hardened authorized board
+  presence; and
+- `194dc722c471ee51417f1f7303b0946283b55d64` / #2570 made Feathers service
+  invocations visible as `feathers.request` APM spans.
+
+The high-rate health behavior predates #2520/#2567. #2518 increased a normal
+active observation from two to three wrapped branch gets; #2570 then made all
+three visible under the same APM resource.
+
+## Executive result
+
+### Confirmed dominant branch amplifier
+
+The standalone environment monitor polls every five seconds. Before this
+change, one ordinary observation of one active environment made exactly three
+registered Feathers `branches.get` invocations:
+
+1. `HealthMonitor` preflighted current lifecycle state with
+   `branchesService.get`;
+2. the direct custom `BranchesService.checkHealth()` call performed its initial
+   `this.get`; and
+3. claim-skip, aborted-observation, and successful-commit paths performed a
+   final/revalidation `this.get`.
+
+A direct custom service method is not itself Feathers-wrapped, but its
+`this.get()` resolves the registered standard method and does run app/service
+around hooks. An isolated Feathers/SQLite receipt proves the deployed shape is
+three wrapped gets and the new automatic shape is zero.
+
+Steady state is:
+
+```text
+12 observations/minute/environment
+× 3 branches.get spans/observation
+= 36 branches.get spans/minute/environment
+= 2,160 branches.get spans/hour/environment
+```
+
+**Inference:** 30,000/hour divided by 2,160/hour is 13.9 average active local
+environments. This is a strong numerical match, but must be confirmed by the
+Datadog five-second clustering and parent/root-span query below.
+
+The fix does not remove current-state or post-observation fencing. Automatic
+checks still make the two required canonical tenant-scoped branch loads; they
+no longer manufacture Feathers requests, and the redundant preflight plus an
+entirely unused `repos.get` are removed.
+
+### Board point reads
+
+There is no board point-read polling loop. A normal cold board tab performs two
+`boards.get` calls:
+
+1. one full-board read in `useAgorData` after the lean global board list; and
+2. one server-side cursor-room admission read for that socket/board.
+
+Idle presence heartbeats, cursor movements, open/closed session panels, normal
+realtime events, and reconnect data resync do not call `boards.get`. A reconnect
+does require one fresh cursor-room admission per displayed board because socket
+authority cannot be reused across connections.
+
+The source alone cannot decide how much of 10,000/hour is cold hydration versus
+cursor admission versus explicit UI/MCP/CLI actions. This change adds only the
+bounded server-authored tag
+`feathers.reason=presence_cursor_admission`. IDs and caller-controlled strings
+are never tags.
+
+### Validated assumptions
+
+- **UI hydration:** confirmed. The normal workspace path uses a lean
+  `boards.findAll`, a board-scoped `branches.findAll`, and one full displayed
+  `boards.get`; it does not point-read every branch.
+- **Prompt volume:** one ordinary agent task produces a model-dependent small
+  constant, typically 2–6 branch gets (working directory/safe-directory/git
+  snapshots plus daemon settlement), not a loop or heartbeat. Explaining
+  30,000/hour from prompts alone requires roughly 5,000–15,000 tasks/hour.
+  Actual production task rate was not available here.
+- **Internal calls:** confirmed. The largest branch source is an internal
+  provider-less timer path. Internal service fanout, MCP ID resolution, and
+  executor calls also contribute. Publication reauthorization itself uses
+  repositories and therefore is not counted as `branches.get`/`boards.get` APM
+  resources.
+
+## What the observed resource counts
+
+`apps/agor-daemon/src/tracing/feathers.ts` registers an app-level around hook.
+For each traced hook invocation it creates:
+
+```text
+operation: feathers.request
+resource:  <normalized service>.<normalized method>
+service:   inherited agor-daemon service
+tags:      feathers.service, feathers.method, feathers.transport, span.kind
+new tag:   feathers.reason (bounded and server-authored only)
+```
+
+`full` depth traces every registered standard service invocation, including
+nested service calls. `entrypoint` depth suppresses work nested inside its
+`AsyncLocalStorage` scope. It does not suppress the three health gets because
+the preflight scope ends before the direct custom call, the custom call is not
+wrapped, and its two sequential `this.get()` calls each establish a new scope.
+Thus the health signature is three in both depths.
+
+The hook creates one span per actual Feathers invocation; it contains no
+double-emission. An HTTP/Express or Socket.IO parent span is a different
+operation, not a duplicate `branches.get`/`boards.get`. PostgreSQL child spans
+are separate database operations. `health` is explicitly excluded.
+
+Transport interpretation:
+
+- browser/executor Socket.IO: `socketio`;
+- REST/CLI: `rest`;
+- MCP service params: `mcp`;
+- standalone health timer: `internal`;
+- internal fanout that preserves an external provider retains that transport.
+
+The separate DogStatsD Feathers metrics hook is not equivalent: it always
+suppresses nested calls and does not count provider-less calls. The reported
+APM resource rates must not be compared directly with
+`agor.daemon.feathers.requests` without accounting for that boundary.
+
+Duration covers the whole Feathers hook: tenant scope/transaction setup,
+authentication, RBAC, repository I/O, enrichment, and after hooks. Database
+time can only be separated by comparing child `postgres.query` spans with the
+parent duration. No production duration sample was available.
+
+## Exact caller/frequency matrix
+
+Counts are per stated action on deployed source unless the “after” column says
+otherwise. Repository reads do not generate a Feathers resource span.
+
+| Caller / trigger                                                | Transport           |                                            Before |                         After | Frequency / fanout                                                | Notes                                                                                                |
+| --------------------------------------------------------------- | ------------------- | ------------------------------------------------: | ----------------------------: | ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| Standalone `HealthMonitor`, active environment                  | internal            |                                     3 branch gets |                 0 branch gets | every 5 s/environment; 2,160 spans/h/environment removed          | Two canonical repository/service-body loads remain; one preflight and unused repo read removed       |
+| Standalone health startup discovery                             | internal            |                                  1 branch get/ref |                             1 | once per daemon start/ref                                         | Not periodic; preserves lifecycle validation                                                         |
+| Distributed HA health observer                                  | none                |                                                 0 |                             0 | scan/claim interval                                               | Direct `BranchRepository.findById`; a second read occurs only when state changed for publication     |
+| UI cold displayed board                                         | socketio            |                            0 branch, 2 board gets |                          same | per tab/cold route                                                | One `useAgorData` full board + one cursor admission                                                  |
+| UI cold Home                                                    | socketio            |                                               0/0 |                          same | per tab                                                           | Lists/finds only; no board cursor consumer                                                           |
+| UI direct active session missing from recent slice              | socketio            |                                     +1 branch get |                          same | once on deep link                                                 | The session can still open when inaccessible; no broad branch hydration                              |
+| UI direct branch link                                           | socketio            |                                     +1 branch get |                          same | once on cold deep link                                            | Establishes board scope, then uses scoped finds                                                      |
+| UI reconnect/resync on displayed board                          | socketio            |                             0 branch, 1 board get |                          same | per reconnect/tab                                                 | Data resync uses full finds; new socket cursor authority is re-established once                      |
+| UI same-socket board navigation                                 | socketio            |                             0 branch, 1 board get |                          same | per new board cursor room                                         | Unwatch removes the old authorization; new board fails closed through `boards.get`                   |
+| UI idle board / 15 s presence heartbeat                         | socketio native     |                                               0/0 |                          same | periodic heartbeat                                                | Association authorization uses one bulk `boards.find` only on set/focus/reconnect changes            |
+| Cursor move/leave (up to 10/s client throttle)                  | socketio native     |                                               0/0 |                          same | per movement                                                      | Uses socket-local authorized set; no service/repository point read                                   |
+| Open/close session panel                                        | socketio            |                                               0/0 |                          same | per toggle                                                        | Existing client store/realtime state                                                                 |
+| Normal realtime branch/session/card events                      | repository          |                                    0 service gets |                          same | per event                                                         | #2520 access cache and direct repository/audience queries; no Feathers point-read resource           |
+| Native board cursor admission                                   | socketio            |                                       1 board get |            1 tagged board get | once per socket/board admission                                   | Duplicate mount/connect/auth emits collapse through pending/authorized maps                          |
+| Board edit modal open                                           | socketio            |                                       1 board get |                             1 | explicit user action                                              | Refreshes current canonical board before edit                                                        |
+| Multiple tabs                                                   | socketio            |                                            linear |                        linear | 2 board gets per cold displayed-board tab; 1 per reconnect/tab    | No shared browser authority/cache by design                                                          |
+| Base Claude/Gemini/Copilot task                                 | socketio            |                           typically 5 branch gets |                          same | per task, not heartbeat                                           | safe-directory, start/end git state, SDK cwd, daemon completion; failure path has same bounded shape |
+| Codex task                                                      | socketio            |                           typically 6 branch gets |                          same | per task                                                          | Includes separate edit-baseline and prompt-service cwd reads                                         |
+| Cursor task                                                     | socketio            |                           typically 5 branch gets |                          same | per task                                                          | Explicit cwd plus safe-directory/start/end/settlement                                                |
+| OpenCode task                                                   | socketio            |                           typically 2 branch gets |                          same | per task                                                          | Direct cwd plus daemon completion; does not use base executor git snapshot flow                      |
+| Task pulse/heartbeat/watchdog                                   | socketio/repository |                               0 branch/board gets |                          same | periodic while active                                             | Task/session writes and runtime reconciliation, not branch/board service reads                       |
+| Session create/fork/spawn hooks                                 | mixed               |                             0–1 branch get/action |                          same | per user/gateway/schedule action                                  | Branch entity and personal sharing checks; not polling                                               |
+| CLI branch show/archive/remove/env actions                      | REST/socket client  |                              1 branch get/command |                          same | explicit command                                                  | Mutation may have its own later canonical reload                                                     |
+| UI filesystem readiness                                         | socketio            |                                 1 branch get/poll |                          same | only while newly created branch is materializing, bounded timeout | Not idle-board polling                                                                               |
+| MCP ID resolver                                                 | mcp                 |                                    1 matching get |             same unless below | once per supplied short/full ID                                   | Canonical service authorization boundary                                                             |
+| MCP card create/bulk-create                                     | mcp                 |                           2 board gets/invocation |                             1 | explicit action                                                   | Reuses the canonical board returned by the first authorized get                                      |
+| MCP branch set-zone                                             | mcp                 |                                     2 branch gets |                             1 | explicit action                                                   | Reuses canonical branch; board zone validation remains one board get                                 |
+| MCP schedules list with board filter                            | mcp                 | N branch gets (one/schedule, duplicates included) | 0 branch gets + 1 branch find | explicit list                                                     | Unique branch IDs are bulk-authorized by scoped `$in`; empty list makes no branch call               |
+| MCP bulk card move with zones                                   | mcp                 |                                up to N board gets |                     unchanged | one/moved card with zone                                          | Residual N+1; boards may differ and no policy-epoch-bound memo exists yet                            |
+| MCP session/context/knowledge/artifact/environment tools        | mcp                 |                               small constant gets |                          same | explicit tool call                                                | Some perform stronger filesystem/policy checks after canonical resolution                            |
+| Repos branch create/branch board move positioning               | inherited provider  |                                1 board get/action |                          same | explicit create/move                                              | Validates full board/zone or computes placement; not a list loop                                     |
+| Files, single-file, artifacts, terminal, upload/download routes | repository          |                                    0 service gets |                          same | explicit request                                                  | Direct tenant-scoped `BranchRepository` reads plus resource-specific authorization                   |
+| Scheduler/gateway/permission callbacks/MCP egress               | repository          |                      0 service gets in core loops |                          same | per scheduled run/message/decision                                | Direct branch lookup and explicit authorization; not represented by service resource rate            |
+| Redis Feathers relay publication                                | repository/cache    |                                    0 service gets |                          same | per relayed event/receiving replica                               | Re-resolves tenant/audience without trusting Redis room names; revocation is preserved               |
+
+## Production call-site inventory
+
+### Standard `branches.get` service callers
+
+- **UI:** `useAgorData.ts` (direct session/branch healing),
+  `waitForBranchFilesystemReady.ts`, gateway channel selection, onboarding, and
+  explicit branch/settings actions.
+- **CLI:** branch show/remove/archive/unarchive and environment
+  status/start/stop/restart commands.
+- **Executor:** safe-directory setup, start/end git snapshots, SDK working
+  directory resolution, file/git/environment commands, and the Feathers-backed
+  branch repository.
+- **Daemon:** standalone health startup/polling, session fork/spawn, session
+  create enrichment, task settlement origin alignment, repo actions, route
+  authorization/context, and widget submissions.
+- **MCP:** `resolveBranchId`, branch get/update/archive/delete/unarchive/zone,
+  session context/create, environment, artifact, Knowledge, schedule, and
+  analytics tools.
+
+Generated `packages/executor/dist` occurrences mirror the TypeScript source and
+are not an additional runtime call path.
+
+### Standard `boards.get` service callers
+
+- **UI:** displayed-board full hydration and Board Edit refresh.
+- **Native Socket.IO:** cursor-room admission.
+- **Daemon:** route branch→board context, branch placement, and repo branch
+  creation validation.
+- **MCP:** `resolveBoardId`, board get/update, card create/move/bulk operations,
+  branch zone context, and session context/detail.
+- **CLI:** board add-session and board import/export/clone operations where a
+  point entity is required.
+
+### Repository point reads (not counted by these APM resources)
+
+`BranchRepository.findById` is used by branch RBAC helpers, files/file,
+artifacts, terminal and upload/download routes, group checks, scheduler,
+gateway, permission decisions, MCP egress, Knowledge, and both health
+architectures. `BoardRepository.findById/findBySlugOrId` is used by board
+authorization, board routes, artifacts, and realtime publication.
+
+These reads matter for database load but cannot explain a
+`resource_name=branches.get|boards.get` count. Conversely, reducing an internal
+Feathers wrapper to a direct canonical load reduces APM and hook/transaction
+overhead even when a required database read remains.
+
+## Authorization and realtime findings
+
+### Branches
+
+#2520 already gives branch point authorization a bounded request cache and
+passes the just-authorized record to the generic Drizzle adapter through
+`_agorPrefetchedRecord`. External `branches.get` therefore does not reread the
+branch row in its service body. The cache is request-local, limited, and bound
+to the same params/tenant unit of work. List visibility is set-based SQL rather
+than `find` followed by per-row gets.
+
+### Boards
+
+Before this change, an external non-admin `boards.get` loaded the canonical
+board in `ensureBoardAccess`, loaded the same board again inside
+`BoardRepository.canView/canMutate`, then loaded it again in the service body.
+Authorization policy/group/user queries occurred between those reads.
+
+Now `canViewResolved/canMutateResolved` accepts only the canonical board loaded
+by the current hook, and the hook passes that same row into the generic adapter.
+Every external call still resolves the current policy. There is no cross-user,
+cross-tenant, cross-request, or time-based cache. For a canonical full ID this
+removes exactly two board-row SELECTs; short identifiers can also avoid a
+second prefix resolution after canonicalization. Policy, membership, user, and
+RLS queries are unchanged.
+
+### Presence and revocation
+
+Cursor rooms are raw Socket.IO rooms, so their one `boards.get` admission is a
+necessary fail-closed boundary. It cannot safely be replaced with UI state or
+shared across sockets/users/tenants. The socket tracks an in-flight admission
+and authorized board set so duplicate React mount/connect/auth emissions do
+not repeat the get. Unwatch, disconnect, authority change, and revocation clear
+authorization; reconnect performs a fresh get.
+
+Low-frequency navbar associations use a bounded `boards.find` with `$in`,
+`archived:false`, `lean:true`, and the authenticated tenant/caller. The 15 s
+heartbeat merely publishes against that acknowledged set. Cursor movement
+does not grant association authority.
+
+Realtime Feathers publication in #2520 uses a bounded access cache for branch
+and session mapping and direct board repository/audience queries. HA Redis
+delivery is a hint, not authority; the receiving replica reauthorizes. None of
+these paths calls standard `branches.get`/`boards.get`, though they can
+contribute separate database query volume. #2567 retained the cursor
+`boards.get`, added in-flight/authorized deduplication, and introduced bulk
+association `boards.find`; it did not add periodic board gets.
+
+## Before/after critical query model
+
+### Active standalone health tick
+
+Before:
+
+```text
+Feathers branches.get
+  -> branch row
+  -> zone-enrichment JOIN when board-attached
+direct checkHealth
+  -> Feathers branches.get
+     -> branch row
+     -> optional zone enrichment
+  -> unused Feathers repos.get -> repo row
+  -> health claim/fetch/commit
+  -> Feathers branches.get
+     -> branch row
+     -> optional zone enrichment
+```
+
+After:
+
+```text
+direct automatic checkHealth under the same tenant ALS/DB scope
+  -> unwrapped canonical branch row (+ optional zone enrichment)
+  -> health claim/fetch/commit
+  -> unwrapped canonical branch row (+ optional zone enrichment)
+```
+
+Savings per active tick are three Feathers spans, one branch-row SELECT, one
+repo-row SELECT, and (for a board-attached branch) one enrichment query. The
+two correctness/fencing branch reads and health coordination queries remain.
+
+### External non-admin board get with a canonical ID
+
+Before:
+
+```text
+slug miss + canonical board row
+second board row in canView/canMutate
+current policy / principal / group resolution
+third board row in service get
+```
+
+After:
+
+```text
+slug miss + canonical board row
+current policy / principal / group resolution against that row's ID
+service adapter consumes the same request-scoped canonical row
+```
+
+The Feathers span count remains one; database board-row reads fall by two.
+Authorization query count and revocation semantics do not change.
+
+## Implemented bounded fixes
+
+1. Remove the standalone health monitor preflight and unused repo read.
+2. Split branch canonical loading from the standard Feathers `get`; automatic
+   health uses the unwrapped loader, explicit user/MCP health keeps standard
+   authorization hooks.
+3. Preserve monitor self-cleanup by using `checkHealth`'s canonical result when
+   a lifecycle realtime hint was missed.
+4. Reuse a freshly authorized canonical board through board policy resolution
+   and the generic adapter, scoped to one request/tenant transaction.
+5. Reuse canonical MCP branch/board entities where an ID resolver immediately
+   performed the same get again.
+6. Replace schedule board-filter N+1 branch gets with one authorized bulk find
+   over unique IDs.
+7. Add the bounded server-only `presence_cursor_admission` APM reason.
+8. Add deterministic UI and daemon call-count receipts.
+
+No global/TTL entity cache was introduced. No production data/configuration was
+changed and no deployment was performed.
+
+## Validation receipts
+
+- Combined daemon health, tracing, native Socket.IO, branch, MCP, hook, and
+  adapter suites: 375 tests passed across 9 files.
+- UI data/presence suites: 40 tests passed.
+- Branch health SQLite/Feathers receipt: 9 focused tests passed, including
+  exact wrapped-get reduction `3 -> 0`.
+- MCP card/branch/schedule focused suites passed, including schedule
+  `N branches.get -> 1 branches.find` and duplicate create/set-zone receipts.
+- Hook/Drizzle prefetch suites: 105 tests passed.
+- Core SQLite board repository suite: 103 tests passed.
+- PostgreSQL 16 under a non-superuser, `NOBYPASSRLS` role: capability-policy
+  concurrency plus environment-health HA suites, 9/9 tests passed.
+- Core and daemon TypeScript checks passed without a production build. The UI
+  check was attempted but the disposable workspace lacked the prebuilt
+  `packages/client/dist/*.d.ts` declarations, cascading into unrelated module
+  resolution errors; per repository instruction no build was run to recreate
+  them. Focused UI tests compile and pass.
+
+The managed disposable UI environment was healthy, but live browser capture
+was blocked by a Vite stale optimized-dependency response. UI scenario counts
+therefore come from source inspection plus deterministic hook/socket tests,
+not a claim of a successful browser network trace.
+
+## Datadog confirmation plan
+
+Use the same time window and graph definition as the reported rates. Never add
+resource IDs, user IDs, tenant IDs, names, raw URLs, payloads, or trace headers
+as tags.
+
+1. Filter `operation_name:feathers.request` and
+   `resource_name:(branches.get OR boards.get)`.
+2. Group by service, `feathers.transport`, build/revision, replica, status/error,
+   and (after rollout) `feathers.reason`.
+3. For `branches.get AND feathers.transport:internal`, graph per-minute counts
+   and inspect autocorrelation/five-second buckets. The predicted signature is
+   three-span clusters every five seconds per active local environment on the
+   owning replica.
+4. Inspect parent/root operations. Health gets should be standalone
+   `feathers.request` roots or timer descendants rather than HTTP/Socket/MCP
+   request descendants. UI hydration/admission should have Socket.IO ancestry;
+   executor reads should cluster under task/executor activity.
+5. Compare distinct recurring **trace-local equality groups** only. If same-ID
+   detection is needed, compute an ephemeral one-way fingerprint offline and
+   discard it; do not emit IDs or fingerprints as production metric tags.
+6. Compare sum of child `postgres.query` duration with Feathers duration and
+   count transaction setup/policy/enrichment children. This separates DB time
+   from hooks/RBAC/ALS/transaction overhead.
+7. Correlate with low-cardinality task settlement, executor connection, and
+   environment counts. Test the 2–6 branch-gets/task and 2,160
+   branch-gets/hour/environment models rather than assuming either.
+8. For boards, split `feathers.reason:presence_cursor_admission`; the remaining
+   Socket.IO volume contains cold full-board hydration and explicit UI actions.
+   Compare it with Socket connect/reconnect and route-load counts.
+9. Compare before/after by build and replica. During a mixed rollout, old
+   replicas retain three health gets and have no reason tag; new replicas have
+   zero automatic health gets and tag cursor admissions.
+
+Expected post-rollout health reduction, if the production pattern matches the
+source-derived model, is up to 2,160 `branches.get` spans/hour per active local
+environment—approximately the reported 30,000/hour at 13.9 average active
+environments. This is an expectation to verify, not an observed production
+result.
+
+## Residual risks and follow-up branches
+
+1. **Datadog attribution receipt (blocking for exact production percentages):**
+   capture the dashboard measure, transport/parent/replica/time-cluster split,
+   duration decomposition, and pre/post build comparison.
+2. **MCP bulk card move:** group moves by board, bulk-load currently authorized
+   boards once, and prove policy-revision semantics before removing its N+1.
+3. **Executor task context:** pass one already-authorized immutable execution
+   context (branch path/repo) through safe-directory, git snapshots, and SDK
+   setup. Today 2–6 gets/task are bounded but duplicated. Preserve task-token
+   caller authority and do not cache across tasks/users/tenants.
+4. **Session/task internal canonical context:** remove small constant internal
+   branch service re-reads only where the same operation already holds an
+   authorized canonical branch. Add request/transaction/authority binding
+   tests first.
+5. **Board policy query timing:** after the board-row reduction is in APM,
+   determine whether policy/principal/group queries rather than row reads
+   dominate duration. Optimize only with a policy-revision/transaction-bound
+   design and cross-tenant negative coverage.

--- a/docs/internal/branch-board-point-read-investigation-2026-08-28.md
+++ b/docs/internal/branch-board-point-read-investigation-2026-08-28.md
@@ -30,9 +30,11 @@ and sampling/extrapolation settings must be captured with the follow-up query.
 | Investigated `main` / `origin/main` / branch base | `5d19fbc6d72f36c9672010396510b35f1f8afbb9`                              | 2026-08-27 | `fix: allow HA Codex auth with delegated user homes (#2575)`            |
 | Deployed sandbox health response                  | `6a0074c1351f0a6d65540267dc7783b06cf7b258` (health reports `6a0074c13`) | 2026-08-26 | `feat(apm): trace postgres.js queries via Drizzle session shim (#2571)` |
 
-The deployed revision is an ancestor of investigated `main`. The health
-response reports Agor 0.25.2 and `realtime.required=false`, so this deployment
-uses the standalone `HealthMonitor`, not the distributed HA health observer.
+Both revisions were reverified at completion on 2026-08-28. The deployed
+revision is an ancestor of investigated `main`. The health response reports
+Agor 0.25.2, build time `2026-08-27T06:00:20.945Z`, and
+`realtime.required=false`, so this deployment uses the standalone
+`HealthMonitor`, not the distributed HA health observer.
 
 Relevant deployed changes are:
 
@@ -106,6 +108,55 @@ bounded server-authored tag
 `feathers.reason=presence_cursor_admission`. IDs and caller-controlled strings
 are never tags.
 
+### Follow-up: `tasks.custom` and `sessions.get`
+
+The follow-up confirms that `tasks.custom` is an attribution bucket, not a
+single transport method. The task service already exposes four distinct custom
+methods: `connectExecutor`, `reportTerminationComplete`,
+`reportRuntimeTelemetry`, and `reportSdkHealthFailure`. The tracing normalizer
+collapses all nonstandard Feathers methods to resource/method `custom`; creating
+another heartbeat method would not improve APM attribution.
+
+`reportRuntimeTelemetry` is sent once immediately and then every ten seconds
+while an executor owns a Task. Its steady-state rate is therefore:
+
+```text
+tasks.custom telemetry = 360 calls/hour/active Task
+```
+
+The other three custom methods are normally once per Task, once per Stop, or
+exceptional. A ten-second comb in production would strongly identify telemetry,
+but production traces were unavailable, so this remains a model rather than an
+observed attribution. This change adds a bounded `feathers.custom_method` tag
+for exactly the four registered methods while deliberately retaining the
+`tasks.custom` resource for dashboard continuity.
+
+The heartbeat write itself is intentional HA control-plane work. It is the
+durable liveness fact used by stale-task reconciliation and the response is how
+an executor connected to any replica observes `STOPPING`. The ten-second
+default was not changed. The optional operator heartbeat callback, however,
+previously performed a fully enriched internal `sessions.get` on every tick
+solely to obtain `branch_id`. It now performs one tenant-scoped branch-pointer
+projection with PostgreSQL RLS. When that callback is configured, this removes
+360 `sessions.get` resources/hour/active Task. The callback is disabled by
+default; production configuration was not accessible.
+
+The follow-up also confirms two independent `sessions.get` amplifiers:
+
+1. external RBAC authorization recursively called the registered
+   `sessions.get`, so `full` tracing recorded two spans and remote-relationship
+   enrichment ran twice for every external get; and
+2. an open session retained separate `none` and `lazy` reactive handles in
+   `SessionPanel` and `ConversationView`, causing two bootstraps and two
+   reconnect resyncs for the same canonical session.
+
+Authorization now loads the canonical Session once through the tenant-scoped
+repository and passes that exact row to the outer service. Both UI consumers
+retain the same `lazy` handle. Session-stream room admission remains a separate,
+fail-closed authorized `sessions.get` and is tagged
+`feathers.reason=session_stream_admission`; it is not cached across sockets,
+users, tenants, or policy epochs.
+
 ### Validated assumptions
 
 - **UI hydration:** confirmed. The normal workspace path uses a lean
@@ -132,7 +183,8 @@ operation: feathers.request
 resource:  <normalized service>.<normalized method>
 service:   inherited agor-daemon service
 tags:      feathers.service, feathers.method, feathers.transport, span.kind
-new tag:   feathers.reason (bounded and server-authored only)
+new tags:  feathers.reason (bounded and server-authored only)
+           feathers.custom_method (reviewed task-method allowlist only)
 ```
 
 `full` depth traces every registered standard service invocation, including
@@ -207,6 +259,35 @@ otherwise. Repository reads do not generate a Feathers resource span.
 | Scheduler/gateway/permission callbacks/MCP egress               | repository          |                      0 service gets in core loops |                          same | per scheduled run/message/decision                                | Direct branch lookup and explicit authorization; not represented by service resource rate            |
 | Redis Feathers relay publication                                | repository/cache    |                                    0 service gets |                          same | per relayed event/receiving replica                               | Re-resolves tenant/audience without trusting Redis room names; revocation is preserved               |
 
+### Follow-up caller/frequency matrix
+
+The counts below are exact source/test counts. “Full” and “entrypoint” refer to
+`metrics.apm.trace_services` depth, not to different numbers of browser calls.
+
+| Caller / trigger                                           | Transport          |                                      Before |                                        After | Frequency / fanout                                       | Security and query notes                                                                                       |
+| ---------------------------------------------------------- | ------------------ | ------------------------------------------: | -------------------------------------------: | -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| Active executor `reportRuntimeTelemetry`                   | socketio           |                            1 `tasks.custom` |                      1 tagged `tasks.custom` | immediate + every 10 s; steady 360/h/Task                | Required durable HA write/control read; interval unchanged                                                     |
+| `connectExecutor`                                          | socketio           |                  1 anonymous `tasks.custom` |                      1 tagged `tasks.custom` | normal once/Task; reconnect/retry can repeat safely      | Row-locked executor admission                                                                                  |
+| `reportTerminationComplete`                                | socketio           |                  1 anonymous `tasks.custom` |                      1 tagged `tasks.custom` | normally once/Stop, retry-safe                           | Task/request-fenced quiescence evidence                                                                        |
+| `reportSdkHealthFailure`                                   | socketio           |                  1 anonymous `tasks.custom` |                      1 tagged `tasks.custom` | exceptional watchdog path                                | Bounded failure reasons; may initiate containment                                                              |
+| Configured heartbeat callback enrichment                   | internal           |                   1 enriched `sessions.get` | 0 service gets + 1 Session branch projection | every telemetry tick; 360/h/Task removed when configured | Fresh originating-tenant DB scope; cross-tenant RLS returns no row                                             |
+| One external authorized `sessions.get`, full tracing       | any external       |                      2 `sessions.get` spans |                                            1 | per call                                                 | Repository authorization remains current; relationship enrichment 2 -> 1                                       |
+| One external authorized `sessions.get`, entrypoint tracing | any external       |                              1 visible span |                                            1 | per call                                                 | Nested auth span was already suppressed, but its work still ran before                                         |
+| Cold-open session UI, full tracing                         | socketio           |                      6 `sessions.get` spans |                                            2 | per open tab/session                                     | Before: stream admission + panel + conversation, each doubled by auth; after: admission + one shared bootstrap |
+| Cold-open session UI, entrypoint tracing                   | socketio           |                             2 visible spans |                                            1 | per open tab/session                                     | Stream admission is nested under `session-streams.create` and remains authorized                               |
+| Cold-open session relationship enrichment                  | socketio/database  |                      6 relationship queries |                                            2 | per open tab/session                                     | Canonical Session-row reads 3 -> 2; no policy cache introduced                                                 |
+| Reconnect with an open session                             | socketio           |                           same as cold open |                            same as cold open | per reconnect/tab                                        | New connection reauthorizes stream room; one shared handle resyncs                                             |
+| Close an open session                                      | socketio           |                            0 `sessions.get` |                                            0 | once/close                                               | Canonical stream ID leaves without a resolve read                                                              |
+| Idle board with no open session                            | socketio           |                   0 periodic `sessions.get` |                                            0 | idle                                                     | No session polling found                                                                                       |
+| External task/message/session RBAC hook needing a Session  | inherited external | 1 nested `sessions.get` plus outer resource |    0 nested service gets + 1 repository load | per protected request                                    | Same request/tenant authority; canonical row is request-local only                                             |
+
+For the open-session full-depth receipt, the six pre-fix spans were one outer
+and one recursive authorization get for each of stream admission, panel
+bootstrap, and conversation bootstrap. After both fixes, the only two are the
+preserved stream admission and one shared bootstrap. This is `6 -> 2` spans and
+relationship queries (66.7% reduction), while entrypoint-visible bootstraps are
+`2 -> 1` (50% reduction).
+
 ## Production call-site inventory
 
 ### Standard `branches.get` service callers
@@ -253,7 +334,52 @@ These reads matter for database load but cannot explain a
 Feathers wrapper to a direct canonical load reduces APM and hook/transaction
 overhead even when a required database read remains.
 
+### Standard `sessions.get` service callers
+
+- **UI/client:** the shared reactive-session bootstrap/reconnect path, direct
+  session-link healing, environment-variable widgets, and explicit session
+  detail actions. The session-stream subscription performs its own server-side
+  access check.
+- **Executor:** safe-directory preparation and Claude/Cursor/OpenCode/base SDK
+  setup. These are bounded startup reads, not the ten-second heartbeat.
+- **Daemon task lifecycle:** startup recovery, executor startup, Stop and
+  reconciliation, completion/auto-title/parent-context paths, permission
+  decisions, callbacks, config/session tokens, widgets, routes, and gateway
+  orchestration.
+- **MCP:** ID resolution, session/context/Knowledge/server tools, and MCP server
+  setup. These are explicit tool actions.
+- **Authorization:** before this follow-up, shared branch/session RBAC helpers
+  recursively invoked `sessions.get` for external session-, task-, and
+  message-scoped operations. These calls were internal provider-less children
+  but visible at `full` APM depth.
+
+No idle `sessions.get` polling loop was found. The only ten-second coupling is
+the opt-in executor-heartbeat callback. Realtime publication uses
+`SessionRepository.findBranchIdBySessionId` behind a one-hour, invalidation-
+fenced session-to-branch cache and a five-minute, invalidation-fenced branch
+visibility cache; it does not call the Feathers Session service. Each replica
+reauthorizes Redis-relayed delivery and never trusts relay room names.
+
 ## Authorization and realtime findings
+
+### Sessions
+
+The shared external authorization loader previously called the registered
+Session service with `provider:undefined`. That was fail-closed, but it crossed
+the full Feathers service/hook/enrichment boundary recursively. The outer get
+reused the returned row through `_agorPrefetchedRecord`; nevertheless both
+service bodies queried remote relationships. The same helper amplified
+session-dependent task and message authorization even when their outer resource
+was not `sessions.get`.
+
+The loader now accepts only a tenant-scoped `SessionRepository.findById`,
+canonicalizes short IDs, and passes the exact row through the same prefetched
+record boundary. The current request still resolves the Session and Branch and
+performs current user/group/policy authorization. Nothing is cached across a
+request, transaction, tenant, user, connection, or policy epoch. Missing and
+cross-tenant rows remain non-enumerating failures. PostgreSQL validation under a
+`NOSUPERUSER`, `NOBYPASSRLS` role proves both the full Session load and the
+heartbeat branch projection return no row in a different tenant scope.
 
 ### Branches
 
@@ -357,6 +483,76 @@ service adapter consumes the same request-scoped canonical row
 The Feathers span count remains one; database board-row reads fall by two.
 Authorization query count and revocation semantics do not change.
 
+### External authorized Session get
+
+Before:
+
+```text
+outer Feathers sessions.get
+  -> external RBAC hook
+     -> inner provider-less Feathers sessions.get
+        -> tenant-scoped Session row + Branch join/derived board_id
+        -> remote relationship enrichment
+     -> current Branch + user/group/policy authorization
+  -> prefetched Session row
+  -> remote relationship enrichment again
+```
+
+After:
+
+```text
+outer Feathers sessions.get
+  -> external RBAC hook
+     -> tenant-scoped canonical Session row + Branch join/derived board_id
+     -> current Branch + user/group/policy authorization
+  -> same request-scoped prefetched Session row
+  -> remote relationship enrichment once
+```
+
+This is `2 -> 1` full-depth service spans and `2 -> 1` relationship queries per
+external call. The required Session/Branch/policy reads remain and still run in
+the request's tenant transaction.
+
+### Executor runtime telemetry tick
+
+For a full UUID on SQLite, the normal heartbeat repository path is one
+`BEGIN IMMEDIATE` unit containing one Task-row SELECT and one UPDATE; row-lock
+acquisition is a no-op and the timestamp uses the process clock. On PostgreSQL,
+it is one transaction containing `SELECT 1 ... FOR UPDATE`, one Task-row SELECT,
+one database-clock SELECT, and one UPDATE. The row is returned to the executor
+and published as `tasks.patched`. If the write is rejected because the Task is
+no longer executor-owned, one exceptional fallback read lets a reconnected
+executor observe `STOPPING`; otherwise the call conflicts.
+
+The main transaction was not weakened or cached. It serializes heartbeat/
+termination races, advances only a newer bounded pulse fact, and supplies the
+durable HA timestamp. Replacing it with an in-memory heartbeat or a blind update
+would break cross-replica stale detection and Stop propagation.
+
+Configured callback enrichment before:
+
+```text
+post-commit callback in originating tenant context
+  -> internal Feathers sessions.get
+     -> full Session row + Branch join/derived board_id
+     -> remote relationship enrichment
+  -> extract branch_id
+```
+
+After:
+
+```text
+post-commit callback in originating tenant context
+  -> fresh tenant/RLS database unit
+     -> SELECT sessions.branch_id for this Session
+```
+
+The default callback is disabled. Operator analytics are also disabled by
+default; if enabled, `executor.heartbeat` is emitted once per tick and the
+built-in HTTP plugin batches it. That analytics event is separate from the
+Feathers/APM count and can be excluded through the existing bounded event
+filter if an operator does not need it.
+
 ## Implemented bounded fixes
 
 1. Remove the standalone health monitor preflight and unused repo read.
@@ -373,6 +569,18 @@ Authorization query count and revocation semantics do not change.
    over unique IDs.
 7. Add the bounded server-only `presence_cursor_admission` APM reason.
 8. Add deterministic UI and daemon call-count receipts.
+9. Add the bounded `feathers.custom_method` tag for exactly the four registered
+   Task custom methods without changing the `tasks.custom` resource.
+10. Replace recursive authorization `sessions.get` calls with a tenant-scoped
+    canonical repository load passed through the current request.
+11. Make `SessionPanel` and `ConversationView` retain the same lazy reactive
+    handle, collapsing duplicate bootstrap/reconnect work.
+12. Replace opt-in heartbeat callback Session enrichment with a fresh
+    originating-tenant `branch_id` projection.
+13. Tag necessary Session stream admission separately, and prove cursor samples
+    perform no Feathers/database work after admission. Cursor positions use
+    lossy Socket.IO volatile fanout; authorization/revocation edge events remain
+    reliable.
 
 No global/TTL entity cache was introduced. No production data/configuration was
 changed and no deployment was performed.
@@ -390,8 +598,24 @@ changed and no deployment was performed.
 - Core SQLite board repository suite: 103 tests passed.
 - PostgreSQL 16 under a non-superuser, `NOBYPASSRLS` role: capability-policy
   concurrency plus environment-health HA suites, 9/9 tests passed.
-- Core and daemon TypeScript checks passed without a production build. The UI
-  check was attempted but the disposable workspace lacked the prebuilt
+- Follow-up daemon tracing/session/auth/heartbeat/native-Socket.IO suites:
+  231/231 tests passed across 6 files.
+- Executor heartbeat cadence/single-flight/control-response suite: 6/6 tests
+  passed. Focused SQLite Task repository telemetry suite: 5/5 tests passed.
+- Follow-up shared client reactive-session suite: 40/40 tests passed, including
+  exact cold/reconnect call counts and final-release unsubscribe.
+- Follow-up SessionPanel suite: 17/17 tests passed, including the shared lazy
+  cache-key contract.
+- Focused UI cursor hot-path receipt: 1/1 test passed; a 20-event mouse burst
+  produces one immediate and one coalesced volatile sample, with no reliable
+  cursor-move emission.
+- Follow-up PostgreSQL 16 Task-runtime HA/RLS suite under a verified
+  `NOSUPERUSER`, `NOBYPASSRLS` role: 6/6 tests passed. A fresh callback
+  projection succeeds for the owning tenant and both full Session and branch
+  projection reads return no row cross-tenant.
+- The multitenancy-boundary static check passed. Core, client, and daemon
+  TypeScript checks passed without a production build. The UI check was
+  attempted but the disposable workspace lacked the prebuilt
   `packages/client/dist/*.d.ts` declarations, cascading into unrelated module
   resolution errors; per repository instruction no build was run to recreate
   them. Focused UI tests compile and pass.
@@ -434,12 +658,34 @@ as tags.
 9. Compare before/after by build and replica. During a mixed rollout, old
    replicas retain three health gets and have no reason tag; new replicas have
    zero automatic health gets and tag cursor admissions.
+10. For `resource_name:tasks.custom`, group new-revision spans by
+    `feathers.custom_method`. `reportRuntimeTelemetry` should show a ten-second
+    comb and scale at 360/hour per average active Task. Old-revision spans are
+    expected to have no custom-method tag; do not interpret them as a fifth
+    method.
+11. For `sessions.get`, split
+    `feathers.reason:session_stream_admission`, transport, trace depth, and
+    parent operation. Compare open-session/reconnect clusters with Task starts
+    and check specifically for ten-second callback coupling. A callback comb
+    can exist only when the operator callback is configured.
+12. For a sampled old-revision external `sessions.get` at full depth, verify
+    the expected child `sessions.get` and two relationship-query children. New
+    revisions should have no recursive Session service span and one
+    relationship query. Compare trace-local resource equality only; never emit
+    a Session/resource fingerprint as a production tag.
 
 Expected post-rollout health reduction, if the production pattern matches the
 source-derived model, is up to 2,160 `branches.get` spans/hour per active local
 environment—approximately the reported 30,000/hour at 13.9 average active
 environments. This is an expectation to verify, not an observed production
 result.
+
+For Session traffic, expected savings are source-dependent: every external
+authorized `sessions.get` loses one full-depth nested span and relationship
+query; an open UI Session loses four of six full-depth spans; and a configured
+heartbeat callback loses all 360 Session service resources/hour/active Task.
+No production percentage is claimed until the tag/config/time-cluster splits
+are observed.
 
 ## Residual risks and follow-up branches
 
@@ -460,3 +706,23 @@ result.
    determine whether policy/principal/group queries rather than row reads
    dominate duration. Optimize only with a policy-revision/transaction-bound
    design and cross-tenant negative coverage.
+6. **Heartbeat transport/DB measurement:** after the bounded custom-method tag
+   is deployed, verify the ten-second comb, active-Task fanout, transaction
+   duration, lock wait, replica balance, errors, and STOPPING fallback rate.
+   Do not change the default interval from 10 s without explicitly accepting
+   that 20 s halves write volume but moves the default stale threshold from
+   30 s to 60 s.
+7. **Heartbeat realtime/analytics:** `tasks.patched` is intentionally published
+   because the UI exposes current heartbeat/pulse state, and realtime authority
+   is invalidation-fenced. Measure Redis/publication and optional analytics
+   plugin cost separately. If it dominates, design a bounded coarse UI signal
+   rather than silently removing durable writes or revocation checks.
+8. **Remaining Session reads:** pass an already-authorized canonical Session
+   within task startup/completion/Stop operations only where the authority and
+   transaction are identical. Executor startup reads are bounded and should be
+   handled as an immutable per-Task execution context, not a global Session
+   cache.
+9. **Mixed-version observation:** old replicas emit untagged `tasks.custom`,
+   recursively trace Session authorization at full depth, and use two reactive
+   UI handles; new replicas emit bounded tags and reduced counts. Group every
+   rollout comparison by build and replica before drawing a rate conclusion.

--- a/docs/internal/branch-board-point-read-investigation-2026-08-28.md
+++ b/docs/internal/branch-board-point-read-investigation-2026-08-28.md
@@ -613,12 +613,12 @@ changed and no deployment was performed.
   `NOSUPERUSER`, `NOBYPASSRLS` role: 6/6 tests passed. A fresh callback
   projection succeeds for the owning tenant and both full Session and branch
   projection reads return no row cross-tenant.
-- The multitenancy-boundary static check passed. Core, client, and daemon
-  TypeScript checks passed without a production build. The UI check was
-  attempted but the disposable workspace lacked the prebuilt
-  `packages/client/dist/*.d.ts` declarations, cascading into unrelated module
-  resolution errors; per repository instruction no build was run to recreate
-  them. Focused UI tests compile and pass.
+- The multitenancy-boundary static check passed. A subsequent `pnpm check`
+  completed end-to-end: workspace typechecks, Biome/lint, short-ID,
+  multitenancy, filesystem, realtime-boundary checks, and the Turbo build all
+  passed (21/21 tasks). The build generated the previously missing client
+  declarations, so the UI workspace typecheck now passes as well. Focused UI
+  tests compile and pass.
 
 The managed disposable UI environment was healthy, but live browser capture
 was blocked by a Vite stale optimized-dependency response. UI scenario counts

--- a/packages/client/src/reactive-session.test.ts
+++ b/packages/client/src/reactive-session.test.ts
@@ -5,6 +5,8 @@ import {
   __streamSubscriptionCountForTest,
   attachReactiveSessionApi,
   ReactiveSessionHandle,
+  releaseReactiveSession,
+  retainReactiveSession,
   type TaskHydrationMode,
 } from './reactive-session';
 
@@ -176,6 +178,34 @@ async function bootstrapHandle(opts: MockClientOptions, taskHydration: TaskHydra
   await handle.ready();
   return { handle, messageFindAll };
 }
+
+describe('shared ReactiveSessionHandle call counts', () => {
+  it('uses one lazy bootstrap and one reconnect resync for two open-session consumers', async () => {
+    const mock = createMockClient({ tasks: [], messagesByTask: {} });
+    const sessionGet = mock.client.service('sessions').get as ReturnType<typeof vi.fn>;
+
+    // SessionPanel and ConversationView now retain this exact same tuple.
+    const panel = retainReactiveSession(mock.client, SESSION_ID, { taskHydration: 'lazy' });
+    const conversation = retainReactiveSession(mock.client, SESSION_ID, {
+      taskHydration: 'lazy',
+    });
+    expect(conversation).toBe(panel);
+    await panel.ready();
+
+    expect(sessionGet).toHaveBeenCalledTimes(1);
+    expect(mock.sessionStreams.create).toHaveBeenCalledTimes(1);
+
+    mock.fireIo('disconnect');
+    mock.fireIo('connect');
+    await vi.waitFor(() => expect(sessionGet).toHaveBeenCalledTimes(2));
+    expect(mock.sessionStreams.create).toHaveBeenCalledTimes(2);
+
+    releaseReactiveSession(mock.client, SESSION_ID, { taskHydration: 'lazy' });
+    expect(mock.sessionStreams.remove).not.toHaveBeenCalled();
+    releaseReactiveSession(mock.client, SESSION_ID, { taskHydration: 'lazy' });
+    await vi.waitFor(() => expect(mock.sessionStreams.remove).toHaveBeenCalledTimes(1));
+  });
+});
 
 describe('ReactiveSessionHandle prompt contract', () => {
   it('returns the admitted Task from the shared sessions helper', async () => {

--- a/packages/core/src/db/repositories/boards.ts
+++ b/packages/core/src/db/repositories/boards.ts
@@ -552,6 +552,11 @@ export class BoardRepository implements BaseRepository<Board, Partial<Board>> {
   async canMutate(boardId: string, userId: UUID): Promise<boolean> {
     const board = await this.findById(boardId);
     if (!board) throw new EntityNotFoundError('Board', boardId);
+    return this.canMutateResolved(board, userId);
+  }
+
+  /** Resolve current edit authority for a canonical board loaded by this request. */
+  async canMutateResolved(board: Pick<Board, 'board_id'>, userId: UUID): Promise<boolean> {
     const access = await new CapabilityPolicyRepository(this.db).resolveBoardAccess(
       board.board_id,
       userId as UserID
@@ -572,6 +577,11 @@ export class BoardRepository implements BaseRepository<Board, Partial<Board>> {
   async canView(boardId: string, userId: UUID): Promise<boolean> {
     const board = await this.findById(boardId);
     if (!board) throw new EntityNotFoundError('Board', boardId);
+    return this.canViewResolved(board, userId);
+  }
+
+  /** Resolve current view authority for a canonical board loaded by this request. */
+  async canViewResolved(board: Pick<Board, 'board_id'>, userId: UUID): Promise<boolean> {
     const access = await new CapabilityPolicyRepository(this.db).resolveBoardAccess(
       board.board_id,
       userId as UserID

--- a/packages/core/src/db/task-runtime-ha.postgres.test.ts
+++ b/packages/core/src/db/task-runtime-ha.postgres.test.ts
@@ -9,7 +9,7 @@
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { generateId } from '../lib/ids';
-import type { SessionID, TaskID, UUID } from '../types/id';
+import type { BranchID, SessionID, TaskID, UUID } from '../types/id';
 import { SessionStatus } from '../types/session';
 import { TaskStatus } from '../types/task';
 import { createDatabase, type Database } from './client';
@@ -31,6 +31,7 @@ let branchUnique = (Date.now() % 1_000_000) + 2_000_000;
 interface TenantSeed {
   tenantId: string;
   userId: UUID;
+  branchId: BranchID;
   sessionId: SessionID;
 }
 
@@ -68,6 +69,7 @@ async function seedTenant(db: Database, label: string): Promise<TenantSeed> {
     return {
       tenantId,
       userId: user.user_id as UUID,
+      branchId: branch.branch_id,
       sessionId: session.session_id,
     };
   });
@@ -135,6 +137,32 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)('Task runtime HA (PostgreSQ
         status: TaskStatus.QUEUED,
         queue_position: 1,
       });
+    });
+  });
+
+  it('keeps deferred heartbeat branch projections inside the originating tenant', async () => {
+    const owner = await seedTenant(db, 'heartbeat-callback-owner');
+    const other = await seedTenant(db, 'heartbeat-callback-other');
+
+    await runWithTenantDatabaseScope(db, owner.tenantId, async (scoped) => {
+      // A fresh repository models the post-commit callback reopening a short
+      // database unit on whichever daemon receives the heartbeat.
+      await expect(new SessionRepository(scoped).findById(owner.sessionId)).resolves.toMatchObject({
+        session_id: owner.sessionId,
+        branch_id: owner.branchId,
+      });
+      await expect(
+        new SessionRepository(scoped).findBranchIdBySessionId(owner.sessionId)
+      ).resolves.toBe(owner.branchId);
+    });
+
+    await runWithTenantDatabaseScope(db, other.tenantId, async (scoped) => {
+      // The same globally unique Session id must not be usable to enrich a
+      // request or callback running under a different tenant's RLS scope.
+      await expect(new SessionRepository(scoped).findById(owner.sessionId)).resolves.toBeNull();
+      await expect(
+        new SessionRepository(scoped).findBranchIdBySessionId(owner.sessionId)
+      ).resolves.toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary

- Removes the standalone health monitor's Feathers `branches.get` amplification while preserving the two tenant-scoped canonical lifecycle/fencing reads.
  - Deterministic receipt: **3 -> 0 Feathers gets per 5-second active-environment observation**.
  - Removes one redundant branch load and one unused repository load.
- Reuses already-authorized canonical entities within one operation.
  - Board authorization/adapter keeps current policy evaluation and has no cross-request cache.
  - MCP card create/bulk-create: **2 -> 1 `boards.get`**.
  - MCP branch set-zone: **2 -> 1 `branches.get`**.
  - MCP schedule board filter: **N `branches.get` -> 1 scoped `branches.find`**; authorization IDs are chunked at the service cap so large tenants are complete.
- Includes the cursor hot-path fixes: one-time board admission, socket-local authority reuse, volatile cursor fanout, and reliable revocation/presence edges. A 20-move receipt performs zero Feathers/service/database calls after admission.
- Adds bounded server-authored APM attribution:
  - `feathers.reason=presence_cursor_admission`
  - `feathers.reason=session_stream_admission`
  - `feathers.custom_method` for the four registered Task custom methods.
- Removes recursive authorization `sessions.get` service calls and shares the UI's reactive Session handle. Adds a narrow heartbeat-callback branch projection.
- Full evidence and the complete caller/frequency matrix are in `docs/internal/branch-board-point-read-investigation-2026-08-28.md`.

## Investigation result

Investigated base: `5d19fbc6d72f36c9672010396510b35f1f8afbb9`.

Observed deployed revision: `6a0074c1351f0a6d65540267dc7783b06cf7b258` (ancestor of base).

Current PR head: `d7f6b5ef4185be544abd5de135e102ecedf464ff`.

The confirmed standalone health shape is:

```
12 observations/minute/environment
x 3 branches.get spans/observation
= 2,160 branches.get spans/hour/environment
```

The reported ~30,000/hour is numerically consistent with ~13.9 average active local environments, but remains an inference until the documented Datadog five-second/transport/parent/replica split is run. No Datadog credential or configured connector was available in the session.

No periodic `boards.get` loop was found. A cold displayed-board tab makes two board gets (full hydration plus cursor admission); reconnect makes one new cursor-admission get. Idle presence heartbeat, cursor movement, open/closed session panel, and normal realtime paths make no point reads.

`tasks.custom` is a normalized bucket, not a missing heartbeat method. `reportRuntimeTelemetry` runs immediately and every 10 seconds (**360/hour/active Task**). The durable write remains unchanged because it is the HA liveness/STOPPING control-plane fact. When the optional callback is configured, its enriched internal `sessions.get` is replaced with one fresh tenant/RLS-scoped `branch_id` projection, removing 360 Session service resources/hour/active Task. The callback is disabled by default.

External authorized Session reads lose one recursive full-depth service span and one relationship-enrichment query (**2 -> 1**). Cold open-session UI reads lose the duplicate reactive bootstrap (**6 -> 2 full-depth spans; 2 -> 1 entrypoint-visible bootstraps**). No idle Session polling was found.

## Security / tenancy

- No cross-tenant, cross-user, cross-request, TTL, or policy-epoch cache was introduced.
- Tenant DB scope remains explicit for automatic health and heartbeat projections.
- Branch/board RBAC and current policy resolution remain on external service boundaries.
- Cursor admission still fails closed on every new socket/board authorization; disconnect, unwatch, and revocation clear authority.
- PostgreSQL RLS was tested through a non-superuser `NOBYPASSRLS` role.
- Durable Task heartbeat transactions, stale-task reconciliation, STOP propagation, and reliable presence/revocation edges were not weakened.

## Receipts

- `pnpm i`: already up to date.
- `pnpm check`: passed end-to-end (workspace typechecks, Biome/lint, short-ID, multitenancy, filesystem, realtime-boundary checks, and Turbo build; **21/21 tasks**).
- Changed daemon suites: **625/625** (including schedule authorization cap-boundary coverage).
- Changed UI suites: **52/52**.
- Shared client reactive-session suite: **40/40**.
- Executor heartbeat cadence/control-response: **6/6**; SQLite telemetry: **5/5**.
- PostgreSQL 16 Task-runtime HA/RLS under `NOSUPERUSER`, `NOBYPASSRLS`: **6/6** when the integration environment is available; the local focused invocation was skipped without that environment.
- Previous GitHub CI code run passed daemon, UI shards, core/CLI/support, typecheck/build, lint, PostgreSQL RLS/HA, browser layout, packaging, and image build/push. This follow-up code fix should trigger the normal CI rerun.

No production data/configuration was modified and nothing was deployed or merged.

