### PR TITLE
Stop publishing pull-request Docker images

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,21 +1,21 @@
-# Build & push the Agor container image.
+# Build, smoke-test, and (for non-PR events) publish the Agor container image.
 #
-# Builds the `production-source` target of docker/Dockerfile and pushes it to
-# Docker Hub (Buildx + GHA cache + docker/metadata tags).
+# Builds the `production-source` target of docker/Dockerfile and, on non-PR
+# events, pushes it to Docker Hub (Buildx + GHA cache + docker/metadata tags).
 #
 # `production-source` builds agor-live from THIS checkout (turbo build via
 # packages/agor-live/build.sh), so the image is pinned to the built commit
 # rather than `agor-live@latest` on npm.
 #
-# Publish model: a successful CI run for a main push first publishes
+# Publish model: pull requests build and smoke-test the production image from
+# their checkout without authenticating to Docker Hub, publishing an image, or
+# exporting an untrusted PR-scoped cache. They can restore the trusted cache
+# produced by non-PR events. A successful CI run for a main push first publishes
 # :<full-sha>, then a serialized promotion may move :main and :latest. Those
 # mutable tags always identify a successfully tested main image; when a newer
 # main commit is red, they remain on the last successful promotion. v* tags
-# and every in-repository PR commit publish directly (PRs use the PR *head* SHA
-# and re-point :pr-<n> on each update), so trusted commits remain deployable by
-# their own SHA. Fork and Dependabot PRs still build and run the boot smoke
-# test, but cannot publish because GitHub intentionally withholds repository
-# secrets from them.
+# and manual runs publish directly, so those trusted commits remain deployable
+# by their own SHA.
 #
 # Pushes to Docker Hub (docker.io/preset/agor). Required repo secrets
 # (Settings → Secrets and variables → Actions):
@@ -70,26 +70,25 @@ jobs:
           # contents match the :<sha> tag.
           ref: ${{ env.IMAGE_REVISION }}
 
+      - name: Validate image publication policy
+        run: node scripts/check-image-publication-policy.mjs
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      # Fork and Dependabot PRs cannot access repository secrets. Keep their
-      # build and smoke test useful without authenticating or publishing.
+      # Pull requests never need registry credentials: every PR validates the
+      # production image locally, including forks and Dependabot.
       - name: Log in to Docker Hub
-        if: >-
-          github.event_name != 'pull_request' ||
-          (
-            github.event.pull_request.head.repo.full_name == github.repository &&
-            github.event.pull_request.user.login != 'dependabot[bot]'
-          )
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v4.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Build once into the local Docker store so it can be smoke-tested before
-      # anything is published. The push step below reuses this build via the
-      # GHA layer cache, so it only re-exports layers.
+      # anything is published. Pull requests restore the trusted GHA cache but
+      # do not export a PR-scoped cache: the source layer changes per commit and
+      # measured exports cost more time than they save.
       - name: Build image
         uses: docker/build-push-action@v6
         with:
@@ -104,7 +103,7 @@ jobs:
           load: true
           tags: ${{ env.IMAGE }}:smoke
           cache-from: type=gha,scope=agor-image
-          cache-to: type=gha,mode=max,scope=agor-image
+          cache-to: ${{ github.event_name != 'pull_request' && 'type=gha,mode=max,scope=agor-image' || '' }}
 
       # Boot the container and require a healthy daemon: exercises the deployed
       # tree end to end (entrypoint init, db migrate, @agor/* symlink
@@ -129,6 +128,7 @@ jobs:
           exit 1
 
       - name: Docker metadata
+        if: github.event_name != 'pull_request'
         id: meta
         uses: docker/metadata-action@v5
         with:
@@ -138,22 +138,16 @@ jobs:
           flavor: latest=false
           tags: |
             type=raw,value=${{ env.IMAGE_REVISION }}
-            type=ref,event=pr
             type=semver,pattern={{version}}
           labels: |
             org.opencontainers.image.title=agor
             org.opencontainers.image.revision=${{ env.IMAGE_REVISION }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
 
-      # Publish trusted events after the smoke test. Fork and Dependabot PRs
-      # stop here after validating the same production image locally.
+      # Publish trusted non-PR events after the smoke test. Keep the historical
+      # job/check name for branch-protection and dashboard compatibility.
       - name: Push image
-        if: >-
-          github.event_name != 'pull_request' ||
-          (
-            github.event.pull_request.head.repo.full_name == github.repository &&
-            github.event.pull_request.user.login != 'dependabot[bot]'
-          )
+        if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/docs/internal/pr-image-publication-audit-2026-08-28.md
+++ b/docs/internal/pr-image-publication-audit-2026-08-28.md
@@ -1,0 +1,189 @@
+# Pull-request Docker image publication audit (2026-08-28)
+
+## Decision
+
+Pull requests build the `production-source` image, load it into the job's local
+Docker engine, and run the existing daemon health smoke test. They do not log in
+to Docker Hub, publish `preset/agor` tags, or export a PR-scoped GitHub Actions
+cache. Main, tag, and manual events retain their existing publication behavior.
+
+This is a system-level CI resource change, not an application tenant-resource
+change. It narrows writes to shared Docker Hub and Actions-cache infrastructure
+and does not change any runtime tenant boundary.
+
+## Revisions and audit scope
+
+- Agor `main` and the audit branch both started at
+  `e031ee50ad6eda0f881e994e4e9e02c41c942181`.
+- External repositories inspected at their then-current `main`:
+  - `preset-io/agor-cloud`:
+    `401824d014a63d678ab7be872ac1d6fd99a4d151`
+  - `preset-io/agor-k8s-poc`:
+    `4c4eb04ac310d9c98c770f1827399ed5faf262a5`
+
+The audit covered every workflow in `.github/workflows`, Dockerfiles and Compose
+files, `.agor.yml`, environment-manager commands, scripts, package/install
+tests, release and promotion workflows, docs, repository rules/protection,
+recent Actions job logs, Docker Hub authentication behavior, and discoverable
+Preset repositories and GitHub code references.
+
+On pull requests the image job is an independent workflow job: no CI, smoke,
+package, deployment, or promotion job declares it as a dependency. The only
+`needs: build` edge is `promote-main`, which is restricted to the successful
+main `workflow_run` event. No reusable workflow consumes the standalone image.
+Classic branch protection had no required status checks, and the active `main`
+ruleset required a pull request but declared no status-check rule. The workflow
+and job names nevertheless remain `Build image / Build & push` to avoid breaking
+dashboards or a future protection rule outside the inspected configuration.
+
+## Consumer trace
+
+| Consumer                                 | Image flow                                                                                                                                           | Needs PR `preset/agor` tag? |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
+| PR image CI                              | Builds `docker/Dockerfile` target `production-source`, loads `preset/agor:smoke`, starts it, and checks `/health` in the same job                    | No                          |
+| Managed sqlite/sandbox/demo environments | `.agor.yml` runs local Compose with `--build`; `docker-compose.yml` builds target `development` from the branch worktree                             | No                          |
+| Managed postgres/rich/full environments  | Same local source build plus a local Postgres service                                                                                                | No                          |
+| Managed HA environment                   | Builds local `agor-ha-source:latest` target `production-source-ha`; pulls only third-party Node, Redis, and nginx bases                              | No                          |
+| Managed docs environment                 | Builds `apps/agor-docs/Dockerfile` from the branch worktree                                                                                          | No                          |
+| Local development and Docker tests       | `pnpm dev`, local Compose builds, or locally named test images                                                                                       | No                          |
+| Packaged `agor-live` install/smoke       | Builds npm tarball artifacts, transfers them between jobs, and installs them into a temp home                                                        | No                          |
+| Main/release promotion                   | Successful main CI publishes immutable full-SHA `preset/agor`, then serially retags it `main`/`latest`; tag/manual runs publish SHA/semver outputs   | Yes, but not a PR tag       |
+| `agor-cloud`                             | Independently checks out an exact Agor SHA and publishes private `preset/agor-daemon`, `preset/agor-executor`, and `preset/agor-ui` component images | No                          |
+| `agor-k8s-poc`                           | Builds/publishes the same three component-image families; local Kind flows load local images with `pullPolicy: Never`                                | No                          |
+
+The only checked-in standalone `preset/agor` runtime reference was the producer
+workflow itself. No exact `preset/agor:pr-*` code reference was discoverable in
+Preset repositories or public GitHub code search. Docker Hub reports the
+repository as private to anonymous clients, so any undocumented pull would also
+need separate credentials. Private/manual consumers and Docker Hub pull
+analytics remain outside the evidence available to repository code and Actions
+metadata.
+
+## Measured Actions cost
+
+The sample is the 35 most recent successful PR image jobs on 2026-08-28. Step
+durations come from the Actions API; BuildKit phase durations come from raw job
+logs. The surrounding 80 recent PR runs comprised 54 successes, 19
+cancellations, 6 build failures, and 1 in progress.
+
+All 35 successful jobs found a GHA cache manifest, so the recent window has no
+statistically valid fully cold-cache cohort from which to report a cold p50/p90.
+It does provide a consistent and more relevant split: every job was
+manifest-warm, but the changed-source builder layer was a cache miss in all 35.
+Older cold runs were not mixed into the distribution because the Dockerfile and
+dependency graph have changed since then.
+
+| Duration                                          |     p50 |     p90 |    Mean |
+| ------------------------------------------------- | ------: | ------: | ------: |
+| Whole image job                                   |   603 s |   746 s | 636.5 s |
+| Local image build/load                            |   549 s |   683 s | 583.0 s |
+| Docker Hub login + metadata + runnable-image push |    14 s |    19 s |  14.8 s |
+| Runnable-image push step alone                    |    12 s |    17 s |  13.2 s |
+| GHA `mode=max` cache export                       | 314.5 s | 430.4 s |       — |
+| Projected PR job without publication/cache export | 284.1 s | 298.9 s | 280.6 s |
+
+Docker Hub publication itself was not the large delay: the second Buildx
+invocation reused the just-built layers and usually finished in seconds. The
+dominant side-effect was Buildx's `cache-to` export. All 35 jobs imported a
+cache manifest, but all 35 rebuilt the source-builder `RUN` layer because the
+preceding `COPY . .` changes with PR source. That layer alone took p50 169.3 s
+and p90 178.6 s before the cache was exported again.
+
+In the paired sample, removing PR cache export and registry publication saves a
+median 318.9 s and p90 447.1 s. The 35 jobs consumed 371.3 runner-minutes;
+199.0 were cache export and 8.65 were direct publication. The projected total
+is 163.7 runner-minutes. During the sampled burst (about 36 successful image
+jobs/day), that is roughly 197 runner-minutes/day reclaimed if the rate
+continued. Public-repository standard GitHub-hosted runner minutes are not
+billed, so this is queue/feedback/resource time rather than a claimed invoice
+saving.
+
+The repository's current Actions-cache snapshot held 12.0 GiB across 58
+entries. A representative PR cache was 2,359,532,682 bytes (2.197 GiB), scoped
+to `refs/pull/2544/merge`; its largest intermediate layer was 1,939,355,832
+bytes. BuildKit logs do not report exact Docker Hub wire bytes and private Hub
+analytics were unavailable. The locally loaded runtime layers were about 485 MB
+uncompressed, but registry compression and layer deduplication make that an
+invalid upload-bandwidth estimate.
+
+Ordinary Docker Hub pull limits did not explain PR time: these jobs publish
+rather than consume, and the repository requires authentication for a pull.
+The practical registry costs were latency, storage/tag churn, and use of a
+shared-namespace write credential. The GHA cache backend has separate API
+throttling and storage behavior; it accounted for the measured large transfer.
+
+The image job was the last completed check for 25/35 sampled commits (71.4%).
+When last, it finished p50 198 s and p90 340 s after the final non-image check.
+The push itself blocked nothing downstream on PRs; it merely extended this
+independent job/check. The main promotion job depends on the build job and is
+unchanged.
+
+## Cache, fork, and supply-chain findings
+
+- A GHA cache export is not a runnable image publication. `cache-to: type=gha`
+  uploads BuildKit cache records; `push: true` publishes an OCI image and its
+  tags to Docker Hub. This change disables both PR writes independently while
+  keeping `cache-from` restore.
+- GitHub scopes PR caches to `refs/pull/<n>/merge`; they cannot update the
+  default-branch cache. PRs can continue restoring the trusted main cache.
+- Fork PR run `33110651714` built and passed the identical local smoke without
+  registry secrets or publication. Its max-cache export took 627.4 s. This is
+  direct evidence that Docker Hub is not required for PR coverage.
+- GitHub withholds repository secrets from fork and Dependabot PRs. Same-repo
+  PR workflows previously received a Docker Hub write token even though no
+  consumer used their tags. Because the workflow file is PR-controlled, that
+  needlessly increased credential-exfiltration and shared-namespace risk.
+- `pr-<number>` tags were mutable. Full-SHA tags were operationally treated as
+  immutable but Docker tags are overwriteable without separate enforcement.
+- Buildx emitted provenance attestations for pushed images. The workflow has no
+  explicit SBOM generation or cosign/Notation signature. Removing unused PR
+  artifacts reduces the unsigned/unpromoted supply-chain surface; main and
+  release provenance behavior is unchanged.
+- The current PR cache is unsigned, generated from untrusted code, large, and
+  branch-local. Avoiding PR cache writes also removes a low-trust cache-poisoning
+  input without exposing any secret to the build.
+
+## Rollout, rollback, and residual risk
+
+The check and job names remain `Build image / Build & push`, and the same
+`production-source` image still boots and passes `/health` before any non-PR
+publication. A deterministic repository script enforces those facts and fails
+if a checked-in standalone `preset/agor` consumer appears elsewhere.
+
+Roll back by reverting the workflow guards and PR `cache-to` condition. If a
+real cross-job consumer emerges, prefer a same-job local load/smoke (current), a
+workflow artifact for a later job, or an explicitly short-lived registry tag
+with least-privilege credentials and cleanup over permanent PR tags in the
+shared namespace.
+
+Residual risks are undocumented private/manual consumers, future external
+repositories that do not land in code search, and possible slower repeated
+builds for a PR that changes dependency inputs while main's trusted cache stays
+stale. The deterministic scan detects new checked-in consumers, and the change
+can be reverted without changing image formats or release tags. Confidence is
+high for checked-in and discoverable consumers, and medium-high overall because
+private Docker Hub pull analytics were unavailable.
+
+## Validation
+
+- `pnpm check:image-publication-policy`
+- `node --check scripts/check-image-publication-policy.mjs`
+- Biome check of the policy script and Prettier check of the changed YAML,
+  JSON, and Markdown
+- PyYAML parse of all 10 workflow files
+- actionlint 1.7.12 over all workflows, suppressing only the pre-existing
+  `concurrency.queue` diagnostic; unfiltered actionlint reported that identical
+  single diagnostic on both starting `main` and the changed workflow
+
+The live PR workflow remains the end-to-end Docker build/boot validation. No
+local package or Docker build was run as part of this workflow-only change.
+
+## References
+
+- [Workflow introduction and design discussion](https://github.com/preset-io/agor/pull/1902)
+- [Fork/Dependabot secret guard](https://github.com/preset-io/agor/pull/1966)
+- [Main image promotion hardening](https://github.com/preset-io/agor/pull/2382)
+- [GitHub cache matching and PR scope](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching)
+- [Docker Buildx GitHub Actions cache backend](https://docs.docker.com/build/cache/backends/gha/)
+- [GitHub Actions secret availability](https://docs.github.com/en/code-security/reference/secret-security/secret-types)
+- [Docker Hub pull accounting and limits](https://docs.docker.com/docker-hub/usage/pulls/)

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "check:daemon-filesystem-boundaries": "node scripts/check-daemon-filesystem-boundaries.mjs",
     "check:realtime-boundaries": "node scripts/check-realtime-boundaries.mjs",
     "check:ci-test-coverage": "node scripts/check-ci-test-coverage.mjs",
+    "check:image-publication-policy": "node scripts/check-image-publication-policy.mjs",
     "test:daemon-filesystem-boundaries": "node --test scripts/check-daemon-filesystem-boundaries.test.mjs",
     "test:sandbox-migration": "node --test scripts/strict-to-sandbox-migration.test.mjs",
     "check:agentic-tool-packages": "node scripts/check-agentic-tool-packages.mjs",

--- a/scripts/check-image-publication-policy.mjs
+++ b/scripts/check-image-publication-policy.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const workflowPath = '.github/workflows/build-image.yml';
+const workflow = await readFile(path.join(root, workflowPath), 'utf8');
+
+function step(name) {
+  const marker = `      - name: ${name}`;
+  const start = workflow.indexOf(marker);
+  assert.notEqual(start, -1, `missing workflow step: ${name}`);
+  const end = workflow.indexOf('\n      - name:', start + marker.length);
+  return workflow.slice(start, end === -1 ? workflow.length : end);
+}
+
+assert.match(workflow, /^name: Build image$/m);
+assert.match(workflow, /^ {2}pull_request:$/m);
+assert.match(workflow, /^ {4}name: Build & push$/m);
+
+const validation = step('Validate image publication policy');
+assert.match(validation, /run: node scripts\/check-image-publication-policy\.mjs/);
+
+for (const name of ['Log in to Docker Hub', 'Docker metadata', 'Push image']) {
+  assert.match(
+    step(name),
+    /if: github\.event_name != 'pull_request'/,
+    `${name} must be disabled for every pull_request`
+  );
+}
+
+const build = step('Build image');
+assert.match(build, /target: production-source/);
+assert.match(build, /load: true/);
+assert.match(build, /tags: \$\{\{ env\.IMAGE \}\}:smoke/);
+assert.match(build, /cache-from: type=gha,scope=agor-image/);
+assert.match(
+  build,
+  /cache-to: \$\{\{ github\.event_name != 'pull_request' && 'type=gha,mode=max,scope=agor-image' \|\| '' \}\}/,
+  'pull_request builds must not export an untrusted, branch-scoped GHA cache'
+);
+
+const smoke = step('Smoke test');
+assert.match(smoke, /\$\{\{ env\.IMAGE \}\}:smoke/);
+assert.match(smoke, /curl -fsS http:\/\/localhost:3030\/health/);
+
+const push = step('Push image');
+assert.match(push, /push: true/);
+assert.match(push, /tags: \$\{\{ steps\.meta\.outputs\.tags \}\}/);
+assert.doesNotMatch(step('Docker metadata'), /type=ref,event=pr/);
+
+const promotion = step('Promote tested main image');
+assert.match(promotion, /--tag "\$\{IMAGE\}:main"/);
+assert.match(promotion, /--tag "\$\{IMAGE\}:latest"/);
+assert.match(promotion, /"\$\{IMAGE\}:\$\{IMAGE_REVISION\}"/);
+
+// A standalone preset/agor image may be produced by this workflow, but no
+// checked-in runtime, environment, test, script, or deployment may consume it
+// unnoticed. Component images such as preset/agor-daemon are intentionally
+// distinct. The audit note is the sole non-runnable evidence file excluded.
+const imageReference = new RegExp(
+  String.raw`(?<![\w-])(?:docker\.io/)?${['preset', 'agor'].join('/')}(?=[:@\s"'\x60]|$)`
+);
+const runnableExtensions = new Set([
+  '',
+  '.bash',
+  '.cjs',
+  '.cts',
+  '.env',
+  '.fish',
+  '.hcl',
+  '.ini',
+  '.js',
+  '.json',
+  '.jsonnet',
+  '.md',
+  '.mdx',
+  '.mjs',
+  '.mts',
+  '.nix',
+  '.properties',
+  '.ps1',
+  '.sh',
+  '.tf',
+  '.toml',
+  '.tpl',
+  '.ts',
+  '.txt',
+  '.xml',
+  '.yaml',
+  '.yml',
+  '.zsh',
+]);
+const excludedDirectories = new Set(['.git', 'node_modules']);
+const excludedPaths = new Set([
+  workflowPath,
+  'docs/internal/pr-image-publication-audit-2026-08-28.md',
+  'scripts/check-image-publication-policy.mjs',
+]);
+const references = [];
+
+async function scan(directory) {
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    if (excludedDirectories.has(entry.name)) continue;
+    const absolute = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      await scan(absolute);
+      continue;
+    }
+    if (!entry.isFile()) continue;
+
+    const relative = path.relative(root, absolute).split(path.sep).join('/');
+    if (excludedPaths.has(relative)) continue;
+    const extension = path.extname(entry.name);
+    const isSpecialName =
+      entry.name === 'Dockerfile' ||
+      entry.name.endsWith('.Dockerfile') ||
+      entry.name === 'Makefile';
+    if (!isSpecialName && !runnableExtensions.has(extension)) continue;
+
+    let contents;
+    try {
+      contents = await readFile(absolute, 'utf8');
+    } catch {
+      continue;
+    }
+    if (imageReference.test(contents)) references.push(relative);
+  }
+}
+
+await scan(root);
+assert.deepEqual(
+  references,
+  [],
+  `standalone preset/agor image consumer(s) found outside ${workflowPath}: ${references.join(', ')}`
+);
+
+const managedEnvironments = await readFile(path.join(root, '.agor.yml'), 'utf8');
+assert.doesNotMatch(managedEnvironments, imageReference);
+assert.doesNotMatch(managedEnvironments, /docker (?:compose )?pull\b/);
+assert.equal(
+  [...managedEnvironments.matchAll(/^\s+start:\s*>-/gm)].length,
+  [...managedEnvironments.matchAll(/\bup -d(?:\s+--build|[\s\S]{0,120}?\s+--build)\b/g)].length,
+  'every explicit managed-environment start must build from its checked-out worktree'
+);
+
+console.log(
+  'Image publication policy valid: PRs build+smoke locally, publish no image/cache, and checked-in consumers do not pull preset/agor.'
+);


### PR DESCRIPTION
## Summary

- stop authenticating to Docker Hub or publishing `preset/agor` images on every `pull_request`
- stop the expensive PR-scoped Buildx `cache-to: type=gha,mode=max` export, while retaining `cache-from`
- preserve the existing `Build image / Build & push` check name, `production-source` local load, daemon `/health` smoke, and every main/tag/manual publish/promotion path
- add a deterministic policy/consumer-path check plus the durable audit and measurements

## Audit result

No checked-in or discoverable consumer pulls the standalone PR tags:

- PR smoke loads `preset/agor:smoke` in the same job
- every `.agor.yml` managed variant builds its branch worktree with Compose `--build`
- local and packaged-install tests use source builds or npm tarball artifacts
- main/release publication still uses the standalone SHA/main/latest/semver image
- `agor-cloud` (`401824d...`) and `agor-k8s-poc` (`4c4eb04...`) independently build the component images `preset/agor-daemon`, `preset/agor-executor`, and `preset/agor-ui`, not `preset/agor:pr-*`
- no staging/production manifest, reusable workflow, or public/Preset code-search result referenced an exact PR tag

The audit started from current `main` `e031ee50ad6eda0f881e994e4e9e02c41c942181`. Full consumer trace and evidence are in `docs/internal/pr-image-publication-audit-2026-08-28.md`.

## Timing evidence

35 recent successful PR image jobs:

| Metric | p50 | p90 |
| --- | ---: | ---: |
| Whole job | 603 s | 746 s |
| Docker Hub login+metadata+image push | 14 s | 19 s |
| GHA max cache export | 314.5 s | 430.4 s |
| Projected job after this change | 284.1 s | 298.9 s |

The direct runnable-image push was cheap; the dominant side-effect was exporting a branch-scoped, typically 2.2 GiB max cache whose changed-source layer missed in all 35 warm-manifest jobs. Paired projected savings are p50 318.9 s and p90 447.1 s. The image job was the final check for 25/35 sampled commits.

## Security

This removes Docker Hub write credentials from all PR jobs (including same-repository PR code), mutable `pr-N` tags, and unsigned/untrusted PR cache writes. Fork coverage is unchanged; run `33110651714` already proved the full local build/boot smoke works without registry access. Main/release Buildx provenance and promotion behavior remain unchanged; the workflow has no explicit SBOM/signing today.

## Validation

- `pnpm check:image-publication-policy`
- `node --check scripts/check-image-publication-policy.mjs`
- Biome and Prettier checks for changed files
- PyYAML parsed all 10 workflow files
- actionlint 1.7.12 passed all workflows after suppressing only the pre-existing `concurrency.queue` diagnostic; unfiltered actionlint reports that same single diagnostic on both base and this branch
- pre-commit hook passed (lint-staged Biome + Prettier)

No local package/Docker build was run; the unchanged PR image job remains the end-to-end build and boot validation.

## Rollback / residual risk

Revert this commit to restore PR publication/cache export. If a real cross-job consumer appears, prefer the existing same-job local load, a workflow artifact, or a least-privilege expiring tag with cleanup. Residual risk is an undocumented private/manual Docker Hub consumer because private Hub pull analytics were unavailable; the deterministic scan catches future checked-in consumers.

## First post-change run

PR run [`33159797605`](https://github.com/preset-io/agor/actions/runs/33159797605) completed `Build image / Build & push` successfully in **245 s** (build/load 215 s, unchanged smoke 6 s). Docker Hub login, metadata, image push, and main promotion were skipped. The emitted Buildx command retained `--cache-from` but contained no `--cache-to`, and the log had no cache-export or registry-push phase. This single observed result is below the projected after-change p50; it is confirmation of the flow, not a replacement distribution.
