### PR TITLE
feat(codex): discover skills and use $plugin:skill prompt autocomplete

### DIFF
--- a/apps/agor-docs/content/guide/rich-chat-ux.mdx
+++ b/apps/agor-docs/content/guide/rich-chat-ux.mdx
@@ -135,7 +135,7 @@ You don't have to wait for a long-running prompt to finish before you start writ
 
 ---
 
-## 💬 Autocomplete (`@`)
+## 💬 Autocomplete (`@` and `/`)
 
 **Type `@` to reference files or users.** Path autocomplete inside a branch, user autocomplete for `@mentions` in comments and prompts.
 
@@ -144,6 +144,11 @@ You don't have to wait for a long-running prompt to finish before you start writ
   alt="File autocomplete in prompt input"
   style={{ maxWidth: '400px' }}
 />
+
+**Type `/` at the beginning of a prompt to discover commands and skills.** Claude Code selections
+keep their native `/name` form. In a Codex session, the same picker includes enabled local and
+plugin-provided skills and inserts Codex's native `$skill-name` mention; plugin skills keep their
+qualified `$plugin:skill` name.
 
 ---
 

--- a/apps/agor-ui/src/components/AutocompleteTextarea/AutocompleteTextarea.test.tsx
+++ b/apps/agor-ui/src/components/AutocompleteTextarea/AutocompleteTextarea.test.tsx
@@ -1,7 +1,11 @@
 import { createEvent, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { useState } from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import { AutocompleteTextarea, type KbDocMention } from './AutocompleteTextarea';
+import {
+  AutocompleteTextarea,
+  type KbDocMention,
+  type SkillMentionStyle,
+} from './AutocompleteTextarea';
 
 const renderSlashAutocomplete = () => {
   const Harness = () => {
@@ -16,6 +20,28 @@ const renderSlashAutocomplete = () => {
         sessionId={null}
         userById={new Map()}
         slashCommands={['alpha', 'beta']}
+      />
+    );
+  };
+
+  render(<Harness />);
+  return screen.getByPlaceholderText('Prompt') as HTMLTextAreaElement;
+};
+
+const renderSkillsAutocomplete = (skillMentionStyle?: SkillMentionStyle) => {
+  const Harness = () => {
+    const [value, setValue] = useState('');
+
+    return (
+      <AutocompleteTextarea
+        value={value}
+        onChange={setValue}
+        placeholder="Prompt"
+        client={null}
+        sessionId={null}
+        userById={new Map()}
+        skills={['weekly-meeting-plugin:collect-from-jira', 'deep-research']}
+        skillMentionStyle={skillMentionStyle}
       />
     );
   };
@@ -182,6 +208,35 @@ describe('AutocompleteTextarea', () => {
 
     await waitFor(() => {
       expect(textarea).toHaveValue('/alpha ');
+    });
+  });
+
+  it('inserts skills as slash commands by default (Claude semantics)', async () => {
+    const textarea = renderSkillsAutocomplete();
+
+    fireEvent.change(textarea, { target: { value: '/jira', selectionStart: 5 } });
+
+    fireEvent.click(await screen.findByText('weekly-meeting-plugin:collect-from-jira'));
+
+    await waitFor(() => {
+      expect(textarea).toHaveValue('/weekly-meeting-plugin:collect-from-jira ');
+    });
+  });
+
+  it('inserts Codex skills as $name mentions when skillMentionStyle is dollar', async () => {
+    const textarea = renderSkillsAutocomplete('dollar');
+
+    fireEvent.change(textarea, { target: { value: '/jira', selectionStart: 5 } });
+
+    await screen.findByText('weekly-meeting-plugin:collect-from-jira');
+    // Codex skills are labeled as skills, not project commands.
+    expect(screen.getByText('skill')).toBeInTheDocument();
+    expect(screen.queryByText('project')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('weekly-meeting-plugin:collect-from-jira'));
+
+    await waitFor(() => {
+      expect(textarea).toHaveValue('$weekly-meeting-plugin:collect-from-jira ');
     });
   });
 

--- a/apps/agor-ui/src/components/AutocompleteTextarea/AutocompleteTextarea.tsx
+++ b/apps/agor-ui/src/components/AutocompleteTextarea/AutocompleteTextarea.tsx
@@ -60,8 +60,10 @@ interface EmojiResult {
 
 interface SlashCommandResult {
   command: string;
-  source: 'built-in' | 'project' | 'personal';
+  source: 'built-in' | 'project' | 'personal' | 'skill';
   type: 'slash_command';
+  /** Full text inserted on select (e.g. `/compact`, or `$dwh-user:dwh-operations` for Codex skills). */
+  insertText: string;
 }
 
 interface KbDocResult {
@@ -81,6 +83,7 @@ type AutocompleteResult =
   | { heading: string };
 
 type KbLinkTarget = 'stable-uri' | 'absolute-route';
+export type SkillMentionStyle = 'slash' | 'dollar';
 
 interface AutocompleteTextareaProps {
   value: string;
@@ -105,6 +108,13 @@ interface AutocompleteTextareaProps {
   slashCommands?: string[];
   /** Available skills from the SDK (stored on session.custom_context) */
   skills?: string[];
+  /**
+   * How selecting a skill inserts it into the prompt. Claude Code invokes
+   * skills as slash commands (`/name`); Codex expects a `$name` mention in
+   * the prompt text (its model-side trigger rule), so Codex sessions pass
+   * 'dollar'. Discovery stays on the `/` trigger for both.
+   */
+  skillMentionStyle?: SkillMentionStyle;
   /** Enable live Knowledge Base lookup for `@` references. Disabled by default so shared comment inputs do not search KB. */
   enableKnowledgeMentions?: boolean;
   /**
@@ -377,6 +387,7 @@ export const AutocompleteTextarea = React.forwardRef<
       suppressEmptyHighlight = false,
       slashCommands = EMPTY_SLASH_COMMANDS,
       skills = EMPTY_SKILLS,
+      skillMentionStyle = 'slash',
       enableKnowledgeMentions = false,
       kbDocs,
       kbLinkTarget = 'stable-uri',
@@ -800,14 +811,33 @@ export const AutocompleteTextarea = React.forwardRef<
             const normalizedCmd = cmd.toLowerCase();
             if (normalizedCmd.includes(q) && !seen.has(normalizedCmd)) {
               seen.add(normalizedCmd);
-              commandResults.push({ command: cmd, source: 'built-in', type: 'slash_command' });
+              commandResults.push({
+                command: cmd,
+                source: 'built-in',
+                type: 'slash_command',
+                insertText: `/${cmd}`,
+              });
             }
           }
           for (const skill of skills) {
             const normalizedSkill = skill.toLowerCase();
             if (normalizedSkill.includes(q) && !seen.has(normalizedSkill)) {
               seen.add(normalizedSkill);
-              commandResults.push({ command: skill, source: 'project', type: 'slash_command' });
+              commandResults.push(
+                skillMentionStyle === 'dollar'
+                  ? {
+                      command: skill,
+                      source: 'skill',
+                      type: 'slash_command',
+                      insertText: `$${skill}`,
+                    }
+                  : {
+                      command: skill,
+                      source: 'project',
+                      type: 'slash_command',
+                      insertText: `/${skill}`,
+                    }
+              );
             }
           }
           commandResults.sort((a, b) =>
@@ -892,6 +922,7 @@ export const AutocompleteTextarea = React.forwardRef<
         searchEmojis,
         slashCommands,
         skills,
+        skillMentionStyle,
         shouldSearchKnowledge,
       ]
     );
@@ -919,8 +950,8 @@ export const AutocompleteTextarea = React.forwardRef<
               ? buildKbMarkdownLink(item.kbTitle, `${window.location.origin}${item.kbRoutePath}`)
               : buildKbDocLink(item.kbTitle, item.kbDocumentId);
         } else if ('command' in item) {
-          // Slash command selection - replace with /command
-          insertText = `/${item.command}`;
+          // Command/skill selection - insert its provider-specific invocation
+          insertText = item.insertText;
         } else if ('emoji' in item) {
           // Emoji selection - just insert the emoji character
           insertText = item.emoji;
@@ -1259,7 +1290,7 @@ export const AutocompleteTextarea = React.forwardRef<
               itemKey = `kb-${item.kbUri}`;
               isKbDoc = true;
             } else if ('command' in item) {
-              label = `/${item.command}`;
+              label = item.insertText;
               itemKey = `cmd-${item.command}`;
               isCommand = true;
             } else if ('emoji' in item) {
@@ -1305,8 +1336,8 @@ export const AutocompleteTextarea = React.forwardRef<
                   e.currentTarget.style.backgroundColor = 'transparent';
                 }}
               >
-                {/* Show command icon for slash commands */}
-                {isCommand && (
+                {/* Show the invocation sigil for commands (/) and Codex skills ($) */}
+                {isCommand && 'insertText' in item && (
                   <span
                     style={{
                       fontFamily: 'monospace',
@@ -1315,7 +1346,7 @@ export const AutocompleteTextarea = React.forwardRef<
                       fontWeight: 600,
                     }}
                   >
-                    /
+                    {item.insertText.charAt(0)}
                   </span>
                 )}
                 {/* Show emoji larger if it's an emoji result */}

--- a/apps/agor-ui/src/components/AutocompleteTextarea/index.ts
+++ b/apps/agor-ui/src/components/AutocompleteTextarea/index.ts
@@ -1,3 +1,3 @@
-export type { KbDocMention } from './AutocompleteTextarea';
+export type { KbDocMention, SkillMentionStyle } from './AutocompleteTextarea';
 export { AutocompleteTextarea } from './AutocompleteTextarea';
 export { hydrateKbDocLinks, kbMentionFromDocument } from './kbMentions';

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.test.tsx
@@ -6,8 +6,15 @@ import { AppActionsProvider } from '../../contexts/AppActionsContext';
 import { ConnectionProvider } from '../../contexts/ConnectionContext';
 import SessionPanel from './SessionPanel';
 
+const autocompleteCapture = vi.hoisted(() => ({
+  props: undefined as Record<string, unknown> | undefined,
+}));
+
 vi.mock('../AutocompleteTextarea', () => ({
-  AutocompleteTextarea: () => <textarea aria-label="Prompt" />,
+  AutocompleteTextarea: (props: Record<string, unknown>) => {
+    autocompleteCapture.props = props;
+    return <textarea aria-label="Prompt" />;
+  },
 }));
 
 vi.mock('../FileUpload', () => ({
@@ -156,6 +163,29 @@ function pressFind(target: Window | Element, modifiers: { metaKey?: boolean; ctr
 function getSearchRow() {
   return screen.getByPlaceholderText('Search session...').closest('div[style*="max-height"]');
 }
+
+describe('SessionPanel provider skill autocomplete wiring', () => {
+  afterEach(() => {
+    autocompleteCapture.props = undefined;
+    reactive.tasks = [];
+    vi.restoreAllMocks();
+  });
+
+  it('passes discovered Codex skills through with dollar-mention insertion semantics', () => {
+    renderPanel({
+      activeSession: {
+        ...session,
+        agentic_tool: 'codex',
+        custom_context: { skills: ['dwh-user:dwh-operations'] },
+      },
+    });
+
+    expect(autocompleteCapture.props).toMatchObject({
+      skills: ['dwh-user:dwh-operations'],
+      skillMentionStyle: 'dollar',
+    });
+  });
+});
 
 describe.each(findShortcuts)('SessionPanel native $label behavior', ({ modifiers }) => {
   afterEach(() => {

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -79,7 +79,7 @@ import { useThemedMessage } from '../../utils/message';
 import { deletePromptDraft, getPromptDraft, savePromptDraft } from '../../utils/promptDrafts';
 import { getSessionDisplayTitle, getSessionTitleStyles } from '../../utils/sessionTitle';
 import { AgentSelectionGrid } from '../AgentSelectionGrid/AgentSelectionGrid';
-import { AutocompleteTextarea } from '../AutocompleteTextarea';
+import { AutocompleteTextarea, type SkillMentionStyle } from '../AutocompleteTextarea';
 import { FileUpload } from '../FileUpload';
 import { ForkSpawnModal } from '../ForkSpawnModal/ForkSpawnModal';
 import type { ModelConfig } from '../ModelSelector';
@@ -140,6 +140,7 @@ interface PromptInputProps {
   suppressEmptyHighlight?: boolean;
   slashCommands?: string[];
   skills?: string[];
+  skillMentionStyle?: SkillMentionStyle;
 }
 
 const PromptInput = React.forwardRef<PromptInputHandle, PromptInputProps>(
@@ -163,6 +164,7 @@ const PromptInput = React.forwardRef<PromptInputHandle, PromptInputProps>(
       suppressEmptyHighlight = false,
       slashCommands,
       skills,
+      skillMentionStyle,
     },
     ref
   ) => {
@@ -275,6 +277,7 @@ const PromptInput = React.forwardRef<PromptInputHandle, PromptInputProps>(
         suppressEmptyHighlight={suppressEmptyHighlight}
         slashCommands={slashCommands}
         skills={skills}
+        skillMentionStyle={skillMentionStyle}
         enableKnowledgeMentions
         kbLinkTarget="absolute-route"
         highlightWhenEmpty
@@ -1055,6 +1058,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
             skills={
               Array.isArray(sessionCustomContext?.skills) ? sessionCustomContext.skills : undefined
             }
+            skillMentionStyle={session.agentic_tool === 'codex' ? 'dollar' : 'slash'}
           />
           <input
             ref={attachmentInputRef}

--- a/packages/agor-codex/package.json
+++ b/packages/agor-codex/package.json
@@ -22,6 +22,7 @@
     "check:pack": "npm pack --dry-run"
   },
   "dependencies": {
+    "@openai/codex": "0.144.0",
     "@openai/codex-sdk": "0.144.0"
   },
   "devDependencies": {

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -299,6 +299,16 @@ export interface Session {
    * Access in templates: {{ session.context.teamName }}
    */
   custom_context?: Record<string, unknown> & {
+    /** Provider-reported slash commands shown by the prompt autocomplete. */
+    slash_commands?: string[];
+    /** Provider-reported skills shown by the prompt autocomplete. */
+    skills?: string[];
+    /** Internal freshness marker for Codex's task-time `skills/list` discovery. */
+    codex_skills_discovery?: {
+      session_id: SessionID;
+      cwd: string;
+      refreshed_at_ms: number;
+    };
     /**
      * Scheduled run metadata (populated by scheduler)
      *

--- a/packages/executor/src/sdk-handlers/codex/app-server-client.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/app-server-client.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Unit tests for response normalization plus a fake-process protocol check
+ * for the Codex app-server sidecar client.
+ */
+
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { CodexAppServerClient, extractCodexSkillsFromListResponse } from './app-server-client.js';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true }))
+  );
+});
+
+async function createFakeAppServer(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), 'agor-codex-app-server-'));
+  temporaryDirectories.push(directory);
+  const command = join(directory, 'fake-codex');
+  await writeFile(
+    command,
+    `#!/usr/bin/env node
+import { createInterface } from 'node:readline';
+const lines = createInterface({ input: process.stdin });
+const send = (value) => process.stdout.write(JSON.stringify(value) + '\\n');
+lines.on('line', (line) => {
+  const request = JSON.parse(line);
+  if (request.method === 'initialize') {
+    send({ id: request.id, result: {} });
+  } else if (request.method === 'skills/list') {
+    send({
+      id: request.id,
+      result: {
+        data: [{
+          cwd: request.params.cwds[0],
+          skills: [{
+            name: process.env.OPENAI_API_KEY ? 'ambient-key-leaked' : 'safe-skill',
+            description: JSON.stringify(request.params),
+            enabled: true,
+          }],
+          errors: [],
+        }],
+      },
+    });
+  }
+});
+`
+  );
+  await chmod(command, 0o755);
+  return command;
+}
+
+describe('extractCodexSkillsFromListResponse', () => {
+  it('flattens per-cwd groups, keeping plugin-qualified names and metadata', () => {
+    const skills = extractCodexSkillsFromListResponse({
+      data: [
+        {
+          cwd: '/work/branch-a',
+          skills: [
+            {
+              name: 'dwh-user:dwh-operations',
+              description: 'DWH reference',
+              enabled: true,
+              scope: 'user',
+              pluginId: 'dwh-user@ug-internal-plugins',
+            },
+            { name: 'deep-research', description: 'Research harness', enabled: true },
+          ],
+        },
+      ],
+    });
+
+    expect(skills).toEqual([
+      {
+        name: 'dwh-user:dwh-operations',
+        description: 'DWH reference',
+        enabled: true,
+        scope: 'user',
+        pluginId: 'dwh-user@ug-internal-plugins',
+      },
+      {
+        name: 'deep-research',
+        description: 'Research harness',
+        enabled: true,
+        scope: undefined,
+        pluginId: undefined,
+      },
+    ]);
+  });
+
+  it('drops disabled skills and dedupes across cwd groups', () => {
+    const skills = extractCodexSkillsFromListResponse({
+      data: [
+        {
+          cwd: '/a',
+          skills: [
+            { name: 'shared-skill', enabled: true },
+            { name: 'disabled-skill', enabled: false },
+          ],
+        },
+        { cwd: '/b', skills: [{ name: 'shared-skill', enabled: true }] },
+      ],
+    });
+
+    expect(skills.map((s) => s.name)).toEqual(['shared-skill']);
+  });
+
+  it('tolerates malformed responses without throwing', () => {
+    expect(extractCodexSkillsFromListResponse(undefined)).toEqual([]);
+    expect(extractCodexSkillsFromListResponse(null)).toEqual([]);
+    expect(extractCodexSkillsFromListResponse({})).toEqual([]);
+    expect(extractCodexSkillsFromListResponse({ data: 'nope' })).toEqual([]);
+    expect(
+      extractCodexSkillsFromListResponse({
+        data: [{ skills: [null, 42, { name: '' }, { name: '   ' }, 'junk'] }, { cwd: '/x' }],
+      })
+    ).toEqual([]);
+  });
+});
+
+describe('CodexAppServerClient', () => {
+  it.skipIf(process.platform === 'win32')(
+    'uses the supplied env as authoritative and sends skills/list with the requested cwd',
+    async () => {
+      const command = await createFakeAppServer();
+      const previousApiKey = process.env.OPENAI_API_KEY;
+      process.env.OPENAI_API_KEY = 'ambient-daemon-key';
+      const client = new CodexAppServerClient({
+        command,
+        env: {
+          HOME: process.env.HOME,
+          PATH: process.env.PATH,
+        },
+      });
+
+      try {
+        await expect(client.listSkills(['/work/branch'])).resolves.toEqual([
+          {
+            name: 'safe-skill',
+            description: '{"cwds":["/work/branch"],"forceReload":true}',
+            enabled: true,
+            scope: undefined,
+            pluginId: undefined,
+          },
+        ]);
+      } finally {
+        await client.close();
+        if (previousApiKey === undefined) delete process.env.OPENAI_API_KEY;
+        else process.env.OPENAI_API_KEY = previousApiKey;
+      }
+    }
+  );
+});

--- a/packages/executor/src/sdk-handlers/codex/app-server-client.ts
+++ b/packages/executor/src/sdk-handlers/codex/app-server-client.ts
@@ -1,5 +1,11 @@
 import { type ChildProcessWithoutNullStreams, spawn } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
 import { createInterface } from 'node:readline';
+import {
+  resolveManagedAgenticToolPackageDirectory,
+  resolveManagedAgenticToolVersion,
+} from '@agor/core/agentic-integrations';
 import { sanitizeMCPExternalError } from '@agor/core/mcp';
 
 interface JsonRpcResponse<T = unknown> {
@@ -12,26 +18,113 @@ interface ThreadForkResult {
   thread?: { id?: string };
 }
 
+/**
+ * One installed skill as reported by the app-server's `skills/list`.
+ * Codex flattens plugin-shipped skills into this list with
+ * `name = "<plugin>:<skill>"` and `pluginId` set, so plugins need no
+ * separate discovery call.
+ */
+export interface CodexDiscoveredSkill {
+  name: string;
+  description?: string;
+  enabled?: boolean;
+  scope?: string;
+  pluginId?: string | null;
+}
+
+interface SkillsListResult {
+  data?: Array<{ cwd?: string; skills?: unknown[] }>;
+}
+
+/**
+ * Flatten a `skills/list` response into unique, enabled skills. Exported for
+ * unit tests; tolerant of shape drift because the app-server protocol is
+ * still marked experimental upstream.
+ */
+export function extractCodexSkillsFromListResponse(result: unknown): CodexDiscoveredSkill[] {
+  const groups = (result as SkillsListResult | undefined)?.data;
+  if (!Array.isArray(groups)) return [];
+
+  const byName = new Map<string, CodexDiscoveredSkill>();
+  for (const group of groups) {
+    if (!Array.isArray(group?.skills)) continue;
+    for (const raw of group.skills) {
+      if (!raw || typeof raw !== 'object') continue;
+      const skill = raw as Record<string, unknown>;
+      const name = typeof skill.name === 'string' ? skill.name.trim() : '';
+      if (!name || skill.enabled === false || byName.has(name)) continue;
+      byName.set(name, {
+        name,
+        description: typeof skill.description === 'string' ? skill.description : undefined,
+        enabled: typeof skill.enabled === 'boolean' ? skill.enabled : undefined,
+        scope: typeof skill.scope === 'string' ? skill.scope : undefined,
+        pluginId: typeof skill.pluginId === 'string' ? skill.pluginId : undefined,
+      });
+    }
+  }
+  return [...byName.values()];
+}
+
 export interface CodexAppServerClientOptions {
-  /** Extra env values to pass to the spawned `codex app-server` process. */
+  /** Complete env to pass to the spawned app-server process. Defaults to `process.env`. */
   env?: NodeJS.ProcessEnv;
-  /** Request timeout for initialize/fork calls. Defaults to 10s. */
+  /** Request timeout for initialize/app-server calls. Defaults to 10s. */
   timeoutMs?: number;
-  /** Override executable for tests or non-standard installs. Defaults to `codex`. */
+  /** Override executable for tests or non-standard installs. */
   command?: string;
+}
+
+interface CodexAppServerLaunch {
+  command: string;
+  args: string[];
+}
+
+/**
+ * Resolve the CLI shipped with the same Codex integration as the SDK. A
+ * packaged Agor install deliberately keeps agentic-tool runtimes outside
+ * PATH, and a developer may also have a newer unrelated global `codex`, so
+ * spawning by bare command would make app-server behavior version-dependent.
+ */
+async function resolveCodexAppServerLaunch(
+  commandOverride?: string
+): Promise<CodexAppServerLaunch> {
+  if (commandOverride) return { command: commandOverride, args: ['app-server'] };
+
+  let codexPackageDirectory: string;
+  if (process.env.AGOR_MANAGED_AGENTIC_TOOLS === '1') {
+    const agorVersion = resolveManagedAgenticToolVersion();
+    if (!agorVersion) {
+      throw new Error('AGOR_VERSION is missing from the packaged Codex runtime');
+    }
+    codexPackageDirectory = await resolveManagedAgenticToolPackageDirectory(
+      'codex',
+      agorVersion,
+      '@openai/codex'
+    );
+  } else {
+    // Resolve the transitive CLI from the SDK's own dependency tree rather
+    // than from the executor package or the operator's PATH.
+    const sdkRequire = createRequire(import.meta.resolve('@openai/codex-sdk'));
+    codexPackageDirectory = dirname(sdkRequire.resolve('@openai/codex/package.json'));
+  }
+
+  return {
+    command: process.execPath,
+    args: [join(codexPackageDirectory, 'bin', 'codex.js'), 'app-server'],
+  };
 }
 
 /**
  * Minimal JSONL client for Codex's local App Server.
  *
- * This intentionally implements only the `thread/fork` sidecar operation so
- * Agor can keep using `@openai/codex-sdk` for normal streaming execution. The
- * App Server is spawned, initialized, asked to fork one stored thread, then
- * torn down immediately.
+ * This intentionally implements only sidecar operations (`thread/fork`,
+ * `skills/list`) so Agor can keep using `@openai/codex-sdk` for normal
+ * streaming execution. The App Server is spawned, initialized, asked one
+ * question, then torn down immediately.
  */
 export class CodexAppServerClient {
   private readonly timeoutMs: number;
-  private readonly command: string;
+  private readonly command?: string;
   private child?: ChildProcessWithoutNullStreams;
   private nextId = 0;
   private readonly pending = new Map<
@@ -44,18 +137,15 @@ export class CodexAppServerClient {
   >();
   private stderr = '';
   private startPromise?: Promise<void>;
+  private initPromise?: Promise<void>;
 
   constructor(private readonly options: CodexAppServerClientOptions = {}) {
     this.timeoutMs = options.timeoutMs ?? 10_000;
-    this.command = options.command ?? 'codex';
+    this.command = options.command;
   }
 
   async forkThread(threadId: string): Promise<string> {
-    await this.start();
-    await this.request('initialize', {
-      clientInfo: { name: 'agor', title: 'Agor', version: '0.0.0' },
-    });
-    this.sendNotification('initialized', {});
+    await this.initialize();
 
     const result = await this.request<ThreadForkResult>('thread/fork', { threadId });
     const forkedThreadId = result.thread?.id;
@@ -65,6 +155,33 @@ export class CodexAppServerClient {
       );
     }
     return forkedThreadId;
+  }
+
+  /**
+   * List installed skills visible to Codex for the given working directories
+   * (user/system/plugin skills plus repo-scoped skills under each cwd).
+   * `skills/list` defaults to the app-server process cwd when `cwds` is empty,
+   * so callers should always pass the branch path. Discovery forces a rescan;
+   * the higher-level Session TTL bounds that filesystem work.
+   */
+  async listSkills(cwds: string[]): Promise<CodexDiscoveredSkill[]> {
+    await this.initialize();
+
+    const result = await this.request<unknown>('skills/list', { cwds, forceReload: true });
+    return extractCodexSkillsFromListResponse(result);
+  }
+
+  private async initialize(): Promise<void> {
+    if (!this.initPromise) {
+      this.initPromise = (async () => {
+        await this.start();
+        await this.request('initialize', {
+          clientInfo: { name: 'agor', title: 'Agor', version: '0.0.0' },
+        });
+        this.sendNotification('initialized', {});
+      })();
+    }
+    return this.initPromise;
   }
 
   async close(): Promise<void> {
@@ -92,43 +209,49 @@ export class CodexAppServerClient {
   private async start(): Promise<void> {
     if (this.startPromise) return this.startPromise;
 
-    this.startPromise = new Promise<void>((resolve, reject) => {
-      const child = spawn(this.command, ['app-server'], {
-        env: { ...process.env, ...this.options.env },
-        stdio: ['pipe', 'pipe', 'pipe'],
+    this.startPromise = (async () => {
+      const launch = await resolveCodexAppServerLaunch(this.command);
+      await new Promise<void>((resolve, reject) => {
+        const child = spawn(launch.command, launch.args, {
+          // `buildAppServerEnv()` passes a complete snapshot and intentionally
+          // deletes ambient API keys in subscription mode. Do not merge
+          // process.env back in here or those credentials are reintroduced.
+          env: this.options.env ?? process.env,
+          stdio: ['pipe', 'pipe', 'pipe'],
+        });
+        this.child = child;
+
+        const rejectStartup = (error: Error) => {
+          this.rejectAll(error);
+          reject(error);
+        };
+
+        child.once('error', (error) => {
+          rejectStartup(new Error(sanitizeMCPExternalError(error, { stage: 'runtime' }).message));
+        });
+
+        child.once('spawn', () => resolve());
+
+        child.stderr.on('data', (chunk: Buffer) => {
+          this.stderr += chunk.toString('utf8');
+          // Keep error payloads useful without unbounded memory growth.
+          if (this.stderr.length > 20_000) this.stderr = this.stderr.slice(-20_000);
+        });
+
+        child.once('exit', (code, signal) => {
+          this.rejectAll(
+            new Error(
+              `Codex app-server exited unexpectedly (code=${code ?? 'null'}, signal=${signal ?? 'null'}).${
+                this.stderr ? ` stderr: ${this.stderr}` : ''
+              }`
+            )
+          );
+        });
+
+        const rl = createInterface({ input: child.stdout });
+        rl.on('line', (line) => this.handleLine(line));
       });
-      this.child = child;
-
-      const rejectStartup = (error: Error) => {
-        this.rejectAll(error);
-        reject(error);
-      };
-
-      child.once('error', (error) => {
-        rejectStartup(new Error(sanitizeMCPExternalError(error, { stage: 'runtime' }).message));
-      });
-
-      child.once('spawn', () => resolve());
-
-      child.stderr.on('data', (chunk: Buffer) => {
-        this.stderr += chunk.toString('utf8');
-        // Keep error payloads useful without unbounded memory growth.
-        if (this.stderr.length > 20_000) this.stderr = this.stderr.slice(-20_000);
-      });
-
-      child.once('exit', (code, signal) => {
-        this.rejectAll(
-          new Error(
-            `Codex app-server exited unexpectedly (code=${code ?? 'null'}, signal=${signal ?? 'null'}).${
-              this.stderr ? ` stderr: ${this.stderr}` : ''
-            }`
-          )
-        );
-      });
-
-      const rl = createInterface({ input: child.stdout });
-      rl.on('line', (line) => this.handleLine(line));
-    });
+    })();
 
     return this.startPromise;
   }
@@ -210,6 +333,22 @@ export async function forkCodexThreadViaAppServer(
   const client = new CodexAppServerClient(options);
   try {
     return await client.forkThread(threadId);
+  } finally {
+    await client.close();
+  }
+}
+
+/**
+ * One-shot `skills/list` lookup: spawn the app-server, list skills for the
+ * given working directories, tear the process down.
+ */
+export async function listCodexSkillsViaAppServer(
+  cwds: string[],
+  options?: CodexAppServerClientOptions
+): Promise<CodexDiscoveredSkill[]> {
+  const client = new CodexAppServerClient(options);
+  try {
+    return await client.listSkills(cwds);
   } finally {
     await client.close();
   }

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
@@ -32,6 +32,7 @@ import type { MessagesService } from '../base/index.js';
 
 const appServerMocks = vi.hoisted(() => ({
   forkCodexThreadViaAppServer: vi.fn(),
+  listCodexSkillsViaAppServer: vi.fn(),
 }));
 
 const mcpScopingMocks = vi.hoisted(() => ({
@@ -72,6 +73,18 @@ async function* streamMockEvents() {
 
 // Mock the Codex SDK to avoid spawning real Codex CLI processes
 vi.mock('./app-server-client.js', () => appServerMocks);
+vi.mock('@agor/core/agentic-integrations', async () => {
+  const actual = await vi.importActual<typeof import('@agor/core/agentic-integrations')>(
+    '@agor/core/agentic-integrations'
+  );
+  return {
+    ...actual,
+    // Keep the managed loader inside Vitest's module graph so its dynamic SDK
+    // import resolves to the mock below rather than the external built Core
+    // module loading a real Codex SDK instance.
+    loadManagedAgenticToolSdk: async () => import('@openai/codex-sdk'),
+  };
+});
 vi.mock('@agor/core/mcp', async () => {
   const actual = await vi.importActual<typeof import('@agor/core/mcp')>('@agor/core/mcp');
   return {
@@ -2675,5 +2688,227 @@ describe('CodexPromptService - MCP tool_permissions', () => {
     // Guards the other direction: an empty list must not be emitted as a filter
     // Codex could read as "disable everything", and must not appear as noise.
     expect(servers.sentry.disabled_tools).toBeUndefined();
+  });
+});
+
+describe('CodexPromptService - skills discovery for prompt autocomplete', () => {
+  type SkillsDiscoveryHarness = {
+    ensureCodexInstructionsFile: () => Promise<string>;
+    buildMcpServersConfig: () => Promise<{ total: number; servers: Record<string, unknown> }>;
+    scheduleCodexSkillsDiscovery: (
+      sessionId: SessionID,
+      session: { custom_context?: Record<string, unknown> },
+      branchPath: string
+    ) => void;
+  };
+
+  const internals = (service: CodexPromptService): SkillsDiscoveryHarness =>
+    service as unknown as SkillsDiscoveryHarness;
+
+  const makeService = (): CodexPromptService => {
+    const service = new CodexPromptService(
+      mockMessagesRepo,
+      mockSessionsRepo,
+      mockSessionMCPServerRepo,
+      mockBranchesRepo,
+      undefined,
+      'test-api-key',
+      mockDb
+    );
+    const serviceWithPrivates = internals(service);
+    serviceWithPrivates.ensureCodexInstructionsFile = vi
+      .fn()
+      .mockResolvedValue('/tmp/agor-codex-instructions-skills.md');
+    serviceWithPrivates.buildMcpServersConfig = vi.fn().mockResolvedValue({
+      total: 0,
+      servers: {},
+    });
+    return service;
+  };
+
+  const scheduleDiscovery = (
+    service: CodexPromptService,
+    session: Record<string, unknown>,
+    branchPath = '/work/branch-skills'
+  ): void => {
+    internals(service).scheduleCodexSkillsDiscovery(
+      'session-skills' as SessionID,
+      session,
+      branchPath
+    );
+  };
+
+  // Discovery is fire-and-forget; drain its promise chain.
+  const flushDiscovery = async (): Promise<void> => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  };
+
+  const sessionFixture = (customContext?: Record<string, unknown>) => ({
+    session_id: 'session-skills',
+    branch_id: 'branch-1',
+    created_at: new Date().toISOString(),
+    sdk_session_id: null,
+    permission_config: { mode: 'auto', codex: {} },
+    mcp_token: 'test-token',
+    ...(customContext ? { custom_context: customContext } : {}),
+  });
+
+  const customContextWrites = () =>
+    mockSessionsRepo.update.mock.calls.filter(
+      ([, update]: [unknown, Record<string, unknown>]) => 'custom_context' in (update ?? {})
+    );
+
+  beforeEach(() => {
+    mockInstanceCount = 0;
+    mockInstanceBaseUrls = [];
+    mockInstanceConfigs = [];
+    mockClosedInstanceIds = [];
+    mockStreamEvents = [];
+    mockStartThreadOptions = [];
+    mockResumeThreadOptions = [];
+    delete process.env.OPENAI_BASE_URL;
+    vi.clearAllMocks();
+    mockSessionsRepo.update.mockResolvedValue(undefined);
+    mockBranchesRepo.findById.mockResolvedValue({
+      branch_id: 'branch-1',
+      path: '/work/branch-skills',
+    });
+    mockSessionMCPServerRepo.listServersWithMetadata.mockResolvedValue([]);
+  });
+
+  it('discovers skills during a prompt turn and persists sorted names to custom_context', async () => {
+    appServerMocks.listCodexSkillsViaAppServer.mockResolvedValue([
+      { name: 'weekly-meeting-plugin:collect-from-jira', enabled: true },
+      { name: 'deep-research', enabled: true },
+    ]);
+    mockSessionsRepo.findById.mockResolvedValue(sessionFixture());
+
+    const service = makeService();
+    mockStreamEvents = [
+      {
+        type: 'turn.completed',
+        usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 },
+      },
+    ];
+    for await (const _event of service.promptSessionStreaming(
+      'session-skills' as SessionID,
+      'hello'
+    )) {
+      // drain
+    }
+
+    await vi.waitFor(() => {
+      expect(appServerMocks.listCodexSkillsViaAppServer).toHaveBeenCalledWith(
+        ['/work/branch-skills'],
+        expect.objectContaining({ env: expect.any(Object) })
+      );
+      expect(mockSessionsRepo.update).toHaveBeenCalledWith('session-skills', {
+        custom_context: {
+          skills: ['deep-research', 'weekly-meeting-plugin:collect-from-jira'],
+          codex_skills_discovery: {
+            session_id: 'session-skills',
+            cwd: '/work/branch-skills',
+            refreshed_at_ms: expect.any(Number),
+          },
+        },
+      });
+    });
+  });
+
+  it('only advances the persistent refresh marker when skill names are already current', async () => {
+    appServerMocks.listCodexSkillsViaAppServer.mockResolvedValue([
+      { name: 'deep-research', enabled: true },
+    ]);
+
+    const service = makeService();
+    scheduleDiscovery(service, sessionFixture({ skills: ['deep-research'] }));
+    await flushDiscovery();
+
+    expect(appServerMocks.listCodexSkillsViaAppServer).toHaveBeenCalledTimes(1);
+    expect(customContextWrites()).toEqual([
+      [
+        'session-skills',
+        {
+          custom_context: {
+            codex_skills_discovery: {
+              session_id: 'session-skills',
+              cwd: '/work/branch-skills',
+              refreshed_at_ms: expect.any(Number),
+            },
+          },
+        },
+      ],
+    ]);
+  });
+
+  it('uses the persisted refresh marker to throttle the next ephemeral executor', async () => {
+    appServerMocks.listCodexSkillsViaAppServer.mockResolvedValue([]);
+
+    const service = makeService();
+    scheduleDiscovery(
+      service,
+      sessionFixture({
+        skills: [],
+        codex_skills_discovery: {
+          session_id: 'session-skills',
+          cwd: '/work/branch-skills',
+          refreshed_at_ms: Date.now(),
+        },
+      })
+    );
+    await flushDiscovery();
+
+    expect(appServerMocks.listCodexSkillsViaAppServer).not.toHaveBeenCalled();
+    expect(customContextWrites()).toEqual([]);
+  });
+
+  it('does not reuse a copied refresh marker from a different session', async () => {
+    appServerMocks.listCodexSkillsViaAppServer.mockResolvedValue([]);
+
+    const service = makeService();
+    scheduleDiscovery(
+      service,
+      sessionFixture({
+        skills: [],
+        codex_skills_discovery: {
+          session_id: 'parent-session',
+          cwd: '/work/branch-skills',
+          refreshed_at_ms: Date.now(),
+        },
+      })
+    );
+    await flushDiscovery();
+
+    expect(appServerMocks.listCodexSkillsViaAppServer).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-discovers when the session branch path changes despite the throttle', async () => {
+    appServerMocks.listCodexSkillsViaAppServer.mockResolvedValue([]);
+
+    const service = makeService();
+    scheduleDiscovery(service, sessionFixture(), '/work/branch-a');
+    await flushDiscovery();
+    scheduleDiscovery(service, sessionFixture(), '/work/branch-b');
+    await flushDiscovery();
+
+    expect(appServerMocks.listCodexSkillsViaAppServer).toHaveBeenCalledTimes(2);
+    expect(appServerMocks.listCodexSkillsViaAppServer).toHaveBeenLastCalledWith(
+      ['/work/branch-b'],
+      expect.anything()
+    );
+  });
+
+  it('swallows discovery failures without writing custom_context (older Codex CLI)', async () => {
+    appServerMocks.listCodexSkillsViaAppServer.mockRejectedValue(
+      new Error('unknown method skills/list')
+    );
+
+    const service = makeService();
+    scheduleDiscovery(service, sessionFixture());
+    await flushDiscovery();
+
+    expect(appServerMocks.listCodexSkillsViaAppServer).toHaveBeenCalledTimes(1);
+    expect(customContextWrites()).toEqual([]);
   });
 });

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -41,7 +41,7 @@ import {
 import type { CodexOptions, Thread, ThreadItem, TurnCompletedEvent } from '@agor/core/sdk';
 import { renderAgorSystemPrompt } from '@agor/core/templates/session-context';
 import { mergeMCPRemoteHeaders } from '@agor/core/tools/mcp/http-headers';
-import type { CodexSandboxMode, ContextUsageSnapshot, MCPServer } from '@agor/core/types';
+import type { CodexSandboxMode, ContextUsageSnapshot, MCPServer, Session } from '@agor/core/types';
 import { getDefaultPermissionMode, isGatewaySession } from '@agor/core/types';
 import { mapToCodexPermissionConfig } from '@agor/core/utils/permission-mode-mapper';
 import type * as CodexSdk from '@openai/codex-sdk';
@@ -62,7 +62,7 @@ import type { TokenUsage } from '../../types/token-usage.js';
 import type { PermissionMode, SessionID, TaskID, UserID } from '../../types.js';
 import { resolveContextUserId } from '../base/context-user.js';
 import type { TasksService } from '../base/index.js';
-import { forkCodexThreadViaAppServer } from './app-server-client.js';
+import { forkCodexThreadViaAppServer, listCodexSkillsViaAppServer } from './app-server-client.js';
 import { applyAgorCodexLaunchPolicy } from './launch-policy.js';
 import { extractCodexContextSnapshotFromEvent, extractCodexTokenUsage } from './usage.js';
 
@@ -189,6 +189,37 @@ function codexDebug(...args: unknown[]): void {
   if (process.env.AGOR_DEBUG_CODEX === '1' || process.env.DEBUG?.includes('codex')) {
     console.debug(...args);
   }
+}
+
+/**
+ * Minimum gap between `skills/list` sidecar spawns for one session. Skill
+ * installs are rare relative to prompts, so a short TTL keeps the composer's
+ * autocomplete fresh without paying an app-server spawn on every turn.
+ */
+const SKILLS_DISCOVERY_TTL_MS = 5 * 60 * 1000;
+
+interface CodexSkillsDiscoveryMetadata {
+  session_id: SessionID;
+  cwd: string;
+  refreshed_at_ms: number;
+}
+
+function parseCodexSkillsDiscoveryMetadata(value: unknown): CodexSkillsDiscoveryMetadata | null {
+  if (!value || typeof value !== 'object') return null;
+  const candidate = value as Record<string, unknown>;
+  if (
+    typeof candidate.session_id !== 'string' ||
+    typeof candidate.cwd !== 'string' ||
+    typeof candidate.refreshed_at_ms !== 'number' ||
+    !Number.isFinite(candidate.refreshed_at_ms)
+  ) {
+    return null;
+  }
+  return {
+    session_id: candidate.session_id as SessionID,
+    cwd: candidate.cwd,
+    refreshed_at_ms: candidate.refreshed_at_ms,
+  };
 }
 
 function applyGatewayMcpStartupGuard(config: CodexConfigObject, requireMcpServers: boolean): void {
@@ -350,6 +381,10 @@ export class CodexPromptService {
   private apiKey: string | undefined;
   private useNativeAuth: boolean;
   private instructionsFilePaths = new Map<SessionID, string>();
+  private skillsDiscovery = new Map<
+    SessionID,
+    { at: number; cwd: string; inFlight?: Promise<void> }
+  >();
 
   /**
    * Resolve the per-user custom OpenAI-compatible base URL.
@@ -1055,16 +1090,8 @@ export class CodexPromptService {
       `🍴 [Codex] Forking from parent thread ${shortId(parentSession.sdk_session_id)} via app-server thread/fork`
     );
 
-    const appServerEnv: NodeJS.ProcessEnv = { ...process.env };
-    if (this.useNativeAuth && !this.apiKey) {
-      delete appServerEnv.OPENAI_API_KEY;
-      delete appServerEnv.CODEX_API_KEY;
-    } else if (this.apiKey) {
-      appServerEnv.CODEX_API_KEY = this.apiKey;
-    }
-
     const forkedThreadId = await forkCodexThreadViaAppServer(parentSession.sdk_session_id, {
-      env: appServerEnv,
+      env: this.buildAppServerEnv(),
     });
     await this.sessionsRepo.update(sessionId, { sdk_session_id: forkedThreadId });
     session.sdk_session_id = forkedThreadId;
@@ -1072,6 +1099,112 @@ export class CodexPromptService {
     console.log(
       `✅ [Codex] Forked thread ${shortId(parentSession.sdk_session_id)} → ${shortId(forkedThreadId)}`
     );
+  }
+
+  /**
+   * Env for `codex app-server` sidecar spawns (`thread/fork`, `skills/list`),
+   * matching the SDK spawn's auth semantics: subscription mode scrubs API-key
+   * vars so the CLI uses `$CODEX_HOME/auth.json`; API-key mode injects
+   * `CODEX_API_KEY`.
+   */
+  private buildAppServerEnv(): NodeJS.ProcessEnv {
+    const env: NodeJS.ProcessEnv = { ...process.env };
+    if (this.useNativeAuth && !this.apiKey) {
+      delete env.OPENAI_API_KEY;
+      delete env.CODEX_API_KEY;
+    } else if (this.apiKey) {
+      env.CODEX_API_KEY = this.apiKey;
+    }
+    return env;
+  }
+
+  /**
+   * Discover the Codex skills installed for this user/branch (standalone
+   * skills plus plugin-shipped ones, already flattened to plugin-qualified
+   * names by Codex) and persist them to `session.custom_context.skills` —
+   * the same slot the Claude executor fills from its SDK init message — so
+   * the prompt composer can offer them in autocomplete.
+   *
+   * Codex's exec/SDK surface never reports installed skills, so this asks the
+   * local `codex app-server` sidecar (`skills/list`) with the branch path as
+   * cwd. Fire-and-forget: runs concurrently with the turn, is throttled per
+   * session so back-to-back prompts don't respawn the sidecar, and never
+   * fails the turn (older Codex CLIs without `skills/list` just log at debug).
+   */
+  private scheduleCodexSkillsDiscovery(
+    sessionId: SessionID,
+    session: Pick<Session, 'custom_context'>,
+    branchPath: string
+  ): void {
+    const now = Date.now();
+    const state = this.skillsDiscovery.get(sessionId);
+    if (
+      state &&
+      state.cwd === branchPath &&
+      (state.inFlight || now - state.at < SKILLS_DISCOVERY_TTL_MS)
+    ) {
+      return;
+    }
+
+    // Executors are intentionally one-task processes, so an in-memory TTL
+    // cannot throttle the next prompt. Persist the last successful refresh on
+    // the Session and require the embedded ID to match so copied/forked custom
+    // context never suppresses discovery for a different Session.
+    const persisted = parseCodexSkillsDiscoveryMetadata(
+      session.custom_context?.codex_skills_discovery
+    );
+    if (
+      persisted?.session_id === sessionId &&
+      persisted.cwd === branchPath &&
+      persisted.refreshed_at_ms <= now &&
+      now - persisted.refreshed_at_ms < SKILLS_DISCOVERY_TTL_MS
+    ) {
+      return;
+    }
+
+    const inFlight = (async () => {
+      const skills = await listCodexSkillsViaAppServer([branchPath], {
+        env: this.buildAppServerEnv(),
+      });
+      const names = skills.map((skill) => skill.name).sort((a, b) => a.localeCompare(b));
+
+      const current = session.custom_context?.skills;
+      const unchanged =
+        Array.isArray(current) &&
+        current.length === names.length &&
+        names.every((name, i) => current[i] === name);
+
+      // Repository deep-merges custom_context objects; arrays replace wholesale.
+      // The success marker is written even when names are unchanged because it
+      // is what makes throttling survive the ephemeral executor process.
+      await this.sessionsRepo.update(sessionId, {
+        custom_context: {
+          ...(!unchanged ? { skills: names } : {}),
+          codex_skills_discovery: {
+            session_id: sessionId,
+            cwd: branchPath,
+            refreshed_at_ms: Date.now(),
+          },
+        },
+      });
+      codexDebug(`✅ [Codex] Refreshed ${names.length} discovered skill(s) for autocomplete`);
+    })();
+
+    this.skillsDiscovery.set(sessionId, { at: now, cwd: branchPath, inFlight });
+
+    void inFlight
+      .catch((error) => {
+        codexDebug(
+          '⚠️ [Codex] Skills discovery failed (autocomplete list not refreshed):',
+          error instanceof Error ? error.message : String(error)
+        );
+      })
+      .finally(() => {
+        const latest = this.skillsDiscovery.get(sessionId);
+        if (latest?.inFlight === inFlight) {
+          this.skillsDiscovery.set(sessionId, { at: Date.now(), cwd: branchPath });
+        }
+      });
   }
 
   /**
@@ -1219,6 +1352,10 @@ export class CodexPromptService {
     }
 
     codexDebug(`   Working directory: ${branch.path}`);
+
+    // Refresh the composer's skill autocomplete in the background; never
+    // blocks or fails the turn.
+    this.scheduleCodexSkillsDiscovery(sessionId, session, branch.path);
 
     await this.ensureForkedCodexThread(sessionId, session);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -691,6 +691,9 @@ importers:
 
   packages/agor-codex:
     dependencies:
+      '@openai/codex':
+        specifier: 0.144.0
+        version: 0.144.0
       '@openai/codex-sdk':
         specifier: 0.144.0
         version: 0.144.0


### PR DESCRIPTION
## Summary

Codex sessions had no skills in the prompt composer's autocomplete because Codex's exec/SDK surface never reports installed skills (unlike Claude, whose SDK init message lists them). This adds skill discovery for Codex and teaches the composer to insert them using Codex's native `$plugin:skill` syntax.

## What changed

**Discovery (executor)**
- Query the local `codex app-server` sidecar via `skills/list` with the branch path as `cwd` — standalone skills plus plugin-shipped ones (already flattened to plugin-qualified names by Codex).
- Persist the enabled/deduplicated, sorted skill names into `session.custom_context.skills` — the same slot the Claude executor fills — so the composer offers them in autocomplete.
- Discovery is **fire-and-forget**: it runs concurrently with the turn, never fails it (older CLIs without `skills/list` just log at debug), and is throttled per session.
- Throttling uses both an in-memory TTL and a persisted `codex_skills_discovery` freshness marker. Executors are one-task processes, so the persisted marker is what makes throttling survive process death. The embedded session ID must match so copied/forked custom context never suppresses discovery for a different session.
- App-server sidecar env is now built by a shared `buildAppServerEnv()` helper so `thread/fork` and `skills/list` share the SDK spawn's auth semantics (subscription mode scrubs API-key vars; API-key mode injects `CODEX_API_KEY`).

**Composer (UI)**
- New `skillMentionStyle` prop on `AutocompleteTextarea` / `PromptInput`. Codex sessions insert `$plugin:skill`; Claude sessions keep `/skill`. Selected via `session.agentic_tool === 'codex' ? 'dollar' : 'slash'`.

**Types / deps / docs**
- `Session.custom_context` documents `slash_commands`, `skills`, and the internal `codex_skills_discovery` marker.
- Adds `@openai/codex` dependency (pinned `0.144.0`, matching `@openai/codex-sdk`) for the app-server client.
- Updates the rich-chat-ux guide.

## Tests
- New `app-server-client.test.ts` plus additions to `prompt-service.test.ts` (executor) and `AutocompleteTextarea` / `SessionPanel` suites (UI).
- UI suites pass 140/140; executor and UI typechecks pass; Biome clean.
- One new streaming-path test is blocked locally by a pre-existing Codex SDK dynamic-import mock issue that also breaks ~45 baseline tests on a clean checkout; CI baseline is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)