### PR TITLE
fix(ui): stop a Home click from wedging the app shell

### DIFF
--- a/apps/agor-ui/src/components/App/App.homeSurface.test.tsx
+++ b/apps/agor-ui/src/components/App/App.homeSurface.test.tsx
@@ -1,0 +1,403 @@
+/**
+ * Home-surface integration tests.
+ *
+ * Two defects, both of the form "the URL and the rendered surface disagree":
+ *
+ *   1. Clicking Home with a session open never reached `/`. React Router
+ *      commits `navigate()` inside a transition, so `setPendingHomeNavigation`
+ *      rendered once at the OLD path with the session already suppressed;
+ *      `useUrlState`'s state→URL self-heal read that transitional
+ *      (board, session=null) pair as authoritative and `replace()`d the URL
+ *      with `/b/<board>/`, cancelling the `/` push. `pendingHomeNavigation`
+ *      then stayed armed forever, because its only reset requires already
+ *      being at `/`. While armed, the shell renders Home for every non-entity
+ *      URL and forces `effectiveSelectedSessionId` to null — so the board
+ *      switcher moves the address bar while Home keeps rendering, and Home's
+ *      session rows resolve but never select.
+ *
+ *   2. Settings is a routed *overlay*: `/settings/...` owns the address bar
+ *      while the surface it was opened over stays mounted behind the modal.
+ *      Deriving the surface from `location.pathname` made opening Settings
+ *      over Home read as a navigation away from Home, swapping in the board
+ *      canvas underneath before the modal painted.
+ *
+ * They are written at the App level on purpose: each is an interaction
+ * between the route table, `useUrlState`'s two effects, and the shell's
+ * surface derivation. No single unit sees it.
+ */
+import type { Board, Branch, Session, SessionID, User } from '@agor-live/client';
+import { sessionPath } from '@agor-live/client';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { App as AntApp } from 'antd';
+import { forwardRef } from 'react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CanvasNavigationProvider, useRecenterMap } from '../../contexts/CanvasNavigationContext';
+import { ThemeProvider } from '../../contexts/ThemeContext';
+import { useSettingsRoute } from '../../hooks/useSettingsRoute';
+import { EMPTY_MAPS } from '../../store/agorMaps';
+import { agorStore } from '../../store/agorStore';
+import { App } from './App';
+
+// Surface stand-ins. Each renders the one attribute the assertions read, so
+// a test can say "the board canvas is showing Beta" without depending on
+// canvas internals.
+vi.mock('../SessionCanvas', () => ({
+  SessionCanvas: forwardRef((props: { board?: { name?: string } | null }) => (
+    <div data-testid="session-canvas" data-board={props.board?.name ?? ''} />
+  )),
+}));
+vi.mock('../SessionPanel', () => ({
+  SessionPanel: (props: { session?: { session_id?: string } | null; open?: boolean }) =>
+    props.open ? (
+      <div data-testid="session-panel" data-session={props.session?.session_id ?? ''} />
+    ) : null,
+}));
+vi.mock('../SessionPanel/PendingToolChoicePanel', () => ({
+  PendingToolChoicePanel: () => null,
+}));
+vi.mock('../EventStreamPanel', () => ({ EventStreamPanel: () => null }));
+vi.mock('../BoardTeammatePanel', () => ({
+  BoardTeammatePanel: () => null,
+  TeammatePanelRail: () => null,
+}));
+vi.mock('../NewSessionButton', () => ({ NewSessionButton: () => null }));
+vi.mock('../SettingsModal', () => ({
+  SettingsModal: (props: { open?: boolean }) =>
+    props.open ? <div data-testid="settings-modal" /> : null,
+  UserSettingsModal: () => null,
+}));
+vi.mock('../BranchModal', () => ({ BranchModal: () => null }));
+vi.mock('../CreateDialog', () => ({ CreateDialog: () => null }));
+vi.mock('../NewSessionModal', () => ({ NewSessionModal: () => null }));
+vi.mock('../SessionSettingsModal', () => ({ SessionSettingsModal: () => null }));
+vi.mock('../TerminalModal', () => ({
+  TerminalModal: () => null,
+  WEB_TERMINAL_MIN_ROLE: 'member',
+}));
+vi.mock('../ThemeEditorModal', () => ({ ThemeEditorModal: () => null }));
+vi.mock('../EnvironmentLogsModal', () => ({ EnvironmentLogsModal: () => null }));
+vi.mock('../../hooks/useTaskCompletionChime', () => ({ useTaskCompletionChime: () => {} }));
+// react-resizable-panels needs real layout measurements jsdom cannot provide,
+// and throws from the imperative handles App drives in effects.
+vi.mock('react-resizable-panels', async () => {
+  const React = await import('react');
+  const noopHandle = { collapse: () => {}, expand: () => {}, resize: () => {} };
+  const Panel = React.forwardRef<unknown, { children?: React.ReactNode }>(({ children }, ref) => {
+    React.useImperativeHandle(ref, () => noopHandle, []);
+    return <div>{children}</div>;
+  });
+  return {
+    Panel,
+    PanelGroup: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+    PanelResizeHandle: () => <div />,
+  };
+});
+
+const USER_ID = '019e6666-0000-7000-8000-000000000001';
+const BOARD_A = '019e7777-0000-7000-8000-00000000000a';
+const BOARD_B = '019e7777-0000-7000-8000-00000000000b';
+const BRANCH_A = '019e8888-0000-7000-8000-00000000000a';
+const BRANCH_B = '019e8888-0000-7000-8000-00000000000b';
+const SESSION_1 = '019e9999-0000-7000-8000-000000000001';
+const SESSION_2 = '019eaaaa-0000-7000-8000-000000000002';
+
+const boardA = { board_id: BOARD_A, name: 'Alpha', slug: 'alpha', archived: false } as Board;
+const boardB = { board_id: BOARD_B, name: 'Beta', slug: 'beta', archived: false } as Board;
+const branchA = {
+  branch_id: BRANCH_A,
+  repo_id: 'repo-1',
+  board_id: BOARD_A,
+  name: 'orbit',
+  archived: false,
+} as unknown as Branch;
+const branchB = {
+  branch_id: BRANCH_B,
+  repo_id: 'repo-1',
+  board_id: BOARD_B,
+  name: 'signal',
+  archived: false,
+} as unknown as Branch;
+const session1 = {
+  session_id: SESSION_1,
+  branch_id: BRANCH_A,
+  created_by: USER_ID,
+  title: 'Orbit standup',
+  status: 'idle',
+  archived: false,
+  genealogy: {},
+  agentic_tool: 'codex',
+  last_updated: '2026-08-25T12:00:00.000Z',
+} as unknown as Session;
+const session2 = {
+  session_id: SESSION_2,
+  branch_id: BRANCH_B,
+  created_by: USER_ID,
+  title: 'Signal triage',
+  status: 'idle',
+  archived: false,
+  genealogy: {},
+  agentic_tool: 'codex',
+  last_updated: '2026-08-25T11:00:00.000Z',
+} as unknown as Session;
+const user = {
+  user_id: USER_ID,
+  name: 'Tester',
+  email: 'tester@example.test',
+  role: 'admin',
+} as unknown as User;
+
+function seedStore() {
+  agorStore.setState({
+    ...EMPTY_MAPS,
+    boardById: new Map([
+      [BOARD_A, boardA],
+      [BOARD_B, boardB],
+    ]),
+    branchById: new Map([
+      [BRANCH_A, branchA],
+      [BRANCH_B, branchB],
+    ]),
+    sessionById: new Map([
+      [SESSION_1, session1],
+      [SESSION_2, session2],
+    ]),
+    sessionsByBranch: new Map([
+      [BRANCH_A, [session1]],
+      [BRANCH_B, [session2]],
+    ]),
+    userById: new Map([[user.user_id, user]]),
+  } as never);
+}
+
+let currentPath = '';
+function PathSpy() {
+  currentPath = useLocation().pathname;
+  return null;
+}
+
+/** Drives the real settings-route open path — the same call the gear menu
+ *  makes — so the test exercises `openSettings`'s history-state contract
+ *  rather than a hand-rolled navigate. */
+function SettingsOpener() {
+  const { openSettings } = useSettingsRoute();
+  return (
+    <button type="button" data-testid="open-settings" onClick={() => openSettings()}>
+      settings
+    </button>
+  );
+}
+
+/** Cross-board recenter — the one flow that moves App's board state with
+ *  no `navigate()` behind it, leaving the state→URL self-heal to carry the
+ *  address bar across. Stands in for a search hit / notification on another
+ *  board; SessionCanvas itself is mocked. */
+function CrossBoardRecenter() {
+  const recenterMap = useRecenterMap();
+  return (
+    <button
+      type="button"
+      data-testid="recenter-cross-board"
+      onClick={() => recenterMap(BRANCH_B, { boardId: BOARD_B })}
+    >
+      recenter
+    </button>
+  );
+}
+
+/** Route table mirrors `apps/agor-ui/src/App.tsx` — the bugs live in how
+ *  these paths resolve, so an approximation would not reproduce them. */
+function renderApp(initialPath: string) {
+  const el = (
+    <App client={null} user={user} connected={true} availableAgents={[]} initialBoardId="" />
+  );
+  return render(
+    <ThemeProvider>
+      <AntApp>
+        <MemoryRouter initialEntries={[initialPath]}>
+          <CanvasNavigationProvider>
+            <PathSpy />
+            <SettingsOpener />
+            <CrossBoardRecenter />
+            <Routes>
+              <Route path="/b/:boardParam/" element={el} />
+              <Route path="/s/:sessionShortId/" element={el} />
+              <Route path="/w/:branchShortId/" element={el} />
+              <Route path="/a/:artifactShortId/" element={el} />
+              <Route path="/*" element={el} />
+            </Routes>
+          </CanvasNavigationProvider>
+        </MemoryRouter>
+      </AntApp>
+    </ThemeProvider>
+  );
+}
+
+/** Let the router transition, both URL⇄state effects, and the deferred
+ *  recenter timer all settle. */
+async function settle() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 80));
+  });
+}
+
+const homeIsShowing = () => !!screen.queryByText(/Hi, Tester/);
+const canvasBoardName = () =>
+  screen.queryByTestId('session-canvas')?.getAttribute('data-board') ?? null;
+const openSessionId = () =>
+  screen.queryByTestId('session-panel')?.getAttribute('data-session') ?? null;
+
+function clickHomeButton() {
+  fireEvent.click(document.querySelector('[aria-label="Go to Home"]') as HTMLElement);
+}
+
+/** Open the navbar board switcher and choose a board by name. */
+async function pickBoardFromSwitcher(name: string) {
+  const trigger = document
+    .querySelector('[data-current-board-name]')
+    ?.closest('button') as HTMLElement;
+  fireEvent.click(trigger);
+  await settle();
+  const item = Array.from(document.querySelectorAll('[role="menuitem"]')).find((el) =>
+    el.textContent?.includes(name)
+  );
+  if (!item) throw new Error(`board "${name}" not offered by the switcher`);
+  fireEvent.click(item);
+  await settle();
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  seedStore();
+});
+
+describe('Settings opens as an overlay, not a navigation', () => {
+  it('keeps Home rendered behind the settings modal', async () => {
+    renderApp('/');
+    await settle();
+    expect(homeIsShowing()).toBe(true);
+
+    fireEvent.click(screen.getByTestId('open-settings'));
+    await settle();
+
+    expect(screen.getByTestId('settings-modal')).toBeTruthy();
+    // The reported symptom: Home tore down and the board canvas appeared
+    // behind the modal before it could open.
+    expect(homeIsShowing()).toBe(true);
+    expect(screen.queryByTestId('session-canvas')).toBeNull();
+  });
+
+  it('keeps the board canvas rendered behind the settings modal', async () => {
+    renderApp('/b/alpha/');
+    await settle();
+    expect(canvasBoardName()).toBe('Alpha');
+
+    fireEvent.click(screen.getByTestId('open-settings'));
+    await settle();
+
+    // Anti-overreach: reading the surface from the recorded origin must not
+    // turn every settings route into Home.
+    expect(screen.getByTestId('settings-modal')).toBeTruthy();
+    expect(canvasBoardName()).toBe('Alpha');
+    expect(homeIsShowing()).toBe(false);
+  });
+
+  it('falls back to the pathname for a cold-loaded settings URL', async () => {
+    // Shared link / hard refresh: no recorded origin in history state, so
+    // there is no prior surface to preserve.
+    renderApp('/settings/boards/');
+    await settle();
+
+    expect(screen.getByTestId('settings-modal')).toBeTruthy();
+    expect(screen.queryByTestId('session-canvas')).toBeTruthy();
+    expect(homeIsShowing()).toBe(false);
+  });
+});
+
+describe('Home navigation with a session open', () => {
+  it('reaches "/" instead of being replaced by the board URL', async () => {
+    renderApp(sessionPath(SESSION_1 as SessionID));
+    await settle();
+    expect(openSessionId()).toBe(SESSION_1);
+
+    clickHomeButton();
+    await settle();
+
+    // Before the fix this settled on `/b/alpha/`: the self-heal saw the
+    // transitional (board, session=null) pair and cancelled the `/` push.
+    expect(currentPath).toBe('/');
+    expect(homeIsShowing()).toBe(true);
+  });
+
+  it('leaves the board switcher working afterwards', async () => {
+    renderApp(sessionPath(SESSION_1 as SessionID));
+    await settle();
+    clickHomeButton();
+    await settle();
+
+    await pickBoardFromSwitcher('Beta');
+
+    // Reported symptom: the URL changed but the view stayed on Home,
+    // because `pendingHomeNavigation` was still armed.
+    expect(currentPath).toBe('/b/beta/');
+    expect(canvasBoardName()).toBe('Beta');
+    expect(homeIsShowing()).toBe(false);
+  });
+
+  it('leaves Home session rows selectable afterwards', async () => {
+    renderApp(sessionPath(SESSION_1 as SessionID));
+    await settle();
+    clickHomeButton();
+    await settle();
+
+    fireEvent.click(await screen.findByText('Signal triage'));
+    await settle();
+
+    // Reported symptom: the row click resolved and the URL changed, but
+    // nothing selected, because the wedged flag nulled the effective
+    // selection.
+    expect(currentPath).toBe(sessionPath(SESSION_2 as SessionID));
+    expect(openSessionId()).toBe(SESSION_2);
+  });
+
+  it('does not wedge when another navigation supersedes the Home click', async () => {
+    renderApp(sessionPath(SESSION_1 as SessionID));
+    await settle();
+    // Pre-open the switcher so the board can be chosen in the same tick as
+    // the Home click. The Home transition loses the race, and the pending
+    // flag must not survive landing somewhere that is not `/`.
+    const trigger = document
+      .querySelector('[data-current-board-name]')
+      ?.closest('button') as HTMLElement;
+    fireEvent.click(trigger);
+    await settle();
+    const betaItem = Array.from(document.querySelectorAll('[role="menuitem"]')).find((el) =>
+      el.textContent?.includes('Beta')
+    ) as HTMLElement;
+
+    clickHomeButton();
+    fireEvent.click(betaItem);
+    await settle();
+
+    expect(currentPath).toBe('/b/beta/');
+    expect(canvasBoardName()).toBe('Beta');
+    expect(homeIsShowing()).toBe(false);
+  });
+
+  it('still lets state heal the URL when no navigation is in flight', async () => {
+    renderApp('/b/alpha/');
+    await settle();
+    expect(canvasBoardName()).toBe('Alpha');
+
+    // Cross-board recenter asks App to switch boards through the canvas
+    // navigation channel — board state moves with no `navigate()` behind
+    // it, so the state→URL self-heal is the only thing that can carry the
+    // address bar across. Suspending it unconditionally would strand the
+    // URL on the old board.
+    fireEvent.click(screen.getByTestId('recenter-cross-board'));
+    await settle();
+
+    expect(canvasBoardName()).toBe('Beta');
+    expect(currentPath).toBe('/b/beta/');
+  });
+});

--- a/apps/agor-ui/src/components/App/App.homeSurface.test.tsx
+++ b/apps/agor-ui/src/components/App/App.homeSurface.test.tsx
@@ -1,51 +1,35 @@
 /**
- * Home-surface integration tests.
- *
- * Two defects, both of the form "the URL and the rendered surface disagree":
- *
- *   1. Clicking Home with a session open never reached `/`. React Router
- *      commits `navigate()` inside a transition, so `setPendingHomeNavigation`
- *      rendered once at the OLD path with the session already suppressed;
- *      `useUrlState`'s state→URL self-heal read that transitional
- *      (board, session=null) pair as authoritative and `replace()`d the URL
- *      with `/b/<board>/`, cancelling the `/` push. `pendingHomeNavigation`
- *      then stayed armed forever, because its only reset requires already
- *      being at `/`. While armed, the shell renders Home for every non-entity
- *      URL and forces `effectiveSelectedSessionId` to null — so the board
- *      switcher moves the address bar while Home keeps rendering, and Home's
- *      session rows resolve but never select.
- *
- *   2. Settings is a routed *overlay*: `/settings/...` owns the address bar
- *      while the surface it was opened over stays mounted behind the modal.
- *      Deriving the surface from `location.pathname` made opening Settings
- *      over Home read as a navigation away from Home, swapping in the board
- *      canvas underneath before the modal painted.
- *
- * They are written at the App level on purpose: each is an interaction
- * between the route table, `useUrlState`'s two effects, and the shell's
- * surface derivation. No single unit sees it.
+ * Shell integration contracts: committed routes select Home/board/session;
+ * Settings preserves its background; state-only recentering still heals URLs.
+ * Exercise the real router and sync effects, with layout-heavy surfaces mocked.
  */
 import type { Board, Branch, Session, SessionID, User } from '@agor-live/client';
 import { sessionPath } from '@agor-live/client';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { App as AntApp } from 'antd';
-import { forwardRef } from 'react';
-import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { forwardRef, useLayoutEffect } from 'react';
+import { MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { CanvasNavigationProvider, useRecenterMap } from '../../contexts/CanvasNavigationContext';
 import { ThemeProvider } from '../../contexts/ThemeContext';
+import { useAppNavigation } from '../../hooks/useAppNavigation';
 import { useSettingsRoute } from '../../hooks/useSettingsRoute';
 import { EMPTY_MAPS } from '../../store/agorMaps';
 import { agorStore } from '../../store/agorStore';
 import { App } from './App';
 
+const canvasCommit = vi.hoisted(() => vi.fn<(boardName: string | null) => void>());
+
 // Surface stand-ins. Each renders the one attribute the assertions read, so
 // a test can say "the board canvas is showing Beta" without depending on
 // canvas internals.
 vi.mock('../SessionCanvas', () => ({
-  SessionCanvas: forwardRef((props: { board?: { name?: string } | null }) => (
-    <div data-testid="session-canvas" data-board={props.board?.name ?? ''} />
-  )),
+  SessionCanvas: forwardRef((props: { board?: { name?: string } | null }, _ref) => {
+    useLayoutEffect(() => {
+      canvasCommit(props.board?.name ?? null);
+    });
+    return <div data-testid="session-canvas" data-board={props.board?.name ?? ''} />;
+  }),
 }));
 vi.mock('../SessionPanel', () => ({
   SessionPanel: (props: { session?: { session_id?: string } | null; open?: boolean }) =>
@@ -179,12 +163,28 @@ function PathSpy() {
 /** Drives the real settings-route open path — the same call the gear menu
  *  makes — so the test exercises `openSettings`'s history-state contract
  *  rather than a hand-rolled navigate. */
-function SettingsOpener() {
-  const { openSettings } = useSettingsRoute();
+function RouteControls() {
+  const { openSettings, closeSettings } = useSettingsRoute();
+  const { goToSession } = useAppNavigation();
+  const navigate = useNavigate();
   return (
-    <button type="button" data-testid="open-settings" onClick={() => openSettings()}>
-      settings
-    </button>
+    <>
+      <button type="button" data-testid="open-settings" onClick={() => openSettings()}>
+        settings
+      </button>
+      <button type="button" data-testid="close-settings" onClick={closeSettings}>
+        close settings
+      </button>
+      <button type="button" data-testid="open-session" onClick={() => goToSession(SESSION_2)}>
+        open session
+      </button>
+      <button type="button" data-testid="back" onClick={() => navigate(-1)}>
+        back
+      </button>
+      <button type="button" data-testid="forward" onClick={() => navigate(1)}>
+        forward
+      </button>
+    </>
   );
 }
 
@@ -217,7 +217,7 @@ function renderApp(initialPath: string) {
         <MemoryRouter initialEntries={[initialPath]}>
           <CanvasNavigationProvider>
             <PathSpy />
-            <SettingsOpener />
+            <RouteControls />
             <CrossBoardRecenter />
             <Routes>
               <Route path="/b/:boardParam/" element={el} />
@@ -269,6 +269,7 @@ async function pickBoardFromSwitcher(name: string) {
 beforeEach(() => {
   localStorage.clear();
   seedStore();
+  canvasCommit.mockClear();
 });
 
 describe('Settings opens as an overlay, not a navigation', () => {
@@ -285,6 +286,12 @@ describe('Settings opens as an overlay, not a navigation', () => {
     // behind the modal before it could open.
     expect(homeIsShowing()).toBe(true);
     expect(screen.queryByTestId('session-canvas')).toBeNull();
+
+    fireEvent.click(screen.getByTestId('close-settings'));
+    await settle();
+    expect(currentPath).toBe('/');
+    expect(homeIsShowing()).toBe(true);
+    expect(screen.queryByTestId('settings-modal')).toBeNull();
   });
 
   it('keeps the board canvas rendered behind the settings modal', async () => {
@@ -302,8 +309,21 @@ describe('Settings opens as an overlay, not a navigation', () => {
     expect(homeIsShowing()).toBe(false);
   });
 
+  it('keeps the selected session behind Settings and restores it on close', async () => {
+    renderApp(sessionPath(SESSION_1 as SessionID));
+    await settle();
+    fireEvent.click(screen.getByTestId('open-settings'));
+    await settle();
+    expect(openSessionId()).toBe(SESSION_1);
+    expect(canvasBoardName()).toBe('Alpha');
+    fireEvent.click(screen.getByTestId('close-settings'));
+    await settle();
+    expect(currentPath).toBe(sessionPath(SESSION_1 as SessionID));
+    expect(openSessionId()).toBe(SESSION_1);
+  });
+
   it('falls back to the pathname for a cold-loaded settings URL', async () => {
-    // Shared link / hard refresh: no recorded origin in history state, so
+    // Shared link: no recorded origin in history state, so
     // there is no prior surface to preserve.
     renderApp('/settings/boards/');
     await settle();
@@ -319,6 +339,7 @@ describe('Home navigation with a session open', () => {
     renderApp(sessionPath(SESSION_1 as SessionID));
     await settle();
     expect(openSessionId()).toBe(SESSION_1);
+    canvasCommit.mockClear();
 
     clickHomeButton();
     await settle();
@@ -327,6 +348,8 @@ describe('Home navigation with a session open', () => {
     // transitional (board, session=null) pair and cancelled the `/` push.
     expect(currentPath).toBe('/');
     expect(homeIsShowing()).toBe(true);
+    // No committed boardless canvas in between the old session and Home.
+    expect(canvasCommit).not.toHaveBeenCalledWith(null);
   });
 
   it('leaves the board switcher working afterwards', async () => {
@@ -375,13 +398,43 @@ describe('Home navigation with a session open', () => {
       el.textContent?.includes('Beta')
     ) as HTMLElement;
 
-    clickHomeButton();
-    fireEvent.click(betaItem);
+    // One act boundary keeps `/` from committing between the two intents.
+    act(() => {
+      clickHomeButton();
+      fireEvent.click(betaItem);
+    });
     await settle();
 
     expect(currentPath).toBe('/b/beta/');
     expect(canvasBoardName()).toBe('Beta');
     expect(homeIsShowing()).toBe(false);
+  });
+
+  it('opens a session when its navigation supersedes Home', async () => {
+    renderApp(sessionPath(SESSION_1 as SessionID));
+    await settle();
+    act(() => {
+      clickHomeButton();
+      fireEvent.click(screen.getByTestId('open-session'));
+    });
+    await settle();
+    expect(currentPath).toBe(sessionPath(SESSION_2 as SessionID));
+    expect(openSessionId()).toBe(SESSION_2);
+  });
+
+  it('restores the session on Back and Home on Forward', async () => {
+    renderApp(sessionPath(SESSION_1 as SessionID));
+    await settle();
+    clickHomeButton();
+    await settle();
+    fireEvent.click(screen.getByTestId('back'));
+    await settle();
+    expect(currentPath).toBe(sessionPath(SESSION_1 as SessionID));
+    expect(openSessionId()).toBe(SESSION_1);
+    fireEvent.click(screen.getByTestId('forward'));
+    await settle();
+    expect(currentPath).toBe('/');
+    expect(homeIsShowing()).toBe(true);
   });
 
   it('still lets state heal the URL when no navigation is in flight', async () => {

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -69,7 +69,7 @@ import { initializeAudioOnInteraction } from '../../utils/audio';
 import { useThemedMessage } from '../../utils/message';
 import type { OnboardingReopenMode } from '../../utils/onboardingLifecycle';
 import { resolveQuickStartMcpServerIds } from '../../utils/resolveQuickStartMcpServerIds';
-import { hasExplicitEntityRouteTarget } from '../../utils/routeTargets';
+import { getShellSurfacePath, hasExplicitEntityRouteTarget } from '../../utils/routeTargets';
 import { startTeammateBootstrapSession } from '../../utils/startTeammateBootstrapSession';
 import {
   buildTeammateBootstrapPrompt,
@@ -130,12 +130,14 @@ const BoardSwitcherBridge: React.FC<{ setCurrentBoardId: (id: string) => void }>
 const UrlStateBridge: React.FC<{
   currentBoardId: string;
   currentSessionId: string | null;
+  suspendStateToUrlSync?: boolean;
   onBoardChange: (boardId: string) => void;
   onSessionChange: (sessionId: string | null) => void;
   onActiveUrlTargetChange: (target: ActiveUrlTarget | null) => void;
 }> = ({
   currentBoardId,
   currentSessionId,
+  suspendStateToUrlSync,
   onBoardChange,
   onSessionChange,
   onActiveUrlTargetChange,
@@ -150,6 +152,7 @@ const UrlStateBridge: React.FC<{
     onBoardChange,
     onSessionChange,
     onActiveUrlTargetChange,
+    suspendStateToUrlSync,
   });
   return null;
 };
@@ -394,7 +397,14 @@ export const App: React.FC<AppProps> = ({
     branchShortId?: string;
     artifactShortId?: string;
   }>();
-  const isRootHomePath = location.pathname === '/';
+  // Settings is a routed *overlay*: `/settings/...` takes over the address
+  // bar but is supposed to leave whatever it was opened over rendered
+  // behind it. `useSettingsRoute` stashes that origin in history state, so
+  // read the surface from there — deriving it from `location.pathname`
+  // instead makes opening settings unmount Home and swap in the board
+  // canvas first, which is visible as a flash of the "normal" view before
+  // the modal appears.
+  const isRootHomePath = getShellSurfacePath(location) === '/';
   const hasExplicitEntityTarget = hasExplicitEntityRouteTarget(routeParams);
   const [pendingHomeNavigation, setPendingHomeNavigation] = useState(false);
   const sessionCanvasRef = useRef<SessionCanvasRef>(null);
@@ -1459,6 +1469,10 @@ export const App: React.FC<AppProps> = ({
       <UrlStateBridge
         currentBoardId={currentBoardId}
         currentSessionId={effectiveSelectedSessionId}
+        // While a Home navigation is in flight the pair above is
+        // transitional (the session is already suppressed, the `/` route
+        // has not committed) — see `suspendStateToUrlSync`.
+        suspendStateToUrlSync={pendingHomeNavigation}
         onBoardChange={handleUrlBoardChange}
         onSessionChange={setSelectedSessionId}
         onActiveUrlTargetChange={setActiveUrlTarget}

--- a/apps/agor-ui/src/components/App/App.tsx
+++ b/apps/agor-ui/src/components/App/App.tsx
@@ -130,14 +130,12 @@ const BoardSwitcherBridge: React.FC<{ setCurrentBoardId: (id: string) => void }>
 const UrlStateBridge: React.FC<{
   currentBoardId: string;
   currentSessionId: string | null;
-  suspendStateToUrlSync?: boolean;
   onBoardChange: (boardId: string) => void;
   onSessionChange: (sessionId: string | null) => void;
   onActiveUrlTargetChange: (target: ActiveUrlTarget | null) => void;
 }> = ({
   currentBoardId,
   currentSessionId,
-  suspendStateToUrlSync,
   onBoardChange,
   onSessionChange,
   onActiveUrlTargetChange,
@@ -152,7 +150,6 @@ const UrlStateBridge: React.FC<{
     onBoardChange,
     onSessionChange,
     onActiveUrlTargetChange,
-    suspendStateToUrlSync,
   });
   return null;
 };
@@ -397,16 +394,10 @@ export const App: React.FC<AppProps> = ({
     branchShortId?: string;
     artifactShortId?: string;
   }>();
-  // Settings is a routed *overlay*: `/settings/...` takes over the address
-  // bar but is supposed to leave whatever it was opened over rendered
-  // behind it. `useSettingsRoute` stashes that origin in history state, so
-  // read the surface from there — deriving it from `location.pathname`
-  // instead makes opening settings unmount Home and swap in the board
-  // canvas first, which is visible as a flash of the "normal" view before
-  // the modal appears.
+  // Settings owns the address bar, not the surface behind its modal.
+  // Preserve the Home/board background recorded by useSettingsRoute.
   const isRootHomePath = getShellSurfacePath(location) === '/';
   const hasExplicitEntityTarget = hasExplicitEntityRouteTarget(routeParams);
-  const [pendingHomeNavigation, setPendingHomeNavigation] = useState(false);
   const sessionCanvasRef = useRef<SessionCanvasRef>(null);
   const [newSessionBranchId, setNewSessionBranchId] = useState<string | null>(null);
   // Set instead of creating a session immediately when quick-start can't
@@ -447,9 +438,7 @@ export const App: React.FC<AppProps> = ({
     useMemo(() => makeSessionExistsSelector(selectedSessionId), [selectedSessionId])
   );
   const effectiveSelectedSessionId =
-    !isRootHomePath && !pendingHomeNavigation && selectedSessionId && selectedSessionExists
-      ? selectedSessionId
-      : null;
+    !isRootHomePath && selectedSessionId && selectedSessionExists ? selectedSessionId : null;
 
   // A real selected session always wins; the pending tool-choice empty state
   // only matters when there's no real session to show yet (see
@@ -541,7 +530,7 @@ export const App: React.FC<AppProps> = ({
   const currentBoard = useAgorStore(
     useMemo(() => makeBoardSelector(currentBoardId), [currentBoardId])
   );
-  const isHomeSurface = (isRootHomePath || pendingHomeNavigation) && !hasExplicitEntityTarget;
+  const isHomeSurface = isRootHomePath && !hasExplicitEntityTarget;
   const headerBoardId = isHomeSurface ? '' : currentBoardId;
   const wasHomeSurfaceRef = useRef(isHomeSurface);
   const isLeavingHomeSurface = wasHomeSurfaceRef.current && !isHomeSurface;
@@ -576,26 +565,17 @@ export const App: React.FC<AppProps> = ({
     setHomeExitPanelDetailsDeferred(false);
   }, []);
 
-  // Home is route-authoritative. Do not clear board/session state while the
-  // old `/b/...` URL is still active — that creates a transient no-board
-  // canvas render. Instead, render Home immediately via `pendingHomeNavigation`
-  // during the route transition, then clean stale board/session state only once
-  // the `/` route has committed. Layout timing keeps the header/board picker
-  // from painting stale board identity on Home.
+  // Let the committed route choose Home before clearing stale selection.
+  // Optimistically hiding the session at the OLD path lets URL self-healing
+  // cancel the Home navigation. A separate pending flag can also outlive a
+  // superseded navigation. Route-derived rendering avoids both races and a
+  // boardless canvas flash; layout cleanup keeps stale identity off Home.
   useLayoutEffect(() => {
     if (!isRootHomePath || hasExplicitEntityTarget) return;
     if (currentBoardId) setCurrentBoardIdInternal('');
     if (selectedSessionId) setSelectedSessionId(null);
     if (activeUrlTarget) setActiveUrlTarget(null);
-    if (pendingHomeNavigation) setPendingHomeNavigation(false);
-  }, [
-    activeUrlTarget,
-    currentBoardId,
-    hasExplicitEntityTarget,
-    isRootHomePath,
-    pendingHomeNavigation,
-    selectedSessionId,
-  ]);
+  }, [activeUrlTarget, currentBoardId, hasExplicitEntityTarget, isRootHomePath, selectedSessionId]);
 
   const leftPanelCollapsed =
     commentsPanelCollapsed ||
@@ -1433,10 +1413,7 @@ export const App: React.FC<AppProps> = ({
   // isn't defeated by a fresh inline-arrow identity on every App re-render. Each
   // delegates to the latest impl via useStableCallback, so they read current
   // state (selection, panel, board) at call time without re-rendering the header.
-  const handleHomeClick = useStableCallback(() => {
-    setPendingHomeNavigation(true);
-    navigation.goHome();
-  });
+  const handleHomeClick = useStableCallback(() => navigation.goHome());
   const handleEventStreamClick = useStableCallback(() => {
     // If a session is open, close it and reveal the event stream; otherwise
     // toggle the event stream panel.
@@ -1469,10 +1446,6 @@ export const App: React.FC<AppProps> = ({
       <UrlStateBridge
         currentBoardId={currentBoardId}
         currentSessionId={effectiveSelectedSessionId}
-        // While a Home navigation is in flight the pair above is
-        // transitional (the session is already suppressed, the `/` route
-        // has not committed) — see `suspendStateToUrlSync`.
-        suspendStateToUrlSync={pendingHomeNavigation}
         onBoardChange={handleUrlBoardChange}
         onSessionChange={setSelectedSessionId}
         onActiveUrlTargetChange={setActiveUrlTarget}

--- a/apps/agor-ui/src/hooks/useUrlState.ts
+++ b/apps/agor-ui/src/hooks/useUrlState.ts
@@ -70,6 +70,17 @@ export interface UseUrlStateOptions {
    *  artifact). Null when the URL has no such target. Fires only on
    *  transitions to keep downstream React state updates idempotent. */
   onActiveUrlTargetChange?: (target: ActiveUrlTarget | null) => void;
+  /** Suspend the state→URL self-heal while the consumer has a deliberate
+   *  navigation in flight.
+   *
+   *  React Router commits `navigate()` inside a transition, so a plain
+   *  `setState` made alongside it renders once at the OLD pathname. If that
+   *  render also changes `currentBoardId` / `currentSessionId` — which is
+   *  exactly what App's "render Home immediately" flag does — the self-heal
+   *  reads the transitional pair as authoritative and `replace()`s the URL,
+   *  cancelling the navigation that was already on its way. The consumer
+   *  owns that knowledge, so it hands it down rather than us guessing. */
+  suspendStateToUrlSync?: boolean;
 }
 
 /** Slug lookup helper — the core `boardPath` builder takes a slug
@@ -106,6 +117,7 @@ export function useUrlState(options: UseUrlStateOptions) {
     onBoardChange,
     onSessionChange,
     onActiveUrlTargetChange,
+    suspendStateToUrlSync = false,
   } = options;
 
   const navigate = useNavigate();
@@ -476,6 +488,9 @@ export function useUrlState(options: UseUrlStateOptions) {
   useEffect(() => {
     if (syncingRef.current) return;
     if (isSettingsRoute) return;
+    // A deliberate navigation is mid-flight and our (board, session) pair
+    // is transitional — see `suspendStateToUrlSync`.
+    if (suspendStateToUrlSync) return;
 
     // Unknown non-root paths have no entity params but are not the Home
     // route. The URL→state effect canonicalizes them to `/`; do not let
@@ -507,6 +522,7 @@ export function useUrlState(options: UseUrlStateOptions) {
     urlBranchShortId,
     urlArtifactShortId,
     isSettingsRoute,
+    suspendStateToUrlSync,
     updateUrlFromState,
     location.pathname,
   ]);

--- a/apps/agor-ui/src/hooks/useUrlState.ts
+++ b/apps/agor-ui/src/hooks/useUrlState.ts
@@ -70,17 +70,6 @@ export interface UseUrlStateOptions {
    *  artifact). Null when the URL has no such target. Fires only on
    *  transitions to keep downstream React state updates idempotent. */
   onActiveUrlTargetChange?: (target: ActiveUrlTarget | null) => void;
-  /** Suspend the state→URL self-heal while the consumer has a deliberate
-   *  navigation in flight.
-   *
-   *  React Router commits `navigate()` inside a transition, so a plain
-   *  `setState` made alongside it renders once at the OLD pathname. If that
-   *  render also changes `currentBoardId` / `currentSessionId` — which is
-   *  exactly what App's "render Home immediately" flag does — the self-heal
-   *  reads the transitional pair as authoritative and `replace()`s the URL,
-   *  cancelling the navigation that was already on its way. The consumer
-   *  owns that knowledge, so it hands it down rather than us guessing. */
-  suspendStateToUrlSync?: boolean;
 }
 
 /** Slug lookup helper — the core `boardPath` builder takes a slug
@@ -117,7 +106,6 @@ export function useUrlState(options: UseUrlStateOptions) {
     onBoardChange,
     onSessionChange,
     onActiveUrlTargetChange,
-    suspendStateToUrlSync = false,
   } = options;
 
   const navigate = useNavigate();
@@ -488,9 +476,6 @@ export function useUrlState(options: UseUrlStateOptions) {
   useEffect(() => {
     if (syncingRef.current) return;
     if (isSettingsRoute) return;
-    // A deliberate navigation is mid-flight and our (board, session) pair
-    // is transitional — see `suspendStateToUrlSync`.
-    if (suspendStateToUrlSync) return;
 
     // Unknown non-root paths have no entity params but are not the Home
     // route. The URL→state effect canonicalizes them to `/`; do not let
@@ -522,7 +507,6 @@ export function useUrlState(options: UseUrlStateOptions) {
     urlBranchShortId,
     urlArtifactShortId,
     isSettingsRoute,
-    suspendStateToUrlSync,
     updateUrlFromState,
     location.pathname,
   ]);

--- a/apps/agor-ui/src/utils/routeTargets.test.ts
+++ b/apps/agor-ui/src/utils/routeTargets.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { hasExplicitEntityRouteTarget } from './routeTargets';
+import { getShellSurfacePath, hasExplicitEntityRouteTarget } from './routeTargets';
 
 describe('hasExplicitEntityRouteTarget', () => {
   it.each([
@@ -9,5 +9,65 @@ describe('hasExplicitEntityRouteTarget', () => {
     [{}, false],
   ])('returns the expected value for params %j', (params, expected) => {
     expect(hasExplicitEntityRouteTarget(params)).toBe(expected);
+  });
+});
+
+describe('getShellSurfacePath', () => {
+  it('returns the pathname on non-settings routes, ignoring history state', () => {
+    expect(
+      getShellSurfacePath({ pathname: '/b/alpha/', state: { settingsBackgroundPath: '/' } })
+    ).toBe('/b/alpha/');
+  });
+
+  it('resolves a settings route to the surface it was opened over', () => {
+    expect(
+      getShellSurfacePath({ pathname: '/settings/boards/', state: { settingsBackgroundPath: '/' } })
+    ).toBe('/');
+    expect(
+      getShellSurfacePath({
+        pathname: '/settings/mcp/',
+        state: { settingsBackgroundPath: '/b/alpha/' },
+      })
+    ).toBe('/b/alpha/');
+  });
+
+  it('drops search and hash from the recorded origin', () => {
+    expect(
+      getShellSurfacePath({
+        pathname: '/settings/boards/',
+        state: { settingsBackgroundPath: '/b/alpha/?tab=x#frag' },
+      })
+    ).toBe('/b/alpha/');
+  });
+
+  it('falls back to the pathname when no usable origin was recorded', () => {
+    // Cold-loaded settings URL (shared link / refresh) — nothing to preserve.
+    expect(getShellSurfacePath({ pathname: '/settings/users/' })).toBe('/settings/users/');
+    expect(getShellSurfacePath({ pathname: '/settings/users/', state: null })).toBe(
+      '/settings/users/'
+    );
+    expect(
+      getShellSurfacePath({ pathname: '/settings/users/', state: { settingsBackgroundPath: 42 } })
+    ).toBe('/settings/users/');
+    // Relative / non-path values are not surfaces.
+    expect(
+      getShellSurfacePath({
+        pathname: '/settings/users/',
+        state: { settingsBackgroundPath: 'https://example.test/elsewhere' },
+      })
+    ).toBe('/settings/users/');
+    // Never resolve one settings route to another.
+    expect(
+      getShellSurfacePath({
+        pathname: '/settings/users/',
+        state: { settingsBackgroundPath: '/settings/mcp/' },
+      })
+    ).toBe('/settings/users/');
+  });
+
+  it('does not treat a path merely prefixed with "/settings" as a settings route', () => {
+    expect(
+      getShellSurfacePath({ pathname: '/settingsomething', state: { settingsBackgroundPath: '/' } })
+    ).toBe('/settingsomething');
   });
 });

--- a/apps/agor-ui/src/utils/routeTargets.test.ts
+++ b/apps/agor-ui/src/utils/routeTargets.test.ts
@@ -41,7 +41,7 @@ describe('getShellSurfacePath', () => {
   });
 
   it('falls back to the pathname when no usable origin was recorded', () => {
-    // Cold-loaded settings URL (shared link / refresh) — nothing to preserve.
+    // Shared settings link without history state — nothing to preserve.
     expect(getShellSurfacePath({ pathname: '/settings/users/' })).toBe('/settings/users/');
     expect(getShellSurfacePath({ pathname: '/settings/users/', state: null })).toBe(
       '/settings/users/'

--- a/apps/agor-ui/src/utils/routeTargets.ts
+++ b/apps/agor-ui/src/utils/routeTargets.ts
@@ -11,3 +11,42 @@ export interface EntityRouteParams {
 export function hasExplicitEntityRouteTarget(params: EntityRouteParams): boolean {
   return Boolean(params.sessionShortId || params.branchShortId || params.artifactShortId);
 }
+
+/** Route prefix owned by the settings modal — kept in step with
+ *  `useSettingsRoute`, which parses and builds these paths. */
+const SETTINGS_PATH_PREFIX = '/settings';
+
+function isSettingsPath(pathname: string): boolean {
+  return pathname === SETTINGS_PATH_PREFIX || pathname.startsWith(`${SETTINGS_PATH_PREFIX}/`);
+}
+
+/**
+ * The path whose surface the workspace shell should render — Home vs. the
+ * board canvas. Normally just the pathname.
+ *
+ * (Distinct from `RouteSurfaceId` in `surfaces/surfaceRegistry.ts`, which
+ * picks between top-level route families such as Workspace and Knowledge.
+ * This chooses between the shell's two interiors, one route family down.)
+ *
+ * Settings is the exception. It is a routed overlay: `/settings/...` owns
+ * the address bar while the surface it was opened over stays mounted
+ * behind the modal. `useSettingsRoute.openSettings` records that origin as
+ * `settingsBackgroundPath` in history state, so read the surface from
+ * there. Deriving it from the pathname makes every settings open look like
+ * a navigation away from Home, swapping in the board canvas underneath
+ * before the modal paints.
+ *
+ * Falls back to the pathname when no usable origin was recorded — a
+ * settings URL opened cold (shared link, hard refresh) has no prior
+ * surface to preserve.
+ */
+export function getShellSurfacePath(location: { pathname: string; state?: unknown }): string {
+  if (!isSettingsPath(location.pathname)) return location.pathname;
+  const background = (location.state as { settingsBackgroundPath?: unknown } | null)
+    ?.settingsBackgroundPath;
+  if (typeof background !== 'string' || !background.startsWith('/')) return location.pathname;
+  // The recorded origin carries search + hash; only the path selects a surface.
+  const backgroundPath = background.split('?')[0].split('#')[0] || '/';
+  // Defensive: never resolve one settings route to another.
+  return isSettingsPath(backgroundPath) ? location.pathname : backgroundPath;
+}

--- a/apps/agor-ui/src/utils/routeTargets.ts
+++ b/apps/agor-ui/src/utils/routeTargets.ts
@@ -36,9 +36,8 @@ function isSettingsPath(pathname: string): boolean {
  * a navigation away from Home, swapping in the board canvas underneath
  * before the modal paints.
  *
- * Falls back to the pathname when no usable origin was recorded — a
- * settings URL opened cold (shared link, hard refresh) has no prior
- * surface to preserve.
+ * Falls back to the pathname when no usable origin was recorded, such as
+ * when opening a shared settings link. A reload can retain history state.
  */
 export function getShellSurfacePath(location: { pathname: string; state?: unknown }): string {
   if (!isSettingsPath(location.pathname)) return location.pathname;


### PR DESCRIPTION
## Symptom

Three reports that look unrelated:

1. The board switcher changes the URL but the view stays on Home.
2. Session rows on Home "sometimes don't select" — the row click resolves, the URL changes, nothing opens.
3. Opening Settings over Home tears Home down and flashes the board canvas behind the modal before it appears.

(1) and (2) are the same bug, and they only reproduce when **a session was open the last time Home was clicked** — which is why they read as intermittent.

## Cause

`handleHomeClick` sets `pendingHomeNavigation` so Home paints immediately instead of flashing a boardless canvas during the route transition. React Router commits `navigate()` inside a transition, so that plain `setState` renders once at the **old** path — and because the flag also gates `effectiveSelectedSessionId`, that render reports `(board, session=null)`. `useUrlState`'s state→URL self-heal reads that transitional pair as authoritative and `replace()`s the URL back to `/b/<board>/`, cancelling the `/` push already in flight.

The flag's only reset requires already being at `/`. So it never clears. Armed permanently, it forces the Home surface for every non-entity URL (symptom 1) and pins the effective selection to null (symptom 2).

Symptom 3 is a second instance of "the surface disagrees with the URL". Settings is a routed *overlay* — `/settings/...` owns the address bar while the surface it was opened over stays mounted behind the modal — but the rendered surface was derived from `location.pathname`, so opening Settings over Home read as a navigation away from Home. `useSettingsRoute` already records the origin in history state; nothing read it.

## Fix

- Home clicks now only request navigation. Remove the optimistic `pendingHomeNavigation` flag and the intermediate `suspendStateToUrlSync` API: the committed route chooses Home, then layout cleanup clears stale board/session selection. This avoids both the original self-heal race and a permanently armed flag when another navigation supersedes Home.
- Keep `getShellSurfacePath` to preserve the background recorded by `useSettingsRoute` when Settings owns the address bar. Settings links without usable history state fall back to their pathname; a reload may retain history state.

## Validation

- Full UI suite: **287 files / 2,107 tests passed**.
- Focused Home, route-target, URL-sync, navigation, and Settings tests: **49 passed**.
- The **11 Home-surface integration tests also passed in headless Chromium**, using the same canvas/session/modal stand-ins as the unit suite; this is shell-routing coverage, not a real-modal focus or canvas-layout audit.
- No-emit UI source typecheck, including the updated test, passed using source exports (with shared-source enums permitted; no build or production tsconfig changes).
- Biome passed on all five touched files; commit hooks ran without bypassing them.

The superseding-navigation regression now batches both intents in one `act` boundary so `/` cannot settle between clicks. Coverage includes board and session supersession, browser Back/Forward, Settings close-to-origin behavior, and the absence of a committed boardless-canvas frame. Existing guards retain board-backed and cold-loaded Settings behavior and state-only cross-board recentering.

Mutation checks confirmed that loading the original PR implementation fails both overlapping-navigation tests, and clearing board state before navigation fails the no-board-flash assertion.
