### PR TITLE
fix(executor): forward resolved provider credentials to templated executors

### DIFF
--- a/apps/agor-daemon/src/utils/spawn-executor.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.ts
@@ -32,6 +32,7 @@ import {
   resolveExecutorResponseTimeoutMs,
 } from '@agor/core/config';
 import { getCurrentTenantId } from '@agor/core/db';
+import { PROVIDER_CONNECTION_FIELDS } from '@agor/core/types';
 import {
   EXECUTOR_RESPONSE_PROTOCOL,
   type ExecutorCommandResult,
@@ -402,6 +403,30 @@ export function findExecutorPath(): string {
  * @param payload - JSON payload matching ExecutorPayload schema
  * @param options - Spawn options
  */
+// Provider credential/endpoint keys (e.g. claude-code → ANTHROPIC_*,
+// CLAUDE_CODE_OAUTH_TOKEN). Never the daemon's infra env (DAEMON_URL,
+// AGOR_DATA_HOME, response origin), which the ephemeral pod sets itself.
+const PROVIDER_ENV_KEYS: ReadonlySet<string> = new Set(
+  Object.values(PROVIDER_CONNECTION_FIELDS).flat()
+);
+
+// The templated (ephemeral-pod) executor inherits no daemon env — it only
+// applies the payload the executor CLI reads. spawnExecutorLocal passes the
+// resolved `preparedEnv` to the subprocess directly; the templated path must
+// instead forward the agent's resolved provider credentials through the payload
+// (persisted as a per-run Secret) or the delegated agent cannot authenticate.
+function forwardedProviderCredentialEnv(
+  source: Record<string, string> | undefined
+): Record<string, string> {
+  const forwarded: Record<string, string> = {};
+  if (!source) return forwarded;
+  for (const key of PROVIDER_ENV_KEYS) {
+    const value = source[key];
+    if (typeof value === 'string' && value.length > 0) forwarded[key] = value;
+  }
+  return forwarded;
+}
+
 export function spawnExecutor(
   payload: Record<string, unknown>,
   options: SpawnExecutorOptions = {}
@@ -419,7 +444,20 @@ export function spawnExecutor(
   };
 
   if (executorCommandTemplate) {
-    spawnExecutorWithTemplate(payloadWithConfig, {
+    const providerCredentialEnv = forwardedProviderCredentialEnv(
+      options.preparedEnv ?? options.env
+    );
+    const templatedPayload =
+      Object.keys(providerCredentialEnv).length > 0
+        ? {
+            ...payloadWithConfig,
+            env: {
+              ...(payloadWithConfig.env as Record<string, string> | undefined),
+              ...providerCredentialEnv,
+            },
+          }
+        : payloadWithConfig;
+    spawnExecutorWithTemplate(templatedPayload, {
       ...options,
       executorCommandTemplate,
       templateVariables: {


### PR DESCRIPTION
## Problem

Templated / ephemeral-pod executors (`agor-cloud-executor-launch --execute-ephemeral`, used for HA cells) run the agent with **no provider credentials**, so the model call returns empty — surfaced to the user as *"The provider ended the request without returning a model response."*

Local executors work: `spawnExecutorLocal` applies the daemon-resolved `preparedEnv` — which includes the per-tool credentials merged by `createUserProcessEnvironment(…, tool)` (e.g. `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_*`) — directly to the subprocess.

The templated path never forwards those credentials:
- `options.preparedEnv` is used only by `spawnExecutorLocal`.
- The launcher env is a curated allowlist (`buildAllowlistedEnv`), and the resolved-config slice embedded in the payload is deliberately **non-secret**.
- The ephemeral executor pod carries no provider env of its own.

The executor CLI already applies `payload.env` (structurally filtered — process-hijacking keys only, credentials pass), but the daemon never populates it. So the delegated agent has no credential and can't authenticate — the model stream ends empty.

## Fix

For the templated path, forward **only** the resolved provider credential/endpoint keys (`PROVIDER_CONNECTION_FIELDS` — e.g. claude-code → `ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_BASE_URL`) from `preparedEnv` into `payload.env`.

Never the daemon's infra env (`DAEMON_URL`, `AGOR_DATA_HOME`, response origin) — the ephemeral pod sets those itself, and clobbering them would break the executor's own wiring. The payload is persisted as a per-run Secret and consumed by the executor CLI's existing `payload.env` path, so nothing is exposed beyond the current boundary and local-executor behavior is unchanged.

Without this, agents cannot run on any deployment that routes through `--execute-ephemeral` (notably HA cells): the executor spawns and runs, but every model call returns empty.
