### PR TITLE
fix(mcp): repair legacy stdio transport rows

### DIFF
--- a/apps/agor-docs/content/guide/mcp-servers.mdx
+++ b/apps/agor-docs/content/guide/mcp-servers.mdx
@@ -17,7 +17,7 @@ For unsupported schemes, configure the server in **Settings → MCP Servers**. C
 
 An stdio configuration uses only its command, arguments, and environment. HTTP/SSE authentication, URL, and custom-header fields do not apply. Agor does not download the command: it must already be available in the actual executor environment, which may differ from the daemon host. Store a per-user token in **Settings → Environment Variables**, then reference it from the server environment, for example `{"SHORTCUT_API_TOKEN":"{{ user.env.SHORTCUT_API_TOKEN }}"}`. The managed value is encrypted and resolved only for the authenticated user whose task is running; do not paste the token directly into the MCP server definition.
 
-Upgrading Agor removes obsolete remote-auth, URL, and header fields from existing stdio rows while preserving their command, arguments, environment, ownership, and session attachments. Editing an stdio server performs the same repair. This keeps strict transport validation in place rather than allowing mixed local/remote configurations at runtime.
+Upgrading Agor removes obsolete remote-auth, URL, and header fields from existing stdio rows while preserving their command, arguments, environment, ownership, and session attachments. It also deletes OAuth grants and pending OAuth attempts that cannot apply to an stdio process; credentials for remote servers are unchanged. Editing an stdio server performs the same repair. This keeps strict transport validation in place rather than allowing mixed local/remote configurations at runtime. If you later switch that server to remote OAuth, sign in again.
 
 ## Safe edits, storage, and removal
 

--- a/apps/agor-docs/content/guide/mcp-servers.mdx
+++ b/apps/agor-docs/content/guide/mcp-servers.mdx
@@ -13,6 +13,12 @@ Marketplace checks the live endpoint before installing it. An entry may be:
 
 For unsupported schemes, configure the server in **Settings → MCP Servers**. Custom headers support services such as Datadog API/application-key pairs; Marketplace's Datadog entry instead asks for the bearer PAT/SAT described in Datadog's MCP setup guide.
 
+### Local stdio servers
+
+An stdio configuration uses only its command, arguments, and environment. HTTP/SSE authentication, URL, and custom-header fields do not apply. Agor does not download the command: it must already be available in the actual executor environment, which may differ from the daemon host. Store a per-user token in **Settings → Environment Variables**, then reference it from the server environment, for example `{"SHORTCUT_API_TOKEN":"{{ user.env.SHORTCUT_API_TOKEN }}"}`. The managed value is encrypted and resolved only for the authenticated user whose task is running; do not paste the token directly into the MCP server definition.
+
+Upgrading Agor removes obsolete remote-auth, URL, and header fields from existing stdio rows while preserving their command, arguments, environment, ownership, and session attachments. Editing an stdio server performs the same repair. This keeps strict transport validation in place rather than allowing mixed local/remote configurations at runtime.
+
 ## Safe edits, storage, and removal
 
 Bearer tokens and other MCP auth/header/env secrets are stored in MCP server JSON according to the deployment's storage security. Catalog installs are private to their owner, access controls restrict the row, and API, realtime, and UI projections redact secrets. Redaction is an output-boundary control, not application-level encryption; encryption at rest applies only when the deployment's documented database or storage configuration guarantees it. OAuth access and refresh tokens use Agor's per-user OAuth token store.

--- a/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.test.ts
+++ b/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.test.ts
@@ -192,6 +192,17 @@ describe('extractOAuthConfigForTesting', () => {
 });
 
 describe('buildAuthFromValues', () => {
+  it('does not submit hidden remote auth for a stdio server', () => {
+    const values = {
+      transport: 'stdio',
+      auth_type: 'bearer',
+      auth_token: 'stale-token',
+    };
+
+    expect(buildAuthFromValues(values)).toBeUndefined();
+    expect(buildAuthFromValues(values, { forPatch: true })).toBeNull();
+  });
+
   it('preserves a legacy absent DCR field across an unrelated edit', () => {
     expect(
       buildAuthFromValues(

--- a/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.ts
+++ b/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.ts
@@ -217,6 +217,14 @@ export function buildAuthFromValues(
     forPatch?: boolean;
   } = {}
 ): BuiltAuth | MCPAuthPatch | null | undefined {
+  // Authentication belongs to remote HTTP/SSE transports. A stale hidden
+  // auth_type can remain in the form after switching transports, and sending
+  // it would either create an invalid stdio row or prevent an existing legacy
+  // row from repairing itself on edit.
+  if (values.transport === 'stdio') {
+    return options.forPatch ? null : undefined;
+  }
+
   const authType = values.auth_type;
   if (authType !== 'bearer' && authType !== 'jwt' && authType !== 'oauth') {
     return options.forPatch ? null : undefined;

--- a/apps/agor-ui/src/components/SettingsModal/MCPServersTable.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPServersTable.test.tsx
@@ -573,6 +573,48 @@ async function chooseSelect(label: string, option: string): Promise<void> {
   fireEvent.click(optionContent);
 }
 
+describe('MCPServersTable transport form state', { timeout: ANT_FORM_INTEGRATION_TIMEOUT }, () => {
+  it('does not submit preserved remote fields after switching the create form to stdio', async () => {
+    const seam = renderTransitionTable({ currentUser: ADMIN, policy: 'allow_crud' });
+    await waitFor(() => expect(seam.find).toHaveBeenCalledTimes(1));
+    await openCreateForm();
+
+    fireEvent.change(screen.getByLabelText('Name (Internal ID)'), {
+      target: { value: 'transport-switch-server' },
+    });
+    await chooseSelect('Transport', 'HTTP');
+    fireEvent.change(await screen.findByLabelText('URL'), {
+      target: { value: 'https://stale-remote.example/mcp' },
+    });
+    await chooseSelect('Auth Type', 'Bearer Token');
+    fireEvent.change(await screen.findByLabelText('Token'), {
+      target: { value: 'stale-remote-token' },
+    });
+    fireEvent.click(screen.getByText('Advanced Configuration'));
+    fireEvent.change(await screen.findByLabelText('Custom HTTP Headers'), {
+      target: { value: '{"X-Stale":"remote"}' },
+    });
+
+    await chooseSelect('Transport', 'stdio (Local process)');
+    fireEvent.change(await screen.findByLabelText('Command'), {
+      target: { value: 'mcp-server-shortcut' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+    await waitFor(() => expect(seam.onCreate).toHaveBeenCalledOnce());
+    const submitted = seam.onCreate.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(submitted).toMatchObject({
+      name: 'transport-switch-server',
+      transport: 'stdio',
+      command: 'mcp-server-shortcut',
+      args: [],
+    });
+    expect(submitted).not.toHaveProperty('url');
+    expect(submitted).not.toHaveProperty('headers');
+    expect(submitted).not.toHaveProperty('auth');
+  });
+});
+
 describe('MCPServersTable open-dialog authority transitions', {
   timeout: AUTHORITY_TRANSITION_TIMEOUT,
 }, () => {

--- a/packages/core/drizzle/postgres/0096_strip_stdio_remote_fields.sql
+++ b/packages/core/drizzle/postgres/0096_strip_stdio_remote_fields.sql
@@ -1,0 +1,8 @@
+-- Authentication, URLs, and HTTP headers never participate in an stdio MCP
+-- connection. Older rows could retain those fields, but strict transport
+-- validation now rejects the whole server before spawning it. Remove only the
+-- inapplicable fields; command, args, env, tenant/owner, and attachments remain.
+UPDATE "mcp_servers"
+SET "data" = "data" - 'auth' - 'url' - 'headers'
+WHERE "transport" = 'stdio'
+  AND "data" ?| ARRAY['auth', 'url', 'headers'];

--- a/packages/core/drizzle/postgres/0096_strip_stdio_remote_fields.sql
+++ b/packages/core/drizzle/postgres/0096_strip_stdio_remote_fields.sql
@@ -1,8 +1,108 @@
 -- Authentication, URLs, and HTTP headers never participate in an stdio MCP
 -- connection. Older rows could retain those fields, but strict transport
--- validation now rejects the whole server before spawning it. Remove only the
--- inapplicable fields; command, args, env, tenant/owner, and attachments remain.
-UPDATE "mcp_servers"
-SET "data" = "data" - 'auth' - 'url' - 'headers'
-WHERE "transport" = 'stdio'
-  AND "data" ?| ARRAY['auth', 'url', 'headers'];
+-- validation now rejects the whole server before spawning it. OAuth grants and
+-- pending flows are likewise unusable after a transport switch and may contain
+-- credentials, so remove them in the same transaction as the row repair.
+--
+-- All three tables use FORCE RLS. Open only this exact transaction-local
+-- migration capability, then remove every temporary policy before commit. This
+-- keeps the repair effective for every tenant under the supported
+-- non-superuser/NOBYPASSRLS migration role without creating a runtime bypass.
+SET LOCAL lock_timeout = '3s';
+--> statement-breakpoint
+DROP POLICY IF EXISTS "stdio_repair_0096_select" ON "mcp_servers";
+--> statement-breakpoint
+CREATE POLICY "stdio_repair_0096_select" ON "mcp_servers"
+  FOR SELECT
+  USING (
+    current_setting('agor.system_scope', true) = 'stdio_remote_repair_0096'
+  );
+--> statement-breakpoint
+DROP POLICY IF EXISTS "stdio_repair_0096_update" ON "mcp_servers";
+--> statement-breakpoint
+CREATE POLICY "stdio_repair_0096_update" ON "mcp_servers"
+  FOR UPDATE
+  USING (
+    current_setting('agor.system_scope', true) = 'stdio_remote_repair_0096'
+  )
+  WITH CHECK (
+    current_setting('agor.system_scope', true) = 'stdio_remote_repair_0096'
+  );
+--> statement-breakpoint
+DROP POLICY IF EXISTS "stdio_repair_0096_delete" ON "user_mcp_oauth_tokens";
+--> statement-breakpoint
+DROP POLICY IF EXISTS "stdio_repair_0096_select" ON "user_mcp_oauth_tokens";
+--> statement-breakpoint
+CREATE POLICY "stdio_repair_0096_select" ON "user_mcp_oauth_tokens"
+  FOR SELECT
+  USING (
+    current_setting('agor.system_scope', true) = 'stdio_remote_repair_0096'
+  );
+--> statement-breakpoint
+CREATE POLICY "stdio_repair_0096_delete" ON "user_mcp_oauth_tokens"
+  FOR DELETE
+  USING (
+    current_setting('agor.system_scope', true) = 'stdio_remote_repair_0096'
+  );
+--> statement-breakpoint
+DROP POLICY IF EXISTS "stdio_repair_0096_delete" ON "mcp_oauth_pending_flows";
+--> statement-breakpoint
+DROP POLICY IF EXISTS "stdio_repair_0096_select" ON "mcp_oauth_pending_flows";
+--> statement-breakpoint
+CREATE POLICY "stdio_repair_0096_select" ON "mcp_oauth_pending_flows"
+  FOR SELECT
+  USING (
+    current_setting('agor.system_scope', true) = 'stdio_remote_repair_0096'
+  );
+--> statement-breakpoint
+CREATE POLICY "stdio_repair_0096_delete" ON "mcp_oauth_pending_flows"
+  FOR DELETE
+  USING (
+    current_setting('agor.system_scope', true) = 'stdio_remote_repair_0096'
+  );
+--> statement-breakpoint
+SELECT set_config('agor.system_scope', 'stdio_remote_repair_0096', true);
+--> statement-breakpoint
+WITH stdio_servers AS MATERIALIZED (
+  SELECT
+    "tenant_id",
+    "mcp_server_id",
+    "data" ?| ARRAY['auth', 'url', 'headers'] AS "has_remote_fields"
+  FROM "mcp_servers"
+  WHERE "transport" = 'stdio'
+  FOR UPDATE
+), deleted_pending_flows AS (
+  DELETE FROM "mcp_oauth_pending_flows" AS flow
+  USING stdio_servers AS server
+  WHERE flow."tenant_id" = server."tenant_id"
+    AND flow."mcp_server_id" = server."mcp_server_id"
+), deleted_grants AS (
+  DELETE FROM "user_mcp_oauth_tokens" AS token
+  USING stdio_servers AS server
+  WHERE token."tenant_id" = server."tenant_id"
+    AND token."mcp_server_id" = server."mcp_server_id"
+)
+UPDATE "mcp_servers" AS server
+SET "data" = server."data" - 'auth' - 'url' - 'headers'
+FROM stdio_servers AS repaired
+WHERE server."tenant_id" = repaired."tenant_id"
+  AND server."mcp_server_id" = repaired."mcp_server_id"
+  AND repaired."has_remote_fields";
+--> statement-breakpoint
+SELECT set_config('agor.system_scope', '', true);
+--> statement-breakpoint
+DROP POLICY "stdio_repair_0096_delete" ON "mcp_oauth_pending_flows";
+--> statement-breakpoint
+DROP POLICY "stdio_repair_0096_select" ON "mcp_oauth_pending_flows";
+--> statement-breakpoint
+DROP POLICY "stdio_repair_0096_delete" ON "user_mcp_oauth_tokens";
+--> statement-breakpoint
+DROP POLICY "stdio_repair_0096_select" ON "user_mcp_oauth_tokens";
+--> statement-breakpoint
+DROP POLICY "stdio_repair_0096_update" ON "mcp_servers";
+--> statement-breakpoint
+DROP POLICY "stdio_repair_0096_select" ON "mcp_servers";
+--> statement-breakpoint
+-- Migrations share one transaction, so do not leak this DDL safety timeout into
+-- later migrations in the same upgrade run.
+SET LOCAL lock_timeout = DEFAULT;

--- a/packages/core/drizzle/postgres/meta/_journal.json
+++ b/packages/core/drizzle/postgres/meta/_journal.json
@@ -666,6 +666,13 @@
       "when": 1787745600000,
       "tag": "0095_board_branch_capability_policies",
       "breakpoints": true
+    },
+    {
+      "idx": 96,
+      "version": "7",
+      "when": 1787947200000,
+      "tag": "0096_strip_stdio_remote_fields",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/drizzle/sqlite/0099_strip_stdio_remote_fields.sql
+++ b/packages/core/drizzle/sqlite/0099_strip_stdio_remote_fields.sql
@@ -1,0 +1,12 @@
+-- Authentication, URLs, and HTTP headers never participate in an stdio MCP
+-- connection. Older rows could retain those fields, but strict transport
+-- validation now rejects the whole server before spawning it. Remove only the
+-- inapplicable fields; command, args, env, ownership, and attachments remain.
+UPDATE `mcp_servers`
+SET `data` = json_remove(`data`, '$.auth', '$.url', '$.headers')
+WHERE `transport` = 'stdio'
+  AND (
+    json_type(`data`, '$.auth') IS NOT NULL
+    OR json_type(`data`, '$.url') IS NOT NULL
+    OR json_type(`data`, '$.headers') IS NOT NULL
+  );

--- a/packages/core/drizzle/sqlite/0099_strip_stdio_remote_fields.sql
+++ b/packages/core/drizzle/sqlite/0099_strip_stdio_remote_fields.sql
@@ -1,7 +1,22 @@
 -- Authentication, URLs, and HTTP headers never participate in an stdio MCP
 -- connection. Older rows could retain those fields, but strict transport
--- validation now rejects the whole server before spawning it. Remove only the
--- inapplicable fields; command, args, env, ownership, and attachments remain.
+-- validation now rejects the whole server before spawning it. OAuth grants and
+-- the cross-dialect pending-flow mirror are likewise unusable for stdio, so
+-- remove those dependent rows in the same migration transaction.
+DELETE FROM `mcp_oauth_pending_flows`
+WHERE `mcp_server_id` IN (
+  SELECT `mcp_server_id`
+  FROM `mcp_servers`
+  WHERE `transport` = 'stdio'
+);
+--> statement-breakpoint
+DELETE FROM `user_mcp_oauth_tokens`
+WHERE `mcp_server_id` IN (
+  SELECT `mcp_server_id`
+  FROM `mcp_servers`
+  WHERE `transport` = 'stdio'
+);
+--> statement-breakpoint
 UPDATE `mcp_servers`
 SET `data` = json_remove(`data`, '$.auth', '$.url', '$.headers')
 WHERE `transport` = 'stdio'

--- a/packages/core/drizzle/sqlite/meta/_journal.json
+++ b/packages/core/drizzle/sqlite/meta/_journal.json
@@ -680,6 +680,13 @@
       "when": 1787745600000,
       "tag": "0098_board_branch_capability_policies",
       "breakpoints": true
+    },
+    {
+      "idx": 99,
+      "version": "6",
+      "when": 1787947200000,
+      "tag": "0099_strip_stdio_remote_fields",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/db/mcp-stdio-repair-migration.postgres.test.ts
+++ b/packages/core/src/db/mcp-stdio-repair-migration.postgres.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Real 0095 -> 0096 upgrade proof under the same non-superuser/NOBYPASSRLS
+ * contract as the PostgreSQL integration runner.
+ *
+ * Run through the root PostgreSQL integration lane; the canonical runner gives
+ * every PostgreSQL suite its own temporary database.
+ */
+
+import { cp, mkdtemp, readFile, rm, unlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { sql } from 'drizzle-orm';
+import { migrate as migratePostgres } from 'drizzle-orm/postgres-js/migrator';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createDatabase, type Database } from './client';
+import { executeRaw, insert, isPostgresDatabase } from './database-wrapper';
+import { runMigrations } from './migrate';
+import * as pg from './schema.postgres';
+import { runWithTenantDatabaseScope } from './tenant-scope';
+
+const postgresUrl = process.env.AGOR_TEST_POSTGRES_URL;
+const usesPostgresSchema = process.env.AGOR_DB_DIALECT === 'postgresql';
+const migrationsFolder = resolve(dirname(fileURLToPath(import.meta.url)), '../../drizzle/postgres');
+
+interface Fixture {
+  tenantId: string;
+  userId: string;
+  repairedServerId: string;
+  cleanServerId: string;
+  remoteServerId: string;
+  repairedAttemptId: string;
+  cleanAttemptId: string;
+  remoteAttemptId: string;
+  hashPrefix: string;
+}
+
+const FIXTURES: Fixture[] = [
+  {
+    tenantId: 'default',
+    userId: '019fdd52-0000-7000-8000-000000000101',
+    repairedServerId: '019fdd52-0000-7000-8000-000000000102',
+    cleanServerId: '019fdd52-0000-7000-8000-000000000103',
+    remoteServerId: '019fdd52-0000-7000-8000-000000000104',
+    repairedAttemptId: '019fdd52-0000-7000-8000-000000000105',
+    cleanAttemptId: '019fdd52-0000-7000-8000-000000000106',
+    remoteAttemptId: '019fdd52-0000-7000-8000-000000000107',
+    hashPrefix: 'a',
+  },
+  {
+    tenantId: 'stdio-repair-non-default',
+    userId: '019fdd52-0000-7000-8000-000000000201',
+    repairedServerId: '019fdd52-0000-7000-8000-000000000202',
+    cleanServerId: '019fdd52-0000-7000-8000-000000000203',
+    remoteServerId: '019fdd52-0000-7000-8000-000000000204',
+    repairedAttemptId: '019fdd52-0000-7000-8000-000000000205',
+    cleanAttemptId: '019fdd52-0000-7000-8000-000000000206',
+    remoteAttemptId: '019fdd52-0000-7000-8000-000000000207',
+    hashPrefix: 'b',
+  },
+];
+
+function rowsOf(result: unknown): Array<Record<string, unknown>> {
+  if (Array.isArray(result)) return result as Array<Record<string, unknown>>;
+  const rows = (result as { rows?: unknown[] } | undefined)?.rows;
+  return Array.isArray(rows) ? (rows as Array<Record<string, unknown>>) : [];
+}
+
+function firstRow(result: unknown): Record<string, unknown> {
+  return rowsOf(result)[0] ?? {};
+}
+
+async function seedFixture(db: Database, fixture: Fixture): Promise<void> {
+  const now = new Date('2026-08-28T12:00:00.000Z');
+  const servers = [
+    {
+      tenant_id: fixture.tenantId,
+      mcp_server_id: fixture.repairedServerId,
+      name: `legacy-stdio-${fixture.tenantId}`,
+      transport: 'stdio' as const,
+      scope: 'global' as const,
+      enabled: true,
+      source: 'user' as const,
+      data: {
+        command: 'mcp-server-shortcut',
+        args: [''],
+        env: { SHORTCUT_API_TOKEN: '{{ user.env.SHORTCUT_API_TOKEN }}' },
+        auth: { type: 'oauth' },
+        url: 'https://unused.example/mcp',
+        headers: { 'X-Unused': 'obsolete' },
+        config_version: 7,
+      },
+      created_at: now,
+    },
+    {
+      tenant_id: fixture.tenantId,
+      mcp_server_id: fixture.cleanServerId,
+      name: `clean-stdio-${fixture.tenantId}`,
+      transport: 'stdio' as const,
+      scope: 'global' as const,
+      enabled: true,
+      source: 'user' as const,
+      data: { command: 'other-server', config_version: 3 },
+      created_at: now,
+    },
+    {
+      tenant_id: fixture.tenantId,
+      mcp_server_id: fixture.remoteServerId,
+      name: `remote-${fixture.tenantId}`,
+      transport: 'http' as const,
+      scope: 'global' as const,
+      enabled: true,
+      source: 'user' as const,
+      data: {
+        url: 'https://mcp.example.test/mcp',
+        headers: { 'X-Key': 'kept' },
+        auth: { type: 'oauth' },
+        config_version: 11,
+      },
+      created_at: now,
+    },
+  ];
+
+  await runWithTenantDatabaseScope(db, fixture.tenantId, async (scoped) => {
+    await insert(scoped, pg.users)
+      .values({
+        tenant_id: fixture.tenantId,
+        user_id: fixture.userId,
+        created_at: now,
+        email: `stdio-repair-${fixture.tenantId}@example.invalid`,
+        password: 'not-a-real-password-hash',
+        role: 'member',
+        onboarding_completed: true,
+        must_change_password: false,
+        credential_generation: 0,
+        data: {},
+      })
+      .run();
+    await insert(scoped, pg.mcpServers).values(servers).run();
+
+    for (const server of servers) {
+      await insert(scoped, pg.userMcpOauthTokens)
+        .values({
+          tenant_id: fixture.tenantId,
+          user_id: fixture.userId,
+          mcp_server_id: server.mcp_server_id,
+          oauth_access_token: `sealed-test-grant-${server.mcp_server_id}`,
+          created_at: now,
+        })
+        .run();
+    }
+
+    const flowServerIds = [
+      [fixture.repairedAttemptId, fixture.repairedServerId, '1'],
+      [fixture.cleanAttemptId, fixture.cleanServerId, '2'],
+      [fixture.remoteAttemptId, fixture.remoteServerId, '3'],
+    ] as const;
+    for (const [attemptId, serverId, hashSuffix] of flowServerIds) {
+      await insert(scoped, pg.mcpOauthPendingFlows)
+        .values({
+          tenant_id: fixture.tenantId,
+          attempt_id: attemptId,
+          state_hash: `${fixture.hashPrefix}${hashSuffix}`.padEnd(64, fixture.hashPrefix),
+          user_id: fixture.userId,
+          mcp_server_id: serverId,
+          oauth_mode: 'per_user',
+          subject_user_id: fixture.userId,
+          grant_generation: 1,
+          config_fingerprint_version: 1,
+          config_fingerprint: fixture.hashPrefix.repeat(64),
+          envelope_version: 1,
+          is_current: true,
+          status: 'pending',
+          sealed_material: `sealed-test-flow-${serverId}`,
+          created_at: now,
+          updated_at: now,
+          expires_at: new Date(now.getTime() + 60_000),
+        })
+        .run();
+    }
+  });
+}
+
+describe.skipIf(!postgresUrl || !usesPostgresSchema)(
+  'MCP stdio 0095 -> 0096 repair migration (PostgreSQL)',
+  () => {
+    let db: Database | null = null;
+    let pre0096Folder: string | null = null;
+
+    beforeAll(async () => {
+      db = createDatabase({ dialect: 'postgresql', url: postgresUrl! });
+      if (!isPostgresDatabase(db)) throw new Error('PostgreSQL test requires PostgreSQL');
+
+      const role = firstRow(
+        await executeRaw(
+          db,
+          sql`SELECT rolsuper, rolbypassrls FROM pg_roles WHERE rolname = current_user`
+        )
+      );
+      expect(role.rolsuper).toBe(false);
+      expect(role.rolbypassrls).toBe(false);
+
+      pre0096Folder = await mkdtemp(join(tmpdir(), 'agor-pg-migrations-through-0095-'));
+      await cp(migrationsFolder, pre0096Folder, { recursive: true });
+      await unlink(join(pre0096Folder, '0096_strip_stdio_remote_fields.sql'));
+      const journalPath = join(pre0096Folder, 'meta', '_journal.json');
+      const journal = JSON.parse(await readFile(journalPath, 'utf8')) as {
+        entries: Array<{ idx: number }>;
+      };
+      journal.entries = journal.entries.filter((entry) => entry.idx <= 95);
+      await writeFile(journalPath, `${JSON.stringify(journal, null, 2)}\n`);
+
+      await migratePostgres(db as never, { migrationsFolder: pre0096Folder });
+      for (const fixture of FIXTURES) await seedFixture(db, fixture);
+    });
+
+    afterAll(async () => {
+      if (db) await (db as Database & { $client: { end: () => Promise<void> } }).$client.end();
+      if (pre0096Folder) await rm(pre0096Folder, { recursive: true, force: true });
+    });
+
+    it('repairs every tenant, removes stdio OAuth state, and preserves remote state', async () => {
+      if (!db) throw new Error('PostgreSQL test database was not initialized');
+
+      await runMigrations(db);
+
+      for (const fixture of FIXTURES) {
+        await runWithTenantDatabaseScope(db, fixture.tenantId, async (scoped) => {
+          const serverRows = rowsOf(
+            await executeRaw(
+              scoped,
+              sql`SELECT mcp_server_id, transport, data
+                  FROM mcp_servers
+                  ORDER BY mcp_server_id`
+            )
+          );
+          const serverById = new Map(serverRows.map((row) => [row.mcp_server_id, row]));
+          expect(serverById.get(fixture.repairedServerId)?.data).toEqual({
+            command: 'mcp-server-shortcut',
+            args: [''],
+            env: { SHORTCUT_API_TOKEN: '{{ user.env.SHORTCUT_API_TOKEN }}' },
+            config_version: 7,
+          });
+          expect(serverById.get(fixture.cleanServerId)?.data).toEqual({
+            command: 'other-server',
+            config_version: 3,
+          });
+          expect(serverById.get(fixture.remoteServerId)?.data).toEqual({
+            url: 'https://mcp.example.test/mcp',
+            headers: { 'X-Key': 'kept' },
+            auth: { type: 'oauth' },
+            config_version: 11,
+          });
+
+          const grants = rowsOf(
+            await executeRaw(
+              scoped,
+              sql`SELECT mcp_server_id
+                  FROM user_mcp_oauth_tokens
+                  ORDER BY mcp_server_id`
+            )
+          );
+          expect(grants.map((row) => row.mcp_server_id)).toEqual([fixture.remoteServerId]);
+
+          const flows = rowsOf(
+            await executeRaw(
+              scoped,
+              sql`SELECT mcp_server_id, sealed_material
+                  FROM mcp_oauth_pending_flows
+                  ORDER BY mcp_server_id`
+            )
+          );
+          expect(flows).toEqual([
+            {
+              mcp_server_id: fixture.remoteServerId,
+              sealed_material: `sealed-test-flow-${fixture.remoteServerId}`,
+            },
+          ]);
+        });
+      }
+
+      const temporaryPolicies = rowsOf(
+        await executeRaw(
+          db,
+          sql`SELECT tablename, policyname
+              FROM pg_policies
+              WHERE policyname LIKE 'stdio_repair_0096_%'`
+        )
+      );
+      expect(temporaryPolicies).toEqual([]);
+    });
+  }
+);

--- a/packages/core/src/db/migrations.test.ts
+++ b/packages/core/src/db/migrations.test.ts
@@ -1026,6 +1026,16 @@ describe('MCP stdio transport repair migrations', () => {
         tenant_id text NOT NULL,
         data text NOT NULL
       );
+      CREATE TABLE user_mcp_oauth_tokens (
+        user_id text,
+        mcp_server_id text NOT NULL,
+        oauth_access_token text NOT NULL
+      );
+      CREATE TABLE mcp_oauth_pending_flows (
+        attempt_id text PRIMARY KEY,
+        mcp_server_id text NOT NULL,
+        sealed_material text
+      );
       INSERT INTO mcp_servers VALUES (
         'legacy-stdio',
         'stdio',
@@ -1044,6 +1054,14 @@ describe('MCP stdio transport repair migrations', () => {
         'tenant-a',
         '{"url":"https://mcp.example.com","headers":{"X-Key":"kept"},"auth":{"type":"bearer","token":"kept"}}'
       );
+      INSERT INTO user_mcp_oauth_tokens VALUES
+        ('user-a', 'legacy-stdio', 'obsolete-legacy-grant'),
+        ('user-b', 'clean-stdio', 'obsolete-clean-grant'),
+        ('user-a', 'remote', 'kept-remote-grant');
+      INSERT INTO mcp_oauth_pending_flows VALUES
+        ('legacy-flow', 'legacy-stdio', 'obsolete-legacy-sealed-material'),
+        ('clean-flow', 'clean-stdio', 'obsolete-clean-sealed-material'),
+        ('remote-flow', 'remote', 'kept-remote-sealed-material');
     `);
 
     const migration = await readFile(
@@ -1078,18 +1096,35 @@ describe('MCP stdio transport repair migrations', () => {
       ['legacy-stdio', 'tenant-a'],
       ['remote', 'tenant-a'],
     ]);
+    const grants = await client.execute(
+      'SELECT mcp_server_id FROM user_mcp_oauth_tokens ORDER BY mcp_server_id'
+    );
+    expect(grants.rows.map((row) => row.mcp_server_id)).toEqual(['remote']);
+    const pendingFlows = await client.execute(
+      'SELECT mcp_server_id, sealed_material FROM mcp_oauth_pending_flows ORDER BY mcp_server_id'
+    );
+    expect(pendingFlows.rows).toEqual([
+      {
+        mcp_server_id: 'remote',
+        sealed_material: 'kept-remote-sealed-material',
+      },
+    ]);
     client.close();
   });
 
-  it('applies the same transport-bounded repair in PostgreSQL', async () => {
+  it('bounds the PostgreSQL cross-tenant repair to a temporary exact capability', async () => {
     const migration = await readFile(
       new URL('../../drizzle/postgres/0096_strip_stdio_remote_fields.sql', import.meta.url),
       'utf8'
     );
 
-    expect(migration).toContain(`SET "data" = "data" - 'auth' - 'url' - 'headers'`);
+    expect(migration).toContain(`SET "data" = server."data" - 'auth' - 'url' - 'headers'`);
     expect(migration).toContain(`WHERE "transport" = 'stdio'`);
-    expect(migration).not.toMatch(/DELETE\s+FROM/i);
-    expect(migration).not.toContain('tenant_id =');
+    expect(migration).toContain('DELETE FROM "user_mcp_oauth_tokens"');
+    expect(migration).toContain('DELETE FROM "mcp_oauth_pending_flows"');
+    expect(migration).toContain("= 'stdio_remote_repair_0096'");
+    expect(migration.match(/CREATE POLICY "stdio_repair_0096_/g)).toHaveLength(6);
+    expect(migration.match(/DROP POLICY "stdio_repair_0096_/g)).toHaveLength(6);
+    expect(migration).toContain("SELECT set_config('agor.system_scope', '', true)");
   });
 });

--- a/packages/core/src/db/migrations.test.ts
+++ b/packages/core/src/db/migrations.test.ts
@@ -1015,3 +1015,81 @@ describe('MCP catalog install identity migration', () => {
     expect(postgres).toContain('coalesce("owner_user_id",\'\')');
   });
 });
+
+describe('MCP stdio transport repair migrations', () => {
+  it('removes only remote fields from SQLite stdio rows', async () => {
+    const client = createClient({ url: ':memory:' });
+    await client.executeMultiple(`
+      CREATE TABLE mcp_servers (
+        mcp_server_id text PRIMARY KEY,
+        transport text NOT NULL,
+        tenant_id text NOT NULL,
+        data text NOT NULL
+      );
+      INSERT INTO mcp_servers VALUES (
+        'legacy-stdio',
+        'stdio',
+        'tenant-a',
+        '{"command":"mcp-server-shortcut","args":[""],"env":{"SHORTCUT_API_TOKEN":"{{ user.env.SHORTCUT_API_TOKEN }}"},"auth":{"type":"bearer","token":"obsolete"},"url":"https://unused.example","headers":{"X-Unused":"obsolete"},"config_version":7}'
+      );
+      INSERT INTO mcp_servers VALUES (
+        'clean-stdio',
+        'stdio',
+        'tenant-b',
+        '{"command":"other-server","env":{"TOKEN":"{{ user.env.OTHER_TOKEN }}"}}'
+      );
+      INSERT INTO mcp_servers VALUES (
+        'remote',
+        'http',
+        'tenant-a',
+        '{"url":"https://mcp.example.com","headers":{"X-Key":"kept"},"auth":{"type":"bearer","token":"kept"}}'
+      );
+    `);
+
+    const migration = await readFile(
+      new URL('../../drizzle/sqlite/0099_strip_stdio_remote_fields.sql', import.meta.url),
+      'utf8'
+    );
+    await client.executeMultiple(migration.replaceAll('--> statement-breakpoint', ''));
+
+    const rows = await client.execute(
+      'SELECT mcp_server_id, tenant_id, data FROM mcp_servers ORDER BY mcp_server_id'
+    );
+    const decoded = Object.fromEntries(
+      rows.rows.map((row) => [row.mcp_server_id, JSON.parse(row.data as string)])
+    );
+    expect(decoded['legacy-stdio']).toEqual({
+      command: 'mcp-server-shortcut',
+      args: [''],
+      env: { SHORTCUT_API_TOKEN: '{{ user.env.SHORTCUT_API_TOKEN }}' },
+      config_version: 7,
+    });
+    expect(decoded['clean-stdio']).toEqual({
+      command: 'other-server',
+      env: { TOKEN: '{{ user.env.OTHER_TOKEN }}' },
+    });
+    expect(decoded.remote).toEqual({
+      url: 'https://mcp.example.com',
+      headers: { 'X-Key': 'kept' },
+      auth: { type: 'bearer', token: 'kept' },
+    });
+    expect(rows.rows.map((row) => [row.mcp_server_id, row.tenant_id])).toEqual([
+      ['clean-stdio', 'tenant-b'],
+      ['legacy-stdio', 'tenant-a'],
+      ['remote', 'tenant-a'],
+    ]);
+    client.close();
+  });
+
+  it('applies the same transport-bounded repair in PostgreSQL', async () => {
+    const migration = await readFile(
+      new URL('../../drizzle/postgres/0096_strip_stdio_remote_fields.sql', import.meta.url),
+      'utf8'
+    );
+
+    expect(migration).toContain(`SET "data" = "data" - 'auth' - 'url' - 'headers'`);
+    expect(migration).toContain(`WHERE "transport" = 'stdio'`);
+    expect(migration).not.toMatch(/DELETE\s+FROM/i);
+    expect(migration).not.toContain('tenant_id =');
+  });
+});


### PR DESCRIPTION
## Summary

- repair pre-existing stdio MCP rows that retain inapplicable remote `auth`, `url`, or `headers` fields
- delete OAuth grants and pending flows that cannot apply to an stdio process
- prevent hidden remote URL/header/auth form state from being submitted after switching an MCP server to stdio
- document the stdio command/runtime, credential cleanup, and encrypted per-user environment-variable contract

Fixes #2585.

## Root cause

PR #2553 (`2b7ab42b376ca6be682367667890ca4ce3d38ddd`) correctly made transport validation strict, but it did not migrate historical rows. A legacy Shortcut row was stored as `transport: stdio` while retaining an inert `auth: bearer` object. Runtime template resolution now rejects that mixed transport configuration, so `getMcpServersForSession` withholds the server before the executor SDK can spawn it. The observed zero-tool state therefore occurs before MCP `initialize` or `tools/list`; it is not a Shortcut framing, package, token, or timeout failure.

The affected sandbox is deployed at `6a0074c1351f0a6d65540267dc7783b06cf7b258` (0.25.2), which includes #2553. Current main at investigation start was `f1ba9474846c703639db71cb5a8cea1edfa73cf1`.

## Evidence

- Shortcut has no current curated-catalog entry and was not removed by the recent OAuth catalog audit. Custom stdio servers are configured under Settings by design; catalog Connect is remote-only.
- Redacted deployed logs repeatedly show the affected stdio row withheld as `invalid_configuration`; there is no corresponding process start.
- The installed `@shortcut/mcp` 0.24.0 command on the sandbox returns a valid MCP 2025-06-18 initialize response and 56 tools under Node 22.22.2. A clean 0.25.0 probe also returns 56 tools. Both probes used a fake token and made no provider mutation.
- A credential-free initialize request to Shortcut's official remote endpoint reached the provider and returned an unauthenticated JSON-RPC response. That is not enough to safely classify/catalog its OAuth flow.
- The agor-cloud executor Dockerfile does not install `@shortcut/mcp`, so host command availability must not be conflated with availability in cloud/delegated executor images.

## Fix and security properties

The SQLite and PostgreSQL migrations remove only `data.auth`, `data.url`, and `data.headers` from stdio rows. They preserve command, args, env templates, tenant/owner identity, configuration version, and session attachments. They also delete dependent OAuth grants and pending OAuth attempts for stdio server IDs; remote server configuration and credentials are unchanged.

PostgreSQL `mcp_servers`, `user_mcp_oauth_tokens`, and `mcp_oauth_pending_flows` all use FORCE RLS. The migration opens a narrowly named, transaction-local capability for only the required SELECT/UPDATE/DELETE operations, repairs default and named tenants under the supported non-superuser/NOBYPASSRLS role, clears the scope, and drops every temporary policy before commit. Runtime and write validation remain fail-closed.

Shortcut tokens remain in the authenticated user's encrypted managed environment and are referenced as `{{ user.env.SHORTCUT_API_TOKEN }}`. This change does not copy credentials across users/tenants, make private rows visible, add daemon ambient secrets, or weaken executor/session authorization.

## Validation

- `pnpm i` — passed
- `pnpm check` — passed (typecheck, lint/policy checks, and workspace builds)
- SQLite migration suite — 29 tests passed
- real PostgreSQL 0095 → 0096 upgrade under non-superuser/NOBYPASSRLS — passed for default and named tenants, including OAuth cleanup and remote-row preservation
- MCP template resolver/scoping focused suites — 100 tests passed
- UI MCP form/OAuth suites — 76 tests passed, including actual Ant form remote → stdio preserved-state submission
- pre-commit hooks — passed

## Rollout / user action

Deploying the migration repairs the existing Shortcut row; no reinstall or token refresh is required if its command and per-user env template are already correct. A user must add/refresh `SHORTCUT_API_TOKEN` only if that managed environment variable is missing or invalid. If a repaired stdio server is later changed to remote OAuth, the user must sign in again because stdio-inapplicable OAuth state is deliberately removed.

Production-like executor images still need the stdio package explicitly baked/pinned, or Shortcut's official remote endpoint needs a separate OAuth security review before catalog inclusion.
