### PR TITLE
fix(executor): restore agent execution on ephemeral/HA cells (launcher creds + provider creds)

### DIFF
--- a/apps/agor-daemon/src/utils/spawn-executor.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.ts
@@ -83,15 +83,24 @@ function withDaemonExecutorEnv(
  * The executor's authenticated payload is sent over stdin; the intermediate
  * `sh -c <launcher>` must not inherit the daemon's database URL, JWT/master
  * secrets, provider credentials, or other ambient deployment configuration.
- * Operators that need launcher authentication must arrange it outside the
- * daemon environment (for example through the delegated substrate's workload
- * identity) rather than implicitly exporting the daemon's credential bag.
+ * The one exception is the launcher's own `AGOR_CLOUD_*` runtime-service
+ * credentials (issue #198); daemon-internal secrets stay withheld.
  */
 function resolveTemplateLauncherEnvironment(logLevel: string): Record<string, string> {
   return {
     ...buildAllowlistedEnv(),
+    ...launcherCredentialEnvironment(),
     LOG_LEVEL: logLevel,
   };
+}
+
+// AGOR_CLOUD_* runtime-service credentials the delegated launcher authenticates with.
+function launcherCredentialEnvironment(): Record<string, string> {
+  const credentials: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined && key.startsWith('AGOR_CLOUD_')) credentials[key] = value;
+  }
+  return credentials;
 }
 
 /** Set the daemon URL for executor payloads. Call once at daemon startup. */

--- a/apps/agor-daemon/src/utils/spawn-executor.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.ts
@@ -36,6 +36,7 @@ import {
   EXECUTOR_RESPONSE_PROTOCOL,
   type ExecutorCommandResult,
 } from '@agor/core/executor-protocol';
+import { PROVIDER_CONNECTION_FIELDS } from '@agor/core/types';
 import { isValidExecutionHomeKey } from '@agor/core/unix';
 import { getCurrentLogLevel } from '@agor/core/utils/logger';
 import type { SignOptions } from 'jsonwebtoken';
@@ -411,6 +412,30 @@ export function findExecutorPath(): string {
  * @param payload - JSON payload matching ExecutorPayload schema
  * @param options - Spawn options
  */
+// Provider credential/endpoint keys (e.g. claude-code → ANTHROPIC_*,
+// CLAUDE_CODE_OAUTH_TOKEN). Never the daemon's infra env (DAEMON_URL,
+// AGOR_DATA_HOME, response origin), which the ephemeral pod sets itself.
+const PROVIDER_ENV_KEYS: ReadonlySet<string> = new Set(
+  Object.values(PROVIDER_CONNECTION_FIELDS).flat()
+);
+
+// The templated (ephemeral-pod) executor inherits no daemon env — it only
+// applies the payload the executor CLI reads. spawnExecutorLocal passes the
+// resolved `preparedEnv` to the subprocess directly; the templated path must
+// instead forward the agent's resolved provider credentials through the payload
+// (persisted as a per-run Secret) or the delegated agent cannot authenticate.
+function forwardedProviderCredentialEnv(
+  source: Record<string, string> | undefined
+): Record<string, string> {
+  const forwarded: Record<string, string> = {};
+  if (!source) return forwarded;
+  for (const key of PROVIDER_ENV_KEYS) {
+    const value = source[key];
+    if (typeof value === 'string' && value.length > 0) forwarded[key] = value;
+  }
+  return forwarded;
+}
+
 export function spawnExecutor(
   payload: Record<string, unknown>,
   options: SpawnExecutorOptions = {}
@@ -428,7 +453,20 @@ export function spawnExecutor(
   };
 
   if (executorCommandTemplate) {
-    spawnExecutorWithTemplate(payloadWithConfig, {
+    const providerCredentialEnv = forwardedProviderCredentialEnv(
+      options.preparedEnv ?? options.env
+    );
+    const templatedPayload =
+      Object.keys(providerCredentialEnv).length > 0
+        ? {
+            ...payloadWithConfig,
+            env: {
+              ...(payloadWithConfig as { env?: Record<string, string> }).env,
+              ...providerCredentialEnv,
+            },
+          }
+        : payloadWithConfig;
+    spawnExecutorWithTemplate(templatedPayload, {
       ...options,
       executorCommandTemplate,
       templateVariables: {


### PR DESCRIPTION
Combines the two ephemeral/HA executor fixes (previously #2601 and #2602) into one branch so it can be built and applied in a single release.

## 1. Launcher credentials (was #2601)
The managed-environment-secrets hardening switched the templated launcher's env to `buildAllowlistedEnv` (`ALLOWED_ENV_PREFIXES=['LC_']`), stripping every `AGOR_CLOUD_*` var. `agor-cloud-executor-launch` authenticates with those runtime-service credentials, so it exited `Missing required env AGOR_CLOUD_API_BASE_URL` before spawning the executor pod — no executor ran at all. Fix: forward only the `AGOR_CLOUD_*` prefix to the trusted launcher; daemon-internal secrets stay withheld.

## 2. Provider credentials (was #2602)
With the launcher fixed, the executor pod spawns and runs — but the agent gets **no provider credential**, so every model call returns empty ("The provider ended the request without returning a model response"). `spawnExecutorLocal` applies the resolved `preparedEnv` (incl. `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_*`) directly, but the templated path never forwards it and the payload's config slice is non-secret. Fix: forward only the resolved provider credential/endpoint keys (`PROVIDER_CONNECTION_FIELDS`) into `payload.env` (already a per-run Secret) — never the daemon's infra env.

Together these restore end-to-end agent execution on ephemeral/HA cells. Both changes are in `apps/agor-daemon/src/utils/spawn-executor.ts`; local-executor behavior is unchanged.
