### PR TITLE
chore: revalidate executor authority on task heartbeat

### DIFF
--- a/apps/agor-daemon/src/auth/executor-runtime-scope.test.ts
+++ b/apps/agor-daemon/src/auth/executor-runtime-scope.test.ts
@@ -2,6 +2,7 @@ import type { HookContext, Params } from '@agor/core/types';
 import { describe, expect, it } from 'vitest';
 import {
   authenticatedExecutorCommandRuntimeScope,
+  authenticatedTaskExecutorRuntimeAuthority,
   authenticatedTaskExecutorRuntimeScope,
   executorRuntimeScopeSessionId,
   isTaskScopedExecutorRequest,
@@ -57,6 +58,65 @@ describe('executor runtime authentication context', () => {
         authentication: { strategy: 'local' },
         headers: { authorization: 'Bearer forged' },
         query: { session_id: 'session-1', task_id: 'task-1' },
+      } as Params)
+    ).toBeNull();
+  });
+
+  it('derives REST heartbeat authority only from verified claims and the authenticated bearer', () => {
+    const accessToken = 'already-verified-task-bearer';
+    expect(
+      authenticatedTaskExecutorRuntimeAuthority({
+        provider: 'rest',
+        tenant: { tenant_id: 'tenant-a', source: 'auth_claim' },
+        authentication: {
+          strategy: 'jwt',
+          accessToken,
+          payload: {
+            ...taskPayload,
+            sub: 'user-1',
+            tenant_id: 'tenant-a',
+          },
+        },
+      } as Params)
+    ).toMatchObject({
+      tenantId: 'tenant-a',
+      userId: 'user-1',
+      sessionId: 'session-1',
+      taskId: 'task-1',
+      branchId: 'branch-1',
+      tokenFingerprint: expect.stringMatching(/^[a-f0-9]{64}$/),
+    });
+  });
+
+  it('fails closed on wrong tenant projection, missing Branch, or absent authenticated bearer', () => {
+    const base = {
+      provider: 'rest',
+      tenant: { tenant_id: 'tenant-a', source: 'auth_claim' },
+      authentication: {
+        strategy: 'jwt',
+        accessToken: 'verified-task-bearer',
+        payload: { ...taskPayload, sub: 'user-1', tenant_id: 'tenant-a' },
+      },
+    };
+    expect(
+      authenticatedTaskExecutorRuntimeAuthority({
+        ...base,
+        tenant: { tenant_id: 'tenant-b', source: 'auth_claim' },
+      } as Params)
+    ).toBeNull();
+    expect(
+      authenticatedTaskExecutorRuntimeAuthority({
+        ...base,
+        authentication: {
+          ...base.authentication,
+          payload: { ...base.authentication.payload, branch_id: undefined },
+        },
+      } as Params)
+    ).toBeNull();
+    expect(
+      authenticatedTaskExecutorRuntimeAuthority({
+        ...base,
+        authentication: { ...base.authentication, accessToken: undefined },
       } as Params)
     ).toBeNull();
   });

--- a/apps/agor-daemon/src/auth/executor-runtime-scope.ts
+++ b/apps/agor-daemon/src/auth/executor-runtime-scope.ts
@@ -1,5 +1,7 @@
+import { createHash } from 'node:crypto';
 import { Forbidden } from '@agor/core/feathers';
 import type { AuthenticatedParams, HookContext, Params } from '@agor/core/types';
+import { getAuthenticatedConnectionAuthority } from './authenticated-connection-authority.js';
 import {
   EXECUTOR_COMMAND_TOKEN_PURPOSE,
   EXECUTOR_SESSION_TOKEN_PURPOSE,
@@ -36,6 +38,16 @@ export interface TaskExecutorRuntimeScope extends ExecutorDelegationContext {
 export interface ExecutorCommandRuntimeScope {
   commandId: string;
   branchId?: string;
+}
+
+/** Immutable Task credential authority needed by runtime-heartbeat revalidation. */
+export interface AuthenticatedTaskExecutorRuntimeAuthority {
+  tenantId: string;
+  userId: string;
+  tokenFingerprint: string;
+  sessionId: string;
+  taskId: string;
+  branchId: string;
 }
 
 /**
@@ -79,6 +91,60 @@ export function authenticatedTaskExecutorRuntimeScope(
   return scope?.purpose === EXECUTOR_SESSION_TOKEN_PURPOSE && scope.taskId && scope.sessionId
     ? { sessionId: scope.sessionId, taskId: scope.taskId, branchId: scope.branchId }
     : null;
+}
+
+/**
+ * Project the exact already-authenticated Task bearer scope for a heartbeat.
+ *
+ * Socket.IO uses its private immutable connection authority because the raw
+ * token is intentionally discarded after admission. REST hashes the bearer
+ * that the JWT authentication hook already verified. Resource and identity
+ * fields always come from that verified JWT, never request data.
+ */
+export function authenticatedTaskExecutorRuntimeAuthority(
+  params?: Params
+): AuthenticatedTaskExecutorRuntimeAuthority | null {
+  const authenticated = params as AuthenticatedParams | undefined;
+  const scope = authenticatedTaskExecutorRuntimeScope(params);
+  const payload = authenticated?.authentication?.payload as ExecutorSessionTokenPayload | undefined;
+  if (
+    !scope?.branchId ||
+    !payload ||
+    typeof payload.sub !== 'string' ||
+    !payload.sub ||
+    typeof payload.tenant_id !== 'string' ||
+    !payload.tenant_id ||
+    authenticated?.tenant?.tenant_id !== payload.tenant_id
+  ) {
+    return null;
+  }
+
+  const connectionAuthority = getAuthenticatedConnectionAuthority(params?.connection);
+  let tokenFingerprint: string;
+  if (connectionAuthority) {
+    if (
+      connectionAuthority.principal.kind !== 'executor' ||
+      connectionAuthority.principal.taskId !== scope.taskId ||
+      connectionAuthority.tenant?.tenant_id !== payload.tenant_id
+    ) {
+      return null;
+    }
+    tokenFingerprint = connectionAuthority.principal.tokenFingerprint;
+  } else {
+    const accessToken = (authenticated?.authentication as { accessToken?: unknown } | undefined)
+      ?.accessToken;
+    if (typeof accessToken !== 'string' || !accessToken) return null;
+    tokenFingerprint = createHash('sha256').update(accessToken, 'utf8').digest('hex');
+  }
+
+  return {
+    tenantId: payload.tenant_id,
+    userId: payload.sub,
+    tokenFingerprint,
+    sessionId: scope.sessionId,
+    taskId: scope.taskId,
+    branchId: scope.branchId,
+  };
 }
 
 /** Verified taskless executor command authority from the authenticated JWT. */

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -1664,9 +1664,7 @@ function createExecuteHandler(
           // Launcher callbacks can outlive the tenant transaction that spawned
           // them. Leave any inherited DB scope before opening the fresh
           // tenant scope derived from the verified token claim.
-          await runWithoutTenantDatabaseScope(() =>
-            appWithExecutor.sessionTokenService?.revokeToken(sessionToken)
-          );
+          await runWithoutTenantDatabaseScope(() => sessionTokenService.revokeToken(sessionToken));
         } finally {
           nativeState?.finished.resolve();
         }

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -256,7 +256,11 @@ import { createSessionEnvSelectionsService } from './services/session-env-select
 import { createSessionMCPServersService } from './services/session-mcp-servers.js';
 import { createSessionStreamsService } from './services/session-streams.js';
 import { createSessionsService } from './services/sessions.js';
-import { createTasksService, TASKS_SERVICE_TRANSPORT_METHODS } from './services/tasks.js';
+import {
+  createTasksService,
+  TASKS_SERVICE_TRANSPORT_METHODS,
+  type TasksService,
+} from './services/tasks.js';
 import { TASKS_SERVICE_CUSTOM_EVENTS } from './services/tasks-events.js';
 import { createTemplatesService } from './services/templates.js';
 import { createTenantAgenticToolSettingsService } from './services/tenant-agentic-tools.js';
@@ -393,13 +397,17 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
   const sessionsService = createSessionsService(db, app, (tool) =>
     isDeploymentAgenticToolAvailable(tool, deploymentAgenticToolPolicy)
   ) as unknown as SessionsServiceImpl;
+  const tasksService = createTasksService(db, app, sessionTokenService, {
+    branchRbacEnabled,
+    allowSuperadmin,
+  });
   app.use('/sessions', sessionsService, {
     events: ['permission:request', 'permission:timeout'],
   });
 
   // Wire up the execute handler for spawning executor processes
   sessionsService.setExecuteHandler(
-    createExecuteHandler(ctx, sessionsService, sessionTokenService)
+    createExecuteHandler(ctx, sessionsService, sessionTokenService, tasksService)
   );
 
   // Realtime control-plane: browsers subscribe (create) / unsubscribe (remove)
@@ -415,7 +423,7 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
   });
   app.service('/session-streams').publish(() => []);
 
-  app.use('/tasks', createTasksService(db, app, sessionTokenService), {
+  app.use('/tasks', tasksService, {
     methods: [...TASKS_SERVICE_TRANSPORT_METHODS],
     // Custom events not in this list are dropped at the FeathersJS transport
     // boundary — they fire on the local EventEmitter but never reach socket
@@ -1022,7 +1030,8 @@ function createDeferredSignal() {
 function createExecuteHandler(
   ctx: RegisterServicesContext,
   sessionsService: SessionsServiceImpl,
-  sessionTokenService: import('./services/session-token-service.js').SessionTokenService
+  sessionTokenService: import('./services/session-token-service.js').SessionTokenService,
+  tasksService: TasksService
 ) {
   const { db, app, config, daemonUrl } = ctx;
   const deploymentAgenticToolPolicy = resolveDeploymentAgenticToolPolicy(config);
@@ -1062,7 +1071,19 @@ function createExecuteHandler(
       session,
       requestedMode: data.permissionMode,
     });
-    const userId = (params as AuthenticatedParams).user?.user_id as UserID | undefined;
+    if (!tenantId) throw new Error('Missing active tenant context for executor launch');
+    const launchAuthority = await runWithTenantDatabaseScope(db, tenantId, () =>
+      tasksService.bindExecutorLaunchAuthority(data.taskId)
+    );
+    if (
+      launchAuthority.session_id !== sessionId ||
+      launchAuthority.branch_id !== session.branch_id
+    ) {
+      throw new Error('Task launch authority does not match its prepared Session');
+    }
+    // Principal, Session, Branch, and projected filesystem floor all come from
+    // the locked Task and normalized capability policy, never request params.
+    const userId = launchAuthority.principal_user_id as UserID;
     if (
       session.agentic_tool_preset_id &&
       data.permissionMode !== undefined &&
@@ -1081,29 +1102,6 @@ function createExecuteHandler(
       });
     }
 
-    // Generate session token for executor authentication
-    const appWithExecutor = app as unknown as {
-      sessionTokenService?: import('./services/session-token-service.js').SessionTokenService;
-    };
-    if (!appWithExecutor.sessionTokenService) {
-      throw new Error('Session token service not initialized');
-    }
-    // Hook chain enforces auth before we get here.
-    const sessionToken = await appWithExecutor.sessionTokenService.generateToken(
-      sessionId,
-      (params as AuthenticatedParams).user!.user_id,
-      {
-        taskId: data.taskId,
-        branchId: session.branch_id,
-        // Executor JWTs authenticate at Socket.IO handshake/reconnect (and on
-        // every REST request), so low use limits make normal execution fail
-        // during transport recovery. Keep expiry + lifecycle revocation for
-        // these runtime credentials. Bounded tokens retain per-validation use
-        // counting for compatibility.
-        maxUses: -1,
-      }
-    );
-
     const taskId = data.taskId;
     const runInFreshTerminationTenantWriteDatabase = <T>(work: () => Promise<T>) =>
       withFreshTenantWrite(db, tenantId, work);
@@ -1117,7 +1115,6 @@ function createExecuteHandler(
     // state rather than parsing the on-disk `.git` pointer (deterministic, and
     // unaffected if a worktree's origin/gitdir is later rewritten).
     const sandboxCfg = config.execution?.sandbox;
-    const rbacOn = config.execution?.branch_rbac === true;
     let cwd = process.cwd();
     let sandboxBaseRepoPath: string | undefined;
     // Per-branch SDK home intent read from the branch record (design §9.2/§8B.3).
@@ -1129,7 +1126,7 @@ function createExecuteHandler(
     // Effective fs access of the prompt actor on the branch: write/read/none.
     // Drives whether the sandbox binds the branch rw / ro / not at all. Defaults
     // to 'write' when RBAC is off (open-access behavior).
-    let principalBranchAccess: 'write' | 'read' | 'none' = 'write';
+    const principalBranchAccess = launchAuthority.fs_access;
     if (session.branch_id) {
       const branchMounts = await runWithTenantDatabaseScope(db, tenantId, async (tenantDb) => {
         const branchRepo = new BranchRepository(tenantDb);
@@ -1147,20 +1144,12 @@ function createExecuteHandler(
           const repo = await new RepoRepository(tenantDb).findById(branch.repo_id);
           baseRepoPath = repo?.local_path ?? undefined;
         }
-        let fsAccess: 'write' | 'read' | 'none' = 'write';
-        if (rbacOn) {
-          if (!userId) throw new Error('Missing prompt actor for branch filesystem authorization');
-          const access = await branchRepo.resolveUserAccess(branch, userId as UUID);
-          fsAccess =
-            access.fs_access === 'write' ? 'write' : access.fs_access === 'read' ? 'read' : 'none';
-        }
-        return { path: branch.path, baseRepoPath, fsAccess, sdkHome: branch.sdk_home ?? null };
+        return { path: branch.path, baseRepoPath, sdkHome: branch.sdk_home ?? null };
       });
       if (!branchMounts)
         throw new Error(`Branch ${session.branch_id} not found for executor startup`);
       cwd = branchMounts.path;
       sandboxBaseRepoPath = branchMounts.baseRepoPath;
-      principalBranchAccess = branchMounts.fsAccess;
       branchSdkHomeIntent = branchMounts.sdkHome;
       // Under the sandbox, 'none' means the branch would not be mounted at all,
       // so the task cannot operate on it. Fail fast with a clear message rather
@@ -1457,6 +1446,17 @@ function createExecuteHandler(
         homeDir: executorHomeDir,
       });
     })();
+
+    // Issue only after every launch prerequisite succeeds. The credential
+    // scope repeats the locked, server-derived launch authority; token retries
+    // cannot lower the already-bound filesystem floor.
+    const sessionToken = await sessionTokenService.generateToken(sessionId, userId, {
+      taskId: data.taskId,
+      branchId: launchAuthority.branch_id,
+      // Runtime JWTs reconnect and authenticate frequently. Expiry + lifecycle
+      // revocation, not bounded validation uses, retire this credential.
+      maxUses: -1,
+    });
 
     // Build executor payload
     const executorPayload = {

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -399,7 +399,6 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
   ) as unknown as SessionsServiceImpl;
   const tasksService = createTasksService(db, app, sessionTokenService, {
     branchRbacEnabled,
-    allowSuperadmin,
   });
   app.use('/sessions', sessionsService, {
     events: ['permission:request', 'permission:timeout'],

--- a/apps/agor-daemon/src/services/session-token-service.postgres.test.ts
+++ b/apps/agor-daemon/src/services/session-token-service.postgres.test.ts
@@ -106,6 +106,9 @@ describe('executor token Feathers authentication contract', () => {
           user_id: input.userId,
         };
       },
+      async isCurrent() {
+        return true;
+      },
       async revoke() {
         return true;
       },
@@ -460,6 +463,38 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
       await expect(daemonB.validateToken(token, { tenantId })).resolves.toBeNull();
     });
 
+    it('revalidates a Task fingerprint on a peer without relying on revocation fanout', async () => {
+      const tenantId = `executor-heartbeat-authority-${randomUUID()}`;
+      const token = await runWithTenantDatabaseScope(dbA, tenantId, () =>
+        daemonA.generateToken('session-heartbeat', 'user-heartbeat', {
+          taskId: 'task-heartbeat',
+          branchId: 'branch-heartbeat',
+          maxUses: -1,
+        })
+      );
+      const authority = {
+        tenantId,
+        tokenFingerprint: fingerprint(token),
+        sessionId: 'session-heartbeat',
+        taskId: 'task-heartbeat',
+        branchId: 'branch-heartbeat',
+        userId: 'user-heartbeat',
+      };
+
+      await expect(daemonB.isTaskTokenAuthorityCurrent(authority)).resolves.toBe(true);
+      await expect(
+        daemonB.isTaskTokenAuthorityCurrent({ ...authority, sessionId: 'session-other' })
+      ).resolves.toBe(false);
+
+      // No realtime/Redis listener is installed between these service
+      // instances. The peer's next exact PostgreSQL check still observes the
+      // committed tombstone.
+      await expect(
+        runWithTenantDatabaseScope(dbA, tenantId, () => daemonA.revokeToken(token))
+      ).resolves.toBe(true);
+      await expect(daemonB.isTaskTokenAuthorityCurrent(authority)).resolves.toBe(false);
+    });
+
     it('revokes every retry credential for one terminal task without widening to its session', async () => {
       const tenantId = `executor-task-revoke-${randomUUID()}`;
       const [first, retry, sibling] = await runWithTenantDatabaseScope(dbA, tenantId, () =>
@@ -548,9 +583,8 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
       // is scoped to tenant B. It would return the row if FORCE RLS were
       // removed, so this is negative proof rather than two positive examples.
       await runWithTenantDatabaseScope(dbB, tenantB, async (scoped) => {
-        const crossTenant = await new ExecutorSessionTokenAuthorityRepository(
-          scoped
-        ).validateAndConsume({
+        const repository = new ExecutorSessionTokenAuthorityRepository(scoped);
+        const crossTenant = await repository.validateAndConsume({
           tenantId: tenantA,
           tokenFingerprint: fingerprint(token),
           tokenType: EXECUTOR_SESSION_TOKEN_TYPE,
@@ -561,6 +595,16 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
           userId: 'user-tenant',
         });
         expect(crossTenant).toBeNull();
+        await expect(
+          repository.isCurrent({
+            tenantId: tenantA,
+            tokenFingerprint: fingerprint(token),
+            sessionId: 'session-tenant',
+            taskId: 'task-tenant',
+            branchId: 'branch-tenant',
+            userId: 'user-tenant',
+          })
+        ).resolves.toBe(false);
       });
 
       await expect(daemonB.validateToken(token, { tenantId: tenantA })).resolves.toMatchObject({

--- a/apps/agor-daemon/src/services/session-token-service.test.ts
+++ b/apps/agor-daemon/src/services/session-token-service.test.ts
@@ -25,6 +25,7 @@ function authorityStore(
       ...(input.branchId ? { branch_id: input.branchId } : {}),
       user_id: input.userId,
     })),
+    isCurrent: vi.fn(async () => true),
     revoke: vi.fn(async () => true),
     revokeByTask: vi.fn(async () => []),
     purgeRetained: vi.fn(async () => 0),
@@ -218,6 +219,58 @@ describe('SessionTokenService runtime scoping', () => {
         })
       )
     ).resolves.toMatchObject({ session_id: 'session-1', user_id: 'user-1' });
+  });
+
+  it('revalidates one standalone Task fingerprint in O(1) and observes revocation', async () => {
+    const service = new SessionTokenService(
+      { expiration_ms: 60_000, max_uses: -1 },
+      { startCleanupTimer: false }
+    );
+    service.setJwtSecret('session-token-test-secret');
+    const token = await runWithTenantDatabaseScope(scopeOnlyDb, 'tenant-a', () =>
+      service.generateToken('session-1', 'user-1', {
+        taskId: 'task-1',
+        branchId: 'branch-1',
+      })
+    );
+    const authority = {
+      tenantId: 'tenant-a',
+      tokenFingerprint: fingerprintExecutorSessionToken(token),
+      sessionId: 'session-1',
+      taskId: 'task-1',
+      branchId: 'branch-1',
+      userId: 'user-1',
+    };
+
+    await expect(service.isTaskTokenAuthorityCurrent(authority)).resolves.toBe(true);
+    await expect(
+      service.isTaskTokenAuthorityCurrent({ ...authority, branchId: 'branch-other' })
+    ).resolves.toBe(false);
+    await service.revokeToken(token);
+    await expect(service.isTaskTokenAuthorityCurrent(authority)).resolves.toBe(false);
+  });
+
+  it('fails heartbeat authority closed when the durable store is uncertain', async () => {
+    const store = authorityStore({
+      isCurrent: vi.fn(async () => {
+        throw new Error('authority store unavailable');
+      }),
+    });
+    const service = new SessionTokenService(
+      { expiration_ms: 60_000, max_uses: -1 },
+      { authorityStore: store, startCleanupTimer: false }
+    );
+
+    await expect(
+      service.isTaskTokenAuthorityCurrent({
+        tenantId: 'tenant-a',
+        tokenFingerprint: 'c'.repeat(64),
+        sessionId: 'session-1',
+        taskId: 'task-1',
+        branchId: 'branch-1',
+        userId: 'user-1',
+      })
+    ).rejects.toThrow('authority store unavailable');
   });
 
   it('preserves standalone expiry, revocation, and cleanup behavior', async () => {

--- a/apps/agor-daemon/src/services/session-token-service.ts
+++ b/apps/agor-daemon/src/services/session-token-service.ts
@@ -1,7 +1,8 @@
 /**
  * SessionTokenService - delegated executor JWT issuance and authority policy.
  *
- * Standalone SQLite preserves the historical process-local raw-token Map.
+ * Standalone SQLite preserves the historical process-local authority Map,
+ * keyed by a SHA-256 fingerprint so the daemon need not retain raw bearers.
  * PostgreSQL stores only a SHA-256 fingerprint plus tenant/user/resource,
  * expiry, revocation, and use-policy facts. A valid JWT signature is necessary
  * but never sufficient: every authentication must also claim the authority row.
@@ -9,6 +10,7 @@
 
 import { createHash, randomUUID } from 'node:crypto';
 import {
+  type CurrentTaskExecutorSessionTokenAuthority,
   type ExecutorSessionTokenAuthorityClaim,
   type ExecutorSessionTokenAuthorityIssue,
   ExecutorSessionTokenAuthorityRepository,
@@ -99,6 +101,7 @@ export interface SessionTokenValidationScope {
 export interface SessionTokenAuthorityStore {
   issue(input: ExecutorSessionTokenAuthorityIssue): Promise<void>;
   validateAndConsume(input: ExecutorSessionTokenAuthorityClaim): Promise<SessionInfo | null>;
+  isCurrent(input: CurrentTaskExecutorSessionTokenAuthority): Promise<boolean>;
   revoke(tokenFingerprint: string, tenantId: string): Promise<boolean>;
   revokeByTask(taskId: string, tenantId: string): Promise<string[]>;
   purgeRetained(cutoff: Date): Promise<number>;
@@ -124,6 +127,12 @@ class PostgreSQLSessionTokenAuthorityStore implements SessionTokenAuthorityStore
       ...(authority.branchId ? { branch_id: authority.branchId } : {}),
       user_id: authority.userId,
     };
+  }
+
+  async isCurrent(input: CurrentTaskExecutorSessionTokenAuthority): Promise<boolean> {
+    return this.withIndependentTenantTransaction(input.tenantId, (scoped) =>
+      new ExecutorSessionTokenAuthorityRepository(scoped).isCurrent(input)
+    );
   }
 
   async revoke(tokenFingerprint: string, tenantId: string): Promise<boolean> {
@@ -349,9 +358,9 @@ export class SessionTokenService {
         maxUses,
       });
     } else {
-      // Compatibility boundary: standalone SQLite keeps the original raw-token
-      // Map, including its process-local revocation and use-count semantics.
-      this.tokens.set(token, {
+      // Compatibility boundary: standalone SQLite keeps process-local
+      // revocation/use-count semantics, but retains only the fingerprint.
+      this.tokens.set(fingerprintExecutorSessionToken(token), {
         ...(tenantId ? { tenant_id: tenantId } : {}),
         purpose,
         session_id: sessionId,
@@ -423,13 +432,14 @@ export class SessionTokenService {
       return sessionInfo;
     }
 
-    const data = this.tokens.get(token);
+    const tokenFingerprint = fingerprintExecutorSessionToken(token);
+    const data = this.tokens.get(tokenFingerprint);
     if (!data) {
       sessionTokenDebug('rejected_by_local_authority');
       return null;
     }
     if (this.now() >= data.expires_at) {
-      this.tokens.delete(token);
+      this.tokens.delete(tokenFingerprint);
       sessionTokenDebug('rejected_expired');
       return null;
     }
@@ -445,7 +455,7 @@ export class SessionTokenService {
       return null;
     }
     if (data.max_uses > 0 && data.use_count >= data.max_uses) {
-      this.tokens.delete(token);
+      this.tokens.delete(tokenFingerprint);
       sessionTokenDebug('rejected_max_uses');
       return null;
     }
@@ -460,15 +470,41 @@ export class SessionTokenService {
     };
   }
 
+  /**
+   * Check the current authority behind an already-authenticated Task bearer.
+   * Callers supply only the server-derived fingerprint and verified claims.
+   */
+  async isTaskTokenAuthorityCurrent(
+    input: CurrentTaskExecutorSessionTokenAuthority
+  ): Promise<boolean> {
+    if (this.authorityStore) return this.authorityStore.isCurrent(input);
+
+    const data = this.tokens.get(input.tokenFingerprint);
+    if (!data) return false;
+    if (this.now() >= data.expires_at) {
+      this.tokens.delete(input.tokenFingerprint);
+      return false;
+    }
+    return (
+      data.tenant_id === input.tenantId &&
+      data.purpose === EXECUTOR_SESSION_TOKEN_PURPOSE &&
+      data.session_id === input.sessionId &&
+      data.task_id === input.taskId &&
+      data.branch_id === input.branchId &&
+      data.user_id === input.userId
+    );
+  }
+
   /** Revoke one exact bearer. PostgreSQL failures are surfaced to the caller. */
   async revokeToken(token: string): Promise<boolean> {
     if (!this.authorityStore) {
-      const existing = this.tokens.get(token);
-      const revoked = this.tokens.delete(token);
+      const tokenFingerprint = fingerprintExecutorSessionToken(token);
+      const existing = this.tokens.get(tokenFingerprint);
+      const revoked = this.tokens.delete(tokenFingerprint);
       if (revoked) {
         await this.onRevoked?.({
           ...(existing?.tenant_id ? { tenantId: existing.tenant_id } : {}),
-          tokenFingerprint: fingerprintExecutorSessionToken(token),
+          tokenFingerprint,
         });
       }
       return revoked;
@@ -501,16 +537,16 @@ export class SessionTokenService {
     if (!taskId) throw new Error('Executor task token revocation requires a task ID');
 
     if (!this.authorityStore) {
-      const revoked: Array<{ token: string; data: SessionTokenData }> = [];
-      for (const [token, data] of this.tokens.entries()) {
+      const revoked: Array<{ tokenFingerprint: string; data: SessionTokenData }> = [];
+      for (const [tokenFingerprint, data] of this.tokens.entries()) {
         if (data.task_id !== taskId) continue;
-        this.tokens.delete(token);
-        revoked.push({ token, data });
+        this.tokens.delete(tokenFingerprint);
+        revoked.push({ tokenFingerprint, data });
       }
-      for (const { token, data } of revoked) {
+      for (const { tokenFingerprint, data } of revoked) {
         await this.onRevoked?.({
           ...(data.tenant_id ? { tenantId: data.tenant_id } : {}),
-          tokenFingerprint: fingerprintExecutorSessionToken(token),
+          tokenFingerprint,
         });
       }
       return revoked.length;
@@ -538,9 +574,9 @@ export class SessionTokenService {
     }
 
     let count = 0;
-    for (const [token, data] of this.tokens.entries()) {
+    for (const [tokenFingerprint, data] of this.tokens.entries()) {
       if (now >= data.expires_at) {
-        this.tokens.delete(token);
+        this.tokens.delete(tokenFingerprint);
         count += 1;
       }
     }

--- a/apps/agor-daemon/src/services/task-runtime-reconciler.postgres.test.ts
+++ b/apps/agor-daemon/src/services/task-runtime-reconciler.postgres.test.ts
@@ -3,11 +3,13 @@
  * reconcilers sharing durable state.
  */
 
+import { createHash } from 'node:crypto';
 import {
   BranchRepository,
   createDatabase,
   createTenantScopedDatabaseProxy,
   type Database,
+  ExecutorSessionTokenAuthorityRepository,
   generateId,
   initializeDatabase,
   RepoRepository,
@@ -43,8 +45,6 @@ function createDaemonApp(
     },
     recordExecutorStartupWarning: (id: string, warning: string) =>
       tasks.recordExecutorStartupWarning(id, warning),
-    reportRuntimeTelemetry: (data: { task_id: string }) =>
-      tasks.reportRuntimeTelemetry(data.task_id),
     claimTermination: async (input: Parameters<TaskRepository['claimTermination']>[0]) => {
       const result = await tasks.claimTermination(input);
       if (result.outcome === 'claimed') {
@@ -148,10 +148,8 @@ async function seed(db: Database) {
       session_id: session.session_id,
       created_by: user.user_id as UUID,
       full_prompt: 'stale remote task',
-      status: TaskStatus.RUNNING,
+      status: TaskStatus.DISPATCHING,
       executor_mode: 'templated',
-      executor_connected_at: '2000-01-01T00:00:00.000Z',
-      last_executor_heartbeat_at: '2000-01-01T00:00:01.000Z',
       message_range: {
         start_index: 0,
         end_index: 0,
@@ -159,6 +157,34 @@ async function seed(db: Database) {
       },
       git_state: { ref_at_start: 'main', sha_at_start: 'stale' },
       tool_use_count: 0,
+    });
+    const tokenFingerprint = createHash('sha256').update(active.task_id).digest('hex');
+    const authority = {
+      token_fingerprint: tokenFingerprint,
+      principal_user_id: user.user_id,
+      session_id: session.session_id,
+      branch_id: branch.branch_id,
+      branchRbacEnabled: true,
+      allowSuperadmin: false,
+    };
+    await tasks.bindExecutorLaunchAuthority(active.task_id, {
+      branchRbacEnabled: true,
+      allowSuperadmin: false,
+    });
+    await tasks.connectExecutor(active.task_id, new Date('2000-01-01T00:00:01.000Z'));
+    const tokenNow = new Date();
+    await new ExecutorSessionTokenAuthorityRepository(scoped).issue({
+      tenantId,
+      tokenFingerprint,
+      tokenType: 'executor-session',
+      purpose: 'executor-task',
+      sessionId: session.session_id,
+      taskId: active.task_id,
+      branchId: branch.branch_id,
+      userId: user.user_id,
+      createdAt: tokenNow,
+      expiresAt: new Date(tokenNow.getTime() + 60_000),
+      maxUses: -1,
     });
     const queued = await tasks.create({
       task_id: generateId() as TaskID,
@@ -175,7 +201,7 @@ async function seed(db: Database) {
       git_state: { ref_at_start: '', sha_at_start: '' },
       tool_use_count: 0,
     });
-    return { tenantId, session, active, queued };
+    return { tenantId, session, active, queued, authority };
   });
 }
 
@@ -284,11 +310,7 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
         } as StartupContext)
       ).resolves.toBeNull();
       await runWithTenantDatabaseScope(scopedB, seeded.tenantId, () =>
-        (
-          appB.service('tasks') as unknown as {
-            reportRuntimeTelemetry(data: { task_id: string }): Promise<unknown>;
-          }
-        ).reportRuntimeTelemetry({ task_id: seeded.active.task_id })
+        new TaskRepository(scopedB).reportRuntimeTelemetry(seeded.active.task_id, seeded.authority)
       );
       const reconcilerB = new TaskRuntimeReconciler({
         app: appB,

--- a/apps/agor-daemon/src/services/task-runtime-reconciler.postgres.test.ts
+++ b/apps/agor-daemon/src/services/task-runtime-reconciler.postgres.test.ts
@@ -165,11 +165,9 @@ async function seed(db: Database) {
       session_id: session.session_id,
       branch_id: branch.branch_id,
       branchRbacEnabled: true,
-      allowSuperadmin: false,
     };
     await tasks.bindExecutorLaunchAuthority(active.task_id, {
       branchRbacEnabled: true,
-      allowSuperadmin: false,
     });
     await tasks.connectExecutor(active.task_id, new Date('2000-01-01T00:00:01.000Z'));
     const tokenNow = new Date();

--- a/apps/agor-daemon/src/services/tasks.executor-connection.test.ts
+++ b/apps/agor-daemon/src/services/tasks.executor-connection.test.ts
@@ -132,7 +132,6 @@ describe('TasksService runtime telemetry', () => {
     Reflect.set(service, 'db', { run() {} });
     Reflect.set(service, 'runtimeAuthorityOptions', {
       branchRbacEnabled: true,
-      allowSuperadmin: false,
     });
     Reflect.set(service, 'executorCredentialRevoker', {
       isTaskTokenAuthorityCurrent: vi.fn().mockResolvedValue(true),

--- a/apps/agor-daemon/src/services/tasks.executor-connection.test.ts
+++ b/apps/agor-daemon/src/services/tasks.executor-connection.test.ts
@@ -93,6 +93,7 @@ describe('TasksService executor patches', () => {
 });
 
 describe('TasksService runtime telemetry', () => {
+  const branchId = '018f0000-0000-7000-8000-000000000004';
   const task = {
     task_id: '018f0000-0000-7000-8000-000000000001',
     session_id: '018f0000-0000-7000-8000-000000000002',
@@ -107,27 +108,67 @@ describe('TasksService runtime telemetry', () => {
     last_executor_heartbeat_at: '2026-01-01T00:00:02.000Z',
   } as Task;
 
+  function runtimeParams(tenantId = 'tenant-a') {
+    return {
+      provider: 'rest',
+      tenant: { tenant_id: tenantId, source: 'auth_claim' },
+      authentication: {
+        strategy: 'jwt',
+        accessToken: 'verified-runtime-bearer',
+        payload: {
+          type: 'executor-session',
+          purpose: 'executor-task',
+          sub: task.created_by,
+          tenant_id: tenantId,
+          session_id: task.session_id,
+          task_id: task.task_id,
+          branch_id: branchId,
+        },
+      },
+    } as never;
+  }
+
+  function setRuntimeDependencies(service: TasksService) {
+    Reflect.set(service, 'db', { run() {} });
+    Reflect.set(service, 'runtimeAuthorityOptions', {
+      branchRbacEnabled: true,
+      allowSuperadmin: false,
+    });
+    Reflect.set(service, 'executorCredentialRevoker', {
+      isTaskTokenAuthorityCurrent: vi.fn().mockResolvedValue(true),
+    });
+  }
+
   it('validates, persists, and publishes one bounded pulse fact', async () => {
     const service = Object.create(TasksService.prototype) as TasksService;
     const emit = vi.fn();
-    const reportRuntimeTelemetry = vi.fn().mockResolvedValue(task);
+    const reportRuntimeTelemetry = vi.fn().mockResolvedValue({ outcome: 'continued', task });
     const heartbeatCallback = vi.fn().mockResolvedValue(undefined);
     Reflect.set(service, 'taskRepo', { reportRuntimeTelemetry });
     Reflect.set(service, 'handleExecutorHeartbeat', heartbeatCallback);
     Reflect.set(service, 'heartbeatCallbackRunner', { isConfigured: () => false });
     Reflect.set(service, 'app', { service: () => ({ emit }) });
+    setRuntimeDependencies(service);
 
-    const result = await service.reportRuntimeTelemetry({
-      task_id: task.task_id,
-      pulse: { sequence: 1, kind: 'progress', detail: 'tool.start' },
-    });
+    const result = await service.reportRuntimeTelemetry(
+      {
+        task_id: task.task_id,
+        pulse: { sequence: 1, kind: 'progress', detail: 'tool.start' },
+      },
+      runtimeParams()
+    );
 
     expect(result).toBe(task);
-    expect(reportRuntimeTelemetry).toHaveBeenCalledWith(task.task_id, {
-      sequence: 1,
-      kind: 'progress',
-      detail: 'tool.start',
-    });
+    expect(reportRuntimeTelemetry).toHaveBeenCalledWith(
+      task.task_id,
+      expect.objectContaining({
+        principal_user_id: task.created_by,
+        session_id: task.session_id,
+        branch_id: branchId,
+        standalone_token_current: true,
+      }),
+      { sequence: 1, kind: 'progress', detail: 'tool.start' }
+    );
     expect(emit).toHaveBeenCalledWith('patched', task, expect.objectContaining({ path: 'tasks' }));
   });
 
@@ -157,7 +198,7 @@ describe('TasksService runtime telemetry', () => {
       });
       const emit = vi.fn();
       Reflect.set(service, 'taskRepo', {
-        reportRuntimeTelemetry: vi.fn().mockResolvedValue(task),
+        reportRuntimeTelemetry: vi.fn().mockResolvedValue({ outcome: 'continued', task }),
       });
       Reflect.set(service, 'heartbeatCallbackRunner', {
         isConfigured: () => true,
@@ -165,11 +206,10 @@ describe('TasksService runtime telemetry', () => {
       });
       Reflect.set(service, 'findHeartbeatBranchId', findHeartbeatBranchId);
       Reflect.set(service, 'app', { service: () => ({ emit }) });
+      setRuntimeDependencies(service);
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
 
-      await service.reportRuntimeTelemetry({ task_id: task.task_id }, {
-        tenant: { tenant_id: tenantId, source: 'auth_claim' },
-      } as never);
+      await service.reportRuntimeTelemetry({ task_id: task.task_id }, runtimeParams(tenantId));
       await vi.waitFor(() => expect(callbackRun).toHaveBeenCalledOnce());
 
       expect(findHeartbeatBranchId).toHaveBeenCalledWith(task.session_id);

--- a/apps/agor-daemon/src/services/tasks.executor-heartbeat.test.ts
+++ b/apps/agor-daemon/src/services/tasks.executor-heartbeat.test.ts
@@ -63,13 +63,39 @@ describe('TasksService executor heartbeat helpers', () => {
     };
     const service = Object.create(TasksService.prototype) as TasksService;
     Reflect.set(service, 'taskRepo', {
-      reportRuntimeTelemetry: vi.fn().mockResolvedValue(null),
-      findById: vi.fn().mockResolvedValue(stoppingTask),
+      reportRuntimeTelemetry: vi.fn().mockResolvedValue({
+        outcome: 'control',
+        task: stoppingTask,
+      }),
+    });
+    Reflect.set(service, 'db', { run() {} });
+    Reflect.set(service, 'runtimeAuthorityOptions', {
+      branchRbacEnabled: true,
+      allowSuperadmin: false,
+    });
+    Reflect.set(service, 'executorCredentialRevoker', {
+      isTaskTokenAuthorityCurrent: vi.fn().mockResolvedValue(true),
     });
 
-    await expect(service.reportRuntimeTelemetry({ task_id: stoppingTask.task_id })).resolves.toBe(
-      stoppingTask
-    );
+    await expect(
+      service.reportRuntimeTelemetry({ task_id: stoppingTask.task_id }, {
+        provider: 'rest',
+        tenant: { tenant_id: 'tenant-a', source: 'auth_claim' },
+        authentication: {
+          strategy: 'jwt',
+          accessToken: 'verified-runtime-bearer',
+          payload: {
+            type: 'executor-session',
+            purpose: 'executor-task',
+            sub: 'user-a',
+            tenant_id: 'tenant-a',
+            session_id: stoppingTask.session_id,
+            task_id: stoppingTask.task_id,
+            branch_id: 'branch-a',
+          },
+        },
+      } as never)
+    ).resolves.toBe(stoppingTask);
   });
 
   it('does not let an executor terminal patch bypass coordinator-owned stopping', async () => {

--- a/apps/agor-daemon/src/services/tasks.executor-heartbeat.test.ts
+++ b/apps/agor-daemon/src/services/tasks.executor-heartbeat.test.ts
@@ -71,7 +71,6 @@ describe('TasksService executor heartbeat helpers', () => {
     Reflect.set(service, 'db', { run() {} });
     Reflect.set(service, 'runtimeAuthorityOptions', {
       branchRbacEnabled: true,
-      allowSuperadmin: false,
     });
     Reflect.set(service, 'executorCredentialRevoker', {
       isTaskTokenAuthorityCurrent: vi.fn().mockResolvedValue(true),

--- a/apps/agor-daemon/src/services/tasks.runtime-authority.test.ts
+++ b/apps/agor-daemon/src/services/tasks.runtime-authority.test.ts
@@ -4,10 +4,17 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const { beginExecutorTermination } = vi.hoisted(() => ({
   beginExecutorTermination: vi.fn(),
 }));
+const withFreshTenantWrite = vi.hoisted(() =>
+  vi.fn(async (_db: unknown, _tenantId: string, work: () => Promise<unknown>) => work())
+);
 
 vi.mock('../termination-coordinator.js', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../termination-coordinator.js')>()),
   beginExecutorTermination,
+}));
+vi.mock('../utils/tenant-db-scope.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../utils/tenant-db-scope.js')>()),
+  withFreshTenantWrite,
 }));
 
 import { TasksService } from './tasks.js';
@@ -47,6 +54,7 @@ function serviceHarness(input: {
   report: Record<string, unknown>;
   tokenCurrent?: boolean;
   tokenFailure?: Error;
+  postgres?: boolean;
 }) {
   const service = Object.create(TasksService.prototype) as TasksService;
   const reportRuntimeTelemetry = vi.fn().mockResolvedValue(input.report);
@@ -54,19 +62,21 @@ function serviceHarness(input: {
     ? vi.fn().mockRejectedValue(input.tokenFailure)
     : vi.fn().mockResolvedValue(input.tokenCurrent ?? true);
   Reflect.set(service, 'taskRepo', { reportRuntimeTelemetry });
-  Reflect.set(service, 'db', { run() {} });
+  const db = input.postgres ? { transaction() {} } : { run() {} };
+  Reflect.set(service, 'db', db);
   Reflect.set(service, 'runtimeAuthorityOptions', {
     branchRbacEnabled: true,
   });
   Reflect.set(service, 'executorCredentialRevoker', { isTaskTokenAuthorityCurrent });
   Reflect.set(service, 'heartbeatCallbackRunner', { isConfigured: () => false });
   Reflect.set(service, 'app', { service: () => ({ emit: vi.fn() }) });
-  return { service, reportRuntimeTelemetry, isTaskTokenAuthorityCurrent };
+  return { service, db, reportRuntimeTelemetry, isTaskTokenAuthorityCurrent };
 }
 
 describe('TasksService heartbeat authority control', () => {
   beforeEach(() => {
     beginExecutorTermination.mockReset();
+    withFreshTenantWrite.mockClear();
   });
 
   it('claims the existing fenced STOPPING path with one sanitized revoked cause', async () => {
@@ -97,6 +107,40 @@ describe('TasksService heartbeat authority control', () => {
         cause: 'authorization_revoked',
         errorMessage: AUTHORIZATION_REVOKED_TERMINATION_MESSAGE,
       })
+    );
+  });
+
+  it('commits the PostgreSQL heartbeat unit before claiming revoked termination', async () => {
+    const stopping = {
+      ...task,
+      status: TaskStatus.STOPPING,
+      termination_request: {
+        cause: 'authorization_revoked',
+        requested_at: '2026-08-28T00:00:10.000Z',
+        error_message: AUTHORIZATION_REVOKED_TERMINATION_MESSAGE,
+      },
+    };
+    beginExecutorTermination.mockResolvedValue(stopping);
+    const { service, db, reportRuntimeTelemetry } = serviceHarness({
+      postgres: true,
+      report: {
+        outcome: 'authorization_revoked',
+        task,
+        reason: 'branch_capability_revoked',
+      },
+    });
+
+    await expect(
+      service.reportRuntimeTelemetry({ task_id: task.task_id }, runtimeParams())
+    ).resolves.toBe(stopping);
+
+    expect(withFreshTenantWrite).toHaveBeenCalledWith(db, 'tenant-a', expect.any(Function));
+    expect(reportRuntimeTelemetry).toHaveBeenCalledOnce();
+    expect(withFreshTenantWrite.mock.invocationCallOrder[0]).toBeLessThan(
+      beginExecutorTermination.mock.invocationCallOrder[0]
+    );
+    expect(reportRuntimeTelemetry.mock.invocationCallOrder[0]).toBeLessThan(
+      beginExecutorTermination.mock.invocationCallOrder[0]
     );
   });
 

--- a/apps/agor-daemon/src/services/tasks.runtime-authority.test.ts
+++ b/apps/agor-daemon/src/services/tasks.runtime-authority.test.ts
@@ -1,0 +1,131 @@
+import { AUTHORIZATION_REVOKED_TERMINATION_MESSAGE, TaskStatus } from '@agor/core/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { beginExecutorTermination } = vi.hoisted(() => ({
+  beginExecutorTermination: vi.fn(),
+}));
+
+vi.mock('../termination-coordinator.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../termination-coordinator.js')>()),
+  beginExecutorTermination,
+}));
+
+import { TasksService } from './tasks.js';
+
+const task = {
+  task_id: '018f0000-0000-7000-8000-000000000001',
+  session_id: '018f0000-0000-7000-8000-000000000002',
+  created_by: '018f0000-0000-7000-8000-000000000003',
+  status: TaskStatus.RUNNING,
+  last_executor_heartbeat_at: '2026-08-28T00:00:01.000Z',
+} as const;
+const branchId = '018f0000-0000-7000-8000-000000000004';
+
+function runtimeParams(overrides: Record<string, unknown> = {}) {
+  const payload = {
+    type: 'executor-session',
+    purpose: 'executor-task',
+    sub: task.created_by,
+    tenant_id: 'tenant-a',
+    session_id: task.session_id,
+    task_id: task.task_id,
+    branch_id: branchId,
+    ...overrides,
+  };
+  return {
+    provider: 'rest',
+    tenant: { tenant_id: payload.tenant_id, source: 'auth_claim' },
+    authentication: {
+      strategy: 'jwt',
+      accessToken: 'verified-task-runtime-token',
+      payload,
+    },
+  } as never;
+}
+
+function serviceHarness(input: {
+  report: Record<string, unknown>;
+  tokenCurrent?: boolean;
+  tokenFailure?: Error;
+}) {
+  const service = Object.create(TasksService.prototype) as TasksService;
+  const reportRuntimeTelemetry = vi.fn().mockResolvedValue(input.report);
+  const isTaskTokenAuthorityCurrent = input.tokenFailure
+    ? vi.fn().mockRejectedValue(input.tokenFailure)
+    : vi.fn().mockResolvedValue(input.tokenCurrent ?? true);
+  Reflect.set(service, 'taskRepo', { reportRuntimeTelemetry });
+  Reflect.set(service, 'db', { run() {} });
+  Reflect.set(service, 'runtimeAuthorityOptions', {
+    branchRbacEnabled: true,
+    allowSuperadmin: false,
+  });
+  Reflect.set(service, 'executorCredentialRevoker', { isTaskTokenAuthorityCurrent });
+  Reflect.set(service, 'heartbeatCallbackRunner', { isConfigured: () => false });
+  Reflect.set(service, 'app', { service: () => ({ emit: vi.fn() }) });
+  return { service, reportRuntimeTelemetry, isTaskTokenAuthorityCurrent };
+}
+
+describe('TasksService heartbeat authority control', () => {
+  beforeEach(() => {
+    beginExecutorTermination.mockReset();
+  });
+
+  it('claims the existing fenced STOPPING path with one sanitized revoked cause', async () => {
+    const stopping = {
+      ...task,
+      status: TaskStatus.STOPPING,
+      termination_request: {
+        cause: 'authorization_revoked',
+        requested_at: '2026-08-28T00:00:10.000Z',
+        error_message: AUTHORIZATION_REVOKED_TERMINATION_MESSAGE,
+      },
+    };
+    beginExecutorTermination.mockResolvedValue(stopping);
+    const { service } = serviceHarness({
+      report: {
+        outcome: 'authorization_revoked',
+        task,
+        reason: 'filesystem_access_revoked',
+      },
+    });
+
+    await expect(
+      service.reportRuntimeTelemetry({ task_id: task.task_id }, runtimeParams())
+    ).resolves.toBe(stopping);
+    expect(beginExecutorTermination).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskId: task.task_id,
+        cause: 'authorization_revoked',
+        errorMessage: AUTHORIZATION_REVOKED_TERMINATION_MESSAGE,
+      })
+    );
+  });
+
+  it('does not refresh liveness or start a second watchdog on authority-store failure', async () => {
+    const { service, reportRuntimeTelemetry } = serviceHarness({
+      report: { outcome: 'continued', task },
+      tokenFailure: new Error('authority store unavailable'),
+    });
+
+    await expect(
+      service.reportRuntimeTelemetry({ task_id: task.task_id }, runtimeParams())
+    ).rejects.toThrow('authority store unavailable');
+    expect(reportRuntimeTelemetry).not.toHaveBeenCalled();
+    expect(beginExecutorTermination).not.toHaveBeenCalled();
+  });
+
+  it('rejects a wrong Task binding before repository mutation or termination', async () => {
+    const { service, reportRuntimeTelemetry } = serviceHarness({
+      report: { outcome: 'continued', task },
+    });
+
+    await expect(
+      service.reportRuntimeTelemetry(
+        { task_id: task.task_id },
+        runtimeParams({ task_id: '018f0000-0000-7000-8000-000000000099' })
+      )
+    ).rejects.toMatchObject({ code: 403 });
+    expect(reportRuntimeTelemetry).not.toHaveBeenCalled();
+    expect(beginExecutorTermination).not.toHaveBeenCalled();
+  });
+});

--- a/apps/agor-daemon/src/services/tasks.runtime-authority.test.ts
+++ b/apps/agor-daemon/src/services/tasks.runtime-authority.test.ts
@@ -57,7 +57,6 @@ function serviceHarness(input: {
   Reflect.set(service, 'db', { run() {} });
   Reflect.set(service, 'runtimeAuthorityOptions', {
     branchRbacEnabled: true,
-    allowSuperadmin: false,
   });
   Reflect.set(service, 'executorCredentialRevoker', { isTaskTokenAuthorityCurrent });
   Reflect.set(service, 'heartbeatCallbackRunner', { isConfigured: () => false });

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -185,7 +185,6 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
     private readonly executorCredentialRevoker?: TaskExecutorCredentialRevoker,
     private readonly runtimeAuthorityOptions: TaskRuntimeAuthorityOptions = {
       branchRbacEnabled: app.get?.('config')?.execution?.branch_rbac === true,
-      allowSuperadmin: false,
     }
   ) {
     const taskRepo = new TaskRepository(db);

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -1542,20 +1542,31 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
       });
     }
 
-    const report = await this.taskRepo.reportRuntimeTelemetry(
-      data.task_id,
-      {
-        token_fingerprint: authority.tokenFingerprint,
-        principal_user_id: authority.userId,
-        session_id: authority.sessionId,
-        branch_id: authority.branchId,
-        ...this.runtimeAuthorityOptions,
-        ...(standaloneTokenCurrent === undefined
-          ? {}
-          : { standalone_token_current: standaloneTokenCurrent }),
-      },
-      data.pulse
-    );
+    const persistTelemetry = () =>
+      this.taskRepo.reportRuntimeTelemetry(
+        data.task_id,
+        {
+          token_fingerprint: authority.tokenFingerprint,
+          principal_user_id: authority.userId,
+          session_id: authority.sessionId,
+          branch_id: authority.branchId,
+          ...this.runtimeAuthorityOptions,
+          ...(standaloneTokenCurrent === undefined
+            ? {}
+            : { standalone_token_current: standaloneTokenCurrent }),
+        },
+        data.pulse
+      );
+
+    // PostgreSQL tenant-owned services run inside a request transaction. The
+    // repository takes the Task row lock while deciding whether this heartbeat
+    // may refresh liveness. Commit that short unit before a denial enters the
+    // termination coordinator, whose fresh claim must lock the same Task row.
+    // SQLite services carry tenant identity only, so their repository mutation
+    // already commits before this method continues.
+    const report = isPostgresDatabaseHandle(this.db)
+      ? await withFreshTenantWrite(this.db, authority.tenantId, persistTelemetry)
+      : await persistTelemetry();
 
     if (report.outcome === 'scope_mismatch') {
       // Do not let a wrong-scope credential stop somebody else's runtime.

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -17,6 +17,7 @@ import {
 } from '@agor/core/config';
 import {
   assertTenantWritable,
+  type CurrentTaskExecutorSessionTokenAuthority,
   type ExecutorLaunchAuthority,
   type ExecutorLaunchAuthorityOptions,
   enqueueTenantDatabasePostCommitCallback,
@@ -89,14 +90,7 @@ import type { SessionsService } from './sessions';
 
 export interface TaskExecutorCredentialRevoker {
   revokeTaskTokens(taskId: string): Promise<number>;
-  isTaskTokenAuthorityCurrent?(input: {
-    tenantId: string;
-    tokenFingerprint: string;
-    sessionId: string;
-    taskId: string;
-    branchId: string;
-    userId: string;
-  }): Promise<boolean>;
+  isTaskTokenAuthorityCurrent?(input: CurrentTaskExecutorSessionTokenAuthority): Promise<boolean>;
 }
 
 export type TaskRuntimeAuthorityOptions = ExecutorLaunchAuthorityOptions;

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -17,8 +17,11 @@ import {
 } from '@agor/core/config';
 import {
   assertTenantWritable,
+  type ExecutorLaunchAuthority,
+  type ExecutorLaunchAuthorityOptions,
   enqueueTenantDatabasePostCommitCallback,
   getCurrentTenantId,
+  isPostgresDatabaseHandle,
   runWithTenantDatabaseScope,
   SessionRepository,
   shortId,
@@ -32,7 +35,7 @@ import {
   type TerminationSettlementInput,
   type TerminationSettlementResult,
 } from '@agor/core/db';
-import { type Application, BadRequest, Conflict } from '@agor/core/feathers';
+import { type Application, BadRequest, Conflict, Forbidden } from '@agor/core/feathers';
 import { deriveTitleFromPrompt } from '@agor/core/sessions';
 import type {
   AuthenticatedParams,
@@ -53,6 +56,7 @@ import type {
   UUID,
 } from '@agor/core/types';
 import {
+  AUTHORIZATION_REVOKED_TERMINATION_MESSAGE,
   ExecutorPulseKind,
   isTerminalTaskStatus,
   SDK_WATCHDOG_FAILURE_REASONS,
@@ -61,6 +65,7 @@ import {
   TaskStatus,
 } from '@agor/core/types';
 import { DrizzleService, type Query } from '../adapters/drizzle';
+import { authenticatedTaskExecutorRuntimeAuthority } from '../auth/executor-runtime-scope.js';
 import { getDaemonMetrics } from '../metrics/index.js';
 import {
   recordDispatchClaim,
@@ -84,7 +89,17 @@ import type { SessionsService } from './sessions';
 
 export interface TaskExecutorCredentialRevoker {
   revokeTaskTokens(taskId: string): Promise<number>;
+  isTaskTokenAuthorityCurrent?(input: {
+    tenantId: string;
+    tokenFingerprint: string;
+    sessionId: string;
+    taskId: string;
+    branchId: string;
+    userId: string;
+  }): Promise<boolean>;
 }
+
+export type TaskRuntimeAuthorityOptions = ExecutorLaunchAuthorityOptions;
 
 /**
  * Task service params
@@ -167,7 +182,11 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
   constructor(
     db: TenantScopeAwareDatabase,
     app: Application,
-    private readonly executorCredentialRevoker?: TaskExecutorCredentialRevoker
+    private readonly executorCredentialRevoker?: TaskExecutorCredentialRevoker,
+    private readonly runtimeAuthorityOptions: TaskRuntimeAuthorityOptions = {
+      branchRbacEnabled: app.get?.('config')?.execution?.branch_rbac === true,
+      allowSuperadmin: false,
+    }
   ) {
     const taskRepo = new TaskRepository(db);
     super(taskRepo, {
@@ -1485,6 +1504,11 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
     return task;
   }
 
+  /** Internal launch boundary; not exposed through the Feathers transport. */
+  bindExecutorLaunchAuthority(taskId: string): Promise<ExecutorLaunchAuthority> {
+    return this.taskRepo.bindExecutorLaunchAuthority(taskId, this.runtimeAuthorityOptions);
+  }
+
   async reportRuntimeTelemetry(data: RuntimeTelemetryInput, params?: TaskParams): Promise<Task> {
     if (data.pulse) {
       const { sequence, kind, detail } = data.pulse;
@@ -1502,15 +1526,73 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
       }
     }
 
-    const task = await this.taskRepo.reportRuntimeTelemetry(data.task_id, data.pulse);
-    if (!task) {
+    const authority = authenticatedTaskExecutorRuntimeAuthority(params);
+    if (!authority || authority.taskId !== data.task_id) {
+      throw new Forbidden('A token scoped to this executor task is required');
+    }
+
+    // PostgreSQL validates the durable credential row in the same transaction
+    // as the Task heartbeat write. Standalone SQLite has no durable authority
+    // table, so its existing process-local fingerprint map supplies the exact
+    // O(1) decision. Store errors propagate and no heartbeat is refreshed.
+    let standaloneTokenCurrent: boolean | undefined;
+    if (!isPostgresDatabaseHandle(this.db)) {
+      const check = this.executorCredentialRevoker?.isTaskTokenAuthorityCurrent;
+      if (!check) throw new Error('Executor task token authority is unavailable');
+      standaloneTokenCurrent = await check.call(this.executorCredentialRevoker, {
+        tenantId: authority.tenantId,
+        tokenFingerprint: authority.tokenFingerprint,
+        sessionId: authority.sessionId,
+        taskId: authority.taskId,
+        branchId: authority.branchId,
+        userId: authority.userId,
+      });
+    }
+
+    const report = await this.taskRepo.reportRuntimeTelemetry(
+      data.task_id,
+      {
+        token_fingerprint: authority.tokenFingerprint,
+        principal_user_id: authority.userId,
+        session_id: authority.sessionId,
+        branch_id: authority.branchId,
+        ...this.runtimeAuthorityOptions,
+        ...(standaloneTokenCurrent === undefined
+          ? {}
+          : { standalone_token_current: standaloneTokenCurrent }),
+      },
+      data.pulse
+    );
+
+    if (report.outcome === 'scope_mismatch') {
+      // Do not let a wrong-scope credential stop somebody else's runtime.
+      throw new Forbidden('Executor task authority does not match this runtime');
+    }
+    if (report.outcome === 'authorization_revoked') {
+      console.warn(
+        `[task.authorization] event=runtime_revoked task_id=${shortId(data.task_id)} ` +
+          `reason=${report.reason}`
+      );
+      return beginExecutorTermination({
+        app: this.app,
+        taskId: report.task.task_id,
+        cause: 'authorization_revoked',
+        errorMessage: AUTHORIZATION_REVOKED_TERMINATION_MESSAGE,
+        params,
+        runInFreshTenantWriteDatabase: (work) =>
+          withFreshTenantWrite(this.db, authority.tenantId, work),
+      });
+    }
+    if (report.outcome === 'control') {
       // Heartbeat responses are also the executor's durable control-plane
-      // read. This lets a reconnected executor observe STOPPING through any
-      // daemon even before cross-replica realtime fanout is enabled.
-      const current = await this.taskRepo.findById(data.task_id);
-      if (current?.status === TaskStatus.STOPPING && current.termination_request) return current;
+      // read. A reconnected executor observes STOPPING through any daemon even
+      // if a realtime notification was missed.
+      if (report.task.status === TaskStatus.STOPPING && report.task.termination_request) {
+        return report.task;
+      }
       throw new Conflict(`Task ${shortId(data.task_id)} is not connected and active`);
     }
+    const task = report.task;
     analyticsLogger.track(
       'executor.heartbeat',
       {
@@ -1690,7 +1772,8 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
 export function createTasksService(
   db: TenantScopeAwareDatabase,
   app: Application,
-  executorCredentialRevoker?: TaskExecutorCredentialRevoker
+  executorCredentialRevoker?: TaskExecutorCredentialRevoker,
+  runtimeAuthorityOptions?: TaskRuntimeAuthorityOptions
 ): TasksService {
-  return new TasksService(db, app, executorCredentialRevoker);
+  return new TasksService(db, app, executorCredentialRevoker, runtimeAuthorityOptions);
 }

--- a/apps/agor-daemon/src/setup/socketio-executor-auth.integration.test.ts
+++ b/apps/agor-daemon/src/setup/socketio-executor-auth.integration.test.ts
@@ -2,11 +2,12 @@ import type { Server as HttpServer } from 'node:http';
 import { type AgorClient, createClient } from '@agor/core/api';
 import { getCurrentTenantId, runWithTenantContext } from '@agor/core/db';
 import { AuthenticationService, feathers, feathersExpress, socketio } from '@agor/core/feathers';
-import { ROLES } from '@agor/core/types';
+import { type Params, ROLES } from '@agor/core/types';
 import jwt from 'jsonwebtoken';
 import { afterEach, describe, expect, it } from 'vitest';
 import { getAuthenticatedConnectionAuthority } from '../auth/authenticated-connection-authority.js';
 import { getOrCreateExecutorConnectionRevocationFence } from '../auth/executor-connection-admission.js';
+import { authenticatedTaskExecutorRuntimeAuthority } from '../auth/executor-runtime-scope.js';
 import { RuntimeJWTStrategy } from '../auth/runtime-jwt-strategy.js';
 import { RUNTIME_JWT_AUDIENCE, RUNTIME_JWT_ISSUER } from '../auth/runtime-tokens.js';
 import {
@@ -146,6 +147,9 @@ async function startHarness(
         ...(input.branchId ? { branch_id: input.branchId } : {}),
         user_id: input.userId,
       };
+    },
+    async isCurrent() {
+      return !revoked;
     },
     async revoke() {
       revoked = true;
@@ -355,6 +359,20 @@ describe('executor Socket.IO connection capability', () => {
         kind: 'executor',
         taskId: TASK_ID,
       },
+    });
+    expect(
+      authenticatedTaskExecutorRuntimeAuthority({
+        ...connection,
+        provider: 'socketio',
+        connection,
+      } as Params)
+    ).toMatchObject({
+      tenantId: TENANT_ID,
+      userId: USER_ID,
+      sessionId: SESSION_ID,
+      taskId: TASK_ID,
+      branchId: BRANCH_ID,
+      tokenFingerprint: expect.stringMatching(/^[a-f0-9]{64}$/),
     });
     expect(connection?.tenant).toMatchObject({ tenant_id: TENANT_ID });
     await expect(

--- a/apps/agor-docs/content/guide/multiplayer-unix-isolation.mdx
+++ b/apps/agor-docs/content/guide/multiplayer-unix-isolation.mdx
@@ -34,6 +34,15 @@ For each launch the daemon derives mount access from trusted tenant and branch a
 - the principal receives a persistent private home overlay;
 - provider and daemon connectivity still use the host network namespace—this is filesystem isolation, not network isolation.
 
+While a Task is running, its existing executor heartbeat rechecks the exact
+user, Task, Session, Branch, prompt permission, and effective file access
+against PostgreSQL authority. Losing prompt permission ends the Task through
+the normal fenced shutdown path. A file-access reduction also ends a runtime
+whose original mounts were broader (`read/write` to `read` or `none`, and
+`read` to `none`). An access increase does not widen or remount a live runtime;
+it applies to a later launch. Redis can accelerate disconnection but is not
+required for the next heartbeat decision.
+
 `users.filesystem_home` can point at a migrated home. Otherwise Agor uses its canonical tenant-scoped home store. Never derive this path from untrusted request data.
 
 ### Per-branch SDK homes
@@ -90,6 +99,10 @@ Interactive terminals do not mount or receive environment variables for a
 per-branch SDK home. Native tool login commands write credentials into their
 config home, so exposing the shared home to an arbitrary shell would violate
 the caller-scoped credential boundary.
+
+Terminals do not share the Task executor heartbeat, so this continuous
+revalidation applies to Task executors only. Closing that live-terminal parity
+gap requires separate terminal lifecycle work.
 
 ```yaml
 execution:

--- a/apps/agor-ui/src/components/TaskBlock/TaskBlock.test.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/TaskBlock.test.tsx
@@ -8,14 +8,18 @@
  * list — WITHOUT disturbing non-widget order, message indices, or identity.
  */
 
+import { AUTHORIZATION_REVOKED_TERMINATION_MESSAGE } from '@agor/core/types';
 import type { Message, Task } from '@agor-live/client';
-import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   type Block,
   groupMessagesIntoBlocks,
+  isAuthorizationRevokedFailure,
   isVerifiedRuntimeInterruption,
   shouldRenderLiveTaskProgress,
+  TaskBlock,
 } from './TaskBlock';
 
 function userMessage(index: number, id: string): Message {
@@ -170,7 +174,7 @@ describe('verified runtime interruption projection', () => {
     expect(isVerifiedRuntimeInterruption(task, false)).toBe(false);
   });
 
-  it('keeps unverified containment and user Stop out of Resume UX', () => {
+  it('keeps non-resumable outcomes out of Resume UX', () => {
     expect(
       isVerifiedRuntimeInterruption(
         { ...task, sdk_failure: { ...task.sdk_failure!, termination: 'unverified' } } as Task,
@@ -183,6 +187,79 @@ describe('verified runtime interruption projection', () => {
         true
       )
     ).toBe(false);
+    expect(
+      isVerifiedRuntimeInterruption(
+        {
+          ...task,
+          termination_request: {
+            ...task.termination_request!,
+            cause: 'authorization_revoked',
+          },
+        },
+        true
+      )
+    ).toBe(false);
+  });
+});
+
+describe('authorization-revoked failure projection', () => {
+  it('shows durable revoked authority without synthesizing a transcript message', () => {
+    expect(
+      isAuthorizationRevokedFailure({
+        status: 'failed',
+        termination_request: { cause: 'authorization_revoked' },
+      } as Task)
+    ).toBe(true);
+  });
+
+  it('does not relabel an in-flight or unrelated failure', () => {
+    expect(
+      isAuthorizationRevokedFailure({
+        status: 'stopping',
+        termination_request: { cause: 'authorization_revoked' },
+      } as Task)
+    ).toBe(false);
+    expect(
+      isAuthorizationRevokedFailure({
+        status: 'failed',
+        termination_request: { cause: 'heartbeat_lost' },
+      } as Task)
+    ).toBe(false);
+  });
+
+  it('renders the durable sanitized reason inside the expanded Task', () => {
+    render(
+      <TaskBlock
+        task={
+          {
+            task_id: 'task-revoked',
+            session_id: 'session-1',
+            status: 'failed',
+            created_at: '2026-08-30T19:26:18.933Z',
+            created_by: 'user-1',
+            full_prompt: 'sleep 300',
+            error_message: AUTHORIZATION_REVOKED_TERMINATION_MESSAGE,
+            termination_request: { cause: 'authorization_revoked' },
+            git_state: { ref_at_start: 'main', sha_at_start: 'unknown' },
+            message_range: {
+              start_index: 0,
+              end_index: 0,
+              start_timestamp: '2026-08-30T19:26:18.933Z',
+            },
+            tool_use_count: 0,
+          } as Task
+        }
+        isExpanded
+        onExpandChange={vi.fn()}
+        taskMessages={[]}
+        taskMessagesLoaded
+        onLoadTaskMessages={vi.fn()}
+        onUnloadTaskMessages={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Task access revoked')).toBeInTheDocument();
+    expect(screen.getByText(AUTHORIZATION_REVOKED_TERMINATION_MESSAGE)).toBeInTheDocument();
   });
 });
 

--- a/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
+++ b/apps/agor-ui/src/components/TaskBlock/TaskBlock.tsx
@@ -9,6 +9,7 @@
  * - Groups 3+ sequential tool-only messages into ToolBlock
  */
 
+import { AUTHORIZATION_REVOKED_TERMINATION_MESSAGE } from '@agor/core/types';
 import type { AgenticToolName, AgorClient, StreamingMessageState } from '@agor-live/client';
 import {
   type Message,
@@ -123,7 +124,15 @@ export function isVerifiedRuntimeInterruption(task: Task, isLatestTask = false):
     isLatestTask &&
     task.status === TaskStatus.FAILED &&
     task.sdk_failure?.termination === 'verified' &&
-    task.termination_request?.cause !== 'user_stop'
+    task.termination_request?.cause !== 'user_stop' &&
+    task.termination_request?.cause !== 'authorization_revoked'
+  );
+}
+
+/** Authorization withdrawal is already durable on the Task; no transcript row is needed. */
+export function isAuthorizationRevokedFailure(task: Task): boolean {
+  return (
+    task.status === TaskStatus.FAILED && task.termination_request?.cause === 'authorization_revoked'
   );
 }
 
@@ -179,6 +188,18 @@ function RuntimeInterruptionNotice({
           </Button>
         ) : undefined
       }
+    />
+  );
+}
+
+function AuthorizationRevokedNotice({ task }: { task: Task }) {
+  return (
+    <Alert
+      type="warning"
+      showIcon
+      style={{ marginBottom: 12 }}
+      title="Task access revoked"
+      description={task.error_message || AUTHORIZATION_REVOKED_TERMINATION_MESSAGE}
     />
   );
 }
@@ -739,6 +760,9 @@ export const TaskBlock = React.memo<TaskBlockProps>(
                 <div style={{ paddingTop: token.sizeUnit }}>
                   {isVerifiedRuntimeInterruption(task, isLatestTask) && (
                     <RuntimeInterruptionNotice task={task} sessionId={sessionId} client={client} />
+                  )}
+                  {isAuthorizationRevokedFailure(task) && (
+                    <AuthorizationRevokedNotice task={task} />
                   )}
                   {/* Show loading spinner while fetching messages */}
                   {messagesLoading && (

--- a/context/concepts/task-runtime-state.md
+++ b/context/concepts/task-runtime-state.md
@@ -164,9 +164,10 @@ an explicit mapping-review point.
 - That same heartbeat is the runtime-authority check; there is no second poll.
   Before the atomic heartbeat write, the repository revalidates the durable
   task-token fingerprint and the exact Task creator → Session → Branch binding,
-  current user existence, current prompt capability, personal sharing when
-  applicable, and effective filesystem access. Access below the immutable
-  launch floor denies the write. Higher access does not change existing mounts.
+  current user existence, current prompt capability, shared-session gates and
+  branch-home scope when applicable, and effective filesystem access. Access
+  below the immutable launch floor denies the write. Higher access does not
+  change existing mounts.
 - An explicit denial claims the normal fenced `stopping` path with cause
   `authorization_revoked`. Authority-store/query errors throw and do not stamp
   liveness. The existing stale-heartbeat threshold supplies the bounded

--- a/context/concepts/task-runtime-state.md
+++ b/context/concepts/task-runtime-state.md
@@ -113,6 +113,13 @@ the explicit create-then-run API and scheduled compatibility/reconciliation.
 | `sdk_failure`                | What runtime-health diagnosis was observed or enforced?                | Proof that execution stopped             |
 | `termination_request`        | Which termination cause owns containment, and for which request epoch? | Final containment outcome by itself      |
 
+The Task JSON also carries one daemon-private
+`executor_launch_fs_access_floor`. The launch path writes it exactly once from
+the locked Task principal and normalized Branch policy before issuing the
+task-scoped credential. Repository mapping removes it from public Task DTOs,
+and generic Task patches preserve rather than accept it. This is launch
+authority, not a request field or a dynamic mount description.
+
 An executor pulse contains a monotonically increasing executor-local sequence,
 a bounded kind/detail, and a daemon-authored observation time. The repository
 keeps only the greatest accepted sequence. Pulses intentionally coalesce to the
@@ -154,6 +161,17 @@ an explicit mapping-review point.
 - Connected active tasks heartbeat every 10 seconds by default. A scoped
   executor continues heartbeat and pulse telemetry while `stopping` until its
   provider cleanup returns and it reports quiescence.
+- That same heartbeat is the runtime-authority check; there is no second poll.
+  Before the atomic heartbeat write, the repository revalidates the durable
+  task-token fingerprint and the exact Task creator → Session → Branch binding,
+  current user existence, current prompt capability, personal sharing when
+  applicable, and effective filesystem access. Access below the immutable
+  launch floor denies the write. Higher access does not change existing mounts.
+- An explicit denial claims the normal fenced `stopping` path with cause
+  `authorization_revoked`. Authority-store/query errors throw and do not stamp
+  liveness. The existing stale-heartbeat threshold supplies the bounded
+  fail-closed backstop; there is no authority cache, Redis dependency, second
+  watchdog, or uncertainty-specific timer.
 - The default stale threshold is at least 30 seconds and at least three
   heartbeat intervals.
 - A stale heartbeat requests containment using the expected status and
@@ -205,7 +223,8 @@ The termination coordinator is the single owner for executor-backed:
 - user Stop;
 - dispatch startup timeout;
 - lost heartbeat;
-- enforced SDK health failure.
+- enforced SDK health failure;
+- authorization revocation observed by the existing heartbeat.
 
 It first atomically claims `stopping` with a durable `termination_request`.
 The request timestamp fences late or duplicate executor quiescence reports.

--- a/context/explorations/heartbeat-authority-revalidation.md
+++ b/context/explorations/heartbeat-authority-revalidation.md
@@ -93,9 +93,15 @@ to this point projection together with the other capability-policy predicates.
 
 A runtime launched by an older daemon has no trustworthy launch floor. Its
 next new-daemon heartbeat therefore fails closed as `launch_authority_missing`
-instead of inventing a possibly lower floor. Operators should drain active
-Tasks before deploying this runtime-contract change; no schema backfill can
-reconstruct already-projected mounts safely.
+instead of inventing a possibly lower floor. This is therefore a coordinated,
+non-rolling daemon contract change: operators must first quiesce prompt/Task
+admission, drain active Tasks, stop or replace **all** old daemon replicas, and
+only then reopen admission on the new cohort. Draining alone is insufficient:
+an old replica could otherwise launch a floor-less Task or accept heartbeats
+without revalidation during the mixed-version window. No schema backfill can
+reconstruct already-projected mounts safely. A future zero-downtime rollout
+would require an explicit version/admission fence or bridge release rather
+than weakening the missing-floor denial.
 
 Web terminals have launch-time admission/mount projection but no Task
 heartbeat. Dynamic terminal authority parity is intentionally outside this

--- a/context/explorations/heartbeat-authority-revalidation.md
+++ b/context/explorations/heartbeat-authority-revalidation.md
@@ -50,6 +50,20 @@ and the token check adds one statement, so the steady-state net is **one SQL
 statement per 10-second heartbeat**. Denial omits the final update. No policy
 list is materialized and there is no N+1 query.
 
+The PostgreSQL service runs those five statements in one short fresh tenant
+write transaction. This is deliberate rather than a second authority path:
+the normal tenant-owned request transaction remains open until the service
+returns, while an authorization denial must commit the repository's Task row
+lock before the existing termination coordinator claims that same row in its
+own transaction. Besides the five domain statements, PostgreSQL therefore sees
+bounded transaction/RLS scaffolding (`BEGIN`, tenant `set_config`, the constant
+tenant write-gate point read, a repository savepoint, and `COMMIT`). Request
+authentication contributes one current-user PK read. The outer tenant-owned
+request scope contributes a second current-user PK read and one constant
+write-gate point read; the fresh unit contributes one more write-gate point
+read. SQLite has no outer transaction and keeps its existing single repository
+mutation transaction.
+
 The access projection is one statement with a constant number of indexed
 point/correlated probes:
 
@@ -75,10 +89,25 @@ On 2026-08-28, a local file-backed LibSQL focused run of 100 sequential
 successful repository heartbeats took **1.219 s total (12.2 ms/heartbeat)** on
 the development container, excluding fixture creation and migrations. This is
 not a production latency claim; it is a reproducible order-of-magnitude check
-that includes transaction and three-statement overhead. PostgreSQL statement
-count and index selection above are code/schema estimates; the gated two-client
-PostgreSQL tests exercise the same query under RLS when a test database is
-available.
+that includes transaction and three-statement overhead.
+
+On 2026-08-30, a live PostgreSQL/RLS executor run captured the successful
+heartbeat's five domain statement execution times as **0.025 ms** (Task lock),
+**0.016 ms** (Task read), **0.057 ms** (access projection), **0.011 ms** (exact
+token authority), and **0.162 ms** (Task update): **0.271 ms total database
+execution time** before transaction scaffolding. The fresh transaction commit
+took 1.086 ms on that local container. Parse/bind/network/application time is
+not included, so this is evidence of query shape and order of magnitude, not a
+production latency promise.
+
+The same live run revoked a write grant during a 90-second command. The next
+scheduled heartbeat began about 1.28 seconds after revocation, omitted the
+token read and liveness update after access denial, committed its short
+authority unit, and claimed termination without waiting on its own Task lock.
+The Task reached its sanitized failed state 1.41 seconds after revocation; its
+last durable heartbeat remained the pre-revocation value and the executor
+exited with code 0 through the existing fenced path. The environment had no
+Redis service, so PostgreSQL alone supplied the decision.
 
 ## Correctness and residual boundary
 
@@ -116,6 +145,11 @@ New concepts are limited to:
 - one closed runtime-access projection beside existing capability SQL;
 - one exact current-token repository method; and
 - one new termination cause consumed by the existing coordinator.
+
+The PostgreSQL service also reuses the existing `withFreshTenantWrite` helper
+to make the heartbeat decision's commit precede a denied termination claim. It
+adds no module, protocol, state, or watchdog; it only makes the row-lock
+ownership boundary explicit.
 
 The launch path no longer separately asks `BranchRepository.resolveUserAccess`
 or trusts request-user identity for token/mount/template inputs. Standalone

--- a/context/explorations/heartbeat-authority-revalidation.md
+++ b/context/explorations/heartbeat-authority-revalidation.md
@@ -10,8 +10,9 @@ response. Before its atomic liveness write, the repository checks:
 
 1. the locked Task's immutable creator and Session;
 2. that Session's Branch and effective inherited/override permission config;
-3. current principal existence, Branch prompt capability, and personal Session
-   sharing when the Task creator differs from the Session owner;
+3. current principal existence, Branch prompt capability, and the workspace /
+   Branch shared-session gates and branch-home scope when the Task creator
+   differs from the Session owner;
 4. current effective `none | read | write` access against the immutable launch
    floor; and
 5. in PostgreSQL, the current exact task-token fingerprint and its tenant,
@@ -59,10 +60,10 @@ point/correlated probes:
 - `branch_permission_entries_config_user_unique` for a direct shadow and
   `branch_permission_entries_config_idx` plus membership/group keys for
   additive groups;
-- sharing-rule primary key and
-  `branch_session_sharing_grants_rule_user_unique` / rule/group indexes; and
 - `app_variables` tenant/namespace/key unique index for the workspace sharing
-  gate.
+  gate. The Branch sharing switch comes from the already joined effective
+  permission config, and the immutable SDK-home scope comes from the Session
+  PK row; neither requires another probe.
 
 The token read starts from the 64-hex `token_fingerprint` primary key and then
 checks the exact tenant/resource/principal tuple. Policy/group work is bounded

--- a/context/explorations/heartbeat-authority-revalidation.md
+++ b/context/explorations/heartbeat-authority-revalidation.md
@@ -1,0 +1,117 @@
+# Heartbeat authority revalidation
+
+This note records the contained design and hot-path cost for runtime authority
+revalidation. Code remains authoritative.
+
+## Decision
+
+Keep the executor's existing `reportRuntimeTelemetry` call and existing Task
+response. Before its atomic liveness write, the repository checks:
+
+1. the locked Task's immutable creator and Session;
+2. that Session's Branch and effective inherited/override permission config;
+3. current principal existence, Branch prompt capability, and personal Session
+   sharing when the Task creator differs from the Session owner;
+4. current effective `none | read | write` access against the immutable launch
+   floor; and
+5. in PostgreSQL, the current exact task-token fingerprint and its tenant,
+   user, Task, Session, Branch, expiry, and revocation predicates. The
+   authenticated runtime-scope guard separately requires the task purpose.
+
+Launch writes `executor_launch_fs_access_floor` into the existing Task JSON
+inside the Task lock, before credential issuance. It is private repository data
+and is stripped from Task DTOs. A launch retry may reuse the same floor, but
+cannot lower it. No new table, endpoint, runtime-authority module, epoch,
+cache, Redis protocol, response envelope, remount path, or watchdog was added.
+
+Explicit denial returns a closed internal repository result. The service then
+uses `beginExecutorTermination` with the single cause
+`authorization_revoked`; the executor already consumes the returned
+`stopping` Task through heartbeat `onTask`, aborts the provider, acknowledges
+quiescence, and exits normally. Scope mismatch throws without stopping another
+runtime. Store/query uncertainty rolls back and leaves liveness unchanged, so
+the existing stale-heartbeat supervisor supplies the configured bound.
+
+## Query shape and indexes
+
+Full UUID Task IDs bypass short-ID lookup. Excluding transaction setup/RLS
+`SET LOCAL` performed at the request boundary, one successful repository
+heartbeat executes:
+
+| Dialect    | Statements | Shape                                                                                                                                      |
+| ---------- | ---------: | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| SQLite     |          3 | Task PK read; one runtime-access projection; Task PK update. The local token fingerprint is one process-map lookup.                        |
+| PostgreSQL |          5 | Task PK `FOR UPDATE`; Task PK read; one runtime-access projection (also returns database time); token-fingerprint PK read; Task PK update. |
+
+The previous PostgreSQL path used four statements: lock, Task read, a separate
+database-time read, and update. The access projection replaces the time read
+and the token check adds one statement, so the steady-state net is **one SQL
+statement per 10-second heartbeat**. Denial omits the final update. No policy
+list is materialized and there is no N+1 query.
+
+The access projection is one statement with a constant number of indexed
+point/correlated probes:
+
+- `sessions` and `branches` primary keys;
+- `branch_permission_configs_branch_unique` or
+  `branch_permission_configs_board_unique` for the effective binding;
+- `users` primary key;
+- `branch_permission_entries_config_user_unique` for a direct shadow and
+  `branch_permission_entries_config_idx` plus membership/group keys for
+  additive groups;
+- sharing-rule primary key and
+  `branch_session_sharing_grants_rule_user_unique` / rule/group indexes; and
+- `app_variables` tenant/namespace/key unique index for the workspace sharing
+  gate.
+
+The token read starts from the 64-hex `token_fingerprint` primary key and then
+checks the exact tenant/resource/principal tuple. Policy/group work is bounded
+by entries in one effective Branch configuration, never tenant-wide users or
+Branches. PostgreSQL RLS and tenant-qualified predicates remain defense in
+depth.
+
+On 2026-08-28, a local file-backed LibSQL focused run of 100 sequential
+successful repository heartbeats took **1.219 s total (12.2 ms/heartbeat)** on
+the development container, excluding fixture creation and migrations. This is
+not a production latency claim; it is a reproducible order-of-magnitude check
+that includes transaction and three-statement overhead. PostgreSQL statement
+count and index selection above are code/schema estimates; the gated two-client
+PostgreSQL tests exercise the same query under RLS when a test database is
+available.
+
+## Correctness and residual boundary
+
+PostgreSQL is sufficient authority. Two independent session-token services and
+database clients prove peer validation/revocation, and a Task repository test
+revokes without notification before the next peer heartbeat. Redis fanout can
+shorten the window by disconnecting a socket but is not in the correctness
+chain.
+
+Current user lifecycle represents deactivation/offboarding as principal
+absence. When persisted active state lands, its active predicate must be added
+to this point projection together with the other capability-policy predicates.
+
+A runtime launched by an older daemon has no trustworthy launch floor. Its
+next new-daemon heartbeat therefore fails closed as `launch_authority_missing`
+instead of inventing a possibly lower floor. Operators should drain active
+Tasks before deploying this runtime-contract change; no schema backfill can
+reconstruct already-projected mounts safely.
+
+Web terminals have launch-time admission/mount projection but no Task
+heartbeat. Dynamic terminal authority parity is intentionally outside this
+contained change and should be tracked as a separate focused lifecycle issue.
+
+## Complexity accounting
+
+New concepts are limited to:
+
+- one private field in existing Task JSON (the minimum durable launch floor);
+- one closed runtime-access projection beside existing capability SQL;
+- one exact current-token repository method; and
+- one new termination cause consumed by the existing coordinator.
+
+The launch path no longer separately asks `BranchRepository.resolveUserAccess`
+or trusts request-user identity for token/mount/template inputs. Standalone
+token storage was simplified from raw bearers to fingerprint keys. The change
+therefore centralizes duplicate authority reads and adds no parallel lifecycle
+or distributed invalidation state.

--- a/context/guides/rbac-and-unix-isolation.md
+++ b/context/guides/rbac-and-unix-isolation.md
@@ -154,6 +154,21 @@ authority immediately before Prompt admission. The scheduler checks its
 creator at Session admission and again before its initial Prompt so revocation
 races and crash recovery fail closed.
 
+Task launch and heartbeat use the narrower
+`resolveSessionRuntimeBranchAccess` point projection in `branch-access.ts`.
+It resolves the exact Session, Branch, effective inherited/override config,
+principal role/file access, and foreign-session sharing in one bounded SQL
+statement. Launch persists only the original file-access floor inside private
+Task JSON. Each normal heartbeat compares current access to that floor before
+writing liveness: `write -> read/none` and `read -> none` terminate, while an
+increase never remounts or widens a live executor. PostgreSQL also checks the
+exact task-token fingerprint in the same Task transaction. Redis invalidation
+can disconnect sooner, but the database check is sufficient on its own.
+
+Web terminals are not Task executors and do not send this heartbeat. Their
+launch admission and mount projection remain enforced, but live terminal
+authority revalidation is a separate residual boundary.
+
 ## Execution modes
 
 Sandbox mode implies application RBAC and projects effective `write | read |

--- a/packages/core/src/db/repositories/branch-access.ts
+++ b/packages/core/src/db/repositories/branch-access.ts
@@ -2,6 +2,10 @@
 
 import type { CapabilityPolicyFsAccess, SessionID, UserID, UUID } from '@agor/core/types';
 import { and, eq, exists, inArray, or, type SQL, type SQLWrapper, sql } from 'drizzle-orm';
+import {
+  CAPABILITY_POLICY_SESSION_SHARING_KEY,
+  CAPABILITY_POLICY_WORKSPACE_PREFERENCES_NAMESPACE,
+} from '../../types/capability-policy';
 import type { Database } from '../client';
 import { select } from '../database-wrapper';
 import {
@@ -78,9 +82,6 @@ function effectiveConfigCondition(): SQL {
     ) ?? sql`false`
   );
 }
-
-const WORKSPACE_PREFERENCES_NAMESPACE = 'workspace_preferences';
-const SESSION_SHARING_KEY = 'session_sharing_enabled';
 
 /**
  * Closed point projection used by Task launch and heartbeat revalidation.
@@ -192,8 +193,8 @@ export async function resolveSessionRuntimeBranchAccess(
         .from(appVariables)
         .where(
           and(
-            eq(appVariables.namespace, WORKSPACE_PREFERENCES_NAMESPACE),
-            eq(appVariables.key, SESSION_SHARING_KEY),
+            eq(appVariables.namespace, CAPABILITY_POLICY_WORKSPACE_PREFERENCES_NAMESPACE),
+            eq(appVariables.key, CAPABILITY_POLICY_SESSION_SHARING_KEY),
             eq(appVariables.value_text, 'true')
           )
         )

--- a/packages/core/src/db/repositories/branch-access.ts
+++ b/packages/core/src/db/repositories/branch-access.ts
@@ -120,6 +120,8 @@ function roleGrantsSessionPrompt(role: unknown): boolean {
  * primary owner -> direct-user shadow -> additive active groups -> unmatched
  * Others. Fixed cumulative roles let group capability be represented by the
  * greatest role rank, while filesystem access is ranked independently.
+ * Global superadmin bypass is intentionally excluded: administration does not
+ * grant prompt authority or widen one principal's projected Branch mounts.
  */
 export async function resolveSessionRuntimeBranchAccess(
   db: Database,
@@ -127,7 +129,6 @@ export async function resolveSessionRuntimeBranchAccess(
     sessionId: SessionID | string;
     principalUserId: UserID | string;
     branchRbacEnabled: boolean;
-    allowSuperadmin: boolean;
   }
 ): Promise<SessionRuntimeBranchAccess | null> {
   const principal = input.principalUserId;
@@ -211,7 +212,6 @@ export async function resolveSessionRuntimeBranchAccess(
     branch_id: branches.branch_id,
     session_owner_user_id: sessions.created_by,
     principal_user_id: users.user_id,
-    principal_role: users.role,
     branch_primary_owner_user_id: branches.primary_owner_user_id,
     sharing_mode: branchPermissionConfigs.sharing_mode,
     others_role: branchPermissionConfigs.others_role,
@@ -256,11 +256,6 @@ export async function resolveSessionRuntimeBranchAccess(
 
   const principalUserId =
     typeof row.principal_user_id === 'string' ? row.principal_user_id : undefined;
-  const principalRole = typeof row.principal_role === 'string' ? row.principal_role : undefined;
-  const isSuperadminBypass =
-    principalUserId !== undefined &&
-    input.allowSuperadmin &&
-    (principalRole === 'superadmin' || principalRole === 'owner');
   const isPrimaryOwner =
     principalUserId !== undefined && row.branch_primary_owner_user_id === principalUserId;
   const directMatched = typeof row.direct_role === 'string';
@@ -269,7 +264,7 @@ export async function resolveSessionRuntimeBranchAccess(
 
   let canPromptOwn = false;
   let fsAccess: CapabilityPolicyFsAccess = 'none';
-  if (principalUserId && (!input.branchRbacEnabled || isSuperadminBypass || isPrimaryOwner)) {
+  if (principalUserId && (!input.branchRbacEnabled || isPrimaryOwner)) {
     canPromptOwn = true;
     fsAccess = 'write';
   } else if (principalUserId && row.sharing_mode === 'shared') {
@@ -298,17 +293,19 @@ export async function resolveSessionRuntimeBranchAccess(
   const ownsSession =
     principalUserId !== undefined && principalUserId === row.session_owner_user_id;
   const sharedSessionAllowed =
-    isSuperadminBypass ||
-    (Boolean(row.workspace_sharing_enabled) &&
-      Boolean(row.owner_sharing_enabled) &&
-      Boolean(row.principal_sharing_granted));
+    Boolean(row.workspace_sharing_enabled) &&
+    Boolean(row.owner_sharing_enabled) &&
+    Boolean(row.principal_sharing_granted);
   const observedAt =
     row.observed_at instanceof Date ? row.observed_at : new Date(String(row.observed_at));
   return {
     branch_id: String(row.branch_id),
     principal_available: principalUserId !== undefined,
     can_prompt_session: Boolean(
-      principalUserId && canPromptOwn && (ownsSession || sharedSessionAllowed)
+      principalUserId &&
+        // RBAC-disabled admission intentionally permits any existing member to
+        // prompt the Session; its legacy filesystem projection remains write.
+        (!input.branchRbacEnabled || (canPromptOwn && (ownsSession || sharedSessionAllowed)))
     ),
     fs_access: principalUserId ? fsAccess : 'none',
     observed_at: observedAt,

--- a/packages/core/src/db/repositories/branch-access.ts
+++ b/packages/core/src/db/repositories/branch-access.ts
@@ -1,20 +1,25 @@
 /** Shared SQL predicates for normalized board/branch capability policies. */
 
-import type { UUID } from '@agor/core/types';
+import type { CapabilityPolicyFsAccess, SessionID, UserID, UUID } from '@agor/core/types';
 import { and, eq, exists, inArray, or, type SQL, type SQLWrapper, sql } from 'drizzle-orm';
 import type { Database } from '../client';
+import { select } from '../database-wrapper';
 import {
+  appVariables,
   boardAccessEntries,
   boardAccessPolicies,
   boards,
   branches,
   branchPermissionConfigs,
   branchPermissionEntries,
+  branchSessionSharingGrants,
+  branchSessionSharingRules,
   groupMemberships,
   groups,
   messages,
   sessions,
   tasks,
+  users,
 } from '../schema';
 
 type UserIdExpression = UUID | SQLWrapper;
@@ -74,6 +79,240 @@ function effectiveConfigCondition(): SQL {
       )
     ) ?? sql`false`
   );
+}
+
+const WORKSPACE_PREFERENCES_NAMESPACE = 'workspace_preferences';
+const PERSONAL_SESSION_SHARING_KEY = 'personal_session_sharing_enabled';
+
+/**
+ * Closed point projection used by Task launch and heartbeat revalidation.
+ *
+ * It deliberately returns only the facts those consumers use. The richer
+ * policy read model still owns permission-editor explanations and group IDs.
+ */
+export interface SessionRuntimeBranchAccess {
+  branch_id: string;
+  principal_available: boolean;
+  can_prompt_session: boolean;
+  fs_access: CapabilityPolicyFsAccess;
+  /** Database time in PostgreSQL; callers may override it in deterministic tests. */
+  observed_at: Date;
+}
+
+function numericValue(value: unknown, fallback = -1): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function fsAccessFromRank(rank: number): CapabilityPolicyFsAccess {
+  return rank >= 2 ? 'write' : rank >= 1 ? 'read' : 'none';
+}
+
+function roleGrantsSessionPrompt(role: unknown): boolean {
+  return role === 'collaborator' || role === 'manager';
+}
+
+/**
+ * Resolve one principal's current right to prompt one exact Session and its
+ * effective Branch filesystem access in one bounded SQL statement.
+ *
+ * The scalar subqueries mirror the normalized-policy precedence exactly:
+ * primary owner -> direct-user shadow -> additive active groups -> unmatched
+ * Others. Fixed cumulative roles let group capability be represented by the
+ * greatest role rank, while filesystem access is ranked independently.
+ */
+export async function resolveSessionRuntimeBranchAccess(
+  db: Database,
+  input: {
+    sessionId: SessionID | string;
+    principalUserId: UserID | string;
+    branchRbacEnabled: boolean;
+    allowSuperadmin: boolean;
+  }
+): Promise<SessionRuntimeBranchAccess | null> {
+  const principal = input.principalUserId;
+  const directRole = sql<string | null>`(
+    SELECT ${branchPermissionEntries.role}
+    FROM ${branchPermissionEntries}
+    WHERE ${branchPermissionEntries.config_id} = ${branchPermissionConfigs.config_id}
+      AND ${branchPermissionEntries.user_id} = ${principal}
+    LIMIT 1
+  )`;
+  const directFsAccess = sql<string | null>`(
+    SELECT ${branchPermissionEntries.fs_access}
+    FROM ${branchPermissionEntries}
+    WHERE ${branchPermissionEntries.config_id} = ${branchPermissionConfigs.config_id}
+      AND ${branchPermissionEntries.user_id} = ${principal}
+    LIMIT 1
+  )`;
+  const activeGroupRoleRank = sql<number>`COALESCE((
+    SELECT MAX(CASE ${branchPermissionEntries.role}
+      WHEN 'manager' THEN 3
+      WHEN 'collaborator' THEN 2
+      WHEN 'viewer' THEN 1
+      ELSE 0 END)
+    FROM ${branchPermissionEntries}
+    INNER JOIN ${groupMemberships}
+      ON ${groupMemberships.group_id} = ${branchPermissionEntries.group_id}
+     AND ${groupMemberships.user_id} = ${principal}
+    INNER JOIN ${groups}
+      ON ${groups.group_id} = ${branchPermissionEntries.group_id}
+     AND ${groups.archived} = false
+    WHERE ${branchPermissionEntries.config_id} = ${branchPermissionConfigs.config_id}
+  ), -1)`;
+  const activeGroupFsRank = sql<number>`COALESCE((
+    SELECT MAX(CASE ${branchPermissionEntries.fs_access}
+      WHEN 'write' THEN 2
+      WHEN 'read' THEN 1
+      ELSE 0 END)
+    FROM ${branchPermissionEntries}
+    INNER JOIN ${groupMemberships}
+      ON ${groupMemberships.group_id} = ${branchPermissionEntries.group_id}
+     AND ${groupMemberships.user_id} = ${principal}
+    INNER JOIN ${groups}
+      ON ${groups.group_id} = ${branchPermissionEntries.group_id}
+     AND ${groups.archived} = false
+    WHERE ${branchPermissionEntries.config_id} = ${branchPermissionConfigs.config_id}
+  ), -1)`;
+  const directSharingGrant = exists(
+    selectRaw(db)
+      .from(branchSessionSharingGrants)
+      .where(
+        and(
+          eq(branchSessionSharingGrants.config_id, branchPermissionConfigs.config_id),
+          eq(branchSessionSharingGrants.session_owner_user_id, sessions.created_by),
+          eq(branchSessionSharingGrants.user_id, principal)
+        )
+      )
+  );
+  const activeGroupSharingGrant = exists(
+    selectRaw(db)
+      .from(branchSessionSharingGrants)
+      .innerJoin(
+        groupMemberships,
+        and(
+          eq(groupMemberships.group_id, branchSessionSharingGrants.group_id),
+          eq(groupMemberships.user_id, principal)
+        )
+      )
+      .innerJoin(
+        groups,
+        and(eq(groups.group_id, branchSessionSharingGrants.group_id), eq(groups.archived, false))
+      )
+      .where(
+        and(
+          eq(branchSessionSharingGrants.config_id, branchPermissionConfigs.config_id),
+          eq(branchSessionSharingGrants.session_owner_user_id, sessions.created_by)
+        )
+      )
+  );
+
+  const row = await select(db, {
+    branch_id: branches.branch_id,
+    session_owner_user_id: sessions.created_by,
+    principal_user_id: users.user_id,
+    principal_role: users.role,
+    branch_primary_owner_user_id: branches.primary_owner_user_id,
+    sharing_mode: branchPermissionConfigs.sharing_mode,
+    others_role: branchPermissionConfigs.others_role,
+    others_fs_access: branchPermissionConfigs.others_fs_access,
+    direct_role: directRole,
+    direct_fs_access: directFsAccess,
+    active_group_role_rank: activeGroupRoleRank,
+    active_group_fs_rank: activeGroupFsRank,
+    workspace_sharing_enabled: exists(
+      selectRaw(db)
+        .from(appVariables)
+        .where(
+          and(
+            eq(appVariables.namespace, WORKSPACE_PREFERENCES_NAMESPACE),
+            eq(appVariables.key, PERSONAL_SESSION_SHARING_KEY),
+            eq(appVariables.value_text, 'true')
+          )
+        )
+    ),
+    owner_sharing_enabled: exists(
+      selectRaw(db)
+        .from(branchSessionSharingRules)
+        .where(
+          and(
+            eq(branchSessionSharingRules.config_id, branchPermissionConfigs.config_id),
+            eq(branchSessionSharingRules.session_owner_user_id, sessions.created_by),
+            eq(branchSessionSharingRules.enabled, true)
+          )
+        )
+    ),
+    principal_sharing_granted: or(directSharingGrant, activeGroupSharingGrant) ?? sql`false`,
+    observed_at: sql<Date>`CURRENT_TIMESTAMP`,
+  })
+    .from(sessions)
+    .innerJoin(branches, eq(branches.branch_id, sessions.branch_id))
+    .innerJoin(branchPermissionConfigs, effectiveConfigCondition())
+    .leftJoin(users, eq(users.user_id, principal))
+    .where(eq(sessions.session_id, input.sessionId))
+    .limit(1)
+    .one();
+  if (!row) return null;
+
+  const principalUserId =
+    typeof row.principal_user_id === 'string' ? row.principal_user_id : undefined;
+  const principalRole = typeof row.principal_role === 'string' ? row.principal_role : undefined;
+  const isSuperadminBypass =
+    principalUserId !== undefined &&
+    input.allowSuperadmin &&
+    (principalRole === 'superadmin' || principalRole === 'owner');
+  const isPrimaryOwner =
+    principalUserId !== undefined && row.branch_primary_owner_user_id === principalUserId;
+  const directMatched = typeof row.direct_role === 'string';
+  const groupRoleRank = numericValue(row.active_group_role_rank);
+  const groupFsRank = numericValue(row.active_group_fs_rank);
+
+  let canPromptOwn = false;
+  let fsAccess: CapabilityPolicyFsAccess = 'none';
+  if (principalUserId && (!input.branchRbacEnabled || isSuperadminBypass || isPrimaryOwner)) {
+    canPromptOwn = true;
+    fsAccess = 'write';
+  } else if (principalUserId && row.sharing_mode === 'shared') {
+    if (directMatched) {
+      canPromptOwn = roleGrantsSessionPrompt(row.direct_role);
+      fsAccess =
+        row.direct_fs_access === 'write'
+          ? 'write'
+          : row.direct_fs_access === 'read'
+            ? 'read'
+            : 'none';
+    } else if (groupRoleRank >= 0) {
+      canPromptOwn = groupRoleRank >= 2;
+      fsAccess = fsAccessFromRank(groupFsRank);
+    } else {
+      canPromptOwn = roleGrantsSessionPrompt(row.others_role);
+      fsAccess =
+        row.others_fs_access === 'write'
+          ? 'write'
+          : row.others_fs_access === 'read'
+            ? 'read'
+            : 'none';
+    }
+  }
+
+  const ownsSession =
+    principalUserId !== undefined && principalUserId === row.session_owner_user_id;
+  const sharedSessionAllowed =
+    isSuperadminBypass ||
+    (Boolean(row.workspace_sharing_enabled) &&
+      Boolean(row.owner_sharing_enabled) &&
+      Boolean(row.principal_sharing_granted));
+  const observedAt =
+    row.observed_at instanceof Date ? row.observed_at : new Date(String(row.observed_at));
+  return {
+    branch_id: String(row.branch_id),
+    principal_available: principalUserId !== undefined,
+    can_prompt_session: Boolean(
+      principalUserId && canPromptOwn && (ownsSession || sharedSessionAllowed)
+    ),
+    fs_access: principalUserId ? fsAccess : 'none',
+    observed_at: observedAt,
+  };
 }
 
 function directBranchEntryExists(db: Database, userId: UserIdExpression, capability?: string): SQL {

--- a/packages/core/src/db/repositories/branch-access.ts
+++ b/packages/core/src/db/repositories/branch-access.ts
@@ -12,8 +12,6 @@ import {
   branches,
   branchPermissionConfigs,
   branchPermissionEntries,
-  branchSessionSharingGrants,
-  branchSessionSharingRules,
   groupMemberships,
   groups,
   messages,
@@ -82,7 +80,7 @@ function effectiveConfigCondition(): SQL {
 }
 
 const WORKSPACE_PREFERENCES_NAMESPACE = 'workspace_preferences';
-const PERSONAL_SESSION_SHARING_KEY = 'personal_session_sharing_enabled';
+const SESSION_SHARING_KEY = 'session_sharing_enabled';
 
 /**
  * Closed point projection used by Task launch and heartbeat revalidation.
@@ -175,47 +173,16 @@ export async function resolveSessionRuntimeBranchAccess(
      AND ${groups.archived} = false
     WHERE ${branchPermissionEntries.config_id} = ${branchPermissionConfigs.config_id}
   ), -1)`;
-  const directSharingGrant = exists(
-    selectRaw(db)
-      .from(branchSessionSharingGrants)
-      .where(
-        and(
-          eq(branchSessionSharingGrants.config_id, branchPermissionConfigs.config_id),
-          eq(branchSessionSharingGrants.session_owner_user_id, sessions.created_by),
-          eq(branchSessionSharingGrants.user_id, principal)
-        )
-      )
-  );
-  const activeGroupSharingGrant = exists(
-    selectRaw(db)
-      .from(branchSessionSharingGrants)
-      .innerJoin(
-        groupMemberships,
-        and(
-          eq(groupMemberships.group_id, branchSessionSharingGrants.group_id),
-          eq(groupMemberships.user_id, principal)
-        )
-      )
-      .innerJoin(
-        groups,
-        and(eq(groups.group_id, branchSessionSharingGrants.group_id), eq(groups.archived, false))
-      )
-      .where(
-        and(
-          eq(branchSessionSharingGrants.config_id, branchPermissionConfigs.config_id),
-          eq(branchSessionSharingGrants.session_owner_user_id, sessions.created_by)
-        )
-      )
-  );
-
   const row = await select(db, {
     branch_id: branches.branch_id,
     session_owner_user_id: sessions.created_by,
+    session_sdk_home_scope: sessions.sdk_home_scope,
     principal_user_id: users.user_id,
     branch_primary_owner_user_id: branches.primary_owner_user_id,
     sharing_mode: branchPermissionConfigs.sharing_mode,
     others_role: branchPermissionConfigs.others_role,
     others_fs_access: branchPermissionConfigs.others_fs_access,
+    allow_shared_session_prompts: branchPermissionConfigs.allow_shared_session_prompts,
     direct_role: directRole,
     direct_fs_access: directFsAccess,
     active_group_role_rank: activeGroupRoleRank,
@@ -226,23 +193,11 @@ export async function resolveSessionRuntimeBranchAccess(
         .where(
           and(
             eq(appVariables.namespace, WORKSPACE_PREFERENCES_NAMESPACE),
-            eq(appVariables.key, PERSONAL_SESSION_SHARING_KEY),
+            eq(appVariables.key, SESSION_SHARING_KEY),
             eq(appVariables.value_text, 'true')
           )
         )
     ),
-    owner_sharing_enabled: exists(
-      selectRaw(db)
-        .from(branchSessionSharingRules)
-        .where(
-          and(
-            eq(branchSessionSharingRules.config_id, branchPermissionConfigs.config_id),
-            eq(branchSessionSharingRules.session_owner_user_id, sessions.created_by),
-            eq(branchSessionSharingRules.enabled, true)
-          )
-        )
-    ),
-    principal_sharing_granted: or(directSharingGrant, activeGroupSharingGrant) ?? sql`false`,
     observed_at: sql<Date>`CURRENT_TIMESTAMP`,
   })
     .from(sessions)
@@ -293,9 +248,9 @@ export async function resolveSessionRuntimeBranchAccess(
   const ownsSession =
     principalUserId !== undefined && principalUserId === row.session_owner_user_id;
   const sharedSessionAllowed =
+    row.session_sdk_home_scope === 'branch' &&
     Boolean(row.workspace_sharing_enabled) &&
-    Boolean(row.owner_sharing_enabled) &&
-    Boolean(row.principal_sharing_granted);
+    Boolean(row.allow_shared_session_prompts);
   const observedAt =
     row.observed_at instanceof Date ? row.observed_at : new Date(String(row.observed_at));
   return {

--- a/packages/core/src/db/repositories/capability-policies.ts
+++ b/packages/core/src/db/repositories/capability-policies.ts
@@ -22,6 +22,8 @@ import { and, eq, inArray, or, sql } from 'drizzle-orm';
 import { generateId } from '../../lib/ids';
 import {
   CAPABILITY_POLICY_SCHEMA_VERSION,
+  CAPABILITY_POLICY_SESSION_SHARING_KEY,
+  CAPABILITY_POLICY_WORKSPACE_PREFERENCES_NAMESPACE,
   capabilityPolicyPresetCapabilities,
   resolveCapabilityPolicyAccess,
   validateCapabilityPolicyDraft,
@@ -67,9 +69,6 @@ const EMPTY_BRANCH_CONFIG: BranchPermissionConfig = {
   },
   allow_shared_session_prompts: false,
 };
-
-const WORKSPACE_PREFERENCES_NAMESPACE = 'workspace_preferences';
-const SESSION_SHARING_KEY = 'session_sharing_enabled';
 
 function assertPolicy(policy: CapabilityPolicy, kind: CapabilityPolicy['policy_kind']): void {
   if (policy.schema_version !== CAPABILITY_POLICY_SCHEMA_VERSION || policy.policy_kind !== kind) {
@@ -942,8 +941,8 @@ export class CapabilityPolicyRepository {
       .from(appVariables)
       .where(
         and(
-          eq(appVariables.namespace, WORKSPACE_PREFERENCES_NAMESPACE),
-          eq(appVariables.key, SESSION_SHARING_KEY)
+          eq(appVariables.namespace, CAPABILITY_POLICY_WORKSPACE_PREFERENCES_NAMESPACE),
+          eq(appVariables.key, CAPABILITY_POLICY_SESSION_SHARING_KEY)
         )
       )
       .one();
@@ -964,8 +963,8 @@ export class CapabilityPolicyRepository {
           .values({
             ...currentTenantInsert(),
             variable_id: generateId(),
-            namespace: WORKSPACE_PREFERENCES_NAMESPACE,
-            key: SESSION_SHARING_KEY,
+            namespace: CAPABILITY_POLICY_WORKSPACE_PREFERENCES_NAMESPACE,
+            key: CAPABILITY_POLICY_SESSION_SHARING_KEY,
             value_text: 'false',
             value_encrypted: null,
             is_encrypted: false,
@@ -985,8 +984,8 @@ export class CapabilityPolicyRepository {
           })
           .where(
             and(
-              eq(appVariables.namespace, WORKSPACE_PREFERENCES_NAMESPACE),
-              eq(appVariables.key, SESSION_SHARING_KEY)
+              eq(appVariables.namespace, CAPABILITY_POLICY_WORKSPACE_PREFERENCES_NAMESPACE),
+              eq(appVariables.key, CAPABILITY_POLICY_SESSION_SHARING_KEY)
             )
           )
           .run();

--- a/packages/core/src/db/repositories/executor-session-token-authorities.ts
+++ b/packages/core/src/db/repositories/executor-session-token-authorities.ts
@@ -42,6 +42,16 @@ export interface ExecutorSessionTokenAuthorityClaim {
   userId: string;
 }
 
+/** Exact already-authenticated Task credential checked by the heartbeat hot path. */
+export interface CurrentTaskExecutorSessionTokenAuthority {
+  tenantId: string;
+  tokenFingerprint: string;
+  sessionId: string;
+  taskId: string;
+  branchId: string;
+  userId: string;
+}
+
 export interface ConsumedExecutorSessionTokenAuthority {
   sessionId: string;
   taskId: string | null;
@@ -194,6 +204,41 @@ export class ExecutorSessionTokenAuthorityRepository {
       return row ? mapConsumed(row) : null;
     } catch (error) {
       throw databaseFailure('validation', error);
+    }
+  }
+
+  /**
+   * Revalidate one task-scoped credential without consuming another token use.
+   *
+   * The fingerprint primary key is the first and only candidate lookup. The
+   * remaining predicates prove that the authenticated socket's durable row is
+   * still current for the exact tenant/principal/resource tuple.
+   */
+  async isCurrent(input: CurrentTaskExecutorSessionTokenAuthority): Promise<boolean> {
+    assertFingerprint(input.tokenFingerprint);
+    if (!input.tenantId || !input.sessionId || !input.taskId || !input.branchId || !input.userId) {
+      throw new RepositoryError('Executor task token authority scope is incomplete');
+    }
+    try {
+      const result = await executeRaw(
+        this.db,
+        sql`
+          SELECT 1 AS current
+          FROM ${executorSessionTokenAuthorities}
+          WHERE tenant_id = ${input.tenantId}
+            AND token_fingerprint = ${input.tokenFingerprint}
+            AND session_id = ${input.sessionId}
+            AND task_id = ${input.taskId}
+            AND branch_id = ${input.branchId}
+            AND user_id = ${input.userId}
+            AND revoked_at IS NULL
+            AND expires_at > CURRENT_TIMESTAMP
+          LIMIT 1
+        `
+      );
+      return rowsOf(result).length === 1;
+    } catch (error) {
+      throw databaseFailure('current-authority check', error);
     }
   }
 

--- a/packages/core/src/db/repositories/task-runtime-authority.test.ts
+++ b/packages/core/src/db/repositories/task-runtime-authority.test.ts
@@ -1,4 +1,4 @@
-import type { BranchID, Task, UserID, UUID } from '@agor/core/types';
+import type { BranchID, SessionSdkHomeScope, Task, UserID, UUID } from '@agor/core/types';
 import { TaskStatus } from '@agor/core/types';
 import { eq } from 'drizzle-orm';
 import { describe, expect } from 'vitest';
@@ -20,6 +20,7 @@ interface RuntimeSeed {
   ownerId: UserID;
   actorId: UserID;
   sessionOwnerId: UserID;
+  sessionSdkHomeScope: SessionSdkHomeScope;
   branchId: BranchID;
   task: Task;
   tasks: TaskRepository;
@@ -30,48 +31,23 @@ interface RuntimeSeedOptions {
   actorRole?: 'member' | 'superadmin';
   branchRbacEnabled?: boolean;
   sessionOwner?: 'actor' | 'branch_owner';
-  grantForeignSessionSharing?: boolean;
+  sessionSdkHomeScope?: SessionSdkHomeScope;
+  allowForeignSessionSharing?: boolean;
 }
 
 async function setForeignSessionSharing(
   db: Database,
   branchId: BranchID,
-  sessionOwnerId: UserID,
   actorId: UserID,
   enabled: boolean
 ): Promise<void> {
   const policies = new CapabilityPolicyRepository(db);
-  await policies.setWorkspacePreferences(
-    { personal_session_sharing_enabled: true },
-    sessionOwnerId
-  );
+  await policies.setWorkspacePreferences({ session_sharing_enabled: true }, actorId);
   const current = await policies.getBranchPolicy(branchId);
   const config = structuredClone(current.override_config);
   if (!config) throw new Error('Expected an override Branch policy');
-  config.session_sharing.owner_rules = [
-    ...config.session_sharing.owner_rules.filter(
-      (rule) => rule.session_owner_user_id !== sessionOwnerId
-    ),
-    ...(enabled
-      ? [
-          {
-            session_owner_user_id: sessionOwnerId,
-            enabled: true,
-            grantees: [
-              {
-                grant_id: generateId() as UUID,
-                principal: { principal_type: 'user' as const, user_id: actorId },
-              },
-            ],
-          },
-        ]
-      : []),
-  ];
-  await policies.replaceBranchPolicy(
-    branchId,
-    { ...current, override_config: config },
-    sessionOwnerId
-  );
+  config.allow_shared_session_prompts = enabled;
+  await policies.replaceBranchPolicy(branchId, { ...current, override_config: config }, actorId);
 }
 
 async function seedRuntime(
@@ -118,14 +94,17 @@ async function seedRuntime(
     owner.user_id
   );
   const sessionOwnerId = options.sessionOwner === 'branch_owner' ? owner.user_id : actor.user_id;
-  if (options.grantForeignSessionSharing) {
-    await setForeignSessionSharing(db, branch.branch_id, sessionOwnerId, actor.user_id, true);
+  if (options.allowForeignSessionSharing) {
+    await setForeignSessionSharing(db, branch.branch_id, actor.user_id, true);
   }
+  const sessionSdkHomeScope =
+    options.sessionSdkHomeScope ?? (sessionOwnerId === actor.user_id ? 'execution_home' : 'branch');
   const session = await new SessionRepository(db).create({
     session_id: generateId(),
     branch_id: branch.branch_id,
     created_by: sessionOwnerId,
     agentic_tool: 'codex',
+    sdk_home_scope: sessionSdkHomeScope,
   });
   const tasks = new TaskRepository(db);
   const task = await tasks.create({
@@ -150,6 +129,7 @@ async function seedRuntime(
     ownerId: owner.user_id,
     actorId: actor.user_id,
     sessionOwnerId,
+    sessionSdkHomeScope,
     branchId: branch.branch_id,
     task,
     tasks,
@@ -211,7 +191,12 @@ describe('Task runtime heartbeat authority (SQLite)', () => {
 
     const [canonicalAccess, canonicalPrompt] = await Promise.all([
       branches.resolveUserAccess(branch, seed.actorId),
-      branches.resolveSessionPromptAuthority(seed.branchId, seed.actorId, seed.sessionOwnerId),
+      branches.resolveSessionPromptAuthority(
+        seed.branchId,
+        seed.actorId,
+        seed.sessionOwnerId,
+        seed.sessionSdkHomeScope
+      ),
     ]);
     expect(canonicalAccess.fs_access).toBe('read');
     expect(canonicalPrompt.allowed).toBe(true);
@@ -230,21 +215,32 @@ describe('Task runtime heartbeat authority (SQLite)', () => {
     const seed = await seedRuntime(db, 'read', {
       actorRole: 'superadmin',
       sessionOwner: 'branch_owner',
-      grantForeignSessionSharing: true,
+      allowForeignSessionSharing: true,
     });
     await expect(
       seed.tasks.reportRuntimeTelemetry(seed.task.task_id, seed.authority)
     ).resolves.toMatchObject({ outcome: 'continued' });
 
-    await setForeignSessionSharing(db, seed.branchId, seed.sessionOwnerId, seed.actorId, false);
+    await setForeignSessionSharing(db, seed.branchId, seed.actorId, false);
     await expect(
       new BranchRepository(db).resolveSessionPromptAuthority(
         seed.branchId,
         seed.actorId,
-        seed.sessionOwnerId
+        seed.sessionOwnerId,
+        seed.sessionSdkHomeScope
       )
     ).resolves.toMatchObject({ allowed: false });
     await expectDeniedWithoutHeartbeatRefresh(seed, 'branch_capability_revoked');
+  });
+
+  dbTest('denies foreign execution-home sessions even when sharing is enabled', async ({ db }) => {
+    await expect(
+      seedRuntime(db, 'read', {
+        sessionOwner: 'branch_owner',
+        sessionSdkHomeScope: 'execution_home',
+        allowForeignSessionSharing: true,
+      })
+    ).rejects.toThrow('Authorization to launch this task is unavailable');
   });
 
   dbTest(
@@ -258,7 +254,8 @@ describe('Task runtime heartbeat authority (SQLite)', () => {
         new BranchRepository(db).resolveSessionPromptAuthority(
           seed.branchId,
           seed.actorId,
-          seed.sessionOwnerId
+          seed.sessionOwnerId,
+          seed.sessionSdkHomeScope
         )
       ).resolves.toMatchObject({ allowed: false });
       await expect(

--- a/packages/core/src/db/repositories/task-runtime-authority.test.ts
+++ b/packages/core/src/db/repositories/task-runtime-authority.test.ts
@@ -1,0 +1,261 @@
+import type { BranchID, Task, UserID, UUID } from '@agor/core/types';
+import { TaskStatus } from '@agor/core/types';
+import { eq } from 'drizzle-orm';
+import { describe, expect } from 'vitest';
+import { generateId } from '../../lib/ids';
+import type { Database } from '../client';
+import { select } from '../database-wrapper';
+import { tasks as tasksTable } from '../schema';
+import { ownedDbTest as dbTest, setTestBranchUserRole } from '../test-helpers';
+import { BranchRepository } from './branches';
+import { RepoRepository } from './repos';
+import { SessionRepository } from './sessions';
+import { TaskRepository, type TaskRuntimeAuthorityScope } from './tasks';
+import { UsersRepository } from './users';
+
+let branchUnique = (Date.now() % 1_000_000) + 7_000_000;
+
+interface RuntimeSeed {
+  ownerId: UserID;
+  actorId: UserID;
+  branchId: BranchID;
+  task: Task;
+  tasks: TaskRepository;
+  authority: TaskRuntimeAuthorityScope;
+}
+
+async function seedRuntime(db: Database, floor: 'read' | 'write' = 'write'): Promise<RuntimeSeed> {
+  const users = new UsersRepository(db);
+  const owner = await users.create({
+    user_id: generateId() as UserID,
+    email: `${generateId()}-authority-owner@example.com`,
+    name: 'Authority owner',
+  });
+  const actor = await users.create({
+    user_id: generateId() as UserID,
+    email: `${generateId()}-authority-actor@example.com`,
+    name: 'Authority actor',
+  });
+  const repo = await new RepoRepository(db).create({
+    repo_id: generateId(),
+    slug: `runtime-authority-${generateId()}`,
+    name: 'Runtime authority',
+    repo_type: 'remote',
+    remote_url: 'https://example.invalid/runtime-authority.git',
+    local_path: `/tmp/${generateId()}`,
+    default_branch: 'main',
+  });
+  const branch = await new BranchRepository(db).create({
+    branch_id: generateId(),
+    repo_id: repo.repo_id,
+    name: 'runtime-authority',
+    ref: 'main',
+    branch_unique_id: branchUnique++,
+    path: `/tmp/${generateId()}`,
+    created_by: owner.user_id,
+  });
+  await setTestBranchUserRole(
+    db,
+    branch.branch_id,
+    actor.user_id,
+    'collaborator',
+    floor,
+    owner.user_id
+  );
+  const session = await new SessionRepository(db).create({
+    session_id: generateId(),
+    branch_id: branch.branch_id,
+    created_by: actor.user_id,
+    agentic_tool: 'codex',
+  });
+  const tasks = new TaskRepository(db);
+  const task = await tasks.create({
+    task_id: generateId(),
+    session_id: session.session_id,
+    created_by: actor.user_id as UUID,
+    full_prompt: 'runtime authority probe',
+    status: TaskStatus.DISPATCHING,
+    message_range: {
+      start_index: 0,
+      end_index: 0,
+      start_timestamp: '2026-08-28T00:00:00.000Z',
+    },
+    git_state: { ref_at_start: 'main', sha_at_start: 'authority' },
+    tool_use_count: 0,
+  });
+  const launch = await tasks.bindExecutorLaunchAuthority(task.task_id, {
+    branchRbacEnabled: true,
+    allowSuperadmin: false,
+  });
+  expect(launch.fs_access).toBe(floor);
+  await tasks.connectExecutor(task.task_id, new Date('2026-08-28T00:00:01.000Z'));
+  return {
+    ownerId: owner.user_id,
+    actorId: actor.user_id,
+    branchId: branch.branch_id,
+    task,
+    tasks,
+    authority: {
+      token_fingerprint: 'b'.repeat(64),
+      principal_user_id: actor.user_id,
+      session_id: session.session_id,
+      branch_id: branch.branch_id,
+      branchRbacEnabled: true,
+      allowSuperadmin: false,
+      standalone_token_current: true,
+    },
+  };
+}
+
+async function expectDeniedWithoutHeartbeatRefresh(
+  seed: RuntimeSeed,
+  reason:
+    | 'token_revoked'
+    | 'principal_unavailable'
+    | 'branch_capability_revoked'
+    | 'filesystem_access_revoked'
+) {
+  const before = await seed.tasks.findById(seed.task.task_id);
+  const result = await seed.tasks.reportRuntimeTelemetry(
+    seed.task.task_id,
+    seed.authority,
+    undefined,
+    new Date('2026-08-28T00:00:10.000Z')
+  );
+  const after = await seed.tasks.findById(seed.task.task_id);
+  expect(result).toMatchObject({ outcome: 'authorization_revoked', reason });
+  expect(after?.last_executor_heartbeat_at).toBe(before?.last_executor_heartbeat_at);
+}
+
+describe('Task runtime heartbeat authority (SQLite)', () => {
+  dbTest(
+    'continues with the exact current principal, capability, and launch floor',
+    async ({ db }) => {
+      const seed = await seedRuntime(db, 'write');
+      await expect(
+        seed.tasks.reportRuntimeTelemetry(
+          seed.task.task_id,
+          seed.authority,
+          undefined,
+          new Date('2026-08-28T00:00:10.000Z')
+        )
+      ).resolves.toMatchObject({
+        outcome: 'continued',
+        task: { last_executor_heartbeat_at: '2026-08-28T00:00:10.000Z' },
+      });
+    }
+  );
+
+  dbTest('denies a removed/deactivated principal without refreshing liveness', async ({ db }) => {
+    const seed = await seedRuntime(db);
+    await new UsersRepository(db).delete(seed.actorId);
+    await expectDeniedWithoutHeartbeatRefresh(seed, 'principal_unavailable');
+  });
+
+  dbTest('denies application-capability revocation without refreshing liveness', async ({ db }) => {
+    const seed = await seedRuntime(db);
+    await setTestBranchUserRole(db, seed.branchId, seed.actorId, 'viewer', 'write', seed.ownerId);
+    await expectDeniedWithoutHeartbeatRefresh(seed, 'branch_capability_revoked');
+  });
+
+  dbTest('denies write -> read/none and read -> none filesystem demotions', async ({ db }) => {
+    for (const [floor, current] of [
+      ['write', 'read'],
+      ['write', 'none'],
+      ['read', 'none'],
+    ] as const) {
+      const seed = await seedRuntime(db, floor);
+      await setTestBranchUserRole(
+        db,
+        seed.branchId,
+        seed.actorId,
+        'collaborator',
+        current,
+        seed.ownerId
+      );
+      await expectDeniedWithoutHeartbeatRefresh(seed, 'filesystem_access_revoked');
+    }
+  });
+
+  dbTest('does not widen an already-bound read launch after an access increase', async ({ db }) => {
+    const seed = await seedRuntime(db, 'read');
+    await setTestBranchUserRole(
+      db,
+      seed.branchId,
+      seed.actorId,
+      'collaborator',
+      'write',
+      seed.ownerId
+    );
+    await expect(
+      seed.tasks.reportRuntimeTelemetry(seed.task.task_id, seed.authority)
+    ).resolves.toMatchObject({ outcome: 'continued' });
+
+    const stored = await select(db, { data: tasksTable.data })
+      .from(tasksTable)
+      .where(eq(tasksTable.task_id, seed.task.task_id))
+      .one();
+    expect(stored?.data.executor_launch_fs_access_floor).toBe('read');
+
+    // A connected runtime cannot be rebound at all. Its original read floor
+    // remains the only projection consumed by the heartbeat comparison.
+    await expect(
+      seed.tasks.bindExecutorLaunchAuthority(seed.task.task_id, {
+        branchRbacEnabled: true,
+        allowSuperadmin: false,
+      })
+    ).rejects.toThrow('not awaiting executor launch authority');
+  });
+
+  dbTest(
+    'rejects wrong principal, Session, or Branch scope without stopping the runtime',
+    async ({ db }) => {
+      const seed = await seedRuntime(db);
+      for (const mismatch of [
+        { principal_user_id: generateId() },
+        { session_id: generateId() },
+        { branch_id: generateId() },
+      ]) {
+        await expect(
+          seed.tasks.reportRuntimeTelemetry(seed.task.task_id, {
+            ...seed.authority,
+            ...mismatch,
+          })
+        ).resolves.toMatchObject({ outcome: 'scope_mismatch' });
+      }
+      await expect(seed.tasks.findById(seed.task.task_id)).resolves.toMatchObject({
+        status: TaskStatus.RUNNING,
+        last_executor_heartbeat_at: '2026-08-28T00:00:01.000Z',
+      });
+    }
+  );
+
+  dbTest('denies a stale or revoked task credential', async ({ db }) => {
+    const seed = await seedRuntime(db);
+    seed.authority.standalone_token_current = false;
+    await expectDeniedWithoutHeartbeatRefresh(seed, 'token_revoked');
+  });
+
+  dbTest(
+    'fails closed when an older live runtime has no trustworthy launch floor',
+    async ({ db }) => {
+      const seed = await seedRuntime(db);
+      const legacy = await seed.tasks.create({
+        ...seed.task,
+        task_id: generateId(),
+        status: TaskStatus.RUNNING,
+        executor_connected_at: '2026-08-28T00:00:01.000Z',
+        last_executor_heartbeat_at: '2026-08-28T00:00:01.000Z',
+      });
+      await expect(
+        seed.tasks.reportRuntimeTelemetry(legacy.task_id, {
+          ...seed.authority,
+          token_fingerprint: 'd'.repeat(64),
+        })
+      ).resolves.toMatchObject({
+        outcome: 'authorization_revoked',
+        reason: 'launch_authority_missing',
+      });
+    }
+  );
+});

--- a/packages/core/src/db/repositories/task-runtime-authority.test.ts
+++ b/packages/core/src/db/repositories/task-runtime-authority.test.ts
@@ -8,6 +8,7 @@ import { select } from '../database-wrapper';
 import { tasks as tasksTable } from '../schema';
 import { ownedDbTest as dbTest, setTestBranchUserRole } from '../test-helpers';
 import { BranchRepository } from './branches';
+import { CapabilityPolicyRepository } from './capability-policies';
 import { RepoRepository } from './repos';
 import { SessionRepository } from './sessions';
 import { TaskRepository, type TaskRuntimeAuthorityScope } from './tasks';
@@ -18,13 +19,66 @@ let branchUnique = (Date.now() % 1_000_000) + 7_000_000;
 interface RuntimeSeed {
   ownerId: UserID;
   actorId: UserID;
+  sessionOwnerId: UserID;
   branchId: BranchID;
   task: Task;
   tasks: TaskRepository;
   authority: TaskRuntimeAuthorityScope;
 }
 
-async function seedRuntime(db: Database, floor: 'read' | 'write' = 'write'): Promise<RuntimeSeed> {
+interface RuntimeSeedOptions {
+  actorRole?: 'member' | 'superadmin';
+  branchRbacEnabled?: boolean;
+  sessionOwner?: 'actor' | 'branch_owner';
+  grantForeignSessionSharing?: boolean;
+}
+
+async function setForeignSessionSharing(
+  db: Database,
+  branchId: BranchID,
+  sessionOwnerId: UserID,
+  actorId: UserID,
+  enabled: boolean
+): Promise<void> {
+  const policies = new CapabilityPolicyRepository(db);
+  await policies.setWorkspacePreferences(
+    { personal_session_sharing_enabled: true },
+    sessionOwnerId
+  );
+  const current = await policies.getBranchPolicy(branchId);
+  const config = structuredClone(current.override_config);
+  if (!config) throw new Error('Expected an override Branch policy');
+  config.session_sharing.owner_rules = [
+    ...config.session_sharing.owner_rules.filter(
+      (rule) => rule.session_owner_user_id !== sessionOwnerId
+    ),
+    ...(enabled
+      ? [
+          {
+            session_owner_user_id: sessionOwnerId,
+            enabled: true,
+            grantees: [
+              {
+                grant_id: generateId() as UUID,
+                principal: { principal_type: 'user' as const, user_id: actorId },
+              },
+            ],
+          },
+        ]
+      : []),
+  ];
+  await policies.replaceBranchPolicy(
+    branchId,
+    { ...current, override_config: config },
+    sessionOwnerId
+  );
+}
+
+async function seedRuntime(
+  db: Database,
+  floor: 'read' | 'write' = 'write',
+  options: RuntimeSeedOptions = {}
+): Promise<RuntimeSeed> {
   const users = new UsersRepository(db);
   const owner = await users.create({
     user_id: generateId() as UserID,
@@ -35,6 +89,7 @@ async function seedRuntime(db: Database, floor: 'read' | 'write' = 'write'): Pro
     user_id: generateId() as UserID,
     email: `${generateId()}-authority-actor@example.com`,
     name: 'Authority actor',
+    role: options.actorRole ?? 'member',
   });
   const repo = await new RepoRepository(db).create({
     repo_id: generateId(),
@@ -62,10 +117,14 @@ async function seedRuntime(db: Database, floor: 'read' | 'write' = 'write'): Pro
     floor,
     owner.user_id
   );
+  const sessionOwnerId = options.sessionOwner === 'branch_owner' ? owner.user_id : actor.user_id;
+  if (options.grantForeignSessionSharing) {
+    await setForeignSessionSharing(db, branch.branch_id, sessionOwnerId, actor.user_id, true);
+  }
   const session = await new SessionRepository(db).create({
     session_id: generateId(),
     branch_id: branch.branch_id,
-    created_by: actor.user_id,
+    created_by: sessionOwnerId,
     agentic_tool: 'codex',
   });
   const tasks = new TaskRepository(db);
@@ -83,15 +142,14 @@ async function seedRuntime(db: Database, floor: 'read' | 'write' = 'write'): Pro
     git_state: { ref_at_start: 'main', sha_at_start: 'authority' },
     tool_use_count: 0,
   });
-  const launch = await tasks.bindExecutorLaunchAuthority(task.task_id, {
-    branchRbacEnabled: true,
-    allowSuperadmin: false,
-  });
-  expect(launch.fs_access).toBe(floor);
+  const branchRbacEnabled = options.branchRbacEnabled ?? true;
+  const launch = await tasks.bindExecutorLaunchAuthority(task.task_id, { branchRbacEnabled });
+  expect(launch.fs_access).toBe(branchRbacEnabled ? floor : 'write');
   await tasks.connectExecutor(task.task_id, new Date('2026-08-28T00:00:01.000Z'));
   return {
     ownerId: owner.user_id,
     actorId: actor.user_id,
+    sessionOwnerId,
     branchId: branch.branch_id,
     task,
     tasks,
@@ -100,8 +158,7 @@ async function seedRuntime(db: Database, floor: 'read' | 'write' = 'write'): Pro
       principal_user_id: actor.user_id,
       session_id: session.session_id,
       branch_id: branch.branch_id,
-      branchRbacEnabled: true,
-      allowSuperadmin: false,
+      branchRbacEnabled,
       standalone_token_current: true,
     },
   };
@@ -143,6 +200,76 @@ describe('Task runtime heartbeat authority (SQLite)', () => {
         outcome: 'continued',
         task: { last_executor_heartbeat_at: '2026-08-28T00:00:10.000Z' },
       });
+    }
+  );
+
+  dbTest('keeps superadmin runtime authority at the normalized policy access', async ({ db }) => {
+    const seed = await seedRuntime(db, 'read', { actorRole: 'superadmin' });
+    const branches = new BranchRepository(db);
+    const branch = await branches.findById(seed.branchId);
+    if (!branch) throw new Error('Expected seeded Branch');
+
+    const [canonicalAccess, canonicalPrompt] = await Promise.all([
+      branches.resolveUserAccess(branch, seed.actorId),
+      branches.resolveSessionPromptAuthority(seed.branchId, seed.actorId, seed.sessionOwnerId),
+    ]);
+    expect(canonicalAccess.fs_access).toBe('read');
+    expect(canonicalPrompt.allowed).toBe(true);
+    await expect(
+      seed.tasks.reportRuntimeTelemetry(seed.task.task_id, seed.authority)
+    ).resolves.toMatchObject({ outcome: 'continued' });
+
+    const stored = await select(db, { data: tasksTable.data })
+      .from(tasksTable)
+      .where(eq(tasksTable.task_id, seed.task.task_id))
+      .one();
+    expect(stored?.data.executor_launch_fs_access_floor).toBe('read');
+  });
+
+  dbTest('revokes a superadmin runtime when foreign-session sharing is removed', async ({ db }) => {
+    const seed = await seedRuntime(db, 'read', {
+      actorRole: 'superadmin',
+      sessionOwner: 'branch_owner',
+      grantForeignSessionSharing: true,
+    });
+    await expect(
+      seed.tasks.reportRuntimeTelemetry(seed.task.task_id, seed.authority)
+    ).resolves.toMatchObject({ outcome: 'continued' });
+
+    await setForeignSessionSharing(db, seed.branchId, seed.sessionOwnerId, seed.actorId, false);
+    await expect(
+      new BranchRepository(db).resolveSessionPromptAuthority(
+        seed.branchId,
+        seed.actorId,
+        seed.sessionOwnerId
+      )
+    ).resolves.toMatchObject({ allowed: false });
+    await expectDeniedWithoutHeartbeatRefresh(seed, 'branch_capability_revoked');
+  });
+
+  dbTest(
+    'preserves RBAC-disabled foreign-session launch and heartbeat admission',
+    async ({ db }) => {
+      const seed = await seedRuntime(db, 'read', {
+        branchRbacEnabled: false,
+        sessionOwner: 'branch_owner',
+      });
+      await expect(
+        new BranchRepository(db).resolveSessionPromptAuthority(
+          seed.branchId,
+          seed.actorId,
+          seed.sessionOwnerId
+        )
+      ).resolves.toMatchObject({ allowed: false });
+      await expect(
+        seed.tasks.reportRuntimeTelemetry(seed.task.task_id, seed.authority)
+      ).resolves.toMatchObject({ outcome: 'continued' });
+
+      const stored = await select(db, { data: tasksTable.data })
+        .from(tasksTable)
+        .where(eq(tasksTable.task_id, seed.task.task_id))
+        .one();
+      expect(stored?.data.executor_launch_fs_access_floor).toBe('write');
     }
   );
 
@@ -202,7 +329,6 @@ describe('Task runtime heartbeat authority (SQLite)', () => {
     await expect(
       seed.tasks.bindExecutorLaunchAuthority(seed.task.task_id, {
         branchRbacEnabled: true,
-        allowSuperadmin: false,
       })
     ).rejects.toThrow('not awaiting executor launch authority');
   });

--- a/packages/core/src/db/repositories/tasks.test.ts
+++ b/packages/core/src/db/repositories/tasks.test.ts
@@ -88,6 +88,24 @@ async function createSessionWithDeps(db: Database): Promise<UUID> {
   return session.session_id;
 }
 
+async function bindTestRuntimeAuthority(db: Database, taskRepo: TaskRepository, task: Task) {
+  const session = await new SessionRepository(db).findById(task.session_id);
+  if (!session?.branch_id) throw new Error('Test runtime Session Branch is unavailable');
+  await taskRepo.bindExecutorLaunchAuthority(task.task_id, {
+    branchRbacEnabled: true,
+    allowSuperadmin: false,
+  });
+  return {
+    token_fingerprint: 'a'.repeat(64),
+    principal_user_id: task.created_by,
+    session_id: task.session_id,
+    branch_id: session.branch_id,
+    branchRbacEnabled: true,
+    allowSuperadmin: false,
+    standalone_token_current: true,
+  };
+}
+
 // ============================================================================
 // Create
 // ============================================================================
@@ -1290,31 +1308,41 @@ describe('TaskRepository.reportRuntimeTelemetry', () => {
     const task = await taskRepo.create(
       createTaskData({ session_id: sessionId, status: TaskStatus.DISPATCHING })
     );
+    const authority = await bindTestRuntimeAuthority(db, taskRepo, task);
     await taskRepo.connectExecutor(task.task_id);
 
     const first = await taskRepo.reportRuntimeTelemetry(
       task.task_id,
+      authority,
       { sequence: 2, kind: 'progress', detail: 'tool.start' },
       new Date('2026-01-01T00:00:02.000Z')
     );
     const retry = await taskRepo.reportRuntimeTelemetry(
       task.task_id,
+      authority,
       { sequence: 2, kind: 'waiting' },
       new Date('2026-01-01T00:00:03.000Z')
     );
 
     expect(first).toMatchObject({
-      last_executor_heartbeat_at: '2026-01-01T00:00:02.000Z',
-      latest_executor_pulse: {
-        sequence: 2,
-        kind: 'progress',
-        detail: 'tool.start',
-        observed_at: '2026-01-01T00:00:02.000Z',
+      outcome: 'continued',
+      task: {
+        last_executor_heartbeat_at: '2026-01-01T00:00:02.000Z',
+        latest_executor_pulse: {
+          sequence: 2,
+          kind: 'progress',
+          detail: 'tool.start',
+          observed_at: '2026-01-01T00:00:02.000Z',
+        },
       },
     });
     expect(retry).toMatchObject({
-      last_executor_heartbeat_at: '2026-01-01T00:00:03.000Z',
-      latest_executor_pulse: first?.latest_executor_pulse,
+      outcome: 'continued',
+      task: {
+        last_executor_heartbeat_at: '2026-01-01T00:00:03.000Z',
+        latest_executor_pulse:
+          first.outcome === 'continued' ? first.task.latest_executor_pulse : {},
+      },
     });
   });
 
@@ -1326,6 +1354,7 @@ describe('TaskRepository.reportRuntimeTelemetry', () => {
       const task = await taskRepo.create(
         createTaskData({ session_id: sessionId, status: TaskStatus.DISPATCHING })
       );
+      const authority = await bindTestRuntimeAuthority(db, taskRepo, task);
       await taskRepo.connectExecutor(task.task_id);
       await taskRepo.claimTermination({
         taskId: task.task_id,
@@ -1337,16 +1366,20 @@ describe('TaskRepository.reportRuntimeTelemetry', () => {
       await expect(
         taskRepo.reportRuntimeTelemetry(
           task.task_id,
+          authority,
           { sequence: 3, kind: 'progress', detail: 'provider.cancel.pending' },
           new Date('2026-01-01T00:00:03.000Z')
         )
       ).resolves.toMatchObject({
-        status: TaskStatus.STOPPING,
-        last_executor_heartbeat_at: '2026-01-01T00:00:03.000Z',
-        latest_executor_pulse: {
-          sequence: 3,
-          kind: 'progress',
-          detail: 'provider.cancel.pending',
+        outcome: 'continued',
+        task: {
+          status: TaskStatus.STOPPING,
+          last_executor_heartbeat_at: '2026-01-01T00:00:03.000Z',
+          latest_executor_pulse: {
+            sequence: 3,
+            kind: 'progress',
+            detail: 'provider.cancel.pending',
+          },
         },
       });
     }
@@ -1358,6 +1391,7 @@ describe('TaskRepository.reportRuntimeTelemetry', () => {
     const task = await taskRepo.create(
       createTaskData({ session_id: sessionId, status: TaskStatus.DISPATCHING })
     );
+    const authority = await bindTestRuntimeAuthority(db, taskRepo, task);
     await taskRepo.connectExecutor(task.task_id);
     const claim = await taskRepo.claimTermination({
       taskId: task.task_id,
@@ -1373,7 +1407,10 @@ describe('TaskRepository.reportRuntimeTelemetry', () => {
       new Date('2026-01-01T00:00:03.000Z')
     );
 
-    await expect(taskRepo.reportRuntimeTelemetry(task.task_id)).resolves.toBeNull();
+    await expect(taskRepo.reportRuntimeTelemetry(task.task_id, authority)).resolves.toMatchObject({
+      outcome: 'control',
+      task: { status: TaskStatus.STOPPING },
+    });
   });
 
   dbTest(
@@ -1384,6 +1421,7 @@ describe('TaskRepository.reportRuntimeTelemetry', () => {
       const task = await taskRepo.create(
         createTaskData({ session_id: sessionId, status: TaskStatus.DISPATCHING })
       );
+      const authority = await bindTestRuntimeAuthority(db, taskRepo, task);
       await taskRepo.connectExecutor(task.task_id);
       await taskRepo.claimTermination({
         taskId: task.task_id,
@@ -1413,14 +1451,18 @@ describe('TaskRepository.reportRuntimeTelemetry', () => {
       await expect(
         taskRepo.reportRuntimeTelemetry(
           task.task_id,
+          authority,
           { sequence: 4, kind: 'progress', detail: 'provider.cancel.still_pending' },
           new Date('2026-01-01T00:00:04.000Z')
         )
       ).resolves.toMatchObject({
-        status: TaskStatus.STOPPING,
-        sdk_failure: { termination: 'unverified' },
-        last_executor_heartbeat_at: '2026-01-01T00:00:04.000Z',
-        latest_executor_pulse: { sequence: 4, detail: 'provider.cancel.still_pending' },
+        outcome: 'continued',
+        task: {
+          status: TaskStatus.STOPPING,
+          sdk_failure: { termination: 'unverified' },
+          last_executor_heartbeat_at: '2026-01-01T00:00:04.000Z',
+          latest_executor_pulse: { sequence: 4, detail: 'provider.cancel.still_pending' },
+        },
       });
     }
   );
@@ -1431,11 +1473,16 @@ describe('TaskRepository.reportRuntimeTelemetry', () => {
     const task = await taskRepo.create(
       createTaskData({ session_id: sessionId, status: TaskStatus.DISPATCHING })
     );
+    const authority = await bindTestRuntimeAuthority(db, taskRepo, task);
 
-    expect(await taskRepo.reportRuntimeTelemetry(task.task_id)).toBeNull();
+    expect(await taskRepo.reportRuntimeTelemetry(task.task_id, authority)).toMatchObject({
+      outcome: 'control',
+    });
     await taskRepo.connectExecutor(task.task_id);
     await taskRepo.update(task.task_id, { status: TaskStatus.COMPLETED });
-    expect(await taskRepo.reportRuntimeTelemetry(task.task_id)).toBeNull();
+    expect(await taskRepo.reportRuntimeTelemetry(task.task_id, authority)).toMatchObject({
+      outcome: 'control',
+    });
   });
 });
 
@@ -1703,13 +1750,14 @@ describe('TaskRepository.update', () => {
     const task = await taskRepo.create(
       createTaskData({
         session_id: sessionId,
-        status: TaskStatus.RUNNING,
-        executor_connected_at: '2026-07-10T20:00:00.000Z',
-        last_executor_heartbeat_at: '2026-07-10T20:00:01.000Z',
+        status: TaskStatus.DISPATCHING,
       })
     );
+    const authority = await bindTestRuntimeAuthority(db, taskRepo, task);
+    await taskRepo.connectExecutor(task.task_id, new Date('2026-07-10T20:00:01.000Z'));
     await taskRepo.reportRuntimeTelemetry(
       task.task_id,
+      authority,
       undefined,
       new Date('2026-07-10T20:00:05Z')
     );

--- a/packages/core/src/db/repositories/tasks.test.ts
+++ b/packages/core/src/db/repositories/tasks.test.ts
@@ -93,7 +93,6 @@ async function bindTestRuntimeAuthority(db: Database, taskRepo: TaskRepository, 
   if (!session?.branch_id) throw new Error('Test runtime Session Branch is unavailable');
   await taskRepo.bindExecutorLaunchAuthority(task.task_id, {
     branchRbacEnabled: true,
-    allowSuperadmin: false,
   });
   return {
     token_fingerprint: 'a'.repeat(64),
@@ -101,7 +100,6 @@ async function bindTestRuntimeAuthority(db: Database, taskRepo: TaskRepository, 
     session_id: task.session_id,
     branch_id: session.branch_id,
     branchRbacEnabled: true,
-    allowSuperadmin: false,
     standalone_token_current: true,
   };
 }

--- a/packages/core/src/db/repositories/tasks.ts
+++ b/packages/core/src/db/repositories/tasks.ts
@@ -5,6 +5,7 @@
  */
 
 import type {
+  CapabilityPolicyFsAccess,
   ExecutorPulse,
   ExecutorTerminationCompleteInput,
   SdkFailure,
@@ -54,6 +55,7 @@ import {
   update,
 } from '../database-wrapper';
 import { type SessionRow, sessions, type TaskInsert, type TaskRow, tasks, users } from '../schema';
+import { getCurrentTenantId } from '../tenant-context';
 import {
   AmbiguousIdError,
   type BaseRepository,
@@ -62,7 +64,11 @@ import {
   RepositoryError,
   resolveByShortIdPrefix,
 } from './base';
-import { visibleSessionReferenceAccessExists } from './branch-access';
+import {
+  resolveSessionRuntimeBranchAccess,
+  visibleSessionReferenceAccessExists,
+} from './branch-access';
+import { ExecutorSessionTokenAuthorityRepository } from './executor-session-token-authorities';
 import { deepMerge } from './merge-utils';
 
 function executorOwnsTask(row: Pick<TaskRow, 'status' | 'executor_connected_at'>): boolean {
@@ -99,6 +105,16 @@ function isSQLiteBusyError(error: unknown): boolean {
     return true;
   }
   return 'cause' in error && isSQLiteBusyError(error.cause);
+}
+
+function fsAccessRank(access: CapabilityPolicyFsAccess): number {
+  return access === 'write' ? 2 : access === 'read' ? 1 : 0;
+}
+
+function requireRuntimeTenantId(): string {
+  const tenantId = getCurrentTenantId();
+  if (!tenantId) throw new RepositoryError('Runtime authority tenant scope is unavailable');
+  return tenantId;
 }
 
 function withTerminalTiming(
@@ -140,6 +156,45 @@ export interface TerminationClaimInput {
   requireExecutorDisconnected?: boolean;
   now?: Date;
 }
+
+export interface ExecutorLaunchAuthorityOptions {
+  branchRbacEnabled: boolean;
+  allowSuperadmin: boolean;
+}
+
+export interface ExecutorLaunchAuthority {
+  principal_user_id: string;
+  session_id: string;
+  branch_id: string;
+  fs_access: CapabilityPolicyFsAccess;
+}
+
+/** Server-authenticated Task-token scope supplied to the repository hot path. */
+export interface TaskRuntimeAuthorityScope extends ExecutorLaunchAuthorityOptions {
+  token_fingerprint: string;
+  principal_user_id: string;
+  session_id: string;
+  branch_id: string;
+  /** O(1) standalone authority decision; PostgreSQL validates its durable row in-transaction. */
+  standalone_token_current?: boolean;
+}
+
+export type RuntimeTelemetryAuthorityDenialReason =
+  | 'token_revoked'
+  | 'principal_unavailable'
+  | 'branch_capability_revoked'
+  | 'filesystem_access_revoked'
+  | 'launch_authority_missing';
+
+export type RuntimeTelemetryReportResult =
+  | { outcome: 'continued'; task: Task }
+  | { outcome: 'control'; task: Task }
+  | { outcome: 'scope_mismatch'; task: Task }
+  | {
+      outcome: 'authorization_revoked';
+      task: Task;
+      reason: RuntimeTelemetryAuthorityDenialReason;
+    };
 
 export interface TerminationClaimResult {
   outcome: 'claimed' | 'unchanged' | 'condition_changed' | 'terminal';
@@ -366,6 +421,8 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
    */
   private rowToTask(row: TaskRow): Task {
     const storedTerminationRequest = row.data.termination_request;
+    const { executor_launch_fs_access_floor: _executorLaunchFsAccessFloor, ...publicData } =
+      row.data;
     const coordination: TerminationCoordinationClaim | undefined =
       row.termination_coordination_token &&
       row.termination_coordination_claimed_at &&
@@ -395,7 +452,7 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
         ? new Date(row.last_executor_heartbeat_at).toISOString()
         : undefined,
       created_by: row.created_by,
-      ...row.data,
+      ...publicData,
       ...(storedTerminationRequest
         ? {
             termination_request: {
@@ -1083,20 +1140,142 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
     });
   }
 
-  /** Atomically stamp heartbeat time and advance the latest pulse fact. */
+  /**
+   * Resolve and immutably bind the filesystem floor used for one Task launch.
+   *
+   * Task.created_by and Task -> Session -> Branch are the only principal and
+   * resource sources. A retry may observe the same floor, but it can never
+   * replace a write projection with read/none (or read with none).
+   */
+  async bindExecutorLaunchAuthority(
+    id: string,
+    options: ExecutorLaunchAuthorityOptions
+  ): Promise<ExecutorLaunchAuthority> {
+    return this.mutateLockedTask(id, async (txDb, row, fullId) => {
+      if (
+        row.status !== TaskStatus.DISPATCHING ||
+        row.executor_connected_at ||
+        row.data.termination_request
+      ) {
+        throw new RepositoryError('Task is not awaiting executor launch authority');
+      }
+      const access = await resolveSessionRuntimeBranchAccess(txDb, {
+        sessionId: row.session_id,
+        principalUserId: row.created_by,
+        ...options,
+      });
+      if (!access?.can_prompt_session) {
+        throw new RepositoryError('Authorization to launch this task is unavailable');
+      }
+
+      const existingFloor = row.data.executor_launch_fs_access_floor;
+      const requestedFloor = access.fs_access;
+      if (existingFloor && fsAccessRank(access.fs_access) < fsAccessRank(existingFloor)) {
+        throw new RepositoryError('Authorization to launch this task is unavailable');
+      }
+      const floor = existingFloor ?? requestedFloor;
+      const data = existingFloor
+        ? row.data
+        : { ...row.data, executor_launch_fs_access_floor: floor };
+      if (!existingFloor) {
+        await update(txDb, tasks).set({ data }).where(eq(tasks.task_id, fullId)).run();
+      }
+      return {
+        principal_user_id: row.created_by,
+        session_id: row.session_id,
+        branch_id: access.branch_id,
+        fs_access: floor,
+      };
+    });
+  }
+
+  /**
+   * Revalidate exact runtime authority, then atomically stamp heartbeat/pulse.
+   * Explicit denial returns the unchanged Task so the service can claim the
+   * existing fenced termination path. Store/query errors throw and roll back,
+   * leaving the stale-heartbeat supervisor as the existing bounded backstop.
+   */
   async reportRuntimeTelemetry(
     id: string,
+    authority: TaskRuntimeAuthorityScope,
     pulse?: Omit<ExecutorPulse, 'observed_at'>,
     observedAt?: Date
-  ): Promise<Task | null> {
+  ): Promise<RuntimeTelemetryReportResult> {
     return this.mutateLockedTask(id, async (txDb, row, fullId) => {
+      const current = this.rowToTask(row);
       // STOPPING remains executor-owned until the scoped executor reports
       // quiescence. An unverified containment guard is not proof of absence,
       // so a still-live executor may continue publishing useful evidence and
       // eventually recover the request with a late task/request-fenced ack.
-      if (!executorMayReportTelemetry(row)) return null;
+      if (!executorMayReportTelemetry(row)) return { outcome: 'control', task: current };
 
-      const heartbeatAt = await this.mutationNow(txDb, fullId, observedAt);
+      const access = await resolveSessionRuntimeBranchAccess(txDb, {
+        sessionId: row.session_id,
+        principalUserId: row.created_by,
+        branchRbacEnabled: authority.branchRbacEnabled,
+        allowSuperadmin: authority.allowSuperadmin,
+      });
+      if (
+        authority.principal_user_id !== row.created_by ||
+        authority.session_id !== row.session_id ||
+        !access ||
+        authority.branch_id !== access.branch_id
+      ) {
+        return { outcome: 'scope_mismatch', task: current };
+      }
+
+      const floor = row.data.executor_launch_fs_access_floor;
+      if (!floor) {
+        return {
+          outcome: 'authorization_revoked',
+          task: current,
+          reason: 'launch_authority_missing',
+        };
+      }
+      if (!access.principal_available) {
+        return {
+          outcome: 'authorization_revoked',
+          task: current,
+          reason: 'principal_unavailable',
+        };
+      }
+      if (!access.can_prompt_session) {
+        return {
+          outcome: 'authorization_revoked',
+          task: current,
+          reason: 'branch_capability_revoked',
+        };
+      }
+      if (fsAccessRank(access.fs_access) < fsAccessRank(floor)) {
+        return {
+          outcome: 'authorization_revoked',
+          task: current,
+          reason: 'filesystem_access_revoked',
+        };
+      }
+
+      const tokenCurrent = isPostgresDatabase(this.db)
+        ? await new ExecutorSessionTokenAuthorityRepository(txDb).isCurrent({
+            tenantId: requireRuntimeTenantId(),
+            tokenFingerprint: authority.token_fingerprint,
+            sessionId: authority.session_id,
+            taskId: fullId,
+            branchId: authority.branch_id,
+            userId: authority.principal_user_id,
+          })
+        : authority.standalone_token_current === true;
+      if (!tokenCurrent) {
+        return {
+          outcome: 'authorization_revoked',
+          task: current,
+          reason: 'token_revoked',
+        };
+      }
+
+      const heartbeatAt = observedAt ?? access.observed_at;
+      if (!Number.isFinite(heartbeatAt.getTime())) {
+        throw new RepositoryError('Runtime authority observation time is invalid');
+      }
 
       const previous = row.data.latest_executor_pulse;
       const latest =
@@ -1108,7 +1287,10 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
         .set({ last_executor_heartbeat_at: heartbeatAt, data })
         .where(eq(tasks.task_id, fullId))
         .run();
-      return this.rowToTask({ ...row, last_executor_heartbeat_at: heartbeatAt, data });
+      return {
+        outcome: 'continued',
+        task: this.rowToTask({ ...row, last_executor_heartbeat_at: heartbeatAt, data }),
+      };
     });
   }
 
@@ -1586,7 +1768,15 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
             termination_coordination_instance_id: insertData.termination_coordination_instance_id,
             termination_coordination_boot_id: insertData.termination_coordination_boot_id,
             termination_unverified_at: insertData.termination_unverified_at,
-            data: insertData.data,
+            data: {
+              ...insertData.data,
+              ...(currentRow.data.executor_launch_fs_access_floor
+                ? {
+                    executor_launch_fs_access_floor:
+                      currentRow.data.executor_launch_fs_access_floor,
+                  }
+                : {}),
+            },
           })
           .where(eq(tasks.task_id, fullId))
           .run();

--- a/packages/core/src/db/repositories/tasks.ts
+++ b/packages/core/src/db/repositories/tasks.ts
@@ -159,7 +159,6 @@ export interface TerminationClaimInput {
 
 export interface ExecutorLaunchAuthorityOptions {
   branchRbacEnabled: boolean;
-  allowSuperadmin: boolean;
 }
 
 export interface ExecutorLaunchAuthority {
@@ -1213,7 +1212,6 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
         sessionId: row.session_id,
         principalUserId: row.created_by,
         branchRbacEnabled: authority.branchRbacEnabled,
-        allowSuperadmin: authority.allowSuperadmin,
       });
       if (
         authority.principal_user_id !== row.created_by ||

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -398,6 +398,12 @@ export const tasks = pgTable(
         sdk_failure?: Task['sdk_failure'];
         termination_request?: Task['termination_request'];
         sdk_watchdog_mode?: Task['sdk_watchdog_mode'];
+        /**
+         * Immutable filesystem authority projected when this executor was
+         * launched. Internal repository fact; deliberately omitted from the
+         * public Task DTO and never accepted from executor writes.
+         */
+        executor_launch_fs_access_floor?: import('@agor/core/types').CapabilityPolicyFsAccess;
       }>()
       .notNull(),
   },

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -376,6 +376,12 @@ export const tasks = sqliteTable(
         sdk_failure?: Task['sdk_failure'];
         termination_request?: Task['termination_request'];
         sdk_watchdog_mode?: Task['sdk_watchdog_mode'];
+        /**
+         * Immutable filesystem authority projected when this executor was
+         * launched. Internal repository fact; deliberately omitted from the
+         * public Task DTO and never accepted from executor writes.
+         */
+        executor_launch_fs_access_floor?: import('@agor/core/types').CapabilityPolicyFsAccess;
       }>()
       .notNull(),
   },

--- a/packages/core/src/db/task-runtime-ha.postgres.test.ts
+++ b/packages/core/src/db/task-runtime-ha.postgres.test.ts
@@ -97,7 +97,6 @@ function runtimeAuthority(seed: TenantSeed, taskId: string) {
     session_id: seed.sessionId,
     branch_id: seed.branchId,
     branchRbacEnabled: true,
-    allowSuperadmin: false,
   };
 }
 
@@ -111,7 +110,6 @@ async function authorizeRuntime(
   const authority = runtimeAuthority(seed, task.task_id);
   await tasks.bindExecutorLaunchAuthority(task.task_id, {
     branchRbacEnabled: true,
-    allowSuperadmin: false,
   });
   await tasks.connectExecutor(task.task_id, connectedAt);
   const now = new Date();

--- a/packages/core/src/db/task-runtime-ha.postgres.test.ts
+++ b/packages/core/src/db/task-runtime-ha.postgres.test.ts
@@ -7,6 +7,7 @@
  *   pnpm --filter @agor/core exec vitest run src/db/task-runtime-ha.postgres.test.ts
  */
 
+import { createHash } from 'node:crypto';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { generateId } from '../lib/ids';
 import type { BranchID, SessionID, TaskID, UUID } from '../types/id';
@@ -17,12 +18,14 @@ import { isPostgresDatabase } from './database-wrapper';
 import { initializeDatabase } from './migrate';
 import {
   BranchRepository,
+  ExecutorSessionTokenAuthorityRepository,
   RepoRepository,
   SessionRepository,
   TaskRepository,
   UsersRepository,
 } from './repositories';
 import { runWithSystemDatabaseScope, runWithTenantDatabaseScope } from './tenant-scope';
+import { setTestBranchUserRole } from './test-helpers';
 
 const postgresUrl = process.env.AGOR_TEST_POSTGRES_URL;
 const usesPostgresSchema = process.env.AGOR_DB_DIALECT === 'postgresql';
@@ -38,6 +41,10 @@ interface TenantSeed {
 async function seedTenant(db: Database, label: string): Promise<TenantSeed> {
   const tenantId = `task-runtime-${label}-${generateId()}`;
   return runWithTenantDatabaseScope(db, tenantId, async (scoped) => {
+    const owner = await new UsersRepository(scoped).create({
+      email: `${tenantId}-owner@example.com`,
+      name: `Runtime ${label} owner`,
+    });
     const user = await new UsersRepository(scoped).create({
       email: `${tenantId}@example.com`,
       name: `Runtime ${label}`,
@@ -58,8 +65,16 @@ async function seedTenant(db: Database, label: string): Promise<TenantSeed> {
       ref: 'main',
       branch_unique_id: branchUnique++,
       path: `/tmp/${generateId()}`,
-      created_by: user.user_id,
+      created_by: owner.user_id,
     });
+    await setTestBranchUserRole(
+      scoped,
+      branch.branch_id,
+      user.user_id,
+      'collaborator',
+      'write',
+      owner.user_id
+    );
     const session = await new SessionRepository(scoped).create({
       session_id: generateId() as SessionID,
       branch_id: branch.branch_id,
@@ -73,6 +88,47 @@ async function seedTenant(db: Database, label: string): Promise<TenantSeed> {
       sessionId: session.session_id,
     };
   });
+}
+
+function runtimeAuthority(seed: TenantSeed, taskId: string) {
+  return {
+    token_fingerprint: createHash('sha256').update(taskId).digest('hex'),
+    principal_user_id: seed.userId,
+    session_id: seed.sessionId,
+    branch_id: seed.branchId,
+    branchRbacEnabled: true,
+    allowSuperadmin: false,
+  };
+}
+
+async function authorizeRuntime(
+  scoped: Database,
+  seed: TenantSeed,
+  task: { task_id: string },
+  connectedAt: Date
+) {
+  const tasks = new TaskRepository(scoped);
+  const authority = runtimeAuthority(seed, task.task_id);
+  await tasks.bindExecutorLaunchAuthority(task.task_id, {
+    branchRbacEnabled: true,
+    allowSuperadmin: false,
+  });
+  await tasks.connectExecutor(task.task_id, connectedAt);
+  const now = new Date();
+  await new ExecutorSessionTokenAuthorityRepository(scoped).issue({
+    tenantId: seed.tenantId,
+    tokenFingerprint: authority.token_fingerprint,
+    tokenType: 'executor-session',
+    purpose: 'executor-task',
+    sessionId: seed.sessionId,
+    taskId: task.task_id,
+    branchId: seed.branchId,
+    userId: seed.userId,
+    createdAt: now,
+    expiresAt: new Date(now.getTime() + 60_000),
+    maxUses: -1,
+  });
+  return authority;
 }
 
 function taskInput(seed: TenantSeed, status: TaskStatus, overrides: Record<string, unknown> = {}) {
@@ -95,47 +151,103 @@ function taskInput(seed: TenantSeed, status: TaskStatus, overrides: Record<strin
 
 describe.skipIf(!postgresUrl || !usesPostgresSchema)('Task runtime HA (PostgreSQL)', () => {
   let db: Database;
+  let peerDb: Database;
 
   beforeAll(async () => {
     db = createDatabase({ dialect: 'postgresql', url: postgresUrl! });
+    peerDb = createDatabase({ dialect: 'postgresql', url: postgresUrl! });
     await initializeDatabase(db);
     if (!isPostgresDatabase(db)) throw new Error('PostgreSQL test requires PostgreSQL');
   });
 
   afterAll(async () => {
     await (db as Database & { $client: { end: () => Promise<void> } }).$client.end();
+    await (peerDb as Database & { $client: { end: () => Promise<void> } }).$client.end();
   });
 
   it('lets a second daemon accept heartbeats without changing the Task or its queue', async () => {
     const seed = await seedTenant(db, 'heartbeat-handoff');
-    const { active, queued } = await runWithTenantDatabaseScope(
+    const { active, queued, authority } = await runWithTenantDatabaseScope(
       db,
       seed.tenantId,
       async (scoped) => {
         const tasks = new TaskRepository(scoped);
         const active = await tasks.create(
-          taskInput(seed, TaskStatus.RUNNING, {
+          taskInput(seed, TaskStatus.DISPATCHING, {
             executor_mode: 'templated',
-            executor_connected_at: '2026-08-06T10:00:00.000Z',
-            last_executor_heartbeat_at: '2026-08-06T10:00:01.000Z',
           })
+        );
+        const authority = await authorizeRuntime(
+          scoped,
+          seed,
+          active,
+          new Date('2026-08-06T10:00:01.000Z')
         );
         const queued = await tasks.create(
           taskInput(seed, TaskStatus.QUEUED, { queue_position: 1 })
         );
-        return { active, queued };
+        return { active, queued, authority };
       }
     );
 
-    await runWithTenantDatabaseScope(db, seed.tenantId, async (scoped) => {
+    let refreshedAt: string | undefined;
+    await runWithTenantDatabaseScope(peerDb, seed.tenantId, async (scoped) => {
       // A separately constructed repository represents daemon B receiving the
       // detached/remote executor's next authenticated heartbeat.
       const daemonB = new TaskRepository(scoped);
-      await daemonB.reportRuntimeTelemetry(active.task_id, undefined);
+      await expect(
+        daemonB.reportRuntimeTelemetry(active.task_id, authority)
+      ).resolves.toMatchObject({ outcome: 'continued' });
+      refreshedAt = (await daemonB.findById(active.task_id))?.last_executor_heartbeat_at;
       expect(await daemonB.findById(active.task_id)).toMatchObject({ status: TaskStatus.RUNNING });
       expect(await daemonB.findById(queued.task_id)).toMatchObject({
         status: TaskStatus.QUEUED,
         queue_position: 1,
+      });
+    });
+    await runWithTenantDatabaseScope(db, seed.tenantId, (scoped) =>
+      new ExecutorSessionTokenAuthorityRepository(scoped).revoke(
+        authority.token_fingerprint,
+        seed.tenantId
+      )
+    );
+    await runWithTenantDatabaseScope(peerDb, seed.tenantId, async (scoped) => {
+      // Daemon A committed revocation while Redis/realtime fanout was missed.
+      // Daemon B's next normal heartbeat still denies from PostgreSQL.
+      const daemonB = new TaskRepository(scoped);
+      await expect(
+        daemonB.reportRuntimeTelemetry(active.task_id, authority)
+      ).resolves.toMatchObject({ outcome: 'authorization_revoked', reason: 'token_revoked' });
+      expect((await daemonB.findById(active.task_id))?.last_executor_heartbeat_at).toBe(
+        refreshedAt
+      );
+    });
+  });
+
+  it('observes a write-to-read policy demotion on a peer heartbeat', async () => {
+    const seed = await seedTenant(db, 'policy-demotion');
+    const { task, authority } = await runWithTenantDatabaseScope(
+      db,
+      seed.tenantId,
+      async (scoped) => {
+        const tasks = new TaskRepository(scoped);
+        const task = await tasks.create(taskInput(seed, TaskStatus.DISPATCHING));
+        const authority = await authorizeRuntime(scoped, seed, task, new Date());
+        return { task, authority };
+      }
+    );
+    await runWithTenantDatabaseScope(peerDb, seed.tenantId, (scoped) =>
+      new TaskRepository(scoped).reportRuntimeTelemetry(task.task_id, authority)
+    );
+    await runWithTenantDatabaseScope(db, seed.tenantId, (scoped) =>
+      setTestBranchUserRole(scoped, seed.branchId, seed.userId, 'collaborator', 'read')
+    );
+    await runWithTenantDatabaseScope(peerDb, seed.tenantId, async (scoped) => {
+      await expect(
+        new TaskRepository(scoped).reportRuntimeTelemetry(task.task_id, authority)
+      ).resolves.toMatchObject({
+        outcome: 'authorization_revoked',
+        reason: 'filesystem_access_revoked',
       });
     });
   });
@@ -168,7 +280,7 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)('Task runtime HA (PostgreSQ
 
   it('fences dispatch and stale-heartbeat races against newer executor facts', async () => {
     const seed = await seedTenant(db, 'fact-races');
-    const { dispatch, running } = await runWithTenantDatabaseScope(
+    const { dispatch, running, runningAuthority } = await runWithTenantDatabaseScope(
       db,
       seed.tenantId,
       async (scoped) => {
@@ -180,13 +292,17 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)('Task runtime HA (PostgreSQ
           })
         );
         const running = await tasks.create(
-          taskInput(seed, TaskStatus.RUNNING, {
+          taskInput(seed, TaskStatus.DISPATCHING, {
             executor_mode: 'templated',
-            executor_connected_at: '2000-01-01T00:00:00.000Z',
-            last_executor_heartbeat_at: '2000-01-01T00:00:01.000Z',
           })
         );
-        return { dispatch, running };
+        const runningAuthority = await authorizeRuntime(
+          scoped,
+          seed,
+          running,
+          new Date('2000-01-01T00:00:01.000Z')
+        );
+        return { dispatch, running, runningAuthority };
       }
     );
 
@@ -208,7 +324,7 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)('Task runtime HA (PostgreSQ
     await runWithTenantDatabaseScope(db, seed.tenantId, async (scoped) => {
       const daemonB = new TaskRepository(scoped);
       await daemonB.connectExecutor(dispatchRef.task_id);
-      await daemonB.reportRuntimeTelemetry(running.task_id, undefined);
+      await daemonB.reportRuntimeTelemetry(running.task_id, runningAuthority);
 
       const daemonA = new TaskRepository(scoped);
       await expect(

--- a/packages/core/src/types/capability-policy.ts
+++ b/packages/core/src/types/capability-policy.ts
@@ -3,6 +3,10 @@ import type { BoardID, GroupID, UserID, UUID } from './id';
 /** Canonical board/branch capability-policy contract. */
 export const CAPABILITY_POLICY_SCHEMA_VERSION = 1 as const;
 
+/** Durable workspace-preference identifiers used by shared-session policy. */
+export const CAPABILITY_POLICY_WORKSPACE_PREFERENCES_NAMESPACE = 'workspace_preferences' as const;
+export const CAPABILITY_POLICY_SESSION_SHARING_KEY = 'session_sharing_enabled' as const;
+
 export type CapabilityPolicySchemaVersion = typeof CAPABILITY_POLICY_SCHEMA_VERSION;
 export type CapabilityPolicySharingMode = 'private' | 'shared';
 export type CapabilityPolicyBindingMode = 'inherit' | 'override';

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -83,7 +83,12 @@ export type TerminationCause =
   | 'user_stop'
   | 'startup_timeout'
   | 'heartbeat_lost'
-  | 'sdk_health_failure';
+  | 'sdk_health_failure'
+  | 'authorization_revoked';
+
+/** Fixed server/executor copy for runtime authorization withdrawal. */
+export const AUTHORIZATION_REVOKED_TERMINATION_MESSAGE =
+  'Authorization to continue this task was revoked.';
 
 /** Why a durable termination request is waiting for another HA coordinator. */
 export const TERMINATION_COORDINATION_PENDING_CODES = [

--- a/packages/executor/src/executor-heartbeat.test.ts
+++ b/packages/executor/src/executor-heartbeat.test.ts
@@ -40,26 +40,33 @@ describe('startExecutorHeartbeat', () => {
     }
   });
 
-  it('forwards the durable Task response so a replacement daemon can request stop', async () => {
+  it('forwards authorization termination control without treating it as a retryable write failure', async () => {
     vi.useFakeTimers();
     try {
       const stopping = {
         task_id: 'task-1',
         status: 'stopping',
-        termination_request: { cause: 'user_stop', requested_at: '2026-08-06T12:00:00.000Z' },
+        termination_request: {
+          cause: 'authorization_revoked',
+          requested_at: '2026-08-06T12:00:00.000Z',
+          error_message: 'Authorization to continue this task was revoked.',
+        },
       };
       const reportRuntimeTelemetry = vi.fn().mockResolvedValue(stopping);
       const onTask = vi.fn();
+      const warn = vi.fn();
       const client = { service: () => ({ reportRuntimeTelemetry }) } as never;
       const handle = startExecutorHeartbeat({
         client,
         taskId: 'task-1',
         intervalMs: 1000,
         onTask,
+        warn,
       });
 
       await vi.advanceTimersByTimeAsync(0);
       expect(onTask).toHaveBeenCalledWith(stopping);
+      expect(warn).not.toHaveBeenCalled();
       handle.stop();
     } finally {
       vi.useRealTimers();

--- a/packages/executor/src/index.test.ts
+++ b/packages/executor/src/index.test.ts
@@ -17,6 +17,7 @@ vi.mock('./handlers/sdk/tool-registry.js', () => ({
   ToolRegistry: { execute: runtime.execute },
 }));
 
+import { AUTHORIZATION_REVOKED_TERMINATION_MESSAGE } from '@agor/core/types';
 import { AgorExecutor } from './index.js';
 import { globalPermissionManager } from './permissions/permission-manager.js';
 
@@ -111,9 +112,10 @@ describe('AgorExecutor watchdog handoff', () => {
     expect(exit).toHaveBeenCalledWith(70);
   });
 
-  it('aborts immediately but retains liveness until it can report quiescence', async () => {
+  it('exits authorization revocation cooperatively with a sanitized message and quiescence ack', async () => {
     const reportTerminationComplete = vi.fn().mockResolvedValue({});
     const heartbeatStop = vi.fn();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     const executor = new AgorExecutor({
       sessionToken: 'token',
       sessionId: 'session-1',
@@ -128,7 +130,7 @@ describe('AgorExecutor watchdog handoff', () => {
       heartbeat: { stop: typeof heartbeatStop } | null;
       abortController: AbortController;
       handleTaskLifecycleUpdate(task: unknown): void;
-      reportTerminationComplete(): Promise<void>;
+      recoverTerminationAfterExecutionError(): Promise<boolean>;
     };
     executor.client = { service: () => ({ reportTerminationComplete }) };
     executor.heartbeat = { stop: heartbeatStop };
@@ -137,14 +139,17 @@ describe('AgorExecutor watchdog handoff', () => {
       task_id: 'task-1',
       status: 'stopping',
       termination_request: {
-        cause: 'user_stop',
+        cause: 'authorization_revoked',
         requested_at: '2026-07-23T12:00:00.000Z',
+        error_message: AUTHORIZATION_REVOKED_TERMINATION_MESSAGE,
       },
     });
 
     expect(executor.abortController.signal.aborted).toBe(true);
+    expect(warn).toHaveBeenCalledWith(AUTHORIZATION_REVOKED_TERMINATION_MESSAGE);
     expect(heartbeatStop).not.toHaveBeenCalled();
-    await executor.reportTerminationComplete();
+    // `run()` maps this recovered result to its normal code-0 exit path.
+    await expect(executor.recoverTerminationAfterExecutionError()).resolves.toBe(true);
     expect(reportTerminationComplete).toHaveBeenCalledWith({
       task_id: 'task-1',
       requested_at: '2026-07-23T12:00:00.000Z',

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -24,7 +24,7 @@ import type {
   Task,
   TaskID,
 } from '@agor/core/types';
-import { TaskStatus } from '@agor/core/types';
+import { AUTHORIZATION_REVOKED_TERMINATION_MESSAGE, TaskStatus } from '@agor/core/types';
 import { patchConsole } from '@agor/core/utils/logger';
 import { type ExecutorHeartbeatHandle, startExecutorHeartbeat } from './executor-heartbeat.js';
 import type { ResolvedConfigSlice } from './payload-types.js';
@@ -236,6 +236,9 @@ export class AgorExecutor {
       `[executor.stop] event=request_observed task_id=${shortId(this.config.taskId)} ` +
         `cause=${task.termination_request.cause} source=${source}`
     );
+    if (task.termination_request.cause === 'authorization_revoked') {
+      console.warn(AUTHORIZATION_REVOKED_TERMINATION_MESSAGE);
+    }
     markCoordinatorTerminationAbort(this.abortController);
     // Keep task-scoped heartbeat/pulse reporting alive until ToolRegistry.execute
     // and provider cleanup actually return. STOPPING is still live work; hiding


### PR DESCRIPTION
## Linked issue

Related: preset-io/agor-cloud#426

## Summary

- revalidate the exact Task executor principal, Task/Session/Branch binding, Branch prompt capability, and effective filesystem access on the existing executor heartbeat
- bind the launch-time filesystem floor privately in existing Task JSON so demotions terminate while increases never widen live mounts
- route authorization withdrawal through the existing fenced `STOPPING` coordinator and clean executor quiescence path
- show a reload-stable inline Task alert to authorized viewers using the already-persisted revoked cause and sanitized error, without creating a transcript message or toast
- validate PostgreSQL task-token authority durably on every heartbeat while keeping Redis notifications optional
- document the hot-path query shape, existing indexes, measured SQLite cost, rollout behavior, and terminal residual boundary

## Why / context

A task-scoped executor previously retained its launch authority until completion. Branch policy changes, user removal, and token revocation could therefore leave a live runtime refreshing durable liveness after its authority had changed.

This keeps the existing approximately 10-second `reportRuntimeTelemetry` call as the sole polling path. The daemon derives all identity and resource scope from the authenticated credential and locked Task, evaluates current normalized capability policy before the heartbeat write, and fails closed without introducing another endpoint, watchdog, table, cache, epoch, or Redis correctness dependency.

## Implementation notes

- `executor_launch_fs_access_floor` is an immutable private Task JSON fact written before credential issuance and stripped from public Task DTOs.
- Launch and heartbeat share the same bounded Session/Branch access projection in `branch-access.ts`. It deliberately excludes global superadmin bypass; prompt and filesystem authority come only from normalized Branch policy. Foreign prompting additionally requires the workspace gate, the effective Branch gate, and an immutable branch-home Session scope.
- PostgreSQL checks the exact task-token fingerprint and tenant/user/Task/Session/Branch tuple in the heartbeat transaction. The service commits that short authority unit before a denied heartbeat enters the existing termination claim, avoiding lock inversion with the outer tenant request transaction.
- SQLite retains its existing process-local authority model but keys it by SHA-256 fingerprint rather than raw bearer.
- Explicit denial uses the new `authorization_revoked` termination cause and fixed sanitized message.
- Store/query uncertainty does not refresh liveness; the existing stale-heartbeat supervisor supplies the bound.
- A current access increase does not modify the launch floor or remount a live executor.
- A failed authorization-revoked Task renders `Task access revoked` from its durable Task projection. This is UI-only, remains visible after reload, and deliberately does not create a Message row, alter future model context, or try to notify a principal who no longer has Branch view access.
- RBAC-disabled deployments retain their existing admission contract: any existing member may launch against the Session and receives the legacy write projection.

### Hot-path work

| Dialect | Successful heartbeat |
| --- | --- |
| SQLite | Task PK read, one access projection, Task PK update, plus one O(1) local fingerprint lookup |
| PostgreSQL | Task `FOR UPDATE`, Task PK read, one access projection, token-fingerprint PK read, Task PK update |

This is a net increase of one PostgreSQL domain statement over the previous heartbeat. PostgreSQL runs the five statements in a short fresh tenant-write transaction so its Task lock commits before a denied termination claim. Request/RLS scaffolding remains bounded: current-user PK reads, constant tenant-write-gate probes, tenant `set_config`, transaction control, and one repository savepoint. The access projection uses the existing Session/Branch/config/direct-entry/group/app-variable indexes and performs no list scans or N+1 queries. The Branch sharing switch comes from the already joined effective config, and Session home scope comes from the Session PK row.

A local file-backed LibSQL run of 100 sequential successful repository heartbeats took 1.219 seconds total (about 12.2 ms per heartbeat) in the development container. A live PostgreSQL/RLS capture measured the five domain statements at 0.025, 0.016, 0.057, 0.011, and 0.162 ms respectively: 0.271 ms total database execution time before transaction scaffolding; local commit took 1.086 ms.

## Validation / test plan

- [x] `pnpm i`
- [x] `pnpm check`
- [x] Core focused tests: 128 passed, 7 PostgreSQL-gated tests skipped
- [x] Daemon authority-focused tests: 23 passed, 2 PostgreSQL-gated tests skipped
- [x] Executor focused tests: 13 passed
- [x] Post-rebase validation against current main: core and daemon typechecks; focused core capability/runtime-authority, daemon heartbeat/runtime-authority, and executor heartbeat suites (43 passed)
- [x] SQLite coverage for continue, principal removal, capability revocation, write/read demotions, access increase without widening, wrong scope, stale/revoked token, missing legacy launch floor, superadmin policy parity, foreign-sharing revocation, and RBAC-disabled foreign-session launch/heartbeat
- [x] Executor coverage proving heartbeat termination control reaches `onTask`, is not swallowed by retry handling, aborts cooperatively, acknowledges quiescence, and selects the code-0 recovery path
- [x] PostgreSQL/RLS/two-client tests added for peer heartbeat, missed notification, durable token revocation, policy demotion, and cross-tenant denial
- [x] Live PostgreSQL/RLS run: revoked a write grant during `sleep 90`; the next scheduled heartbeat denied without refreshing liveness, committed before termination claim, returned the sanitized authorization-revoked control, and the executor exited cleanly with code 0
- [x] Live timing: denial heartbeat started about 1.28 seconds after revocation and the Task reached its fenced failed state about 1.41 seconds after revocation; Redis was absent
- [x] Live SQL capture: successful heartbeat executed five bounded domain statements totaling 0.271 ms of PostgreSQL execution time before transaction scaffolding
- [x] Post-live-fix checks: `pnpm check`; 25 focused daemon tests and 12 SQLite runtime-authority tests
- [x] UI projection: 17 focused TaskBlock tests, including the rendered durable authorization-revoked alert; UI typecheck and focused Biome check

## Risks / rollout / rollback

- Runtimes launched by an older daemon do not have a trustworthy launch floor. This is a coordinated, non-rolling daemon contract change: quiesce prompt/Task admission, drain active Tasks, stop or replace every old daemon replica, then reopen admission on the new cohort. A zero-downtime rollout would require a separate version/admission fence or bridge release.
- Current user lifecycle represents deactivation/offboarding as principal absence. A future persisted active-state field must be included in the point projection.
- Rollback removes heartbeat revalidation but leaves the private JSON field harmless and ignored by older code.

## Out of scope / follow-ups

Web terminals do not share the Task heartbeat. Dynamic terminal authority parity remains out of scope and should be tracked as a separate focused lifecycle issue.




