### PR TITLE
fix(db): let migration 0095 reach every tenant under forced RLS

### DIFF
--- a/packages/core/drizzle/postgres/0095_board_branch_capability_policies.sql
+++ b/packages/core/drizzle/postgres/0095_board_branch_capability_policies.sql
@@ -1,5 +1,22 @@
 SET LOCAL lock_timeout = '3s';
 --> statement-breakpoint
+-- Drop FORCE RLS so the owning migrate role sees every tenant during the
+-- cross-tenant backfill/normalization below; without this the statements run
+-- against only the 'default' tenant and SET NOT NULL fails. Restored at the end.
+ALTER TABLE "boards" NO FORCE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "branches" NO FORCE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "users" NO FORCE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "board_owners" NO FORCE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "branch_owners" NO FORCE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "board_group_grants" NO FORCE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "branch_group_grants" NO FORCE ROW LEVEL SECURITY;
+--> statement-breakpoint
 -- Offline/big-bang RBAC remodel. No runtime dual-read/dual-write bridge is retained.
 ALTER TABLE "boards" ADD COLUMN "primary_owner_user_id" varchar(36);
 --> statement-breakpoint
@@ -361,3 +378,19 @@ ALTER TABLE branch_session_sharing_grants ENABLE ROW LEVEL SECURITY;
 ALTER TABLE branch_session_sharing_grants FORCE ROW LEVEL SECURITY;
 --> statement-breakpoint
 CREATE POLICY "tenant_isolation_branch_session_sharing_grants" ON "branch_session_sharing_grants" USING (tenant_id=COALESCE(NULLIF(current_setting('agor.tenant_id',true),''),'default')) WITH CHECK (tenant_id=COALESCE(NULLIF(current_setting('agor.tenant_id',true),''),'default'));
+--> statement-breakpoint
+
+-- Restore FORCE row-level security dropped at the top of this migration.
+ALTER TABLE "boards" FORCE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "branches" FORCE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "users" FORCE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "board_owners" FORCE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "branch_owners" FORCE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "board_group_grants" FORCE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "branch_group_grants" FORCE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Problem

Migration `0095_board_branch_capability_policies` cannot land on a populated
multi-tenant runtime database.

The migration is applied by the runtime **migrate role**, which *owns* the
runtime tables but is subject to `FORCE ROW LEVEL SECURITY`, and migrations run
with no `agor.tenant_id` set. Every tenant-isolation policy resolves to:

```
tenant_id = COALESCE(NULLIF(current_setting('agor.tenant_id', true), ''), 'default')
```

so with no tenant set the migrate role sees only the **`default`** tenant. As a
result `0095`'s cross-tenant work only touches `default`:

- the two `primary_owner_user_id` backfills (`UPDATE boards` / `UPDATE branches`),
- the `DO $$ … RAISE …` owner-attribution guard,
- every `INSERT … SELECT` that populates the new policy tables from
  `boards`/`branches`/`board_owners`/`branch_owners`/`board_group_grants`/
  `branch_group_grants`/`users`,
- the legacy `DELETE FROM board_owners` / `branch_owners` / `*_group_grants`.

On any database with more than the `default` tenant, the other tenants' rows are
skipped, so the new policy tables are under-populated and
`ALTER COLUMN primary_owner_user_id SET NOT NULL` then fails (`23502`) on the
rows the backfill never reached — aborting the migration.

This was observed on a real cell: physically 59 boards / 45 branches / 46 users
across 10 tenants, but as the migrate role `SELECT count(*) FROM boards` returns
`1` (only `default`). It slipped through because the only databases where `0095`
"succeeded" were empty (single seed tenant, 0 rows → `SET NOT NULL` trivially
passes).

## Fix

Drop `FORCE ROW LEVEL SECURITY` on the seven participating tables at the start of
the migration — the migrate role owns them, so it then bypasses its own RLS and
sees every tenant — and restore `FORCE` at the end. The net schema is unchanged
(all seven end forced again), so the drizzle snapshot is unaffected.

Editing `0095` in place (rather than adding a follow-up migration) is safe:
drizzle applies migrations by journal timestamp, not by content hash, so a
database that already applied the old `0095` (only empty ones could) will not
re-run it; and a follow-up migration could not help anyway because `0095` aborts
before any later migration runs.

The owner-attribution guard is intentionally unchanged: it still rejects a board
or branch that has no attributable owner.
