### PR TITLE
fix(ui): save footer model only on commit

### DIFF
--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -96,6 +96,10 @@ import { buildCompletedOnboardingPreferences } from './utils/onboardingGoals';
 import { savePromptDraft } from './utils/promptDrafts';
 import { seedOnboardingTeammate } from './utils/seedOnboardingTeammate';
 import { updateSessionMcpServers } from './utils/sessionMcpServers';
+import {
+  type LatestSessionUpdateRequests,
+  runSessionUpdateWithLatestNotification,
+} from './utils/sessionUpdateNotifications';
 import { getRouterBasename, responsiveRoutePath } from './utils/uiRoutes';
 
 type RouteModuleKey = RouteSurfaceId | 'mobile';
@@ -441,6 +445,7 @@ function AppContent() {
     },
   });
   const pendingEnvironmentToastsRef = useRef<Map<string, PendingEnvironmentToast>>(new Map());
+  const latestSessionUpdateRequestsRef = useRef<LatestSessionUpdateRequests>(new Map());
 
   useEffect(() => {
     if (!client) return;
@@ -1386,12 +1391,16 @@ function AppContent() {
 
   // Handle update session
   const handleUpdateSession = async (sessionId: string, updates: Partial<Session>) => {
-    const session = await updateSession(sessionId as SessionID, updates);
-    if (session) {
-      showSuccess('Session updated successfully!');
-    } else {
-      showError('Failed to update session');
-    }
+    const authority = appAuthorityGuard.begin();
+    await runSessionUpdateWithLatestNotification({
+      sessionId: sessionId as SessionID,
+      updates,
+      latestRequests: latestSessionUpdateRequestsRef.current,
+      authority,
+      updateSession,
+      showSuccess,
+      showError,
+    });
   };
 
   // Handle delete session

--- a/apps/agor-ui/src/components/ModelSelector/ModelSelector.test.tsx
+++ b/apps/agor-ui/src/components/ModelSelector/ModelSelector.test.tsx
@@ -35,11 +35,13 @@ describe('ModelSelector (Claude)', () => {
 
   it('updates pin mode when a controlled value changes', () => {
     const pinned = 'claude-sonnet-4-6-20260101';
+    const onCommit = vi.fn();
     const { rerender } = render(
       <ModelSelector
         agentic_tool="claude-code"
         showAdvisor={false}
         value={{ mode: 'alias', model: 'claude-sonnet-5' }}
+        onCommit={onCommit}
       />
     );
 
@@ -48,11 +50,46 @@ describe('ModelSelector (Claude)', () => {
         agentic_tool="claude-code"
         showAdvisor={false}
         value={{ mode: 'exact', model: pinned }}
+        onCommit={onCommit}
       />
     );
 
     expect(screen.getByRole('combobox')).toHaveValue(pinned);
     expect(screen.getByText('Use a recommended model')).toBeInTheDocument();
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('filters aliases without change or commit on first mount and remount', () => {
+    const onChange = vi.fn();
+    const onCommit = vi.fn();
+    const picker = (
+      <ModelSelector
+        agentic_tool="claude-code"
+        showAdvisor={false}
+        value={{ mode: 'alias' as const, model: 'claude-sonnet-5' }}
+        onChange={onChange}
+        onCommit={onCommit}
+      />
+    );
+    const first = render(picker);
+
+    let input = screen.getByRole('combobox');
+    fireEvent.mouseDown(input);
+    for (const query of ['f', 'fa', 'fable']) {
+      fireEvent.change(input, { target: { value: query } });
+    }
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(onChange).not.toHaveBeenCalled();
+    expect(onCommit).not.toHaveBeenCalled();
+
+    first.unmount();
+    render(picker);
+    input = screen.getByRole('combobox');
+    fireEvent.mouseDown(input);
+    fireEvent.change(input, { target: { value: 'sonnet' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(onChange).not.toHaveBeenCalled();
+    expect(onCommit).not.toHaveBeenCalled();
   });
 
   it('updates exact model text without committing until selection or blur', () => {
@@ -203,6 +240,89 @@ describe('ModelSelector (Claude)', () => {
     expect(onCommit).toHaveBeenCalledWith({ mode: 'exact', model: 'claude-fable-5' });
   });
 
+  it('does not commit an unchanged exact model on blur', () => {
+    const onCommit = vi.fn();
+    render(
+      <ModelSelector
+        agentic_tool="claude-code"
+        showAdvisor={false}
+        value={{ mode: 'exact', model: 'claude-sonnet-5' }}
+        onCommit={onCommit}
+      />
+    );
+
+    const input = screen.getByRole('combobox');
+    fireEvent.blur(input);
+    fireEvent.blur(input);
+
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('cancels a dirty exact-model draft on Escape without committing on blur', () => {
+    const onCommit = vi.fn();
+    render(
+      <ModelSelector
+        agentic_tool="claude-code"
+        showAdvisor={false}
+        value={{ mode: 'exact', model: 'claude-sonnet-5' }}
+        onCommit={onCommit}
+      />
+    );
+
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, { target: { value: 'claude-fable-5' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+    fireEvent.blur(input);
+
+    expect(input).toHaveValue('claude-sonnet-5');
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('does not commit an unfinished exact-model draft when unmounted', () => {
+    const onCommit = vi.fn();
+    const view = render(
+      <ModelSelector
+        agentic_tool="claude-code"
+        showAdvisor={false}
+        value={{ mode: 'exact', model: 'claude-sonnet-5' }}
+        onCommit={onCommit}
+      />
+    );
+
+    fireEvent.change(screen.getByRole('combobox'), {
+      target: { value: 'claude-fable-5' },
+    });
+    view.unmount();
+
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('commits one advisor selection with a pending exact draft and no blur duplicate', () => {
+    const onCommit = vi.fn();
+    render(
+      <ModelSelector
+        agentic_tool="claude-code"
+        value={{ mode: 'exact', model: 'claude-sonnet-5' }}
+        onCommit={onCommit}
+      />
+    );
+
+    const [exactInput, advisorInput] = screen.getAllByRole('combobox');
+    fireEvent.change(exactInput, { target: { value: 'claude-custom-20260828' } });
+    fireEvent.mouseDown(advisorInput);
+    fireEvent.click(screen.getAllByText('Claude Fable 5 · 1M').at(-1)!);
+    expect(onCommit).toHaveBeenCalledOnce();
+    expect(onCommit).toHaveBeenCalledWith({
+      mode: 'exact',
+      model: 'claude-custom-20260828',
+      advisorModel: 'claude-fable-5',
+    });
+
+    fireEvent.blur(advisorInput);
+    fireEvent.blur(exactInput);
+    expect(onCommit).toHaveBeenCalledOnce();
+  });
+
   it('commits an alias when the user selects it', () => {
     const onCommit = vi.fn();
     render(
@@ -216,6 +336,27 @@ describe('ModelSelector (Claude)', () => {
 
     fireEvent.mouseDown(screen.getByRole('combobox'));
     fireEvent.click(screen.getByText('Claude Fable 5 · 1M'));
+    expect(onCommit).toHaveBeenCalledWith({ mode: 'alias', model: 'claude-fable-5' });
+  });
+
+  it('commits one keyboard-selected alias on Enter', () => {
+    const onCommit = vi.fn();
+    render(
+      <ModelSelector
+        agentic_tool="claude-code"
+        showAdvisor={false}
+        value={{ mode: 'alias', model: 'claude-sonnet-5' }}
+        onCommit={onCommit}
+      />
+    );
+
+    const input = screen.getByRole('combobox');
+    fireEvent.mouseDown(input);
+    fireEvent.change(input, { target: { value: 'fable' } });
+    fireEvent.keyDown(input, { key: 'ArrowDown', keyCode: 40, which: 40 });
+    fireEvent.keyDown(input, { key: 'Enter', keyCode: 13, which: 13 });
+
+    expect(onCommit).toHaveBeenCalledOnce();
     expect(onCommit).toHaveBeenCalledWith({ mode: 'alias', model: 'claude-fable-5' });
   });
 

--- a/apps/agor-ui/src/components/ModelSelector/ModelSelector.test.tsx
+++ b/apps/agor-ui/src/components/ModelSelector/ModelSelector.test.tsx
@@ -278,6 +278,117 @@ describe('ModelSelector (Claude)', () => {
     expect(onCommit).not.toHaveBeenCalled();
   });
 
+  it('restores the pre-edit baseline through a controlled parent on Escape', () => {
+    const onChange = vi.fn();
+    const onCommit = vi.fn();
+
+    function ControlledPicker() {
+      const [value, setValue] = useState({
+        mode: 'exact' as const,
+        model: 'claude-sonnet-5',
+      });
+      return (
+        <ModelSelector
+          agentic_tool="claude-code"
+          showAdvisor={false}
+          value={value}
+          onChange={(next) => {
+            onChange(next);
+            setValue(next);
+          }}
+          onCommit={onCommit}
+        />
+      );
+    }
+
+    render(<ControlledPicker />);
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, { target: { value: 'claude-fable-5' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+    fireEvent.blur(input);
+
+    expect(input).toHaveValue('claude-sonnet-5');
+    expect(onChange).toHaveBeenLastCalledWith({
+      mode: 'exact',
+      model: 'claude-sonnet-5',
+    });
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('restores recommended mode when cancelling a newly enabled pin draft', () => {
+    const onChange = vi.fn();
+    const onCommit = vi.fn();
+
+    function ControlledPicker() {
+      const [value, setValue] = useState({
+        mode: 'alias' as const,
+        model: 'claude-sonnet-5',
+      });
+      return (
+        <ModelSelector
+          agentic_tool="claude-code"
+          showAdvisor={false}
+          value={value}
+          onChange={(next) => {
+            onChange(next);
+            setValue(next);
+          }}
+          onCommit={onCommit}
+        />
+      );
+    }
+
+    render(<ControlledPicker />);
+    fireEvent.click(screen.getByRole('button', { name: 'Pin a specific version…' }));
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, { target: { value: 'claude-fable-5' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    expect(screen.getByText('Claude Sonnet 5 · 1M')).toBeInTheDocument();
+    expect(onChange).toHaveBeenLastCalledWith({
+      mode: 'alias',
+      model: 'claude-sonnet-5',
+    });
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it('clears a blank exact draft and accepts the next realtime model', () => {
+    const onChange = vi.fn();
+    const onCommit = vi.fn();
+    const { rerender } = render(
+      <ModelSelector
+        agentic_tool="claude-code"
+        showAdvisor={false}
+        value={{ mode: 'exact', model: 'claude-sonnet-5' }}
+        onChange={onChange}
+        onCommit={onCommit}
+      />
+    );
+
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, { target: { value: '   ' } });
+    fireEvent.blur(input);
+
+    expect(input).toHaveValue('claude-sonnet-5');
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(onChange).toHaveBeenLastCalledWith({
+      mode: 'exact',
+      model: 'claude-sonnet-5',
+    });
+
+    const realtimeModel = 'claude-fable-5';
+    rerender(
+      <ModelSelector
+        agentic_tool="claude-code"
+        showAdvisor={false}
+        value={{ mode: 'exact', model: realtimeModel }}
+        onChange={onChange}
+        onCommit={onCommit}
+      />
+    );
+    expect(input).toHaveValue(realtimeModel);
+  });
+
   it('does not commit an unfinished exact-model draft when unmounted', () => {
     const onCommit = vi.fn();
     const view = render(

--- a/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
+++ b/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
@@ -278,12 +278,17 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
   // version, anything else is a discovered alias selection.
   const [pinned, setPinned] = useState(value?.mode === 'exact');
   const [pinnedModel, setPinnedModel] = useState(value?.model ?? '');
+  const pinnedDirtyRef = useRef(false);
   const pickerRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     setPinned(value?.mode === 'exact');
+    if (value?.mode !== 'exact') pinnedDirtyRef.current = false;
   }, [value?.mode]);
   useEffect(() => {
-    setPinnedModel(value?.model ?? '');
+    // Controlled form parents echo each draft through `value`; footer parents
+    // instead replace it from realtime. Preserve an active local edit in both
+    // cases, then accept the authoritative value after the edit commits.
+    if (!pinnedDirtyRef.current) setPinnedModel(value?.model ?? '');
   }, [value?.model]);
 
   if (ToolModelSelector) {
@@ -331,17 +336,20 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
   const currentModel = value?.model || fallbackModel;
 
   const selectAlias = (model: string) => {
+    pinnedDirtyRef.current = false;
     const selection: ModelConfig = { ...value, mode: 'alias', model };
     onChange?.(selection);
     onCommit?.(selection);
   };
   const selectPinned = (model: string) => {
     // Keep the text input responsive even when a controlled parent needs a
-    // render to persist each draft character.
+    // render to reflect each draft character.
+    pinnedDirtyRef.current = true;
     setPinnedModel(model);
     onChange?.({ ...value, mode: 'exact', model });
   };
   const commitPinned = (draft = pinnedModel) => {
+    if (!pinnedDirtyRef.current) return;
     const model = draft.trim();
     const selection: ModelConfig = { ...value, mode: 'exact', model };
     // Keep the displayed value and submitted payload aligned when the user
@@ -350,22 +358,35 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
       setPinnedModel(model);
       onChange?.(selection);
     }
-    if (model) onCommit?.(selection);
+    if (model) {
+      pinnedDirtyRef.current = false;
+      onCommit?.(selection);
+    }
   };
   const handleAdvisorModelChange = (advisorModel: string | undefined) => {
-    onChange?.({
+    const exactDraft = pinnedModel.trim();
+    const commitsExactDraft = pinned && pinnedDirtyRef.current && Boolean(exactDraft);
+    const selection: ModelConfig = {
       ...value,
-      mode: value?.mode ?? 'alias',
-      model: currentModel,
+      mode: pinned ? 'exact' : (value?.mode ?? 'alias'),
+      model: commitsExactDraft ? exactDraft : currentModel,
       advisorModel,
-    });
+    };
+    if (commitsExactDraft) {
+      pinnedDirtyRef.current = false;
+      setPinnedModel(exactDraft);
+    }
+    onChange?.(selection);
+    onCommit?.(selection);
   };
 
   const enablePin = () => {
+    pinnedDirtyRef.current = true;
     setPinnedModel(currentModel);
     setPinned(true);
   };
   const disablePin = () => {
+    pinnedDirtyRef.current = false;
     setPinned(false);
     const model = curated.some((candidate) => candidate.id === currentModel)
       ? currentModel
@@ -507,6 +528,11 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
             value={pinnedModel}
             onChange={selectPinned}
             onSelect={commitPinned}
+            onKeyDown={(event) => {
+              if (event.key !== 'Escape') return;
+              pinnedDirtyRef.current = false;
+              setPinnedModel(value?.model ?? '');
+            }}
             options={pinOptions}
             filterOption={(input, option) =>
               `${option?.value ?? ''} ${option?.label ?? ''}`

--- a/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
+++ b/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
@@ -72,6 +72,11 @@ interface DynamicModelsResponse {
   source: 'dynamic' | 'static';
 }
 
+interface PinnedEditBaseline {
+  mode: ModelConfig['mode'];
+  model: string;
+}
+
 // Codex model options (derived from @agor/core metadata)
 const CODEX_MODEL_OPTIONS = Object.entries(CODEX_MODEL_METADATA).map(([modelId, meta]) => ({
   id: modelId,
@@ -279,17 +284,32 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
   const [pinned, setPinned] = useState(value?.mode === 'exact');
   const [pinnedModel, setPinnedModel] = useState(value?.model ?? '');
   const pinnedDirtyRef = useRef(false);
+  const pinnedBaselineRef = useRef<PinnedEditBaseline>({
+    mode: value?.mode === 'exact' ? 'exact' : 'alias',
+    model: value?.model ?? '',
+  });
   const pickerRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     setPinned(value?.mode === 'exact');
-    if (value?.mode !== 'exact') pinnedDirtyRef.current = false;
-  }, [value?.mode]);
+    if (value?.mode !== 'exact') {
+      pinnedDirtyRef.current = false;
+      pinnedBaselineRef.current = { mode: 'alias', model: value?.model ?? '' };
+    } else if (!pinnedDirtyRef.current) {
+      pinnedBaselineRef.current = { mode: 'exact', model: value?.model ?? '' };
+    }
+  }, [value?.mode, value?.model]);
   useEffect(() => {
     // Controlled form parents echo each draft through `value`; footer parents
     // instead replace it from realtime. Preserve an active local edit in both
     // cases, then accept the authoritative value after the edit commits.
-    if (!pinnedDirtyRef.current) setPinnedModel(value?.model ?? '');
-  }, [value?.model]);
+    if (!pinnedDirtyRef.current) {
+      pinnedBaselineRef.current = {
+        mode: value?.mode === 'exact' ? 'exact' : 'alias',
+        model: value?.model ?? '',
+      };
+      setPinnedModel(value?.model ?? '');
+    }
+  }, [value?.model, value?.mode]);
 
   if (ToolModelSelector) {
     return (
@@ -337,6 +357,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
 
   const selectAlias = (model: string) => {
     pinnedDirtyRef.current = false;
+    pinnedBaselineRef.current = { mode: 'alias', model };
     const selection: ModelConfig = { ...value, mode: 'alias', model };
     onChange?.(selection);
     onCommit?.(selection);
@@ -344,6 +365,9 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
   const selectPinned = (model: string) => {
     // Keep the text input responsive even when a controlled parent needs a
     // render to reflect each draft character.
+    if (!pinnedDirtyRef.current) {
+      pinnedBaselineRef.current = { mode: 'exact', model: pinnedModel };
+    }
     pinnedDirtyRef.current = true;
     setPinnedModel(model);
     onChange?.({ ...value, mode: 'exact', model });
@@ -351,6 +375,14 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
   const commitPinned = (draft = pinnedModel) => {
     if (!pinnedDirtyRef.current) return;
     const model = draft.trim();
+    if (!model) {
+      const baseline = pinnedBaselineRef.current;
+      pinnedDirtyRef.current = false;
+      setPinned(baseline.mode === 'exact');
+      setPinnedModel(baseline.model);
+      onChange?.({ ...value, mode: baseline.mode, model: baseline.model });
+      return;
+    }
     const selection: ModelConfig = { ...value, mode: 'exact', model };
     // Keep the displayed value and submitted payload aligned when the user
     // finishes an edit with surrounding whitespace (or whitespace only).
@@ -358,10 +390,9 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
       setPinnedModel(model);
       onChange?.(selection);
     }
-    if (model) {
-      pinnedDirtyRef.current = false;
-      onCommit?.(selection);
-    }
+    pinnedDirtyRef.current = false;
+    pinnedBaselineRef.current = { mode: 'exact', model };
+    onCommit?.(selection);
   };
   const handleAdvisorModelChange = (advisorModel: string | undefined) => {
     const exactDraft = pinnedModel.trim();
@@ -374,13 +405,19 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
     };
     if (commitsExactDraft) {
       pinnedDirtyRef.current = false;
+      pinnedBaselineRef.current = { mode: 'exact', model: exactDraft };
       setPinnedModel(exactDraft);
     }
+    pinnedBaselineRef.current = { mode: selection.mode, model: selection.model };
     onChange?.(selection);
     onCommit?.(selection);
   };
 
   const enablePin = () => {
+    pinnedBaselineRef.current = {
+      mode: value?.mode === 'exact' ? 'exact' : 'alias',
+      model: currentModel,
+    };
     pinnedDirtyRef.current = true;
     setPinnedModel(currentModel);
     setPinned(true);
@@ -391,6 +428,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
     const model = curated.some((candidate) => candidate.id === currentModel)
       ? currentModel
       : fallbackModel;
+    pinnedBaselineRef.current = { mode: 'alias', model };
     // This only switches editing modes. The user still needs to choose an
     // alias before the picker reports a committed selection.
     onChange?.({ ...value, mode: 'alias', model });
@@ -530,8 +568,12 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
             onSelect={commitPinned}
             onKeyDown={(event) => {
               if (event.key !== 'Escape') return;
+              if (!pinnedDirtyRef.current) return;
+              const baseline = pinnedBaselineRef.current;
               pinnedDirtyRef.current = false;
-              setPinnedModel(value?.model ?? '');
+              setPinned(baseline.mode === 'exact');
+              setPinnedModel(baseline.model);
+              onChange?.({ ...value, mode: baseline.mode, model: baseline.model });
             }}
             options={pinOptions}
             filterOption={(input, option) =>

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.model-picker.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.model-picker.test.tsx
@@ -1,0 +1,183 @@
+import type {
+  CodexApprovalPolicy,
+  CodexSandboxMode,
+  PermissionMode,
+  Session,
+  SessionID,
+} from '@agor-live/client';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { App, ConfigProvider } from 'antd';
+import type React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  type LatestSessionUpdateRequests,
+  runSessionUpdateWithLatestNotification,
+} from '../../utils/sessionUpdateNotifications';
+import type { ModelConfig } from '../ModelSelector';
+import { SessionFooter } from './SessionFooter';
+
+vi.mock('../EffortSelector', () => ({ EffortSelector: () => null }));
+vi.mock('../PermissionModeSelector', () => ({ PermissionModeSelector: () => null }));
+vi.mock('../Pill', () => ({ TimerPill: () => null }));
+vi.mock('./SessionMcpFooterControl', () => ({ SessionMcpFooterControl: () => null }));
+
+const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <ConfigProvider>
+    <App>{children}</App>
+  </ConfigProvider>
+);
+
+const exactModel = 'claude-sonnet-4-6-20260101';
+const session = {
+  session_id: 'session-1',
+  branch_id: 'branch-1',
+  created_by: 'user-1',
+  status: 'idle',
+  agentic_tool: 'claude-code',
+  model_config: {
+    mode: 'exact',
+    model: exactModel,
+    updated_at: '2026-08-28T00:00:00.000Z',
+  },
+} as unknown as Session;
+
+const baseProps = {
+  session,
+  currentUserId: 'user-1',
+  footerTimerTask: null,
+  tokenBreakdown: {
+    total: 0,
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheCreation: 0,
+    cost: 0,
+  },
+  latestContextWindow: null,
+  sessionMcpServerIds: [] as string[],
+  unauthedMcpServers: [],
+  mcpServerById: new Map(),
+  userAuthenticatedMcpServerIds: new Set<string>(),
+  isRunning: false,
+  isStopping: false,
+  stopRequestInFlight: false,
+  hasInput: false,
+  connectionDisabled: false,
+  permissionMode: 'default' as PermissionMode,
+  codexSandboxMode: 'on' as CodexSandboxMode,
+  codexApprovalPolicy: 'auto' as CodexApprovalPolicy,
+  queuedTasks: [],
+  client: null,
+  modelConfig: { mode: 'exact' as const, model: exactModel },
+  onOpenSessionSettings: undefined,
+  onSendPrompt: vi.fn(),
+  onStop: vi.fn(),
+  onFork: vi.fn(),
+  onBtwSend: vi.fn(),
+  onSpawnOpen: vi.fn(),
+  onAttachFiles: vi.fn(),
+  onUploadOpen: vi.fn(),
+  onEffortChange: vi.fn(),
+  onPermissionModeChange: vi.fn(),
+  onCodexPermissionChange: vi.fn(),
+  promptInputSlot: <div />,
+};
+
+describe('SessionFooter model picker persistence boundary', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('persists no rapid typeahead drafts and one completed edit on first open and reopen', async () => {
+    const updateSession = vi.fn(async () => session);
+    const showSuccess = vi.fn();
+    const showError = vi.fn();
+    const latestRequests: LatestSessionUpdateRequests = new Map();
+    const onModelConfigCommit = vi.fn((modelConfig: ModelConfig) => {
+      void runSessionUpdateWithLatestNotification({
+        sessionId: session.session_id as SessionID,
+        updates: {
+          model_config: {
+            ...modelConfig,
+            updated_at: new Date().toISOString(),
+          },
+        },
+        latestRequests,
+        authority: { isCurrent: () => true },
+        updateSession,
+        showSuccess,
+        showError,
+      });
+    });
+    const firstOpen = render(
+      <SessionFooter {...baseProps} onModelConfigCommit={onModelConfigCommit} />,
+      { wrapper: Wrapper }
+    );
+
+    const modelChip = screen.getByTestId('model-chip');
+    fireEvent.click(modelChip);
+    const input = await screen.findByDisplayValue(exactModel);
+    for (const draft of ['c', 'cl', 'claude-fable-5']) {
+      fireEvent.change(input, { target: { value: draft } });
+    }
+
+    expect(onModelConfigCommit).not.toHaveBeenCalled();
+    expect(updateSession).not.toHaveBeenCalled();
+    expect(showSuccess).not.toHaveBeenCalled();
+    expect(showError).not.toHaveBeenCalled();
+
+    fireEvent.blur(input);
+    expect(onModelConfigCommit).toHaveBeenCalledOnce();
+    expect(onModelConfigCommit).toHaveBeenCalledWith({
+      mode: 'exact',
+      model: 'claude-fable-5',
+    });
+    await waitFor(() => expect(showSuccess).toHaveBeenCalledOnce());
+    expect(updateSession).toHaveBeenCalledOnce();
+    expect(showError).not.toHaveBeenCalled();
+
+    // A second blur/outside transition from the same edit is not a second
+    // explicit action and must not save again.
+    fireEvent.blur(input);
+    expect(onModelConfigCommit).toHaveBeenCalledOnce();
+
+    // Close the existing popover, apply the authoritative realtime echo, and
+    // reopen the same footer instance. This is the reported failing lifecycle.
+    fireEvent.click(modelChip);
+    const savedModel = 'claude-fable-5';
+    firstOpen.rerender(
+      <SessionFooter
+        {...baseProps}
+        session={
+          {
+            ...session,
+            model_config: {
+              mode: 'exact',
+              model: savedModel,
+              updated_at: '2026-08-28T00:01:00.000Z',
+            },
+          } as Session
+        }
+        modelConfig={{ mode: 'exact', model: savedModel }}
+        onModelConfigCommit={onModelConfigCommit}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('model-chip'));
+    const reopenedInput = await screen.findByDisplayValue(savedModel);
+    for (const draft of ['g', 'gp', 'gpt-5.6-sol']) {
+      fireEvent.change(reopenedInput, { target: { value: draft } });
+    }
+
+    expect(onModelConfigCommit).toHaveBeenCalledOnce();
+    expect(updateSession).toHaveBeenCalledOnce();
+    expect(showSuccess).toHaveBeenCalledOnce();
+    fireEvent.blur(reopenedInput);
+    expect(onModelConfigCommit).toHaveBeenCalledTimes(2);
+    expect(onModelConfigCommit).toHaveBeenLastCalledWith({
+      mode: 'exact',
+      model: 'gpt-5.6-sol',
+    });
+    await waitFor(() => expect(showSuccess).toHaveBeenCalledTimes(2));
+    expect(updateSession).toHaveBeenCalledTimes(2);
+    expect(showError).not.toHaveBeenCalled();
+  });
+});

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.model-picker.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.model-picker.test.tsx
@@ -180,4 +180,41 @@ describe('SessionFooter model picker persistence boundary', () => {
     expect(updateSession).toHaveBeenCalledTimes(2);
     expect(showError).not.toHaveBeenCalled();
   });
+
+  it('resets an unfinished exact draft when the footer switches sessions', async () => {
+    const onModelConfigCommit = vi.fn();
+    const view = render(
+      <SessionFooter {...baseProps} onModelConfigCommit={onModelConfigCommit} />,
+      { wrapper: Wrapper }
+    );
+
+    fireEvent.click(screen.getByTestId('model-chip'));
+    const input = await screen.findByDisplayValue(exactModel);
+    fireEvent.change(input, { target: { value: 'session-a-draft' } });
+
+    const secondModel = 'claude-fable-5';
+    view.rerender(
+      <SessionFooter
+        {...baseProps}
+        session={
+          {
+            ...session,
+            session_id: 'session-2',
+            model_config: {
+              mode: 'exact',
+              model: secondModel,
+              updated_at: '2026-08-28T00:02:00.000Z',
+            },
+          } as Session
+        }
+        modelConfig={{ mode: 'exact', model: secondModel }}
+        onModelConfigCommit={onModelConfigCommit}
+      />
+    );
+
+    const nextInput = await screen.findByDisplayValue(secondModel);
+    expect(nextInput).toHaveValue(secondModel);
+    fireEvent.blur(nextInput);
+    expect(onModelConfigCommit).not.toHaveBeenCalled();
+  });
 });

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
@@ -74,7 +74,7 @@ const baseProps = {
   client: null,
   modelLabel: undefined,
   modelConfig: undefined,
-  onModelConfigChange: vi.fn(),
+  onModelConfigCommit: vi.fn(),
   onOpenSessionSettings: undefined,
   onSendPrompt: vi.fn(),
   onStop: vi.fn(),

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
@@ -334,6 +334,7 @@ const SessionFooterInner: React.FC<SessionFooterProps> = ({
           }
         >
           <ModelSelector
+            key={session.session_id}
             value={modelConfig}
             onCommit={onModelConfigCommit}
             agentic_tool={session.agentic_tool}
@@ -1412,6 +1413,7 @@ const SessionFooterInner: React.FC<SessionFooterProps> = ({
                       </Typography.Text>
                     ) : (
                       <ModelSelector
+                        key={session.session_id}
                         value={modelConfig}
                         onCommit={onModelConfigCommit}
                         agentic_tool={session.agentic_tool}

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
@@ -98,7 +98,7 @@ export interface SessionFooterProps {
   modelLabel?: string;
   modelConfig?: ModelConfig;
   // Handlers
-  onModelConfigChange: (config: ModelConfig) => void;
+  onModelConfigCommit: (config: ModelConfig) => void;
   onOpenSessionSettings?: (sessionId: string) => void;
   onSendPrompt: () => void;
   onStop: () => void;
@@ -146,7 +146,7 @@ const SessionFooterInner: React.FC<SessionFooterProps> = ({
   client,
   modelLabel,
   modelConfig,
-  onModelConfigChange,
+  onModelConfigCommit,
   onOpenSessionSettings,
   onSendPrompt,
   onStop,
@@ -335,7 +335,7 @@ const SessionFooterInner: React.FC<SessionFooterProps> = ({
         >
           <ModelSelector
             value={modelConfig}
-            onChange={onModelConfigChange}
+            onCommit={onModelConfigCommit}
             agentic_tool={session.agentic_tool}
             client={client}
             branchId={session.branch_id}
@@ -1413,7 +1413,7 @@ const SessionFooterInner: React.FC<SessionFooterProps> = ({
                     ) : (
                       <ModelSelector
                         value={modelConfig}
-                        onChange={onModelConfigChange}
+                        onCommit={onModelConfigCommit}
                         agentic_tool={session.agentic_tool}
                         client={client}
                         branchId={session.branch_id}

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -924,7 +924,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   // lifetime-stable wrappers that delegate to the latest implementations via
   // a ref (re-pointed each render, right where the impls are defined).
   const footerHandlersRef = React.useRef<{
-    onModelConfigChange: (config: ModelConfig) => void;
+    onModelConfigCommit: (config: ModelConfig) => void;
     onSendPrompt: () => void;
     onStop: () => void;
     onFork: () => void;
@@ -938,8 +938,8 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   } | null>(null);
   const stableFooterHandlers = React.useMemo(
     () => ({
-      onModelConfigChange: (config: ModelConfig) =>
-        footerHandlersRef.current?.onModelConfigChange(config),
+      onModelConfigCommit: (config: ModelConfig) =>
+        footerHandlersRef.current?.onModelConfigCommit(config),
       onSendPrompt: () => footerHandlersRef.current?.onSendPrompt(),
       onStop: () => footerHandlersRef.current?.onStop(),
       onFork: () => footerHandlersRef.current?.onFork(),
@@ -1515,7 +1515,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     }
   };
 
-  const handleModelConfigChange = (newConfig: ModelConfig) => {
+  const handleModelConfigCommit = (newConfig: ModelConfig) => {
     if (session && onUpdateSession) {
       const nextConfig: NonNullable<Session['model_config']> = {
         ...session.model_config,
@@ -1556,7 +1556,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   // Render-phase ref write (instead of the usual useLayoutEffect) because the
   // impls above only exist when `session` is non-null, past the early return.
   footerHandlersRef.current = {
-    onModelConfigChange: handleModelConfigChange,
+    onModelConfigCommit: handleModelConfigCommit,
     onSendPrompt: handleSendPrompt,
     onStop: handleStop,
     onFork: handleFork,
@@ -1597,7 +1597,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
       client={client}
       modelLabel={modelLabel}
       modelConfig={modelConfig}
-      onModelConfigChange={stableFooterHandlers.onModelConfigChange}
+      onModelConfigCommit={stableFooterHandlers.onModelConfigCommit}
       onOpenSessionSettings={onOpenSettings}
       onSendPrompt={stableFooterHandlers.onSendPrompt}
       onStop={stableFooterHandlers.onStop}

--- a/apps/agor-ui/src/pages/marketing/DemoSessionStage.tsx
+++ b/apps/agor-ui/src/pages/marketing/DemoSessionStage.tsx
@@ -592,7 +592,7 @@ export const DemoSessionStage = ({ scene, t, variant = 'coding' }: DemoSessionSt
           queuedTasks={queuedTasks}
           client={null}
           modelConfig={modelConfig}
-          onModelConfigChange={NOOP}
+          onModelConfigCommit={NOOP}
           onSendPrompt={NOOP}
           onStop={NOOP}
           onFork={NOOP}

--- a/apps/agor-ui/src/utils/sessionUpdateNotifications.test.ts
+++ b/apps/agor-ui/src/utils/sessionUpdateNotifications.test.ts
@@ -1,0 +1,168 @@
+import type { Session, SessionID } from '@agor-live/client';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  type LatestSessionUpdateRequests,
+  runSessionUpdateWithLatestNotification,
+} from './sessionUpdateNotifications';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
+
+const session = (id: string) => ({ session_id: id }) as Session;
+
+describe('runSessionUpdateWithLatestNotification', () => {
+  it('notifies only for the latest out-of-order completion on one session', async () => {
+    const first = deferred<Session | null>();
+    const second = deferred<Session | null>();
+    const updateSession = vi
+      .fn<(sessionId: SessionID, updates: Partial<Session>) => Promise<Session | null>>()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    const latestRequests: LatestSessionUpdateRequests = new Map();
+    const showSuccess = vi.fn();
+    const showError = vi.fn();
+    const authority = { isCurrent: () => true };
+    const options = { latestRequests, authority, updateSession, showSuccess, showError };
+
+    const firstRun = runSessionUpdateWithLatestNotification({
+      ...options,
+      sessionId: 'session-1' as SessionID,
+      updates: { title: 'first' },
+    });
+    const secondRun = runSessionUpdateWithLatestNotification({
+      ...options,
+      sessionId: 'session-1' as SessionID,
+      updates: { title: 'second' },
+    });
+
+    second.resolve(session('session-1'));
+    await secondRun;
+    expect(showSuccess).toHaveBeenCalledOnce();
+    expect(showError).not.toHaveBeenCalled();
+
+    first.resolve(session('session-1'));
+    await firstRun;
+    expect(showSuccess).toHaveBeenCalledOnce();
+    expect(showError).not.toHaveBeenCalled();
+  });
+
+  it('reports only the latest failure and ignores a superseded success', async () => {
+    const first = deferred<Session | null>();
+    const second = deferred<Session | null>();
+    const updateSession = vi
+      .fn<(sessionId: SessionID, updates: Partial<Session>) => Promise<Session | null>>()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    const latestRequests: LatestSessionUpdateRequests = new Map();
+    const showSuccess = vi.fn();
+    const showError = vi.fn();
+    const authority = { isCurrent: () => true };
+    const options = { latestRequests, authority, updateSession, showSuccess, showError };
+
+    const firstRun = runSessionUpdateWithLatestNotification({
+      ...options,
+      sessionId: 'session-1' as SessionID,
+      updates: { title: 'first' },
+    });
+    const retry = runSessionUpdateWithLatestNotification({
+      ...options,
+      sessionId: 'session-1' as SessionID,
+      updates: { title: 'retry' },
+    });
+
+    second.resolve(null);
+    await retry;
+    expect(showError).toHaveBeenCalledOnce();
+    expect(showSuccess).not.toHaveBeenCalled();
+
+    first.resolve(session('session-1'));
+    await firstRun;
+    expect(showError).toHaveBeenCalledOnce();
+    expect(showSuccess).not.toHaveBeenCalled();
+  });
+
+  it('suppresses completion feedback after its authority is invalidated', async () => {
+    const pending = deferred<Session | null>();
+    let current = true;
+    const showSuccess = vi.fn();
+    const showError = vi.fn();
+    const run = runSessionUpdateWithLatestNotification({
+      sessionId: 'session-1' as SessionID,
+      updates: { title: 'obsolete' },
+      latestRequests: new Map(),
+      authority: { isCurrent: () => current },
+      updateSession: vi.fn(() => pending.promise),
+      showSuccess,
+      showError,
+    });
+
+    current = false;
+    pending.resolve(session('session-1'));
+    await run;
+
+    expect(showSuccess).not.toHaveBeenCalled();
+    expect(showError).not.toHaveBeenCalled();
+  });
+
+  it('keeps concurrent notifications for different sessions independent', async () => {
+    const updateSession = vi.fn(async (sessionId: SessionID) => session(sessionId));
+    const showSuccess = vi.fn();
+    const showError = vi.fn();
+    const latestRequests: LatestSessionUpdateRequests = new Map();
+    const authority = { isCurrent: () => true };
+
+    await Promise.all([
+      runSessionUpdateWithLatestNotification({
+        sessionId: 'session-1' as SessionID,
+        updates: { title: 'one' },
+        latestRequests,
+        authority,
+        updateSession,
+        showSuccess,
+        showError,
+      }),
+      runSessionUpdateWithLatestNotification({
+        sessionId: 'session-2' as SessionID,
+        updates: { title: 'two' },
+        latestRequests,
+        authority,
+        updateSession,
+        showSuccess,
+        showError,
+      }),
+    ]);
+
+    expect(updateSession).toHaveBeenCalledTimes(2);
+    expect(showSuccess).toHaveBeenCalledTimes(2);
+    expect(showError).not.toHaveBeenCalled();
+  });
+
+  it('keeps separate tab-local request fences independent for the same session', async () => {
+    const updateSession = vi.fn(async (sessionId: SessionID) => session(sessionId));
+    const showSuccess = vi.fn();
+    const showError = vi.fn();
+    const authority = { isCurrent: () => true };
+    const shared = {
+      sessionId: 'session-1' as SessionID,
+      updates: { title: 'tab action' },
+      authority,
+      updateSession,
+      showSuccess,
+      showError,
+    };
+
+    await Promise.all([
+      runSessionUpdateWithLatestNotification({ ...shared, latestRequests: new Map() }),
+      runSessionUpdateWithLatestNotification({ ...shared, latestRequests: new Map() }),
+    ]);
+
+    expect(updateSession).toHaveBeenCalledTimes(2);
+    expect(showSuccess).toHaveBeenCalledTimes(2);
+    expect(showError).not.toHaveBeenCalled();
+  });
+});

--- a/apps/agor-ui/src/utils/sessionUpdateNotifications.ts
+++ b/apps/agor-ui/src/utils/sessionUpdateNotifications.ts
@@ -1,0 +1,43 @@
+import type { Session, SessionID } from '@agor-live/client';
+import type { AuthorityOperation } from '../hooks/useAuthorityOperationGuard';
+
+export type LatestSessionUpdateRequests = Map<SessionID, symbol>;
+
+interface RunSessionUpdateWithLatestNotificationOptions {
+  sessionId: SessionID;
+  updates: Partial<Session>;
+  latestRequests: LatestSessionUpdateRequests;
+  authority: Pick<AuthorityOperation, 'isCurrent'>;
+  updateSession: (sessionId: SessionID, updates: Partial<Session>) => Promise<Session | null>;
+  showSuccess: (message: string) => void;
+  showError: (message: string) => void;
+}
+
+/**
+ * Persist a session update while keeping completion feedback latest-only.
+ *
+ * Requests for different sessions are independent. If requests for one session
+ * overlap, only the newest request may notify; an authority change or unmount
+ * suppresses every completion from the obsolete UI lifetime.
+ */
+export async function runSessionUpdateWithLatestNotification({
+  sessionId,
+  updates,
+  latestRequests,
+  authority,
+  updateSession,
+  showSuccess,
+  showError,
+}: RunSessionUpdateWithLatestNotificationOptions): Promise<void> {
+  if (!authority.isCurrent()) return;
+
+  const request = Symbol(sessionId);
+  latestRequests.set(sessionId, request);
+  const session = await updateSession(sessionId, updates);
+
+  if (!authority.isCurrent() || latestRequests.get(sessionId) !== request) return;
+  latestRequests.delete(sessionId);
+
+  if (session) showSuccess('Session updated successfully!');
+  else showError('Failed to update session');
+}


### PR DESCRIPTION
## Summary

- persist conversation-footer model changes only from `ModelSelector.onCommit`, never from typeahead drafts
- make exact-model blur/select commits idempotent across popover focus transitions and protect active drafts from realtime echoes
- reset picker draft/baseline state when the footer switches sessions, and restore controlled values on Escape or blank edits
- fence generic session-update notifications per session so only the latest overlapping request can toast
- add regression coverage for first open/reopen, rapid filtering, blur/outside transitions, Enter/Escape, unmount, session replacement, realtime replacement, failures, multiple tab-local fences, and out-of-order completions

## Root cause

`ModelSelector` has separate `onChange` (draft/search text) and `onCommit` (selection/completed edit) channels, but `SessionFooter` still wired `onChange` directly to `sessions.patch`. In exact/pinned mode Ant Design `AutoComplete.onChange` fires for every typed character, so every character produced a PATCH and every completion produced the generic session-save success toast. Alias search did not reproduce because Ant `Select.onChange` fires only when an option is selected, which made the bug appear intermittent and reopen/mode dependent.

## Review follow-up

- Footer selectors are keyed by `session_id` so an unfinished exact draft cannot cross-write after a session switch.
- Exact edits retain a mode/model pre-edit baseline; controlled consumers are restored through `onChange` on Escape and rejected blank/whitespace blur, and dirty state is cleared.

## Validation

- `pnpm i` — dependencies already up to date
- `pnpm check` — passed (typecheck, lint, policy checks, and builds)
- focused model-picker/session-footer suite — 70 tests passed across 7 files
- `pnpm --filter agor-ui exec vitest run src/components/ModelSelector/ModelSelector.test.tsx src/components/SessionPanel/SessionFooter.model-picker.test.tsx` — 20 passed
- `pnpm --filter @agor/agentic-tool-opencode exec vitest run src/ui/OpenCodeModelSelector.test.tsx` — 20 passed
- multitenancy, realtime-boundary, and short-ID checks — passed
- full UI suite locally: 2026 passed; 14 unrelated settings/permissions tests timed out only under full parallel load (the same-area `SessionMcpFooterControl` file passes 4/4 alone); CI UI shards pass
- PR CI: all checks pass, including typecheck/build, UI shards, daemon/core/CLI/support tests, and browser layout tests

The managed SQLite environment reported inactive/unknown, so it was not started manually.
