### PR TITLE
fix(executor): pass AGOR_CLOUD_* launcher credentials to the templated launcher

### DIFF
--- a/apps/agor-daemon/src/utils/spawn-executor.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.ts
@@ -83,15 +83,24 @@ function withDaemonExecutorEnv(
  * The executor's authenticated payload is sent over stdin; the intermediate
  * `sh -c <launcher>` must not inherit the daemon's database URL, JWT/master
  * secrets, provider credentials, or other ambient deployment configuration.
- * Operators that need launcher authentication must arrange it outside the
- * daemon environment (for example through the delegated substrate's workload
- * identity) rather than implicitly exporting the daemon's credential bag.
+ * The one exception is the launcher's own `AGOR_CLOUD_*` runtime-service
+ * credentials (issue #198); daemon-internal secrets stay withheld.
  */
 function resolveTemplateLauncherEnvironment(logLevel: string): Record<string, string> {
   return {
     ...buildAllowlistedEnv(),
+    ...launcherCredentialEnvironment(),
     LOG_LEVEL: logLevel,
   };
+}
+
+// AGOR_CLOUD_* runtime-service credentials the delegated launcher authenticates with.
+function launcherCredentialEnvironment(): Record<string, string> {
+  const credentials: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined && key.startsWith('AGOR_CLOUD_')) credentials[key] = value;
+  }
+  return credentials;
 }
 
 /** Set the daemon URL for executor payloads. Call once at daemon startup. */


### PR DESCRIPTION
## Problem

Delegated/templated executor launches fail before the executor pod is ever created:

```
agor-cloud-executor-launch: Missing required env AGOR_CLOUD_API_BASE_URL
Executor exited with code 1
```

The daemon container **has** `AGOR_CLOUD_API_BASE_URL` (and the other `AGOR_CLOUD_*`
runtime-service credentials), but the launcher it spawns does not — so it exits at its
required-env check and no ephemeral executor pod is spawned. Every cloud executor run
fails immediately ("Agor lost contact with the executor").

## Cause

The managed-environment-secrets hardening (#2561) switched the templated launcher's env
from the daemon's `process.env` to `resolveTemplateLauncherEnvironment` →
`buildAllowlistedEnv()`. That allowlist starts empty and only lets through `PATH`,
`HOME`, a couple `AGOR_AGENTIC_*`, `AGOR_VERSION`, and the `LC_` prefix — so **every
`AGOR_CLOUD_*` variable is stripped**.

The delegated launcher (`agor-cloud-executor-launch`) authenticates to its control plane
with exactly those variables (`AGOR_CLOUD_API_BASE_URL`,
`AGOR_CLOUD_RUNTIME_CREDENTIAL_ID`, `AGOR_CLOUD_RUNTIME_KEY_ID`,
`AGOR_CLOUD_RUNTIME_SIGNING_KEY`, `AGOR_CLOUD_CELL_ID` / `AGOR_CLOUD_INSTANCE_ID` +
`AGOR_CLOUD_TEAM_ID`; issue #198). The hardening correctly keeps the daemon's *internal*
secrets away from the launcher, but it also stripped the launcher's **own** credential
contract, which is delivered to the daemon specifically for it.

## Fix

Pass only the `AGOR_CLOUD_*` prefix — the launcher's designated auth — through to the
trusted templated launcher. Daemon-internal secrets (`DATABASE_URL`,
`AGOR_MASTER_SECRET`, provider keys) remain withheld, and the untrusted agent-session env
(`buildAllowlistedEnv`) is unchanged, so the hardening's intent is preserved.

Without this, executors are broken on any deployment that routes runs through
`agor-cloud-executor-launch --execute-ephemeral`.
