### PR TITLE
fix(ui): disable card edits the caller can't save

### DIFF
--- a/apps/agor-ui/src/components/CardModal/CardModal.test.tsx
+++ b/apps/agor-ui/src/components/CardModal/CardModal.test.tsx
@@ -1,0 +1,104 @@
+import type { AgorClient, Board, CardWithType } from '@agor-live/client';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { App as AntApp } from 'antd';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { __resetAuthConfigForTests, __setAuthConfigForTests } from '../../hooks/useAuthConfig';
+import CardModal from './CardModal';
+
+function renderWithApp(ui: React.ReactElement) {
+  return render(<AntApp>{ui}</AntApp>);
+}
+
+const board: Board = { board_id: 'board-1', name: 'Team Board' } as Board;
+
+const card: CardWithType = {
+  card_id: 'card-1',
+  board_id: 'board-1',
+  title: 'A card',
+  note: 'Existing note',
+  description: 'Existing description',
+} as CardWithType;
+
+function makeClient(capabilities: string[]) {
+  const patch = vi.fn(async (id: string, data: unknown) => ({ ...card, ...(data as object) }));
+  const remove = vi.fn(async () => undefined);
+  const effectiveAccessFind = vi.fn(async () => ({
+    capabilities,
+    fs_access: 'none',
+    source: 'direct_user',
+    group_ids: [],
+    is_primary_owner: false,
+  }));
+  const client = {
+    service: (path: string) => {
+      if (path === 'cards') return { patch, remove };
+      if (path === 'boards/:id/effective-access') return { find: effectiveAccessFind };
+      return {};
+    },
+  } as unknown as AgorClient;
+  return { client, patch, remove, effectiveAccessFind };
+}
+
+describe('CardModal permission gating', () => {
+  afterEach(() => {
+    __resetAuthConfigForTests();
+  });
+
+  it('leaves edit/archive/delete enabled by default when RBAC is disabled', async () => {
+    __setAuthConfigForTests({ requireAuth: true }, { branchRbac: false });
+    const { client } = makeClient(['board.view']);
+
+    renderWithApp(<CardModal open card={card} board={board} client={client} onClose={vi.fn()} />);
+
+    for (const el of screen.getAllByText('Edit')) {
+      expect(el.closest('button')).not.toBeDisabled();
+    }
+    expect(screen.getByText('Archive').closest('button')).not.toBeDisabled();
+    expect(screen.getByText('Delete').closest('button')).not.toBeDisabled();
+  });
+
+  it('disables note/description editing, archive, and delete when the caller lacks board.edit', async () => {
+    __setAuthConfigForTests({ requireAuth: true }, { branchRbac: true });
+    const { client, effectiveAccessFind } = makeClient(['board.view']);
+
+    renderWithApp(<CardModal open card={card} board={board} client={client} onClose={vi.fn()} />);
+
+    await waitFor(() => expect(effectiveAccessFind).toHaveBeenCalled());
+
+    const editButtons = screen.getAllByText('Edit').map((el) => el.closest('button'));
+    for (const button of editButtons) {
+      expect(button).toBeDisabled();
+    }
+    expect(screen.getByText('Archive').closest('button')).toBeDisabled();
+    expect(screen.getByText('Delete').closest('button')).toBeDisabled();
+    expect(screen.getByText('Save').closest('button')).toBeDisabled();
+  });
+
+  it('enables editing once the caller has board.edit, and saves through cards.patch', async () => {
+    __setAuthConfigForTests({ requireAuth: true }, { branchRbac: true });
+    const { client, patch, effectiveAccessFind } = makeClient(['board.view', 'board.edit']);
+
+    renderWithApp(<CardModal open card={card} board={board} client={client} onClose={vi.fn()} />);
+    await waitFor(() => expect(effectiveAccessFind).toHaveBeenCalled());
+
+    const editButtons = screen.getAllByText('Edit').map((el) => el.closest('button'));
+    for (const button of editButtons) {
+      expect(button).not.toBeDisabled();
+    }
+
+    fireEvent.click(editButtons[0] as HTMLButtonElement);
+    fireEvent.change(screen.getByPlaceholderText("Agent's live commentary..."), {
+      target: { value: 'Updated note' },
+    });
+    fireEvent.click(screen.getByText('Save').closest('button') as HTMLButtonElement);
+
+    await waitFor(() =>
+      expect(patch).toHaveBeenCalledWith(
+        'card-1',
+        expect.objectContaining({
+          note: 'Updated note',
+        })
+      )
+    );
+  });
+});

--- a/apps/agor-ui/src/components/CardModal/CardModal.tsx
+++ b/apps/agor-ui/src/components/CardModal/CardModal.tsx
@@ -10,7 +10,12 @@
  * - Archive/Delete/Save actions
  */
 
-import type { AgorClient, Board, CardWithType } from '@agor-live/client';
+import type {
+  AgorClient,
+  Board,
+  CardWithType,
+  EffectiveCapabilityPolicyAccess,
+} from '@agor-live/client';
 import {
   DeleteOutlined,
   EditOutlined,
@@ -18,8 +23,9 @@ import {
   PushpinFilled,
   SaveOutlined,
 } from '@ant-design/icons';
-import { Button, Collapse, Input, Modal, Space, Tag, Typography, theme } from 'antd';
+import { Button, Collapse, Input, Modal, Space, Tag, Tooltip, Typography, theme } from 'antd';
 import React, { useCallback, useEffect, useState } from 'react';
+import { useAuthConfig } from '../../hooks/useAuthConfig';
 import { useAgorStore } from '../../store/agorStore';
 import { selectBranchById } from '../../store/selectors';
 import { useThemedMessage } from '../../utils/message';
@@ -67,6 +73,8 @@ const CardModalComponent = ({
   const { showSuccess, showError } = useThemedMessage();
   const branchById = useAgorStore(selectBranchById);
   const boardEmoji = board ? getBoardEmoji(board, branchById) : undefined;
+  const { featuresConfig } = useAuthConfig();
+  const branchRbacEnabled = featuresConfig?.branchRbac === true;
 
   // Edit state
   const [editingNote, setEditingNote] = useState(false);
@@ -74,6 +82,7 @@ const CardModalComponent = ({
   const [noteValue, setNoteValue] = useState('');
   const [descValue, setDescValue] = useState('');
   const [saving, setSaving] = useState(false);
+  const [boardAccess, setBoardAccess] = useState<EffectiveCapabilityPolicyAccess | null>(null);
 
   // Sync local state when card changes
   useEffect(() => {
@@ -85,10 +94,42 @@ const CardModalComponent = ({
     }
   }, [card]);
 
+  // Mirrors the daemon's card-mutation check (`cardAccess('mutate', ...)`),
+  // which resolves to the same `board.edit` capability as the board itself.
+  // A card list is already scoped to boards the caller can VIEW, which is a
+  // weaker guarantee than being able to edit them.
+  const boardId = board?.board_id;
+  useEffect(() => {
+    if (!open || !client || !boardId || !branchRbacEnabled) {
+      setBoardAccess(null);
+      return;
+    }
+    let cancelled = false;
+    client
+      .service('boards/:id/effective-access')
+      .find({ route: { id: boardId } })
+      .then((access: unknown) => {
+        if (!cancelled) setBoardAccess(access as EffectiveCapabilityPolicyAccess);
+      })
+      .catch(() => {
+        if (!cancelled) setBoardAccess(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, client, boardId, branchRbacEnabled]);
+
+  const canEdit = branchRbacEnabled
+    ? Boolean(boardAccess?.capabilities.includes('board.edit'))
+    : true;
+  const editBlockedReason = canEdit
+    ? undefined
+    : "You don't have Board Editor or Manager access to change this card.";
+
   const hasChanges = noteValue !== (card?.note || '') || descValue !== (card?.description || '');
 
   const handleSave = useCallback(async () => {
-    if (!card || !client || !hasChanges) return;
+    if (!card || !client || !hasChanges || !canEdit) return;
     setSaving(true);
     try {
       const updated = await client.service('cards').patch(card.card_id, {
@@ -105,10 +146,20 @@ const CardModalComponent = ({
     } finally {
       setSaving(false);
     }
-  }, [card, client, noteValue, descValue, hasChanges, onCardUpdated, showSuccess, showError]);
+  }, [
+    card,
+    client,
+    noteValue,
+    descValue,
+    hasChanges,
+    canEdit,
+    onCardUpdated,
+    showSuccess,
+    showError,
+  ]);
 
   const handleArchive = useCallback(async () => {
-    if (!card || !client) return;
+    if (!card || !client || !canEdit) return;
     Modal.confirm({
       title: 'Archive card?',
       content: `This will hide "${card.title}" from the board while preserving its data.`,
@@ -128,10 +179,10 @@ const CardModalComponent = ({
         }
       },
     });
-  }, [card, client, onCardUpdated, onClose, showSuccess, showError]);
+  }, [card, client, canEdit, onCardUpdated, onClose, showSuccess, showError]);
 
   const handleDelete = useCallback(async () => {
-    if (!card || !client) return;
+    if (!card || !client || !canEdit) return;
     Modal.confirm({
       title: 'Delete card?',
       content: `This will permanently delete "${card.title}".`,
@@ -149,7 +200,7 @@ const CardModalComponent = ({
         }
       },
     });
-  }, [card, client, onCardDeleted, onClose, showSuccess, showError]);
+  }, [card, client, canEdit, onCardDeleted, onClose, showSuccess, showError]);
 
   if (!card) return null;
 
@@ -165,22 +216,36 @@ const CardModalComponent = ({
       footer={
         <div style={{ display: 'flex', justifyContent: 'space-between' }}>
           <Space>
-            <ArchiveActionButton tooltip="" size="middle" onClick={handleArchive}>
+            <ArchiveActionButton
+              tooltip={editBlockedReason ?? ''}
+              size="middle"
+              disabled={!canEdit}
+              onClick={handleArchive}
+            >
               Archive
             </ArchiveActionButton>
-            <Button danger icon={<DeleteOutlined />} onClick={handleDelete}>
-              Delete
-            </Button>
+            {/* A disabled button can't host a tooltip of its own — hence the span. */}
+            <Tooltip title={editBlockedReason}>
+              <span>
+                <Button danger icon={<DeleteOutlined />} disabled={!canEdit} onClick={handleDelete}>
+                  Delete
+                </Button>
+              </span>
+            </Tooltip>
           </Space>
-          <Button
-            type="primary"
-            icon={<SaveOutlined />}
-            onClick={handleSave}
-            disabled={!hasChanges}
-            loading={saving}
-          >
-            Save
-          </Button>
+          <Tooltip title={editBlockedReason}>
+            <span>
+              <Button
+                type="primary"
+                icon={<SaveOutlined />}
+                onClick={handleSave}
+                disabled={!hasChanges || !canEdit}
+                loading={saving}
+              >
+                Save
+              </Button>
+            </span>
+          </Tooltip>
         </div>
       }
       title={null}
@@ -259,14 +324,19 @@ const CardModalComponent = ({
           <Typography.Text strong style={{ fontSize: 12, color: token.colorTextSecondary }}>
             Note
           </Typography.Text>
-          <Button
-            type="text"
-            size="small"
-            icon={<EditOutlined />}
-            onClick={() => setEditingNote(!editingNote)}
-          >
-            {editingNote ? 'Preview' : 'Edit'}
-          </Button>
+          <Tooltip title={editBlockedReason}>
+            <span>
+              <Button
+                type="text"
+                size="small"
+                icon={<EditOutlined />}
+                disabled={!canEdit}
+                onClick={() => setEditingNote(!editingNote)}
+              >
+                {editingNote ? 'Preview' : 'Edit'}
+              </Button>
+            </span>
+          </Tooltip>
         </div>
         {editingNote ? (
           <TextArea
@@ -308,14 +378,19 @@ const CardModalComponent = ({
           <Typography.Text strong style={{ fontSize: 12, color: token.colorTextSecondary }}>
             Description
           </Typography.Text>
-          <Button
-            type="text"
-            size="small"
-            icon={<EditOutlined />}
-            onClick={() => setEditingDesc(!editingDesc)}
-          >
-            {editingDesc ? 'Preview' : 'Edit'}
-          </Button>
+          <Tooltip title={editBlockedReason}>
+            <span>
+              <Button
+                type="text"
+                size="small"
+                icon={<EditOutlined />}
+                disabled={!canEdit}
+                onClick={() => setEditingDesc(!editingDesc)}
+              >
+                {editingDesc ? 'Preview' : 'Edit'}
+              </Button>
+            </span>
+          </Tooltip>
         </div>
         {editingDesc ? (
           <TextArea


### PR DESCRIPTION
## Summary

Third in the permission-gating series (#2578 boards, #2579 branch-to-board moves) — this is the smallest of the three, pure reuse of the endpoint #2578 already added.

`CardModal` let anyone who could *view* a card's board type into its note/description and click Archive/Delete/Save with zero permission signal — the only `disabled` in the whole component was `!hasChanges`. Card mutation resolves to the exact same `board.edit` capability as the board itself (`cardAccess('mutate', ...)` → `authorizeExternalBoard` → `boardRepository.canMutate`, `apps/agor-daemon/src/register-hooks.ts:1370-1397`), and a card's board is visible to strictly more people than can edit it, so this is the same reachable gap #2578 fixed for `BoardEditModal` directly, just one layer down.

- Reuses `boards/:id/effective-access` (added in #2578) — no new daemon surface. Fetches the card's board capabilities once per open/board change, gated behind the `branch_rbac` feature flag like the other two PRs (defaults to fully enabled when RBAC is off, matching existing behavior).
- `canEdit = branchRbacEnabled ? capabilities.includes('board.edit') : true`.
- Note/Description: the "Edit" toggle button is disabled, so their textareas are simply never reachable — same "swap to read-only" approach as #2578's appearance-tab fix, rather than fighting to disable an editor that's already open.
- Archive/Delete/Save: all disabled, each wrapped in a `Tooltip` explaining why (`"You don't have Board Editor or Manager access to change this card."`), following the existing disabled-button-tooltip pattern from `MCPServerEditModal.tsx` (a disabled button can't host its own tooltip, hence the `<span>` wrapper).
- `handleSave`/`handleArchive`/`handleDelete` also guard on `canEdit` directly, not just the button's `disabled` prop.

## Test plan

- [x] New `CardModal.test.tsx` (previously no test coverage existed): edit/archive/delete stay enabled by default when RBAC is off; all three (plus both Edit toggles and Save) disable when the caller lacks `board.edit`; editing works and calls `cards.patch` once capability is present.
- [x] `pnpm typecheck` — clean across all 21 workspace tasks.
- [x] `pnpm biome check` — clean (pre-commit hook also passed).
- [x] Full suite for `CardModal` + both consumers (`CardsTable`, `SessionCanvas`) — 100/100 passing, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)