### PR TITLE
fix(auth): make AI credential banner tool-authoritative

### DIFF
--- a/apps/agor-daemon/src/services/check-auth.sqlite.test.ts
+++ b/apps/agor-daemon/src/services/check-auth.sqlite.test.ts
@@ -1,0 +1,77 @@
+import {
+  runWithTenantContext,
+  TenantAgenticToolSettingsRepository,
+  UsersRepository,
+} from '@agor/core/db';
+import type { UserID } from '@agor/core/types';
+import { afterEach, beforeAll, describe, expect, vi } from 'vitest';
+import { dbTest } from '../../../../packages/core/src/db/test-helpers';
+import { createCheckAuthService } from './check-auth';
+
+beforeAll(() => {
+  process.env.AGOR_MASTER_SECRET ||= 'check-auth-sqlite-synthetic-master-secret';
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('check-auth managed SQLite credential resolution', () => {
+  dbTest('uses the same stored Claude bearer connection as session execution', async ({ db }) => {
+    const users = new UsersRepository(db);
+    const user = await users.create({ email: 'claude-bearer@example.test' });
+    const syntheticToken = 'synthetic-claude-bearer-token';
+    await users.setToolConfigField(
+      user.user_id,
+      'claude-code',
+      'ANTHROPIC_AUTH_TOKEN',
+      syntheticToken
+    );
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue({ ok: true, status: 200 } as Response);
+
+    const service = createCheckAuthService(db, {} as never);
+    const result = await runWithTenantContext('tenant-sqlite-test', () =>
+      service.create({ tool: 'claude-code' }, {
+        user: { user_id: user.user_id as UserID },
+      } as never)
+    );
+
+    expect(result).toMatchObject({ status: 'authenticated', method: 'api-key' });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.anthropic.com/v1/models',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: `Bearer ${syntheticToken}` }),
+      })
+    );
+    expect(JSON.stringify(result)).not.toContain(syntheticToken);
+  });
+
+  dbTest('uses a workspace Claude bearer connection when policy requires it', async ({ db }) => {
+    const users = new UsersRepository(db);
+    const user = await users.create({ email: 'claude-workspace-bearer@example.test' });
+    const syntheticToken = 'synthetic-workspace-claude-bearer-token';
+    await new TenantAgenticToolSettingsRepository(db).patch('claude-code', {
+      resolution_policy: 'tenant_required',
+      connection: { ANTHROPIC_AUTH_TOKEN: syntheticToken },
+    });
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue({ ok: true, status: 200 } as Response);
+
+    const service = createCheckAuthService(db, {} as never);
+    const result = await runWithTenantContext('tenant-sqlite-test', () =>
+      service.create({ tool: 'claude-code' }, {
+        user: { user_id: user.user_id as UserID },
+      } as never)
+    );
+
+    expect(result).toMatchObject({ status: 'authenticated', method: 'api-key' });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.anthropic.com/v1/models',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: `Bearer ${syntheticToken}` }),
+      })
+    );
+    expect(JSON.stringify(result)).not.toContain(syntheticToken);
+  });
+});

--- a/apps/agor-daemon/src/services/check-auth.test.ts
+++ b/apps/agor-daemon/src/services/check-auth.test.ts
@@ -54,7 +54,7 @@ function mockClaudeAccount(account: Record<string, unknown> | null) {
 }
 
 const service = () => {
-  const delegate = createCheckAuthService(TEST_DB);
+  const delegate = createCheckAuthService(TEST_DB, {} as never);
   return {
     create: (...args: Parameters<typeof delegate.create>) =>
       runWithTenantContext('tenant-test', () => delegate.create(...args)),
@@ -65,6 +65,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
   delete process.env.ANTHROPIC_API_KEY;
+  delete process.env.ANTHROPIC_AUTH_TOKEN;
   isTenantAgenticToolEnabledMock.mockResolvedValue(true);
   resolveApiKeyMock.mockResolvedValue({ apiKey: undefined, source: 'none', useNativeAuth: false });
 });
@@ -91,13 +92,12 @@ describe('check-auth Claude subscription tokens', () => {
   });
 
   it('checks stored CLAUDE_CODE_OAUTH_TOKEN when no Anthropic API key is configured', async () => {
-    resolveApiKeyMock
-      .mockResolvedValueOnce({ apiKey: undefined, source: 'none', useNativeAuth: false })
-      .mockResolvedValueOnce({
-        apiKey: 'sk-ant-oat01-stored',
-        source: 'user',
-        useNativeAuth: false,
-      });
+    resolveApiKeyMock.mockResolvedValueOnce({
+      apiKey: undefined,
+      connection: { CLAUDE_CODE_OAUTH_TOKEN: 'sk-ant-oat01-stored' },
+      source: 'user',
+      useNativeAuth: false,
+    });
     mockClaudeAccount({ tokenSource: 'CLAUDE_CODE_OAUTH_TOKEN' });
 
     const result = await service().create({ tool: 'claude-code' }, {
@@ -113,12 +113,8 @@ describe('check-auth Claude subscription tokens', () => {
       })
     );
     expect(process.env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
-    expect(resolveApiKeyMock).toHaveBeenNthCalledWith(1, 'ANTHROPIC_API_KEY', {
-      userId: 'user-1',
-      db: TEST_DB,
-      tool: 'claude-code',
-    });
-    expect(resolveApiKeyMock).toHaveBeenNthCalledWith(2, 'CLAUDE_CODE_OAUTH_TOKEN', {
+    expect(resolveApiKeyMock).toHaveBeenCalledTimes(1);
+    expect(resolveApiKeyMock).toHaveBeenCalledWith('ANTHROPIC_API_KEY', {
       userId: 'user-1',
       db: TEST_DB,
       tool: 'claude-code',
@@ -126,13 +122,12 @@ describe('check-auth Claude subscription tokens', () => {
   });
 
   it('treats missing subscription account metadata as unknown, not rejected', async () => {
-    resolveApiKeyMock
-      .mockResolvedValueOnce({ apiKey: undefined, source: 'none', useNativeAuth: false })
-      .mockResolvedValueOnce({
-        apiKey: 'sk-ant-oat01-stored',
-        source: 'user',
-        useNativeAuth: false,
-      });
+    resolveApiKeyMock.mockResolvedValueOnce({
+      apiKey: undefined,
+      connection: { CLAUDE_CODE_OAUTH_TOKEN: 'sk-ant-oat01-stored' },
+      source: 'user',
+      useNativeAuth: false,
+    });
     mockClaudeAccount(null);
 
     const result = await service().create({ tool: 'claude-code' }, {
@@ -174,6 +169,67 @@ describe('check-auth tri-state', () => {
 
     const result = await service().create({ tool: 'claude-code' }, params);
     expect(result.status).toBe('unauthenticated');
+    fetchMock.mockRestore();
+  });
+
+  it('validates the resolved Claude bearer token exactly as the executor uses it', async () => {
+    const syntheticToken = 'synthetic-bearer-token';
+    resolveApiKeyMock.mockResolvedValue({
+      apiKey: undefined,
+      connection: { ANTHROPIC_AUTH_TOKEN: syntheticToken },
+      source: 'user',
+      useNativeAuth: false,
+    });
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue({ ok: true, status: 200 } as Response);
+
+    const result = await service().create({ tool: 'claude-code' }, params);
+
+    expect(result).toMatchObject({ status: 'authenticated', method: 'api-key' });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.anthropic.com/v1/models',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: `Bearer ${syntheticToken}` }),
+      })
+    );
+    expect(JSON.stringify(result)).not.toContain(syntheticToken);
+    fetchMock.mockRestore();
+  });
+
+  it('expired/revoked Claude bearer token rejected with 401 → unauthenticated', async () => {
+    const syntheticToken = 'synthetic-expired-token';
+    resolveApiKeyMock.mockResolvedValue({
+      apiKey: undefined,
+      connection: { ANTHROPIC_AUTH_TOKEN: syntheticToken },
+      source: 'user',
+      useNativeAuth: false,
+    });
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue({ ok: false, status: 401 } as Response);
+
+    const result = await service().create({ tool: 'claude-code' }, params);
+
+    expect(result).toMatchObject({ status: 'unauthenticated', method: 'api-key' });
+    expect(JSON.stringify(result)).not.toContain(syntheticToken);
+    fetchMock.mockRestore();
+  });
+
+  it('Claude bearer-token timeout stays unknown and secret-free', async () => {
+    const syntheticToken = 'synthetic-timeout-token';
+    resolveApiKeyMock.mockResolvedValue({
+      apiKey: undefined,
+      connection: { ANTHROPIC_AUTH_TOKEN: syntheticToken },
+      source: 'user',
+      useNativeAuth: false,
+    });
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('timeout'));
+
+    const result = await service().create({ tool: 'claude-code' }, params);
+
+    expect(result.status).toBe('unknown');
+    expect(JSON.stringify(result)).not.toContain(syntheticToken);
     fetchMock.mockRestore();
   });
 

--- a/apps/agor-daemon/src/services/check-auth.ts
+++ b/apps/agor-daemon/src/services/check-auth.ts
@@ -161,14 +161,13 @@ async function validateClaudeSubscriptionToken(token: string): Promise<AuthCheck
 }
 
 /**
- * Validate a concrete API key against the provider. `authenticated` only on a 2xx;
+ * Validate a concrete provider connection against the provider. `authenticated` only on a 2xx;
  * `unauthenticated` only on a real 401/403 rejection; everything else (timeout,
  * 5xx, network error) is `unknown` — a failure to VERIFY is not proof of invalidity.
  */
-async function validateApiKey(
+async function validateProviderCredential(
   tool: string,
-  key: string,
-  connection: Record<string, string | undefined> = {}
+  connection: Record<string, string | undefined>
 ): Promise<AuthCheckStatus> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
@@ -180,22 +179,27 @@ async function validateApiKey(
     switch (tool) {
       case 'claude-code': {
         url = `${(connection.ANTHROPIC_BASE_URL ?? 'https://api.anthropic.com').replace(/\/$/, '')}/v1/models`;
-        headers['x-api-key'] = key;
+        if (connection.ANTHROPIC_API_KEY) {
+          headers['x-api-key'] = connection.ANTHROPIC_API_KEY;
+        }
+        if (connection.ANTHROPIC_AUTH_TOKEN) {
+          headers.Authorization = `Bearer ${connection.ANTHROPIC_AUTH_TOKEN}`;
+        }
         headers['anthropic-version'] = '2023-06-01';
         break;
       }
       case 'codex': {
         url = `${(connection.OPENAI_BASE_URL ?? 'https://api.openai.com/v1').replace(/\/$/, '')}/models`;
-        headers.Authorization = `Bearer ${key}`;
+        headers.Authorization = `Bearer ${connection.OPENAI_API_KEY}`;
         break;
       }
       case 'gemini': {
-        url = `https://generativelanguage.googleapis.com/v1/models?key=${encodeURIComponent(key)}`;
+        url = `https://generativelanguage.googleapis.com/v1/models?key=${encodeURIComponent(connection.GEMINI_API_KEY ?? '')}`;
         break;
       }
       case 'copilot': {
         url = 'https://api.github.com/user';
-        headers.Authorization = `token ${key}`;
+        headers.Authorization = `token ${connection.COPILOT_GITHUB_TOKEN}`;
         headers.Accept = 'application/vnd.github.v3+json';
         break;
       }
@@ -205,7 +209,7 @@ async function validateApiKey(
         // successful call as authenticated and any throw as unknown (fail safe).
         const { Cursor } = await loadManagedAgenticToolSdk<typeof import('@cursor/sdk')>('cursor');
         await Promise.race([
-          Cursor.me({ apiKey: key }),
+          Cursor.me({ apiKey: connection.CURSOR_API_KEY ?? '' }),
           new Promise<never>((_, reject) =>
             setTimeout(() => reject(new Error('Cursor auth check timed out')), FETCH_TIMEOUT_MS)
           ),
@@ -224,6 +228,23 @@ async function validateApiKey(
     return 'unknown';
   } finally {
     clearTimeout(timer);
+  }
+}
+
+function rawProviderConnection(tool: string, key: string): Record<string, string | undefined> {
+  switch (tool) {
+    case 'claude-code':
+      return { ANTHROPIC_API_KEY: key };
+    case 'codex':
+      return { OPENAI_API_KEY: key };
+    case 'gemini':
+      return { GEMINI_API_KEY: key };
+    case 'copilot':
+      return { COPILOT_GITHUB_TOKEN: key };
+    case 'cursor':
+      return { CURSOR_API_KEY: key };
+    default:
+      return {};
   }
 }
 
@@ -363,7 +384,7 @@ export function createCheckAuthService(
         }
 
         return resultFromKeyStatus(
-          await validateApiKey(tool, rawKey.trim()),
+          await validateProviderCredential(tool, rawProviderConnection(tool, rawKey.trim())),
           tool === 'copilot'
             ? 'GitHub token rejected — check the token has not expired or been revoked.'
             : 'Key rejected by provider — double-check and try again.'
@@ -387,12 +408,10 @@ export function createCheckAuthService(
         );
       }
 
-      if (apiKey) {
-        return resultFromKeyStatus(
-          await validateApiKey(tool, apiKey, connection as Record<string, string | undefined>),
-          'Stored key was rejected by provider — update it in Settings → Agent Setup.'
-        );
-      }
+      const resolvedConnection = {
+        ...rawProviderConnection(tool, apiKey ?? ''),
+        ...(connection ?? {}),
+      } as Record<string, string | undefined>;
 
       if (tool === 'codex' && useNativeAuth) {
         // The persisted method is the cheap default used by app-shell banners.
@@ -404,22 +423,12 @@ export function createCheckAuthService(
       }
 
       if (tool === 'claude-code') {
-        const subscriptionResolution = await withTenantDatabase((tenantDb) =>
-          resolveApiKey('CLAUDE_CODE_OAUTH_TOKEN', {
-            userId,
-            db: tenantDb,
-            tool: 'claude-code',
-          })
-        );
-
-        if (subscriptionResolution.decryptionFailed) {
-          return unauthenticated(
-            'none',
-            'Stored Claude subscription token could not be decrypted (master-secret mismatch). Re-enter it in Settings → Agent Setup.'
-          );
-        }
-
-        const subscriptionToken = subscriptionResolution.apiKey;
+        // The atomic provider resolver returns the exact connection exported to
+        // the executor. Do not reduce it to TOOL_API_KEY_NAMES: Claude also
+        // supports ANTHROPIC_AUTH_TOKEN (Bearer auth) and subscription tokens.
+        // Reducing this connection to ANTHROPIC_API_KEY is what made a working
+        // Claude session look disconnected in the app-shell banner.
+        const subscriptionToken = resolvedConnection.CLAUDE_CODE_OAUTH_TOKEN;
         if (subscriptionToken) {
           const status = await validateClaudeSubscriptionToken(subscriptionToken);
           if (status === 'authenticated') return authed('oauth');
@@ -431,6 +440,16 @@ export function createCheckAuthService(
           }
           return unknown('Could not verify the Claude subscription token — try again.');
         }
+      }
+
+      const hasResolvedCredential =
+        Boolean(apiKey) ||
+        (tool === 'claude-code' && Boolean(resolvedConnection.ANTHROPIC_AUTH_TOKEN));
+      if (hasResolvedCredential) {
+        return resultFromKeyStatus(
+          await validateProviderCredential(tool, resolvedConnection),
+          'Stored key was rejected by provider — update it in Settings → Agent Setup.'
+        );
       }
 
       return unauthenticated('none', `No usable ${keyName} is available under workspace policy.`);

--- a/apps/agor-daemon/src/services/tenant-agentic-tools.deployment-boundary.test.ts
+++ b/apps/agor-daemon/src/services/tenant-agentic-tools.deployment-boundary.test.ts
@@ -14,11 +14,13 @@ describe('tenant agentic tool deployment boundary', () => {
 
     await expect(service.get('codex')).resolves.toMatchObject({
       tool: 'codex',
+      revision: 0,
       deployment_available: false,
       enabled: false,
     });
     await expect(service.get('claude-code')).resolves.toMatchObject({
       tool: 'claude-code',
+      revision: 0,
       deployment_available: true,
       enabled: true,
     });
@@ -33,5 +35,23 @@ describe('tenant agentic tool deployment boundary', () => {
     await expect(service.patch('codex', { enabled: true })).rejects.toThrow(
       /unavailable under this deployment's agentic-tool policy/
     );
+  });
+
+  it('publishes the durable revision without exposing the rotated credential', async () => {
+    const syntheticSecret = 'synthetic-workspace-secret-must-not-leak';
+    vi.spyOn(TenantAgenticToolSettingsRepository.prototype, 'find').mockResolvedValue({
+      revision: 7,
+      connection: { ANTHROPIC_AUTH_TOKEN: syntheticSecret },
+    });
+    const service = new TenantAgenticToolSettingsService({} as TenantScopeAwareDatabase);
+
+    const settings = await service.get('claude-code');
+
+    expect(settings).toMatchObject({
+      tool: 'claude-code',
+      revision: 7,
+      connection: { ANTHROPIC_AUTH_TOKEN: { configured: true } },
+    });
+    expect(JSON.stringify(settings)).not.toContain(syntheticSecret);
   });
 });

--- a/apps/agor-daemon/src/services/tenant-agentic-tools.ts
+++ b/apps/agor-daemon/src/services/tenant-agentic-tools.ts
@@ -51,6 +51,7 @@ export class TenantAgenticToolSettingsService {
     }
     return {
       tool,
+      revision: stored.revision ?? 0,
       deployment_available: deploymentEnabled,
       enabled: deploymentEnabled && stored.enabled !== false,
       resolution_policy: stored.resolution_policy ?? DEFAULT_PROVIDER_RESOLUTION_POLICY,

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -2180,6 +2180,7 @@ function AppContent() {
           onOpenWorkspaceSettings={(tab) => setSettingsTabToOpen(tab)}
           onCheckAuth={handleCheckAuth}
           credentialVersion={credentialVersion}
+          connectionReady={connected && !connecting}
         />
       }
       onCreateSession={handleCreateSession}

--- a/apps/agor-ui/src/components/AgentSelectionGrid/AgentSelectionGrid.tsx
+++ b/apps/agor-ui/src/components/AgentSelectionGrid/AgentSelectionGrid.tsx
@@ -15,7 +15,7 @@
  * - ScheduleModal (select)
  */
 
-import type { TenantAgenticToolName } from '@agor-live/client';
+import type { AgenticToolName, TenantAgenticToolName } from '@agor-live/client';
 import { Alert, Select, Space, Spin, Typography, theme } from 'antd';
 import { useEffect, useMemo } from 'react';
 import { useAgorStore } from '../../store/agorStore';
@@ -23,6 +23,7 @@ import type { AgenticToolOption } from '../../types';
 import { AgentSelectionCard } from '../AgentSelectionCard';
 import { Tag } from '../Tag';
 import { ToolIcon } from '../ToolIcon';
+import { resolveAvailableAgenticTool } from './availableAgents';
 
 const { Text } = Typography;
 
@@ -82,15 +83,22 @@ export const AgentSelectionGrid: React.FC<AgentSelectionGridProps> = ({
     [agents, settings, settingsHydrated]
   );
   useEffect(() => {
-    if (
-      fallbackToFirstVisibleAgent &&
-      selectedAgentId &&
-      !visibleAgents.some((agent) => agent.id === selectedAgentId) &&
-      visibleAgents[0]
-    ) {
-      onSelect(visibleAgents[0].id);
+    if (fallbackToFirstVisibleAgent && selectedAgentId && visibleAgents.length > 0) {
+      const resolved = resolveAvailableAgenticTool(
+        selectedAgentId as AgenticToolName,
+        settings,
+        agents
+      );
+      if (resolved !== selectedAgentId) onSelect(resolved);
     }
-  }, [fallbackToFirstVisibleAgent, onSelect, selectedAgentId, visibleAgents]);
+  }, [
+    agents,
+    fallbackToFirstVisibleAgent,
+    onSelect,
+    selectedAgentId,
+    settings,
+    visibleAgents.length,
+  ]);
   if (!settingsHydrated) {
     return (
       <div

--- a/apps/agor-ui/src/components/AgentSelectionGrid/availableAgents.ts
+++ b/apps/agor-ui/src/components/AgentSelectionGrid/availableAgents.ts
@@ -7,6 +7,13 @@
 
 import { AGENTIC_TOOL_DISPLAY_NAMES } from '@agor/agentic-tools';
 import { getAgenticToolUIIntegration } from '@agor/agentic-tools/ui';
+import type {
+  AgenticToolName,
+  TenantAgenticToolName,
+  TenantAgenticToolSettings,
+  User,
+} from '@agor-live/client';
+import { resolveUserPrimaryAgenticTool } from '@agor-live/client';
 import type { AgenticToolOption } from './AgentSelectionGrid';
 
 const openCodeOption = getAgenticToolUIIntegration('opencode').agentSelectionOption;
@@ -52,3 +59,35 @@ export const AVAILABLE_AGENTS: AgenticToolOption[] = [
     beta: true,
   },
 ];
+
+/**
+ * Resolve the tool that a creation picker will actually select once workspace
+ * availability is known: the user's primary/default tool when visible, then
+ * the first enabled option in the picker's canonical display order.
+ *
+ * Persistent shell affordances (including credential status) must use this
+ * helper rather than inferring a tool from stored credentials. A credential
+ * for another provider does not change which tool New Session selects.
+ */
+export function resolveAvailableUserAgenticTool(
+  user: User | null | undefined,
+  settings: ReadonlyMap<TenantAgenticToolName, TenantAgenticToolSettings>,
+  agents: readonly AgenticToolOption[] = AVAILABLE_AGENTS
+): AgenticToolName {
+  return resolveAvailableAgenticTool(resolveUserPrimaryAgenticTool(user), settings, agents);
+}
+
+/** Apply the creation picker's enabled-tool fallback to an explicit preference. */
+export function resolveAvailableAgenticTool(
+  preferred: AgenticToolName,
+  settings: ReadonlyMap<TenantAgenticToolName, TenantAgenticToolSettings>,
+  agents: readonly AgenticToolOption[] = AVAILABLE_AGENTS
+): AgenticToolName {
+  const isEnabled = (tool: string) =>
+    settings.get(tool as TenantAgenticToolName)?.enabled !== false;
+
+  if (agents.some((agent) => agent.id === preferred && isEnabled(agent.id))) return preferred;
+  return (
+    (agents.find((agent) => isEnabled(agent.id))?.id as AgenticToolName | undefined) ?? preferred
+  );
+}

--- a/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.test.tsx
+++ b/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.test.tsx
@@ -24,6 +24,7 @@ vi.mock('../../store/agorStore', () => ({
     selector({
       mcpServerById: new Map(),
       userById: new Map(),
+      agenticToolSettingsByName: new Map(),
     }),
 }));
 

--- a/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.tsx
+++ b/apps/agor-ui/src/components/AppHeader/NavbarComposeButton.tsx
@@ -13,7 +13,6 @@ import {
   getDefaultPermissionMode,
   getTeammateConfig,
   mapToCodexPermissionConfig,
-  resolveUserPrimaryAgenticTool,
 } from '@agor-live/client';
 import { BulbOutlined, CloseOutlined, EditOutlined, RobotOutlined } from '@ant-design/icons';
 import {
@@ -43,6 +42,7 @@ import {
   getUserDefaultConfigurationSource,
 } from '../AgenticToolConfigurationPicker/useAgenticConfigurationSources';
 import { AgentSelectionGrid, AVAILABLE_AGENTS } from '../AgentSelectionGrid';
+import { resolveAvailableUserAgenticTool } from '../AgentSelectionGrid/availableAgents';
 import { AutocompleteTextarea } from '../AutocompleteTextarea';
 import { SessionAttachmentTray } from '../SessionPanel/SessionAttachmentTray';
 import { SessionComposerDropZone } from '../SessionPanel/SessionComposerDropZone';
@@ -102,6 +102,7 @@ export const NavbarComposeButton: React.FC<NavbarComposeButtonProps> = ({
 
   const mcpServerById = useAgorStore(selectMcpServerById);
   const userById = useAgorStore(selectUserById);
+  const agenticToolSettings = useAgorStore((state) => state.agenticToolSettingsByName);
 
   const [open, setOpen] = useState(false);
   const [resolving, setResolving] = useState(false);
@@ -186,7 +187,11 @@ export const NavbarComposeButton: React.FC<NavbarComposeButtonProps> = ({
     if (!open) return;
     mcpEditedRef.current = false;
     mcpInitializedBranchIdRef.current = null;
-    const primaryTool = resolveUserPrimaryAgenticTool(currentUser);
+    const primaryTool = resolveAvailableUserAgenticTool(
+      currentUser,
+      agenticToolSettings,
+      AVAILABLE_AGENTS
+    );
     setSelectedAgent(primaryTool);
     const agentDefaults = getUserAgenticToolDefault(currentUser, primaryTool).configuration;
     form.resetFields();

--- a/apps/agor-ui/src/components/NewSessionModal/NewSessionModal.test.tsx
+++ b/apps/agor-ui/src/components/NewSessionModal/NewSessionModal.test.tsx
@@ -142,7 +142,11 @@ vi.mock('../AgenticConfigChipRow', () => ({
 
 vi.mock('../../store/agorStore', () => ({
   useAgorStore: (selector: (state: unknown) => unknown) =>
-    selector({ userById: new Map(), mcpServerById: new Map() }),
+    selector({
+      userById: new Map(),
+      mcpServerById: new Map(),
+      agenticToolSettingsByName: new Map(),
+    }),
 }));
 vi.mock('../../utils/message', () => ({
   useThemedMessage: () => ({ showError: vi.fn() }),

--- a/apps/agor-ui/src/components/NewSessionModal/NewSessionModal.tsx
+++ b/apps/agor-ui/src/components/NewSessionModal/NewSessionModal.tsx
@@ -12,7 +12,6 @@ import {
   DEFAULT_AGENTIC_TOOL_NAME,
   getDefaultPermissionMode,
   mapToCodexPermissionConfig,
-  resolveUserPrimaryAgenticTool,
 } from '@agor-live/client';
 import { DownOutlined } from '@ant-design/icons';
 import { Button, Collapse, Flex, Form, Input, Modal, Tooltip, Typography, theme } from 'antd';
@@ -37,6 +36,7 @@ import {
   type AgenticToolOption,
   AgentSelectionGrid,
 } from '../AgentSelectionGrid/AgentSelectionGrid';
+import { resolveAvailableUserAgenticTool } from '../AgentSelectionGrid/availableAgents';
 import { AutocompleteTextarea } from '../AutocompleteTextarea';
 import { CodexSettingsForm } from '../CodexSettingsForm';
 import { SessionEnvVarsSelector } from '../SessionEnvVarsSelector';
@@ -76,6 +76,7 @@ export const NewSessionModal: React.FC<NewSessionModalProps> = ({
   // the App shell doesn't have to forward them into every modal.
   const mcpServerById = useAgorStore(selectMcpServerById);
   const userById = useAgorStore(selectUserById);
+  const agenticToolSettings = useAgorStore((state) => state.agenticToolSettingsByName);
   const [form] = Form.useForm();
   const { token } = theme.useToken();
   const { showError } = useThemedMessage();
@@ -120,7 +121,11 @@ export const NewSessionModal: React.FC<NewSessionModalProps> = ({
   useEffect(() => {
     if (!open) return;
 
-    const primaryTool = resolveUserPrimaryAgenticTool(currentUser);
+    const primaryTool = resolveAvailableUserAgenticTool(
+      currentUser,
+      agenticToolSettings,
+      availableAgents
+    );
     setSelectedAgent(primaryTool);
     setIsCreating(false); // Reset creating state when modal opens
     setEnvVarNames([]);

--- a/apps/agor-ui/src/components/OnboardingBanners/OnboardingBanners.browser.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingBanners/OnboardingBanners.browser.test.tsx
@@ -1,0 +1,58 @@
+import type { User } from '@agor-live/client';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { ConfigProvider } from 'antd';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { agorStore } from '../../store/agorStore';
+import { OnboardingBanners } from './OnboardingBanners';
+
+const USER = {
+  user_id: 'browser-user',
+  onboarding_completed: true,
+  primary_agentic_tool: 'claude-code',
+  agentic_tools: { 'claude-code': { ANTHROPIC_AUTH_TOKEN: true } },
+  agentic_auth_methods: { 'claude-code': 'api_key' },
+} as User;
+
+beforeEach(() => {
+  agorStore.getState().reset();
+  agorStore.getState().setAgenticToolSettings([]);
+  window.localStorage.clear();
+});
+
+afterEach(cleanup);
+
+describe('OnboardingBanners real-browser UX', () => {
+  it('keeps the agent-specific warning and accessible snooze usable at every viewport', async () => {
+    render(
+      <ConfigProvider theme={{ token: { motion: false } }}>
+        <OnboardingBanners
+          user={USER}
+          mcpServerCount={1}
+          gatewayChannelCount={0}
+          integrationsHydrated
+          canManageMcp={false}
+          onOpenUserSettings={vi.fn()}
+          onOpenWorkspaceSettings={vi.fn()}
+          onCheckAuth={vi.fn(async () => ({
+            status: 'unauthenticated',
+            authenticated: false,
+            method: 'api-key',
+          }))}
+          credentialVersion={0}
+          connectionReady
+        />
+      </ConfigProvider>
+    );
+
+    expect(await screen.findByText(/Claude Code rejected the configured credential/)).toBeVisible();
+    expect(document.documentElement.scrollWidth).toBeLessThanOrEqual(window.innerWidth + 1);
+    expect(screen.getByRole('button', { name: 'Review Claude Code settings' })).toBeVisible();
+    const snooze = screen.getByRole('button', {
+      name: 'Snooze Claude Code warning for 24 hours',
+    });
+    snooze.focus();
+    expect(snooze).toHaveFocus();
+    fireEvent.click(snooze);
+    expect(screen.queryByText(/Claude Code rejected/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/agor-ui/src/components/OnboardingBanners/OnboardingBanners.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingBanners/OnboardingBanners.test.tsx
@@ -1,6 +1,6 @@
 import type { AgenticToolName, AuthCheckResult, User } from '@agor-live/client';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { agorStore } from '../../store/agorStore';
 import { OnboardingBanners, type OnboardingBannersProps } from './OnboardingBanners';
 
@@ -23,17 +23,25 @@ const baseProps = (over: Partial<OnboardingBannersProps>): OnboardingBannersProp
   onOpenWorkspaceSettings: vi.fn(),
   onCheckAuth: vi.fn(async () => result('unauthenticated')),
   credentialVersion: 0,
+  connectionReady: true,
   ...over,
 });
 
 describe('OnboardingBanners probe effect', () => {
-  beforeEach(() => agorStore.getState().reset());
+  beforeEach(() => {
+    agorStore.getState().reset();
+    agorStore.getState().setAgenticToolSettings([]);
+    window.localStorage.clear();
+  });
+  afterEach(() => vi.useRealTimers());
 
-  it('shows "No AI" once every probe positively reports unauthenticated', async () => {
+  it('shows an agent-specific missing warning on a positive unauthenticated result', async () => {
     render(
       <OnboardingBanners {...baseProps({ onCheckAuth: async () => result('unauthenticated') })} />
     );
-    await waitFor(() => expect(screen.getByText(/No AI connected/)).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByText(/Claude Code isn't connected/)).toBeInTheDocument()
+    );
   });
 
   it('shows no amber banner when the probe confirms authenticated', async () => {
@@ -41,7 +49,7 @@ describe('OnboardingBanners probe effect', () => {
       <OnboardingBanners {...baseProps({ onCheckAuth: async () => result('authenticated') })} />
     );
     // Give the effect a chance to resolve, then assert nothing scary rendered.
-    await waitFor(() => expect(screen.queryByText(/No AI connected/)).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByText(/isn't connected/)).not.toBeInTheDocument());
   });
 
   it('shows no amber banner when the probe throws (fail safe → Unknown)', async () => {
@@ -50,7 +58,39 @@ describe('OnboardingBanners probe effect', () => {
     });
     render(<OnboardingBanners {...baseProps({ onCheckAuth })} />);
     await waitFor(() => expect(onCheckAuth).toHaveBeenCalled());
-    expect(screen.queryByText(/No AI connected/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/isn't connected/)).not.toBeInTheDocument();
+  });
+
+  it('stays Unknown until workspace agent policy finishes hydrating', async () => {
+    agorStore.getState().reset();
+    const onCheckAuth = vi.fn(async () => result('unauthenticated'));
+    render(<OnboardingBanners {...baseProps({ onCheckAuth })} />);
+
+    expect(onCheckAuth).not.toHaveBeenCalled();
+    expect(screen.queryByText(/isn't connected/)).not.toBeInTheDocument();
+
+    act(() => agorStore.getState().setAgenticToolSettings([]));
+    expect(await screen.findByText(/Claude Code isn't connected/)).toBeVisible();
+  });
+
+  it('does not call a disabled tool a credential failure when no agent is available', () => {
+    const onCheckAuth = vi.fn(async () => result('unauthenticated'));
+    const disabled = ['claude-code', 'codex', 'gemini', 'copilot', 'cursor', 'opencode'].map(
+      (tool) => ({
+        tool,
+        deployment_available: true,
+        enabled: false,
+        resolution_policy: 'user_preferred',
+        inline_configuration_allowed: true,
+        connection: {},
+      })
+    );
+    act(() => agorStore.getState().setAgenticToolSettings(disabled as never));
+
+    render(<OnboardingBanners {...baseProps({ onCheckAuth })} />);
+
+    expect(onCheckAuth).not.toHaveBeenCalled();
+    expect(screen.queryByText(/isn't connected|rejected the configured credential/)).toBeNull();
   });
 
   it('re-probes and resets state on a user-identity change', async () => {
@@ -60,7 +100,9 @@ describe('OnboardingBanners probe effect', () => {
 
     onCheckAuth.mockImplementation(async () => result('unauthenticated'));
     rerender(<OnboardingBanners {...baseProps({ user: onboardedUser('user-2'), onCheckAuth })} />);
-    await waitFor(() => expect(screen.getByText(/No AI connected/)).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByText(/Claude Code isn't connected/)).toBeInTheDocument()
+    );
   });
 
   it('re-probes and clears the banner when a Codex subscription login lands via a user patch (no remount)', async () => {
@@ -70,7 +112,9 @@ describe('OnboardingBanners probe effect', () => {
     // the banner stuck until a page refresh.
     const onCheckAuth = vi.fn(async () => result('unauthenticated'));
     const { rerender } = render(<OnboardingBanners {...baseProps({ onCheckAuth })} />);
-    await waitFor(() => expect(screen.getByText(/No AI connected/)).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByText(/Claude Code isn't connected/)).toBeInTheDocument()
+    );
     const callsBefore = onCheckAuth.mock.calls.length;
 
     onCheckAuth.mockImplementation(async () => result('authenticated'));
@@ -87,7 +131,7 @@ describe('OnboardingBanners probe effect', () => {
 
     // Same identity → same component instance (no remount); the method-marker
     // dep change re-fires the probe, which now clears the banner.
-    await waitFor(() => expect(screen.queryByText(/No AI connected/)).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByText(/isn't connected/)).not.toBeInTheDocument());
     expect(onCheckAuth.mock.calls.length).toBeGreaterThan(callsBefore);
   });
 
@@ -128,22 +172,23 @@ describe('OnboardingBanners probe effect', () => {
     expect(onCheckAuth).toHaveBeenCalledTimes(1);
   });
 
-  it('treats CLAUDE_CODE_OAUTH_TOKEN in user env vars as Claude auth (probes claude-code, no banner)', async () => {
+  it('treats provider-scoped CLAUDE_CODE_OAUTH_TOKEN as Claude auth (probes claude-code, no banner)', async () => {
     const onCheckAuth = vi.fn(async () => result('authenticated'));
     render(
       <OnboardingBanners
         {...baseProps({
           user: onboardedUser('user-1', {
-            env_vars: {
-              CLAUDE_CODE_OAUTH_TOKEN: { set: true, scope: 'global', resource_id: null },
+            agentic_tools: {
+              'claude-code': { CLAUDE_CODE_OAUTH_TOKEN: true },
             },
+            agentic_auth_methods: { 'claude-code': 'subscription' },
           } as Partial<User>),
           onCheckAuth,
         })}
       />
     );
     await waitFor(() => expect(onCheckAuth).toHaveBeenCalledWith('claude-code'));
-    expect(screen.queryByText(/No AI connected/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/isn't connected/)).not.toBeInTheDocument();
   });
 
   it('uses the standard alert action to open AI settings', async () => {
@@ -157,7 +202,7 @@ describe('OnboardingBanners probe effect', () => {
       />
     );
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Connect AI' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Open Claude Code settings' }));
     expect(onOpenUserSettings).toHaveBeenCalledWith('claude-code');
   });
 
@@ -198,7 +243,7 @@ describe('OnboardingBanners probe effect', () => {
         })}
       />
     );
-    fireEvent.click((await screen.findByText('Reconnect AI')).closest('button')!);
+    fireEvent.click(await screen.findByRole('button', { name: 'Review Claude Code settings' }));
     expect(onOpenWorkspaceSettings).toHaveBeenCalledWith('agentic-tools');
     expect(onOpenUserSettings).not.toHaveBeenCalled();
   });
@@ -225,7 +270,7 @@ describe('OnboardingBanners probe effect', () => {
         })}
       />
     );
-    fireEvent.click((await screen.findByText('Reconnect AI')).closest('button')!);
+    fireEvent.click(await screen.findByRole('button', { name: 'Review Claude Code settings' }));
     expect(onOpenUserSettings).toHaveBeenCalledWith('claude-code');
     expect(onOpenWorkspaceSettings).not.toHaveBeenCalled();
   });
@@ -253,7 +298,171 @@ describe('OnboardingBanners probe effect', () => {
         {...baseProps({ onOpenUserSettings, onCheckAuth: async () => result('unauthenticated') })}
       />
     );
-    fireEvent.click((await screen.findByText('Connect AI')).closest('button')!);
+    fireEvent.click(await screen.findByRole('button', { name: 'Open Codex settings' }));
     expect(onOpenUserSettings).toHaveBeenCalledWith('codex');
+  });
+
+  it('renders Claude bearer-token rejection as Claude-only and never exposes secret data', async () => {
+    const syntheticSecret = 'synthetic-secret-must-not-render';
+    const onCheckAuth = vi.fn(async () => ({
+      ...result('unauthenticated'),
+      hint: syntheticSecret,
+    }));
+    render(
+      <OnboardingBanners
+        {...baseProps({
+          user: onboardedUser('user-1', {
+            primary_agentic_tool: 'claude-code',
+            agentic_tools: { 'claude-code': { ANTHROPIC_AUTH_TOKEN: true } },
+            agentic_auth_methods: { 'claude-code': 'api_key' },
+          }),
+          onCheckAuth,
+        })}
+      />
+    );
+
+    expect(await screen.findByText(/Claude Code rejected the configured credential/)).toBeVisible();
+    expect(screen.getByText(/New Claude Code sessions will fail/)).toBeVisible();
+    expect(screen.queryByText(/Codex rejected/)).not.toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent(syntheticSecret);
+  });
+
+  it('does not probe or surface another-agent-only failure', async () => {
+    const onCheckAuth = vi.fn(async (tool: AgenticToolName) =>
+      result(tool === 'claude-code' ? 'authenticated' : 'unauthenticated')
+    );
+    render(
+      <OnboardingBanners
+        {...baseProps({
+          user: onboardedUser('user-1', { primary_agentic_tool: 'claude-code' }),
+          onCheckAuth,
+        })}
+      />
+    );
+
+    await waitFor(() => expect(onCheckAuth).toHaveBeenCalledTimes(1));
+    expect(onCheckAuth).toHaveBeenCalledWith('claude-code');
+    expect(screen.queryByText(/rejected the configured credential/)).not.toBeInTheDocument();
+  });
+
+  it('resets to Unknown while disconnected, then clears a stale warning after reconnect success', async () => {
+    const onCheckAuth = vi
+      .fn<(tool: AgenticToolName) => Promise<AuthCheckResult>>()
+      .mockResolvedValueOnce(result('unauthenticated'))
+      .mockResolvedValueOnce(result('authenticated'));
+    const props = baseProps({ onCheckAuth });
+    const { rerender } = render(<OnboardingBanners {...props} />);
+    await screen.findByText(/Claude Code isn't connected/);
+
+    rerender(<OnboardingBanners {...props} connectionReady={false} />);
+    await waitFor(() => expect(screen.queryByText(/isn't connected/)).not.toBeInTheDocument());
+    rerender(<OnboardingBanners {...props} connectionReady />);
+    await waitFor(() => expect(onCheckAuth).toHaveBeenCalledTimes(2));
+    expect(screen.queryByText(/isn't connected/)).not.toBeInTheDocument();
+  });
+
+  it('shows the warning again when a reconnect positively confirms failure', async () => {
+    const onCheckAuth = vi.fn(async () => result('unauthenticated'));
+    const props = baseProps({ onCheckAuth, connectionReady: false });
+    const { rerender } = render(<OnboardingBanners {...props} />);
+    expect(onCheckAuth).not.toHaveBeenCalled();
+
+    rerender(<OnboardingBanners {...props} connectionReady />);
+    expect(await screen.findByText(/Claude Code isn't connected/)).toBeVisible();
+  });
+
+  it('re-probes a same-field credential rotation delivered by realtime updated_at', async () => {
+    const onCheckAuth = vi
+      .fn<(tool: AgenticToolName) => Promise<AuthCheckResult>>()
+      .mockResolvedValueOnce(result('unauthenticated'))
+      .mockResolvedValueOnce(result('authenticated'));
+    const credentialState = {
+      primary_agentic_tool: 'claude-code' as const,
+      agentic_tools: { 'claude-code': { ANTHROPIC_AUTH_TOKEN: true } },
+      agentic_auth_methods: { 'claude-code': 'api_key' as const },
+    };
+    const { rerender } = render(
+      <OnboardingBanners
+        {...baseProps({
+          user: onboardedUser('user-1', {
+            ...credentialState,
+            updated_at: new Date('2026-08-29T10:00:00Z'),
+          }),
+          onCheckAuth,
+        })}
+      />
+    );
+    await screen.findByText(/Claude Code rejected/);
+
+    rerender(
+      <OnboardingBanners
+        {...baseProps({
+          user: onboardedUser('user-1', {
+            ...credentialState,
+            updated_at: new Date('2026-08-29T10:01:00Z'),
+          }),
+          onCheckAuth,
+        })}
+      />
+    );
+    await waitFor(() => expect(onCheckAuth).toHaveBeenCalledTimes(2));
+    expect(screen.queryByText(/Claude Code rejected/)).not.toBeInTheDocument();
+  });
+
+  it('persists an accessible 24-hour snooze per user and tool, then reminds again', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const start = new Date('2026-08-29T12:00:00Z');
+    vi.setSystemTime(start);
+    const onCheckAuth = vi.fn(async () => result('unauthenticated'));
+    const props = baseProps({ onCheckAuth });
+    const first = render(<OnboardingBanners {...props} />);
+    const close = await screen.findByRole('button', {
+      name: 'Snooze Claude Code warning for 24 hours',
+    });
+    fireEvent.click(close);
+    await waitFor(() => expect(screen.queryByText(/Claude Code isn't connected/)).toBeNull());
+    first.unmount();
+
+    const second = render(<OnboardingBanners {...props} />);
+    await waitFor(() => expect(screen.queryByText(/Claude Code isn't connected/)).toBeNull());
+    const callsBeforeReminder = onCheckAuth.mock.calls.length;
+
+    await act(() => vi.advanceTimersByTimeAsync(24 * 60 * 60 * 1000 + 1));
+    expect(onCheckAuth.mock.calls.length).toBeGreaterThan(callsBeforeReminder);
+    expect(await screen.findByText(/Claude Code isn't connected/)).toBeVisible();
+    second.unmount();
+    vi.useRealTimers();
+  });
+
+  it('does not transfer a dismissed warning across logout or user switch', async () => {
+    const onCheckAuth = vi.fn(async () => result('unauthenticated'));
+    const props = baseProps({ onCheckAuth });
+    const { rerender } = render(<OnboardingBanners {...props} />);
+    fireEvent.click(
+      await screen.findByRole('button', { name: /Snooze Claude Code warning for 24 hours/ })
+    );
+    rerender(<OnboardingBanners {...props} user={null} />);
+    expect(screen.queryByText(/isn't connected/)).not.toBeInTheDocument();
+
+    rerender(<OnboardingBanners {...props} user={onboardedUser('user-2')} />);
+    expect(await screen.findByText(/Claude Code isn't connected/)).toBeVisible();
+  });
+
+  it('clears a snooze after a local credential save so reconnect failure is visible', async () => {
+    const onCheckAuth = vi.fn(async () => result('unauthenticated'));
+    const props = baseProps({
+      user: onboardedUser('user-1', {
+        agentic_tools: { 'claude-code': { ANTHROPIC_API_KEY: true } },
+      }),
+      onCheckAuth,
+    });
+    const { rerender } = render(<OnboardingBanners {...props} />);
+    fireEvent.click(
+      await screen.findByRole('button', { name: /Snooze Claude Code warning for 24 hours/ })
+    );
+    await waitFor(() => expect(screen.queryByText(/Claude Code rejected/)).toBeNull());
+
+    rerender(<OnboardingBanners {...props} credentialVersion={1} />);
+    expect(await screen.findByText(/Claude Code rejected/)).toBeVisible();
   });
 });

--- a/apps/agor-ui/src/components/OnboardingBanners/OnboardingBanners.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingBanners/OnboardingBanners.test.tsx
@@ -287,6 +287,35 @@ describe('OnboardingBanners probe effect', () => {
     expect(onOpenWorkspaceSettings).not.toHaveBeenCalled();
   });
 
+  it('lets a member override a rejected workspace fallback under user-preferred policy', async () => {
+    agorStore.getState().setAgenticToolSettings([
+      {
+        tool: 'claude-code',
+        enabled: true,
+        resolution_policy: 'user_preferred',
+        inline_configuration_allowed: true,
+        connection: { ANTHROPIC_API_KEY: { configured: true } },
+      },
+    ]);
+    const onOpenUserSettings = vi.fn();
+    const onOpenWorkspaceSettings = vi.fn();
+    render(
+      <OnboardingBanners
+        {...baseProps({
+          user: onboardedUser('member-1', { role: 'member', agentic_tools: {} }),
+          onOpenUserSettings,
+          onOpenWorkspaceSettings,
+          onCheckAuth: async () => result('unauthenticated'),
+        })}
+      />
+    );
+
+    expect(await screen.findByText(/rejected the workspace fallback credential/)).toBeVisible();
+    fireEvent.click(screen.getByRole('button', { name: 'Add personal Claude Code credential' }));
+    expect(onOpenUserSettings).toHaveBeenCalledWith('claude-code');
+    expect(onOpenWorkspaceSettings).not.toHaveBeenCalled();
+  });
+
   it('routes user-preferred credential failures to the selected user tool tab', async () => {
     agorStore.getState().setAgenticToolSettings([
       {

--- a/apps/agor-ui/src/components/OnboardingBanners/OnboardingBanners.test.tsx
+++ b/apps/agor-ui/src/components/OnboardingBanners/OnboardingBanners.test.tsx
@@ -2,6 +2,10 @@ import type { AgenticToolName, AuthCheckResult, User } from '@agor-live/client';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { agorStore } from '../../store/agorStore';
+import {
+  CREDENTIAL_WARNING_SNOOZE_MS,
+  credentialWarningSnoozeStorageKey,
+} from './credentialWarningDismissal';
 import { OnboardingBanners, type OnboardingBannersProps } from './OnboardingBanners';
 
 const onboardedUser = (userId: string, overrides: Partial<User> = {}): User =>
@@ -111,10 +115,15 @@ describe('OnboardingBanners probe effect', () => {
     // stored key and no credentialVersion bump — the case that previously left
     // the banner stuck until a page refresh.
     const onCheckAuth = vi.fn(async () => result('unauthenticated'));
-    const { rerender } = render(<OnboardingBanners {...baseProps({ onCheckAuth })} />);
-    await waitFor(() =>
-      expect(screen.getByText(/Claude Code isn't connected/)).toBeInTheDocument()
+    const { rerender } = render(
+      <OnboardingBanners
+        {...baseProps({
+          user: onboardedUser('user-1', { primary_agentic_tool: 'codex' }),
+          onCheckAuth,
+        })}
+      />
     );
+    await waitFor(() => expect(screen.getByText(/Codex isn't connected/)).toBeInTheDocument());
     const callsBefore = onCheckAuth.mock.calls.length;
 
     onCheckAuth.mockImplementation(async () => result('authenticated'));
@@ -122,6 +131,7 @@ describe('OnboardingBanners probe effect', () => {
       <OnboardingBanners
         {...baseProps({
           user: onboardedUser('user-1', {
+            primary_agentic_tool: 'codex',
             agentic_auth_methods: { codex: 'subscription' },
           } as Partial<User>),
           onCheckAuth,
@@ -135,7 +145,7 @@ describe('OnboardingBanners probe effect', () => {
     expect(onCheckAuth.mock.calls.length).toBeGreaterThan(callsBefore);
   });
 
-  it('does not re-probe on an unrelated user-record patch (e.g. a name edit)', async () => {
+  it('does not re-probe solely because a nested auth-method object has new identity', async () => {
     const onCheckAuth = vi.fn(async () => result('authenticated'));
     // Seed a codex method so the effect's method deps are non-empty in BOTH
     // renders (each a FRESH object). This pins the object-identity hazard: the
@@ -154,9 +164,9 @@ describe('OnboardingBanners probe effect', () => {
     );
     await waitFor(() => expect(onCheckAuth).toHaveBeenCalledTimes(1));
 
-    // A field that touches neither identity, stored keys, nor auth methods must
-    // NOT spawn another ~5–10s probe — even though the whole user object (and its
-    // agentic_auth_methods) is a fresh reference from the patch.
+    // This intentionally omits a new server `updated_at`: production user
+    // patches carry that durable revision and do re-probe. The assertion here
+    // is only that a freshly allocated nested object is not itself a dependency.
     rerender(
       <OnboardingBanners
         {...baseProps({
@@ -248,7 +258,7 @@ describe('OnboardingBanners probe effect', () => {
     expect(onOpenUserSettings).not.toHaveBeenCalled();
   });
 
-  it('routes members to user settings when tenant credentials are preferred', async () => {
+  it('directs members to an admin instead of unusable personal settings for a tenant credential', async () => {
     agorStore.getState().setAgenticToolSettings([
       {
         tool: 'claude-code',
@@ -270,8 +280,10 @@ describe('OnboardingBanners probe effect', () => {
         })}
       />
     );
-    fireEvent.click(await screen.findByRole('button', { name: 'Review Claude Code settings' }));
-    expect(onOpenUserSettings).toHaveBeenCalledWith('claude-code');
+    expect(await screen.findByText(/rejected the workspace-managed credential/)).toBeVisible();
+    expect(screen.getByText(/Ask a workspace admin to update it/)).toBeVisible();
+    expect(screen.queryByRole('button', { name: 'Review Claude Code settings' })).toBeNull();
+    expect(onOpenUserSettings).not.toHaveBeenCalled();
     expect(onOpenWorkspaceSettings).not.toHaveBeenCalled();
   });
 
@@ -409,6 +421,73 @@ describe('OnboardingBanners probe effect', () => {
     expect(screen.queryByText(/Claude Code rejected/)).not.toBeInTheDocument();
   });
 
+  it('re-probes and clears a snooze on a durable same-presence workspace rotation', async () => {
+    const workspaceSettings = (revision: number) => ({
+      tool: 'claude-code' as const,
+      revision,
+      deployment_available: true,
+      enabled: true,
+      resolution_policy: 'tenant_preferred' as const,
+      inline_configuration_allowed: true,
+      connection: { ANTHROPIC_AUTH_TOKEN: { configured: true } },
+    });
+    act(() => agorStore.getState().setAgenticToolSettings([workspaceSettings(1)]));
+    const onCheckAuth = vi.fn(async () => result('unauthenticated'));
+    const props = baseProps({
+      user: onboardedUser('admin-1', { role: 'admin' }),
+      onCheckAuth,
+    });
+    render(<OnboardingBanners {...props} />);
+    fireEvent.click(
+      await screen.findByRole('button', { name: /Snooze Claude Code warning for 24 hours/ })
+    );
+    await waitFor(() => expect(screen.queryByText(/Claude Code rejected/)).toBeNull());
+
+    act(() => agorStore.getState().upsertAgenticToolSetting(workspaceSettings(2)));
+
+    await waitFor(() => expect(onCheckAuth).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText(/Claude Code rejected/)).toBeVisible();
+    expect(
+      window.localStorage.getItem(credentialWarningSnoozeStorageKey('admin-1', 'claude-code'))
+    ).toBeNull();
+  });
+
+  it('ignores an older in-flight probe after a same-presence workspace rotation', async () => {
+    const workspaceSettings = (revision: number) => ({
+      tool: 'claude-code' as const,
+      revision,
+      deployment_available: true,
+      enabled: true,
+      resolution_policy: 'tenant_preferred' as const,
+      inline_configuration_allowed: true,
+      connection: { ANTHROPIC_AUTH_TOKEN: { configured: true } },
+    });
+    act(() => agorStore.getState().setAgenticToolSettings([workspaceSettings(1)]));
+    let settleOldProbe!: (value: AuthCheckResult) => void;
+    const oldProbe = new Promise<AuthCheckResult>((resolve) => {
+      settleOldProbe = resolve;
+    });
+    const onCheckAuth = vi
+      .fn<(tool: AgenticToolName) => Promise<AuthCheckResult>>()
+      .mockReturnValueOnce(oldProbe)
+      .mockResolvedValueOnce(result('authenticated'));
+    render(
+      <OnboardingBanners
+        {...baseProps({
+          user: onboardedUser('admin-1', { role: 'admin' }),
+          onCheckAuth,
+        })}
+      />
+    );
+    await waitFor(() => expect(onCheckAuth).toHaveBeenCalledTimes(1));
+
+    act(() => agorStore.getState().upsertAgenticToolSetting(workspaceSettings(2)));
+    await waitFor(() => expect(onCheckAuth).toHaveBeenCalledTimes(2));
+    act(() => settleOldProbe(result('unauthenticated')));
+
+    await waitFor(() => expect(screen.queryByText(/Claude Code rejected/)).toBeNull());
+  });
+
   it('persists an accessible 24-hour snooze per user and tool, then reminds again', async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     const start = new Date('2026-08-29T12:00:00Z');
@@ -464,5 +543,31 @@ describe('OnboardingBanners probe effect', () => {
 
     rerender(<OnboardingBanners {...props} credentialVersion={1} />);
     expect(await screen.findByText(/Claude Code rejected/)).toBeVisible();
+  });
+
+  it('synchronizes snooze and clear events across browser tabs', async () => {
+    const onCheckAuth = vi.fn(async () => result('unauthenticated'));
+    render(<OnboardingBanners {...baseProps({ onCheckAuth })} />);
+    await screen.findByText(/Claude Code isn't connected/);
+    const key = credentialWarningSnoozeStorageKey('user-1', 'claude-code');
+    const snoozedUntil = Date.now() + CREDENTIAL_WARNING_SNOOZE_MS;
+    const serialized = JSON.stringify({ version: 1, snoozedUntil });
+
+    window.localStorage.setItem(key, serialized);
+    act(() =>
+      window.dispatchEvent(
+        new StorageEvent('storage', { key, newValue: serialized, storageArea: window.localStorage })
+      )
+    );
+    await waitFor(() => expect(screen.queryByText(/Claude Code isn't connected/)).toBeNull());
+
+    window.localStorage.removeItem(key);
+    act(() =>
+      window.dispatchEvent(
+        new StorageEvent('storage', { key, oldValue: serialized, storageArea: window.localStorage })
+      )
+    );
+    await waitFor(() => expect(onCheckAuth).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText(/Claude Code isn't connected/)).toBeVisible();
   });
 });

--- a/apps/agor-ui/src/components/OnboardingBanners/OnboardingBanners.tsx
+++ b/apps/agor-ui/src/components/OnboardingBanners/OnboardingBanners.tsx
@@ -26,6 +26,7 @@ import {
 } from './bannerLogic';
 import {
   clearCredentialWarningSnooze,
+  credentialWarningSnoozeStorageKey,
   readCredentialWarningSnooze,
   writeCredentialWarningSnooze,
 } from './credentialWarningDismissal';
@@ -61,12 +62,13 @@ function AmberBanner({
   dismissLabel,
 }: {
   message: string;
-  buttonLabel: string;
-  onClick: () => void;
+  buttonLabel?: string;
+  onClick?: () => void;
   docsHref?: string;
   onDismiss: () => void;
   dismissLabel: string;
 }) {
+  const hasAction = !!docsHref || (!!buttonLabel && !!onClick);
   return (
     <Alert
       banner
@@ -75,22 +77,26 @@ function AmberBanner({
       title={message}
       closable={{ closeIcon: true, onClose: onDismiss, 'aria-label': dismissLabel }}
       action={
-        <Space size="small">
-          {docsHref && (
-            <Button
-              type="link"
-              size="small"
-              href={docsHref}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Documentation
-            </Button>
-          )}
-          <Button type="primary" size="small" onClick={onClick}>
-            {buttonLabel}
-          </Button>
-        </Space>
+        hasAction ? (
+          <Space size="small">
+            {docsHref && (
+              <Button
+                type="link"
+                size="small"
+                href={docsHref}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Documentation
+              </Button>
+            )}
+            {buttonLabel && onClick && (
+              <Button type="primary" size="small" onClick={onClick}>
+                {buttonLabel}
+              </Button>
+            )}
+          </Space>
+        ) : undefined
       }
     />
   );
@@ -117,7 +123,11 @@ export function OnboardingBanners({
     null
   );
   const [probeRefreshVersion, setProbeRefreshVersion] = useState(0);
-  const priorCredentialVersion = useRef<{ owner: string | null; version: number } | null>(null);
+  const priorCredentialRevision = useRef<{
+    owner: string;
+    userVersion: number;
+    workspaceRevision: number;
+  } | null>(null);
   const agenticToolSettings = useAgorStore((state) => state.agenticToolSettingsByName);
   const agenticToolSettingsHydrated = useAgorStore((state) => state.agenticToolSettingsHydrated);
 
@@ -133,17 +143,16 @@ export function OnboardingBanners({
   const displayName = AGENTIC_TOOL_DISPLAY_NAMES[probeAgent] ?? probeAgent;
   const dismissalOwner = userId ? `${userId}:${probeAgent}` : null;
   const userCredentialRevision = user?.updated_at ? String(user.updated_at) : '';
+  const workspaceCredentialRevision = probeSettings?.revision ?? 0;
 
-  // Auth-method markers for the subscription/native paths (ChatGPT device
-  // sign-in, imported Codex login, Claude subscription token). These land
-  // server-side via their own services and flow back on the users `patched`
-  // event WITHOUT a stored key or a credentialVersion bump — so hasLlm alone
-  // can't see them. They are primitives ('api_key' | 'subscription' |
-  // undefined) that change only on a genuine method flip, never on unrelated
-  // user-record patches, keeping the ~5–10s probe from firing on name/emoji
-  // edits. `agentic_auth_methods` only ever carries these two tools.
-  const codexAuthMethod = user?.agentic_auth_methods?.codex;
-  const claudeAuthMethod = user?.agentic_auth_methods?.['claude-code'];
+  // Auth-method marker for the selected tool's subscription/native path. It
+  // lands server-side via its own service and can change without a stored key
+  // or credentialVersion bump. Keep only the selected primitive in the probe
+  // key so a login for an unrelated tool does not re-probe this one.
+  const probeAuthMethod =
+    probeAgent === 'codex' || probeAgent === 'claude-code'
+      ? user?.agentic_auth_methods?.[probeAgent]
+      : undefined;
   const probeOwner = JSON.stringify([
     userId,
     userCredentialRevision,
@@ -155,8 +164,7 @@ export function OnboardingBanners({
     probeSettings,
     credentialVersion,
     probeRefreshVersion,
-    codexAuthMethod,
-    claudeAuthMethod,
+    probeAuthMethod,
   ]);
   // Never render an old user's/tool's verdict for one frame while the effect
   // below is scheduling its replacement.
@@ -168,9 +176,9 @@ export function OnboardingBanners({
   // credential rotation delivered by realtime (presence stays `true`, so a
   // boolean-only dependency would be stale). userId resets state on a switch;
   // credentialVersion covers the local save path before realtime lands;
-  // codexAuthMethod/claudeAuthMethod re-probe after a subscription/native login
+  // probeAuthMethod re-probes after a selected-tool subscription/native login
   // lands server-side (device sign-in, auth.json import) — paths that bump
-  // neither hasLlm nor credentialVersion — and cover a second browser tab too.
+  // neither hasLlm nor credentialVersion — and covers a second browser tab too.
   useEffect(() => {
     if (!onboardingCompleted || !connectionReady || !agenticToolSettingsHydrated || !probeEnabled) {
       setProbeResult({ owner: probeOwner, state: ProbeState.Unknown });
@@ -199,20 +207,32 @@ export function OnboardingBanners({
   ]);
 
   // A warning can be snoozed for 24 hours, scoped to one user + one selected
-  // tool. A local credential save clears the snooze so failed reconnects are
-  // immediately actionable; successful reconnects disappear through the probe.
+  // tool. Local user saves and durable workspace-settings revisions clear it,
+  // so failed reconnects are immediately actionable; successful reconnects
+  // disappear through the probe. Wait for policy hydration before recording
+  // the workspace revision, otherwise an initial 0 -> persisted revision load
+  // would incorrectly erase a snooze on every page refresh.
   useEffect(() => {
-    const previous = priorCredentialVersion.current;
+    if (!agenticToolSettingsHydrated) return;
+
+    const previous = priorCredentialRevision.current;
     const credentialChanged =
       !!dismissalOwner &&
       previous?.owner === dismissalOwner &&
-      previous.version !== credentialVersion;
-    priorCredentialVersion.current = { owner: dismissalOwner, version: credentialVersion };
+      (previous.userVersion !== credentialVersion ||
+        previous.workspaceRevision !== workspaceCredentialRevision);
 
     if (!userId || !dismissalOwner || typeof window === 'undefined') {
+      priorCredentialRevision.current = null;
       setCredentialWarningSnoozedUntil(null);
       return;
     }
+
+    priorCredentialRevision.current = {
+      owner: dismissalOwner,
+      userVersion: credentialVersion,
+      workspaceRevision: workspaceCredentialRevision,
+    };
 
     if (credentialChanged) {
       clearCredentialWarningSnooze(window.localStorage, userId, probeAgent);
@@ -221,7 +241,36 @@ export function OnboardingBanners({
       ? null
       : readCredentialWarningSnooze(window.localStorage, userId, probeAgent);
     setCredentialWarningSnoozedUntil(snoozedUntil);
-  }, [credentialVersion, dismissalOwner, probeAgent, userId]);
+  }, [
+    agenticToolSettingsHydrated,
+    credentialVersion,
+    dismissalOwner,
+    probeAgent,
+    userId,
+    workspaceCredentialRevision,
+  ]);
+
+  // localStorage changes are not delivered back to the tab that made them,
+  // but other tabs receive a storage event. Mirror those changes so a snooze
+  // or credential-save clear has browser-wide semantics. Clearing starts from
+  // Unknown and re-probes rather than briefly resurfacing a day-old rejection.
+  useEffect(() => {
+    if (!userId || typeof window === 'undefined') return;
+    const key = credentialWarningSnoozeStorageKey(userId, probeAgent);
+    const handleStorage = (event: StorageEvent) => {
+      if (
+        event.key !== key ||
+        (event.storageArea !== null && event.storageArea !== window.localStorage)
+      ) {
+        return;
+      }
+      const snoozedUntil = readCredentialWarningSnooze(window.localStorage, userId, probeAgent);
+      setCredentialWarningSnoozedUntil(snoozedUntil);
+      if (snoozedUntil === null) setProbeRefreshVersion((version) => version + 1);
+    };
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
+  }, [probeAgent, userId]);
 
   useEffect(() => {
     if (!credentialWarningSnoozedUntil || typeof window === 'undefined') return;
@@ -257,6 +306,13 @@ export function OnboardingBanners({
     credentialWarningDismissed:
       credentialWarningSnoozedUntil !== null && credentialWarningSnoozedUntil > Date.now(),
   });
+  const workspaceManagedForMember = credentialOwner === 'tenant' && !canManageWorkspaceCredentials;
+  const openCredentialSettings = workspaceManagedForMember
+    ? undefined
+    : () =>
+        credentialOwner === 'tenant'
+          ? onOpenWorkspaceSettings('agentic-tools')
+          : onOpenUserSettings(probeAgent);
 
   switch (decision) {
     case BannerDecision.None:
@@ -264,13 +320,13 @@ export function OnboardingBanners({
     case BannerDecision.NoAi:
       return (
         <AmberBanner
-          message={`${displayName} isn't connected. New ${displayName} sessions won't run until you configure it.`}
-          buttonLabel={`Open ${displayName} settings`}
-          onClick={() =>
-            credentialOwner === 'tenant' && canManageWorkspaceCredentials
-              ? onOpenWorkspaceSettings('agentic-tools')
-              : onOpenUserSettings(probeAgent)
+          message={
+            workspaceManagedForMember
+              ? `${displayName} is managed by your workspace but isn't connected. Ask a workspace admin to configure it before starting ${displayName} sessions.`
+              : `${displayName} isn't connected. New ${displayName} sessions won't run until you configure it.`
           }
+          buttonLabel={workspaceManagedForMember ? undefined : `Open ${displayName} settings`}
+          onClick={openCredentialSettings}
           docsHref="https://agor.live/guide"
           onDismiss={dismissCredentialWarning}
           dismissLabel={`Snooze ${displayName} warning for 24 hours`}
@@ -279,13 +335,13 @@ export function OnboardingBanners({
     case BannerDecision.KeyInvalid:
       return (
         <AmberBanner
-          message={`${displayName} rejected the configured credential. New ${displayName} sessions will fail until you update it.`}
-          buttonLabel={`Review ${displayName} settings`}
-          onClick={() =>
-            credentialOwner === 'tenant' && canManageWorkspaceCredentials
-              ? onOpenWorkspaceSettings('agentic-tools')
-              : onOpenUserSettings(probeAgent)
+          message={
+            workspaceManagedForMember
+              ? `${displayName} rejected the workspace-managed credential. Ask a workspace admin to update it before starting new ${displayName} sessions.`
+              : `${displayName} rejected the configured credential. New ${displayName} sessions will fail until you update it.`
           }
+          buttonLabel={workspaceManagedForMember ? undefined : `Review ${displayName} settings`}
+          onClick={openCredentialSettings}
           onDismiss={dismissCredentialWarning}
           dismissLabel={`Snooze ${displayName} warning for 24 hours`}
         />

--- a/apps/agor-ui/src/components/OnboardingBanners/OnboardingBanners.tsx
+++ b/apps/agor-ui/src/components/OnboardingBanners/OnboardingBanners.tsx
@@ -17,6 +17,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useAgorStore } from '../../store/agorStore';
 import {
   BannerDecision,
+  credentialRemediationTarget,
   decideBanner,
   hasConfiguredCredentialFor,
   ProbeState,
@@ -306,11 +307,18 @@ export function OnboardingBanners({
     credentialWarningDismissed:
       credentialWarningSnoozedUntil !== null && credentialWarningSnoozedUntil > Date.now(),
   });
-  const workspaceManagedForMember = credentialOwner === 'tenant' && !canManageWorkspaceCredentials;
+  const remediationTarget = credentialRemediationTarget(
+    credentialOwner,
+    probeSettings?.resolution_policy,
+    canManageWorkspaceCredentials
+  );
+  const workspaceManagedForMember = remediationTarget === 'workspace-admin';
+  const personalOverrideForWorkspaceFallback =
+    credentialOwner === 'tenant' && remediationTarget === 'user';
   const openCredentialSettings = workspaceManagedForMember
     ? undefined
     : () =>
-        credentialOwner === 'tenant'
+        remediationTarget === 'tenant'
           ? onOpenWorkspaceSettings('agentic-tools')
           : onOpenUserSettings(probeAgent);
 
@@ -323,9 +331,17 @@ export function OnboardingBanners({
           message={
             workspaceManagedForMember
               ? `${displayName} is managed by your workspace but isn't connected. Ask a workspace admin to configure it before starting ${displayName} sessions.`
-              : `${displayName} isn't connected. New ${displayName} sessions won't run until you configure it.`
+              : personalOverrideForWorkspaceFallback
+                ? `${displayName} isn't connected through the workspace fallback. Add a personal credential to use for your ${displayName} sessions.`
+                : `${displayName} isn't connected. New ${displayName} sessions won't run until you configure it.`
           }
-          buttonLabel={workspaceManagedForMember ? undefined : `Open ${displayName} settings`}
+          buttonLabel={
+            workspaceManagedForMember
+              ? undefined
+              : personalOverrideForWorkspaceFallback
+                ? `Add personal ${displayName} credential`
+                : `Open ${displayName} settings`
+          }
           onClick={openCredentialSettings}
           docsHref="https://agor.live/guide"
           onDismiss={dismissCredentialWarning}
@@ -338,9 +354,17 @@ export function OnboardingBanners({
           message={
             workspaceManagedForMember
               ? `${displayName} rejected the workspace-managed credential. Ask a workspace admin to update it before starting new ${displayName} sessions.`
-              : `${displayName} rejected the configured credential. New ${displayName} sessions will fail until you update it.`
+              : personalOverrideForWorkspaceFallback
+                ? `${displayName} rejected the workspace fallback credential. Add a personal credential to use for your ${displayName} sessions.`
+                : `${displayName} rejected the configured credential. New ${displayName} sessions will fail until you update it.`
           }
-          buttonLabel={workspaceManagedForMember ? undefined : `Review ${displayName} settings`}
+          buttonLabel={
+            workspaceManagedForMember
+              ? undefined
+              : personalOverrideForWorkspaceFallback
+                ? `Add personal ${displayName} credential`
+                : `Review ${displayName} settings`
+          }
           onClick={openCredentialSettings}
           onDismiss={dismissCredentialWarning}
           dismissLabel={`Snooze ${displayName} warning for 24 hours`}

--- a/apps/agor-ui/src/components/OnboardingBanners/OnboardingBanners.tsx
+++ b/apps/agor-ui/src/components/OnboardingBanners/OnboardingBanners.tsx
@@ -10,19 +10,25 @@
  * decision logic lives in `bannerLogic.ts`.
  */
 
+import { AGENTIC_TOOL_DISPLAY_NAMES } from '@agor/agentic-tools';
 import type { AgenticToolName, AuthCheckResult, User } from '@agor-live/client';
 import { Alert, Button, Space } from 'antd';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useAgorStore } from '../../store/agorStore';
 import {
   BannerDecision,
   decideBanner,
   hasConfiguredCredentialFor,
   ProbeState,
-  preferredCredentialOwner,
+  resolvedCredentialOwner,
   resolveGovernedProbeAgent,
   resolveProbeState,
 } from './bannerLogic';
+import {
+  clearCredentialWarningSnooze,
+  readCredentialWarningSnooze,
+  writeCredentialWarningSnooze,
+} from './credentialWarningDismissal';
 
 export interface OnboardingBannersProps {
   user: User | null | undefined;
@@ -42,6 +48,8 @@ export interface OnboardingBannersProps {
   onCheckAuth: (tool: AgenticToolName, apiKey?: string) => Promise<AuthCheckResult>;
   /** Bumped by the parent whenever credentials are saved — forces a re-probe even if key presence is unchanged (e.g. key rotation). */
   credentialVersion: number;
+  /** False during disconnect/reauth. Probes resume from Unknown after reconnect. */
+  connectionReady: boolean;
 }
 
 function AmberBanner({
@@ -49,11 +57,15 @@ function AmberBanner({
   buttonLabel,
   onClick,
   docsHref,
+  onDismiss,
+  dismissLabel,
 }: {
   message: string;
   buttonLabel: string;
   onClick: () => void;
   docsHref?: string;
+  onDismiss: () => void;
+  dismissLabel: string;
 }) {
   return (
     <Alert
@@ -61,6 +73,7 @@ function AmberBanner({
       showIcon
       type="warning"
       title={message}
+      closable={{ closeIcon: true, onClose: onDismiss, 'aria-label': dismissLabel }}
       action={
         <Space size="small">
           {docsHref && (
@@ -93,19 +106,33 @@ export function OnboardingBanners({
   onOpenWorkspaceSettings,
   onCheckAuth,
   credentialVersion,
+  connectionReady,
 }: OnboardingBannersProps) {
-  const [probeState, setProbeState] = useState<ProbeState>(ProbeState.Unknown);
+  const [probeResult, setProbeResult] = useState<{ owner: string; state: ProbeState }>({
+    owner: '',
+    state: ProbeState.Unknown,
+  });
   const [integrationsBannerDismissed, setIntegrationsBannerDismissed] = useState(false);
+  const [credentialWarningSnoozedUntil, setCredentialWarningSnoozedUntil] = useState<number | null>(
+    null
+  );
+  const [probeRefreshVersion, setProbeRefreshVersion] = useState(0);
+  const priorCredentialVersion = useRef<{ owner: string | null; version: number } | null>(null);
   const agenticToolSettings = useAgorStore((state) => state.agenticToolSettingsByName);
+  const agenticToolSettingsHydrated = useAgorStore((state) => state.agenticToolSettingsHydrated);
 
   // Pre-compute user-derived values so the effect captures primitives, not the full user object.
   const userId = user?.user_id;
   const onboardingCompleted = !!user?.onboarding_completed;
   const probeAgent = resolveGovernedProbeAgent(user, agenticToolSettings);
   const probeSettings = agenticToolSettings.get(probeAgent as never);
+  const probeEnabled = probeSettings?.enabled !== false;
   const hasLlm = hasConfiguredCredentialFor(user, probeAgent, probeSettings);
-  const credentialOwner = preferredCredentialOwner(probeSettings);
+  const credentialOwner = resolvedCredentialOwner(user, probeAgent, probeSettings);
   const canManageWorkspaceCredentials = user?.role === 'admin' || user?.role === 'superadmin';
+  const displayName = AGENTIC_TOOL_DISPLAY_NAMES[probeAgent] ?? probeAgent;
+  const dismissalOwner = userId ? `${userId}:${probeAgent}` : null;
+  const userCredentialRevision = user?.updated_at ? String(user.updated_at) : '';
 
   // Auth-method markers for the subscription/native paths (ChatGPT device
   // sign-in, imported Codex login, Claude subscription token). These land
@@ -117,47 +144,106 @@ export function OnboardingBanners({
   // edits. `agentic_auth_methods` only ever carries these two tools.
   const codexAuthMethod = user?.agentic_auth_methods?.codex;
   const claudeAuthMethod = user?.agentic_auth_methods?.['claude-code'];
+  const probeOwner = JSON.stringify([
+    userId,
+    userCredentialRevision,
+    onboardingCompleted,
+    connectionReady,
+    agenticToolSettingsHydrated,
+    probeAgent,
+    probeEnabled,
+    probeSettings,
+    credentialVersion,
+    probeRefreshVersion,
+    codexAuthMethod,
+    claudeAuthMethod,
+  ]);
+  // Never render an old user's/tool's verdict for one frame while the effect
+  // below is scheduling its replacement.
+  const probeState = probeResult.owner === probeOwner ? probeResult.state : ProbeState.Unknown;
 
-  // One probe (plus a bounded fallback) per identity/credential change. Deps are
+  // One selected-tool probe per identity/credential change. Deps are
   // primitives/stable so the effect never re-fires on board navigation or
-  // unrelated re-renders of the persistent App shell — each claude-code probe
-  // spawns a ~5–10s subprocess. userId resets stale state on a user switch;
-  // credentialVersion is a trigger-only dep re-probing after a legacy key save;
+  // unrelated App-shell renders. `updated_at` deliberately covers a same-field
+  // credential rotation delivered by realtime (presence stays `true`, so a
+  // boolean-only dependency would be stale). userId resets state on a switch;
+  // credentialVersion covers the local save path before realtime lands;
   // codexAuthMethod/claudeAuthMethod re-probe after a subscription/native login
   // lands server-side (device sign-in, auth.json import) — paths that bump
   // neither hasLlm nor credentialVersion — and cover a second browser tab too.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: credentialVersion is an intentional trigger dep
   useEffect(() => {
-    if (!onboardingCompleted) {
-      setProbeState(ProbeState.Unknown);
+    if (!onboardingCompleted || !connectionReady || !agenticToolSettingsHydrated || !probeEnabled) {
+      setProbeResult({ owner: probeOwner, state: ProbeState.Unknown });
       return;
     }
-    setProbeState(ProbeState.Unknown);
+    setProbeResult({ owner: probeOwner, state: ProbeState.Unknown });
     let cancelled = false;
-    resolveProbeState(
-      (tool) => onCheckAuth(tool).then((result) => result.status),
-      probeAgent,
-      hasLlm
-    )
+    resolveProbeState((tool) => onCheckAuth(tool).then((result) => result.status), probeAgent)
       .then((state) => {
-        if (!cancelled) setProbeState(state);
+        if (!cancelled) setProbeResult({ owner: probeOwner, state });
       })
       .catch(() => {
-        if (!cancelled) setProbeState(ProbeState.Unknown);
+        if (!cancelled) setProbeResult({ owner: probeOwner, state: ProbeState.Unknown });
       });
     return () => {
       cancelled = true;
     };
   }, [
-    userId,
     onboardingCompleted,
+    connectionReady,
+    agenticToolSettingsHydrated,
     probeAgent,
-    hasLlm,
+    probeEnabled,
     onCheckAuth,
-    credentialVersion,
-    codexAuthMethod,
-    claudeAuthMethod,
+    probeOwner,
   ]);
+
+  // A warning can be snoozed for 24 hours, scoped to one user + one selected
+  // tool. A local credential save clears the snooze so failed reconnects are
+  // immediately actionable; successful reconnects disappear through the probe.
+  useEffect(() => {
+    const previous = priorCredentialVersion.current;
+    const credentialChanged =
+      !!dismissalOwner &&
+      previous?.owner === dismissalOwner &&
+      previous.version !== credentialVersion;
+    priorCredentialVersion.current = { owner: dismissalOwner, version: credentialVersion };
+
+    if (!userId || !dismissalOwner || typeof window === 'undefined') {
+      setCredentialWarningSnoozedUntil(null);
+      return;
+    }
+
+    if (credentialChanged) {
+      clearCredentialWarningSnooze(window.localStorage, userId, probeAgent);
+    }
+    const snoozedUntil = credentialChanged
+      ? null
+      : readCredentialWarningSnooze(window.localStorage, userId, probeAgent);
+    setCredentialWarningSnoozedUntil(snoozedUntil);
+  }, [credentialVersion, dismissalOwner, probeAgent, userId]);
+
+  useEffect(() => {
+    if (!credentialWarningSnoozedUntil || typeof window === 'undefined') return;
+
+    const timer = window.setTimeout(
+      () => {
+        setCredentialWarningSnoozedUntil(null);
+        // A day-old rejection is no longer authoritative enough to re-display.
+        // Re-probe from Unknown before reminding the user.
+        setProbeRefreshVersion((version) => version + 1);
+      },
+      Math.min(credentialWarningSnoozedUntil - Date.now(), 2_147_483_647)
+    );
+    return () => window.clearTimeout(timer);
+  }, [credentialWarningSnoozedUntil]);
+
+  const dismissCredentialWarning = () => {
+    if (!userId || typeof window === 'undefined') return;
+    setCredentialWarningSnoozedUntil(
+      writeCredentialWarningSnooze(window.localStorage, userId, probeAgent)
+    );
+  };
 
   const decision = decideBanner({
     onboardingCompleted,
@@ -168,6 +254,8 @@ export function OnboardingBanners({
     gatewayChannelCount,
     integrationsHydrated,
     integrationsBannerDismissed,
+    credentialWarningDismissed:
+      credentialWarningSnoozedUntil !== null && credentialWarningSnoozedUntil > Date.now(),
   });
 
   switch (decision) {
@@ -176,26 +264,30 @@ export function OnboardingBanners({
     case BannerDecision.NoAi:
       return (
         <AmberBanner
-          message="⚡ No AI connected - sessions will open but nothing will run."
-          buttonLabel="Connect AI"
+          message={`${displayName} isn't connected. New ${displayName} sessions won't run until you configure it.`}
+          buttonLabel={`Open ${displayName} settings`}
           onClick={() =>
             credentialOwner === 'tenant' && canManageWorkspaceCredentials
               ? onOpenWorkspaceSettings('agentic-tools')
               : onOpenUserSettings(probeAgent)
           }
           docsHref="https://agor.live/guide"
+          onDismiss={dismissCredentialWarning}
+          dismissLabel={`Snooze ${displayName} warning for 24 hours`}
         />
       );
     case BannerDecision.KeyInvalid:
       return (
         <AmberBanner
-          message="Your AI credentials aren't working. Sessions will fail until you reconnect."
-          buttonLabel="Reconnect AI"
+          message={`${displayName} rejected the configured credential. New ${displayName} sessions will fail until you update it.`}
+          buttonLabel={`Review ${displayName} settings`}
           onClick={() =>
             credentialOwner === 'tenant' && canManageWorkspaceCredentials
               ? onOpenWorkspaceSettings('agentic-tools')
               : onOpenUserSettings(probeAgent)
           }
+          onDismiss={dismissCredentialWarning}
+          dismissLabel={`Snooze ${displayName} warning for 24 hours`}
         />
       );
     case BannerDecision.Integrations:

--- a/apps/agor-ui/src/components/OnboardingBanners/bannerLogic.test.ts
+++ b/apps/agor-ui/src/components/OnboardingBanners/bannerLogic.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   BannerDecision,
   type BannerDecisionInput,
+  credentialRemediationTarget,
   decideBanner,
   hasConfiguredCredentialFor,
   ProbeState,
@@ -274,5 +275,15 @@ describe('hasConfiguredCredentialFor — active policy route', () => {
     expect(
       resolvedCredentialOwner(asUser({}), 'claude-code', settings('user_preferred', true))
     ).toBe('tenant');
+  });
+
+  it('separates effective tenant ownership from a user-preferred member override', () => {
+    expect(credentialRemediationTarget('tenant', 'user_preferred', false)).toBe('user');
+    expect(credentialRemediationTarget('tenant', 'tenant_preferred', false)).toBe(
+      'workspace-admin'
+    );
+    expect(credentialRemediationTarget('tenant', 'tenant_required', false)).toBe('workspace-admin');
+    expect(credentialRemediationTarget('tenant', 'user_preferred', true)).toBe('tenant');
+    expect(credentialRemediationTarget('user', 'tenant_preferred', false)).toBe('user');
   });
 });

--- a/apps/agor-ui/src/components/OnboardingBanners/bannerLogic.test.ts
+++ b/apps/agor-ui/src/components/OnboardingBanners/bannerLogic.test.ts
@@ -4,11 +4,10 @@ import {
   BannerDecision,
   type BannerDecisionInput,
   decideBanner,
-  hasAnyLlmKey,
   hasConfiguredCredentialFor,
   ProbeState,
   resolvedCredentialOwner,
-  resolveProbeAgent,
+  resolveGovernedProbeAgent,
   resolveProbeState,
 } from './bannerLogic';
 
@@ -142,45 +141,55 @@ describe('decideBanner — onboarding gate', () => {
   });
 });
 
-describe('resolveProbeAgent', () => {
+describe('resolveGovernedProbeAgent — matches session creation', () => {
+  const setting = (tool: AgenticToolName, enabled: boolean) => ({
+    tool,
+    revision: 0,
+    deployment_available: true,
+    enabled,
+    resolution_policy: 'user_preferred' as const,
+    inline_configuration_allowed: true,
+    connection: {},
+  });
+
   it('prefers the explicit primary coding agent', () => {
     expect(
-      resolveProbeAgent(
+      resolveGovernedProbeAgent(
         asUser({
           primary_agentic_tool: 'gemini',
           agentic_tools: { codex: { OPENAI_API_KEY: 'sk' } },
-        })
+        }),
+        new Map([['gemini', setting('gemini', true)]])
       )
     ).toBe('gemini');
   });
 
-  it('prefers the tool a stored DB key points at', () => {
-    expect(resolveProbeAgent(asUser({ agentic_tools: { codex: { OPENAI_API_KEY: 'sk' } } }))).toBe(
-      'codex'
-    );
-  });
-
-  it('resolves the tool a Cursor / Copilot stored key points at', () => {
-    expect(resolveProbeAgent(asUser({ agentic_tools: { cursor: { CURSOR_API_KEY: 'k' } } }))).toBe(
-      'cursor'
-    );
+  it('does not let another tool credential/default override the creation default', () => {
+    const settings = new Map([
+      ['claude-code', setting('claude-code', true)],
+      ['codex', setting('codex', true)],
+    ]);
     expect(
-      resolveProbeAgent(asUser({ agentic_tools: { copilot: { COPILOT_GITHUB_TOKEN: 't' } } }))
-    ).toBe('copilot');
+      resolveGovernedProbeAgent(
+        asUser({
+          agentic_tools: { codex: { OPENAI_API_KEY: 'sk' } },
+          default_agentic_config: { codex: {} },
+        }),
+        settings
+      )
+    ).toBe('claude-code');
   });
 
-  it('falls back to the onboarding-selected agent when no DB key is present', () => {
-    expect(resolveProbeAgent(asUser({ default_agentic_config: { gemini: {} } }))).toBe('gemini');
-    // OpenCode is server-based (no credential field) — a user who selected it must
-    // still resolve to probing opencode, not fall through to claude-code.
-    expect(resolveProbeAgent(asUser({ default_agentic_config: { opencode: {} } }))).toBe(
-      'opencode'
-    );
-  });
-
-  it('falls back to claude-code when nothing is known', () => {
-    expect(resolveProbeAgent(null)).toBe('claude-code');
-    expect(resolveProbeAgent(asUser({}))).toBe('claude-code');
+  it('uses the canonical creation order when the preferred tools are disabled', () => {
+    const settings = new Map([
+      ['claude-code', setting('claude-code', false)],
+      ['codex', setting('codex', false)],
+      ['gemini', setting('gemini', false)],
+      ['opencode', setting('opencode', true)],
+      ['cursor', setting('cursor', true)],
+      ['copilot', setting('copilot', true)],
+    ]);
+    expect(resolveGovernedProbeAgent(asUser({}), settings)).toBe('opencode');
   });
 });
 
@@ -218,68 +227,6 @@ describe('resolveProbeState — selected tool only', () => {
     const { calls, checkStatus } = collect({ gemini: 'unauthenticated' });
     expect(await resolveProbeState(checkStatus, 'gemini')).toBe(ProbeState.Unauthenticated);
     expect(calls).toEqual(['gemini']);
-  });
-});
-
-describe('other-tool false positives (Cursor / Copilot / OpenCode)', () => {
-  it('a Cursor-connected user probes cursor and, once authenticated, sees no "No AI" banner', () => {
-    const user = asUser({ agentic_tools: { cursor: { CURSOR_API_KEY: 'k' } } });
-    expect(resolveProbeAgent(user)).toBe('cursor');
-    // hasLlm is true (stored key) → an unauthenticated probe would word as key-invalid,
-    // but an authenticated probe shows no amber banner at all.
-    expect(
-      decideBanner({ ...baseInput, hasLlm: true, probeState: ProbeState.Authenticated })
-    ).not.toBe(BannerDecision.KeyInvalid);
-  });
-
-  it('an OpenCode user (no DB key) probes opencode; authenticated → no "No AI" banner', () => {
-    const user = asUser({ default_agentic_config: { opencode: {} } });
-    expect(resolveProbeAgent(user)).toBe('opencode');
-    expect(hasAnyLlmKey(user)).toBe(false);
-    expect(
-      decideBanner({ ...baseInput, hasLlm: false, probeState: ProbeState.Authenticated })
-    ).not.toBe(BannerDecision.NoAi);
-  });
-});
-
-describe('hasAnyLlmKey', () => {
-  it('is false for a user with no stored keys (executor-filesystem creds are invisible here)', () => {
-    expect(hasAnyLlmKey(asUser({}))).toBe(false);
-    expect(hasAnyLlmKey(null)).toBe(false);
-  });
-
-  it('is true for any supported tool with a stored key, including Cursor / Copilot', () => {
-    expect(
-      hasAnyLlmKey(asUser({ agentic_tools: { 'claude-code': { ANTHROPIC_API_KEY: 'sk' } } }))
-    ).toBe(true);
-    expect(hasAnyLlmKey(asUser({ agentic_tools: { cursor: { CURSOR_API_KEY: 'k' } } }))).toBe(true);
-    expect(
-      hasAnyLlmKey(asUser({ agentic_tools: { copilot: { COPILOT_GITHUB_TOKEN: 't' } } }))
-    ).toBe(true);
-  });
-
-  it('counts Claude bearer auth and Codex subscription state', () => {
-    expect(
-      hasAnyLlmKey(
-        asUser({
-          agentic_tools: { 'claude-code': { ANTHROPIC_AUTH_TOKEN: true } },
-          agentic_auth_methods: { 'claude-code': 'api_key' },
-        })
-      )
-    ).toBe(true);
-    expect(hasAnyLlmKey(asUser({ agentic_auth_methods: { codex: 'subscription' } }))).toBe(true);
-  });
-
-  it('does not treat general env vars as provider credentials after managed-env hardening', () => {
-    expect(hasAnyLlmKey(asUser({ env_vars: { GEMINI_API_KEY: { set: true } } }))).toBe(false);
-  });
-
-  it('ignores non-credential fields — a base-URL-only user has no key', () => {
-    expect(
-      hasAnyLlmKey(
-        asUser({ agentic_tools: { 'claude-code': { ANTHROPIC_BASE_URL: 'https://x' } } })
-      )
-    ).toBe(false);
   });
 });
 

--- a/apps/agor-ui/src/components/OnboardingBanners/bannerLogic.test.ts
+++ b/apps/agor-ui/src/components/OnboardingBanners/bannerLogic.test.ts
@@ -5,7 +5,9 @@ import {
   type BannerDecisionInput,
   decideBanner,
   hasAnyLlmKey,
+  hasConfiguredCredentialFor,
   ProbeState,
+  resolvedCredentialOwner,
   resolveProbeAgent,
   resolveProbeState,
 } from './bannerLogic';
@@ -19,6 +21,7 @@ const baseInput: BannerDecisionInput = {
   gatewayChannelCount: 0,
   integrationsHydrated: true,
   integrationsBannerDismissed: false,
+  credentialWarningDismissed: false,
 };
 
 const asUser = (partial: Partial<User>): User => partial as User;
@@ -50,6 +53,17 @@ describe('decideBanner — fail-safe amber banners', () => {
     expect(
       decideBanner({ ...baseInput, hasLlm: true, probeState: ProbeState.Unauthenticated })
     ).toBe(BannerDecision.KeyInvalid);
+  });
+
+  it('a snoozed credential warning stays hidden without becoming an integrations prompt', () => {
+    expect(
+      decideBanner({
+        ...baseInput,
+        hasLlm: true,
+        probeState: ProbeState.Unauthenticated,
+        credentialWarningDismissed: true,
+      })
+    ).toBe(BannerDecision.None);
   });
 });
 
@@ -170,7 +184,7 @@ describe('resolveProbeAgent', () => {
   });
 });
 
-describe('resolveProbeState — multi-tool fallback', () => {
+describe('resolveProbeState — selected tool only', () => {
   const collect = (map: Partial<Record<AgenticToolName, AuthCheckStatus>>) => {
     const calls: AgenticToolName[] = [];
     const checkStatus = (tool: AgenticToolName): Promise<AuthCheckStatus> => {
@@ -180,50 +194,30 @@ describe('resolveProbeState — multi-tool fallback', () => {
     return { calls, checkStatus };
   };
 
-  it('returns Authenticated on a working primary without any fallback probes', async () => {
+  it('returns Authenticated on a working selected tool', async () => {
     const { calls, checkStatus } = collect({ codex: 'authenticated' });
-    expect(await resolveProbeState(checkStatus, 'codex', false)).toBe(ProbeState.Authenticated);
+    expect(await resolveProbeState(checkStatus, 'codex')).toBe(ProbeState.Authenticated);
     expect(calls).toEqual(['codex']);
   });
 
-  it('returns Unknown (fail safe) when the primary probe is unknown', async () => {
+  it('returns Unknown (fail safe) when the selected probe is unknown', async () => {
     const { checkStatus } = collect({ 'claude-code': 'unknown' });
-    expect(await resolveProbeState(checkStatus, 'claude-code', false)).toBe(ProbeState.Unknown);
+    expect(await resolveProbeState(checkStatus, 'claude-code')).toBe(ProbeState.Unknown);
   });
 
-  it('does NOT fall back when a stored key is present — unauthenticated is key-invalid', async () => {
-    const { calls, checkStatus } = collect({ gemini: 'unauthenticated' });
-    expect(await resolveProbeState(checkStatus, 'gemini', true)).toBe(ProbeState.Unauthenticated);
-    expect(calls).toEqual(['gemini']);
-  });
-
-  it('probes other native tools when primary is unauthenticated and no key; a hit clears the banner', async () => {
-    // gemini (wrong resolved tool) unauthenticated, but claude /login works.
+  it('does not collapse another agent failure into the selected agent verdict', async () => {
     const { calls, checkStatus } = collect({
-      gemini: 'unauthenticated',
       'claude-code': 'authenticated',
-    });
-    expect(await resolveProbeState(checkStatus, 'gemini', false)).toBe(ProbeState.Authenticated);
-    expect(calls).toContain('claude-code');
-  });
-
-  it('concludes Unauthenticated only when EVERY probe positively says so', async () => {
-    const { checkStatus } = collect({}); // everything defaults to unauthenticated
-    expect(await resolveProbeState(checkStatus, 'gemini', false)).toBe(ProbeState.Unauthenticated);
-  });
-
-  it('fails safe to Unknown if any fallback probe is unknown', async () => {
-    const { checkStatus } = collect({ gemini: 'unauthenticated', 'claude-code': 'unknown' });
-    expect(await resolveProbeState(checkStatus, 'gemini', false)).toBe(ProbeState.Unknown);
-  });
-
-  it('does not re-probe the primary tool during fallback', async () => {
-    const { calls, checkStatus } = collect({
-      'claude-code': 'unauthenticated',
       codex: 'unauthenticated',
     });
-    await resolveProbeState(checkStatus, 'claude-code', false);
-    expect(calls.filter((t) => t === 'claude-code')).toHaveLength(1);
+    expect(await resolveProbeState(checkStatus, 'claude-code')).toBe(ProbeState.Authenticated);
+    expect(calls).toEqual(['claude-code']);
+  });
+
+  it('returns Unauthenticated only on a positive rejection for the selected tool', async () => {
+    const { calls, checkStatus } = collect({ gemini: 'unauthenticated' });
+    expect(await resolveProbeState(checkStatus, 'gemini')).toBe(ProbeState.Unauthenticated);
+    expect(calls).toEqual(['gemini']);
   });
 });
 
@@ -264,8 +258,20 @@ describe('hasAnyLlmKey', () => {
     ).toBe(true);
   });
 
-  it('reads keys stored as plain env vars too', () => {
-    expect(hasAnyLlmKey(asUser({ env_vars: { GEMINI_API_KEY: { value: 'g' } } }))).toBe(true);
+  it('counts Claude bearer auth and Codex subscription state', () => {
+    expect(
+      hasAnyLlmKey(
+        asUser({
+          agentic_tools: { 'claude-code': { ANTHROPIC_AUTH_TOKEN: true } },
+          agentic_auth_methods: { 'claude-code': 'api_key' },
+        })
+      )
+    ).toBe(true);
+    expect(hasAnyLlmKey(asUser({ agentic_auth_methods: { codex: 'subscription' } }))).toBe(true);
+  });
+
+  it('does not treat general env vars as provider credentials after managed-env hardening', () => {
+    expect(hasAnyLlmKey(asUser({ env_vars: { GEMINI_API_KEY: { set: true } } }))).toBe(false);
   });
 
   it('ignores non-credential fields — a base-URL-only user has no key', () => {
@@ -274,5 +280,52 @@ describe('hasAnyLlmKey', () => {
         asUser({ agentic_tools: { 'claude-code': { ANTHROPIC_BASE_URL: 'https://x' } } })
       )
     ).toBe(false);
+  });
+});
+
+describe('hasConfiguredCredentialFor — active policy route', () => {
+  const settings = (
+    resolution_policy: 'user_required' | 'user_preferred' | 'tenant_preferred' | 'tenant_required',
+    tenantConfigured: boolean
+  ) => ({
+    tool: 'claude-code' as const,
+    deployment_available: true,
+    enabled: true,
+    inline_configuration_allowed: true,
+    resolution_policy,
+    connection: { ANTHROPIC_API_KEY: { configured: tenantConfigured } },
+  });
+
+  it('ignores inactive Claude API keys while subscription auth is selected', () => {
+    const user = asUser({
+      agentic_tools: { 'claude-code': { ANTHROPIC_API_KEY: true } },
+      agentic_auth_methods: { 'claude-code': 'subscription' },
+    });
+    expect(hasConfiguredCredentialFor(user, 'claude-code', settings('user_required', false))).toBe(
+      false
+    );
+  });
+
+  it('does not count a user key under tenant-required policy', () => {
+    const user = asUser({
+      agentic_tools: { 'claude-code': { ANTHROPIC_API_KEY: true } },
+      agentic_auth_methods: { 'claude-code': 'api_key' },
+    });
+    expect(
+      hasConfiguredCredentialFor(user, 'claude-code', settings('tenant_required', false))
+    ).toBe(false);
+  });
+
+  it('routes preferred policies to the owner that actually supplies the connection', () => {
+    const user = asUser({
+      agentic_tools: { 'claude-code': { ANTHROPIC_API_KEY: true } },
+      agentic_auth_methods: { 'claude-code': 'api_key' },
+    });
+    expect(resolvedCredentialOwner(user, 'claude-code', settings('tenant_preferred', false))).toBe(
+      'user'
+    );
+    expect(
+      resolvedCredentialOwner(asUser({}), 'claude-code', settings('user_preferred', true))
+    ).toBe('tenant');
   });
 });

--- a/apps/agor-ui/src/components/OnboardingBanners/bannerLogic.ts
+++ b/apps/agor-ui/src/components/OnboardingBanners/bannerLogic.ts
@@ -14,51 +14,24 @@ import type {
   TenantAgenticToolSettings,
   User,
 } from '@agor-live/client';
-import { getUserPrimaryAgenticTool, PROVIDER_CREDENTIAL_FIELDS } from '@agor-live/client';
+import { PROVIDER_CREDENTIAL_FIELDS } from '@agor-live/client';
+import { resolveAvailableUserAgenticTool } from '../AgentSelectionGrid/availableAgents';
 
-const CLAUDE_CREDENTIAL_FIELDS = [
-  'ANTHROPIC_API_KEY',
-  'CLAUDE_CODE_OAUTH_TOKEN',
-  'ANTHROPIC_AUTH_TOKEN',
-];
-
-/**
- * Single source of truth for the agentic tools onboarding offers AND check-auth
- * can verify, in probe-preference order (recommended tools first). `hasAnyLlmKey`,
- * `primaryAgentForUser`, and `onboardingSelectedAgent` all derive from this so the
- * three lists cannot drift apart.
- *
- * `credentialFields` are provider-scoped fields in `agentic_tools[tool]`;
- * base-URL fields and general managed env vars are excluded. OpenCode is
- * server-based — no credential field — so it never contributes a stored key,
- * but a user who selected it still resolves to probing `opencode` (always
- * authenticated).
- */
-const SUPPORTED_AGENTIC_TOOLS: readonly {
-  tool: AgenticToolName;
-  credentialFields: readonly string[];
-}[] = [
-  { tool: 'claude-code', credentialFields: CLAUDE_CREDENTIAL_FIELDS },
-  { tool: 'codex', credentialFields: ['OPENAI_API_KEY'] },
-  { tool: 'gemini', credentialFields: ['GEMINI_API_KEY'] },
-  { tool: 'copilot', credentialFields: ['COPILOT_GITHUB_TOKEN'] },
-  { tool: 'cursor', credentialFields: ['CURSOR_API_KEY'] },
-  { tool: 'opencode', credentialFields: [] },
-];
+function credentialFieldsFor(tool: AgenticToolName): readonly string[] {
+  return Object.hasOwn(PROVIDER_CREDENTIAL_FIELDS, tool)
+    ? PROVIDER_CREDENTIAL_FIELDS[tool as keyof typeof PROVIDER_CREDENTIAL_FIELDS]
+    : [];
+}
 
 /** Whether `user` carries the active, provider-scoped credential for `tool`. */
-function hasStoredCredentialFor(
-  user: User,
-  tool: AgenticToolName,
-  credentialFields: readonly string[]
-): boolean {
+function hasStoredCredentialFor(user: User, tool: AgenticToolName): boolean {
   const toolStatus = user.agentic_tools?.[tool] as Record<string, boolean | undefined> | undefined;
   const authMethod =
     tool === 'claude-code' || tool === 'codex' ? user.agentic_auth_methods?.[tool] : undefined;
 
   if (tool === 'codex' && authMethod === 'subscription') return true;
 
-  return credentialFields.some((field) => {
+  return credentialFieldsFor(tool).some((field) => {
     if (tool === 'claude-code') {
       if (authMethod === 'subscription' && field !== 'CLAUDE_CODE_OAUTH_TOKEN') return false;
       if (authMethod === 'api_key' && field === 'CLAUDE_CODE_OAUTH_TOKEN') return false;
@@ -67,63 +40,12 @@ function hasStoredCredentialFor(
   });
 }
 
-/**
- * Whether the client `user` object carries any active, provider-scoped LLM
- * credential. General `env_vars` intentionally do not count: provider
- * credentials are resolved only from `agentic_tools` under workspace policy,
- * and the executor strips ambient provider variables before installing that
- * resolved connection.
- */
-export function hasAnyLlmKey(user: User | null | undefined): boolean {
-  if (!user) return false;
-  return SUPPORTED_AGENTIC_TOOLS.some(({ tool, credentialFields }) =>
-    hasStoredCredentialFor(user, tool, credentialFields)
-  );
-}
-
-/** The first supported tool (preference order) with an active credential, if any. */
-export function primaryAgentForUser(user: User | null | undefined): AgenticToolName | null {
-  if (!user) return null;
-  return (
-    SUPPORTED_AGENTIC_TOOLS.find(({ tool, credentialFields }) =>
-      hasStoredCredentialFor(user, tool, credentialFields)
-    )?.tool ?? null
-  );
-}
-
-/** The first supported tool the user configured a default for during onboarding. */
-function onboardingSelectedAgent(user: User | null | undefined): AgenticToolName | null {
-  const config = user?.default_agentic_config;
-  if (!config) return null;
-  return SUPPORTED_AGENTIC_TOOLS.find(({ tool }) => config[tool])?.tool ?? null;
-}
-
-/**
- * The single tool to probe for a given user: their explicit primary tool, a
- * stored key's tool, the onboarding-selected default, then Claude Code.
- * Always resolves so the probe can run even when no DB key is present (the
- * false-positive case).
- */
-export function resolveProbeAgent(user: User | null | undefined): AgenticToolName {
-  return (
-    getUserPrimaryAgenticTool(user) ??
-    primaryAgentForUser(user) ??
-    onboardingSelectedAgent(user) ??
-    'claude-code'
-  );
-}
-
-/** Pick one enabled, policy-governed provider for the persistent auth banner. */
+/** Pick the same enabled tool that a new-session picker will initially select. */
 export function resolveGovernedProbeAgent(
   user: User | null | undefined,
   settings: Map<TenantAgenticToolName, TenantAgenticToolSettings>
 ): AgenticToolName {
-  const preferred = resolveProbeAgent(user);
-  if (settings.get(preferred as TenantAgenticToolName)?.enabled !== false) return preferred;
-  const fallback = SUPPORTED_AGENTIC_TOOLS.find(
-    ({ tool }) => settings.get(tool as TenantAgenticToolName)?.enabled !== false
-  );
-  return fallback?.tool ?? 'claude-code';
+  return resolveAvailableUserAgenticTool(user, settings);
 }
 
 export function hasConfiguredCredentialFor(
@@ -142,9 +64,7 @@ function credentialPresenceFor(
   tool: AgenticToolName,
   settings?: TenantAgenticToolSettings
 ): { hasUserCredential: boolean; hasTenantCredential: boolean } {
-  const spec = SUPPORTED_AGENTIC_TOOLS.find((candidate) => candidate.tool === tool);
-  const hasUserCredential =
-    !!user && !!spec && hasStoredCredentialFor(user, tool, spec.credentialFields);
+  const hasUserCredential = !!user && hasStoredCredentialFor(user, tool);
   const fields: readonly string[] = Object.hasOwn(PROVIDER_CREDENTIAL_FIELDS, tool)
     ? PROVIDER_CREDENTIAL_FIELDS[tool as keyof typeof PROVIDER_CREDENTIAL_FIELDS]
     : [];

--- a/apps/agor-ui/src/components/OnboardingBanners/bannerLogic.ts
+++ b/apps/agor-ui/src/components/OnboardingBanners/bannerLogic.ts
@@ -2,10 +2,9 @@
  * Pure decision logic for the post-onboarding banners.
  *
  * Guiding invariant: FAIL SAFE — never surface a "not connected" / "broken key"
- * banner without POSITIVE proof (`probeState === 'unauthenticated'`). The
- * client `user` object only carries DB-stored keys, so it cannot see
- * executor-filesystem credentials; the amber banners are therefore driven by
- * the server-side check-auth probe, not by a presence check.
+ * banner without POSITIVE proof (`probeState === 'unauthenticated'`) for the
+ * selected, enabled tool. Credential presence only chooses the copy; the
+ * server-side check-auth probe owns the verdict.
  */
 
 import type {
@@ -29,10 +28,11 @@ const CLAUDE_CREDENTIAL_FIELDS = [
  * `primaryAgentForUser`, and `onboardingSelectedAgent` all derive from this so the
  * three lists cannot drift apart.
  *
- * `credentialFields` are the auth-indicating env-var names for each tool (matching
- * both `agentic_tools[tool]` and `env_vars`); base-URL fields are excluded. OpenCode
- * is server-based — no credential field — so it never contributes a stored key, but
- * a user who SELECTED it still resolves to probing `opencode` (always authenticated).
+ * `credentialFields` are provider-scoped fields in `agentic_tools[tool]`;
+ * base-URL fields and general managed env vars are excluded. OpenCode is
+ * server-based — no credential field — so it never contributes a stored key,
+ * but a user who selected it still resolves to probing `opencode` (always
+ * authenticated).
  */
 const SUPPORTED_AGENTIC_TOOLS: readonly {
   tool: AgenticToolName;
@@ -46,39 +46,47 @@ const SUPPORTED_AGENTIC_TOOLS: readonly {
   { tool: 'opencode', credentialFields: [] },
 ];
 
-/** Reliably server-probeable native tools, tried as a fallback before concluding "No AI". */
-const NATIVE_FALLBACK_TOOLS: readonly AgenticToolName[] = ['claude-code', 'codex'];
-
-/** Whether `user` carries a stored (DB or env-var) credential for `tool`. */
-function hasStoredKeyFor(
+/** Whether `user` carries the active, provider-scoped credential for `tool`. */
+function hasStoredCredentialFor(
   user: User,
   tool: AgenticToolName,
   credentialFields: readonly string[]
 ): boolean {
   const toolStatus = user.agentic_tools?.[tool] as Record<string, boolean | undefined> | undefined;
-  const envVars = user.env_vars;
-  return credentialFields.some((field) => !!toolStatus?.[field] || !!envVars?.[field]);
+  const authMethod =
+    tool === 'claude-code' || tool === 'codex' ? user.agentic_auth_methods?.[tool] : undefined;
+
+  if (tool === 'codex' && authMethod === 'subscription') return true;
+
+  return credentialFields.some((field) => {
+    if (tool === 'claude-code') {
+      if (authMethod === 'subscription' && field !== 'CLAUDE_CODE_OAUTH_TOKEN') return false;
+      if (authMethod === 'api_key' && field === 'CLAUDE_CODE_OAUTH_TOKEN') return false;
+    }
+    return !!toolStatus?.[field];
+  });
 }
 
 /**
- * Whether the client `user` object carries any LLM credential. This only sees
- * DB-stored keys — it CANNOT observe executor-filesystem credentials (e.g. a
- * `claude /login` token) or server-based tools, so a `false` result does not
- * mean the user is unconnected.
+ * Whether the client `user` object carries any active, provider-scoped LLM
+ * credential. General `env_vars` intentionally do not count: provider
+ * credentials are resolved only from `agentic_tools` under workspace policy,
+ * and the executor strips ambient provider variables before installing that
+ * resolved connection.
  */
 export function hasAnyLlmKey(user: User | null | undefined): boolean {
   if (!user) return false;
   return SUPPORTED_AGENTIC_TOOLS.some(({ tool, credentialFields }) =>
-    hasStoredKeyFor(user, tool, credentialFields)
+    hasStoredCredentialFor(user, tool, credentialFields)
   );
 }
 
-/** The first supported tool (preference order) with a stored key, if any. */
+/** The first supported tool (preference order) with an active credential, if any. */
 export function primaryAgentForUser(user: User | null | undefined): AgenticToolName | null {
   if (!user) return null;
   return (
     SUPPORTED_AGENTIC_TOOLS.find(({ tool, credentialFields }) =>
-      hasStoredKeyFor(user, tool, credentialFields)
+      hasStoredCredentialFor(user, tool, credentialFields)
     )?.tool ?? null
   );
 }
@@ -123,52 +131,63 @@ export function hasConfiguredCredentialFor(
   tool: AgenticToolName,
   settings?: TenantAgenticToolSettings
 ): boolean {
+  const { hasUserCredential, hasTenantCredential } = credentialPresenceFor(user, tool, settings);
+  if (settings?.resolution_policy === 'user_required') return hasUserCredential;
+  if (settings?.resolution_policy === 'tenant_required') return hasTenantCredential;
+  return hasUserCredential || hasTenantCredential;
+}
+
+function credentialPresenceFor(
+  user: User | null | undefined,
+  tool: AgenticToolName,
+  settings?: TenantAgenticToolSettings
+): { hasUserCredential: boolean; hasTenantCredential: boolean } {
   const spec = SUPPORTED_AGENTIC_TOOLS.find((candidate) => candidate.tool === tool);
-  const hasUserCredential = !!user && !!spec && hasStoredKeyFor(user, tool, spec.credentialFields);
+  const hasUserCredential =
+    !!user && !!spec && hasStoredCredentialFor(user, tool, spec.credentialFields);
   const fields: readonly string[] = Object.hasOwn(PROVIDER_CREDENTIAL_FIELDS, tool)
     ? PROVIDER_CREDENTIAL_FIELDS[tool as keyof typeof PROVIDER_CREDENTIAL_FIELDS]
     : [];
   const hasTenantCredential = fields.some(
     (field) => settings?.connection[field as keyof typeof settings.connection]?.configured
   );
-  return hasUserCredential || hasTenantCredential;
+  return { hasUserCredential, hasTenantCredential };
 }
 
-export function preferredCredentialOwner(settings?: TenantAgenticToolSettings): 'user' | 'tenant' {
-  return settings?.resolution_policy === 'tenant_preferred' ||
-    settings?.resolution_policy === 'tenant_required'
-    ? 'tenant'
-    : 'user';
+/** The owner whose complete connection the resolver will select under policy. */
+export function resolvedCredentialOwner(
+  user: User | null | undefined,
+  tool: AgenticToolName,
+  settings?: TenantAgenticToolSettings
+): 'user' | 'tenant' {
+  const { hasUserCredential, hasTenantCredential } = credentialPresenceFor(user, tool, settings);
+  switch (settings?.resolution_policy) {
+    case 'tenant_required':
+      return 'tenant';
+    case 'user_required':
+      return 'user';
+    case 'tenant_preferred':
+      return hasTenantCredential ? 'tenant' : 'user';
+    default:
+      return hasUserCredential || !hasTenantCredential ? 'user' : 'tenant';
+  }
 }
 
 /**
- * Resolve the probe state for a user, with a bounded multi-tool fallback.
+ * Resolve the probe state for exactly one selected, enabled tool.
  *
- * The primary tool's verdict wins outright unless it is a positive
- * `unauthenticated` AND the user has no stored key: only then do we also probe
- * the reliably-native tools (a working `claude /login` under a stale non-claude
- * default would otherwise false-positive). We show Unauthenticated only if EVERY
- * probe positively says so; any `authenticated` clears it, any `unknown` fails
- * safe to Unknown. Early-exits on the first `authenticated`; at most a couple of
- * extra sequential probes on the already-rare no-key path.
+ * A working credential for a different tool does not make sessions for this
+ * tool runnable, and a failure for a different tool must not produce a global
+ * warning. `unknown` remains fail-safe.
  */
 export async function resolveProbeState(
   checkStatus: (tool: AgenticToolName) => Promise<AuthCheckStatus>,
-  probeAgent: AgenticToolName,
-  hasLlm: boolean
+  probeAgent: AgenticToolName
 ): Promise<ProbeState> {
-  const primary = await checkStatus(probeAgent);
-  if (primary === 'authenticated') return ProbeState.Authenticated;
-  if (primary === 'unknown') return ProbeState.Unknown;
-  if (hasLlm) return ProbeState.Unauthenticated;
-
-  for (const tool of NATIVE_FALLBACK_TOOLS) {
-    if (tool === probeAgent) continue;
-    const status = await checkStatus(tool);
-    if (status === 'authenticated') return ProbeState.Authenticated;
-    if (status === 'unknown') return ProbeState.Unknown;
-  }
-  return ProbeState.Unauthenticated;
+  const status = await checkStatus(probeAgent);
+  if (status === 'authenticated') return ProbeState.Authenticated;
+  if (status === 'unauthenticated') return ProbeState.Unauthenticated;
+  return ProbeState.Unknown;
 }
 
 /**
@@ -205,6 +224,8 @@ export interface BannerDecisionInput {
   /** Whether both integration collections (mcp-servers + gateway-channels) have finished their first hydration. */
   integrationsHydrated: boolean;
   integrationsBannerDismissed: boolean;
+  /** A user-scoped 24-hour snooze of the selected tool's warning. */
+  credentialWarningDismissed: boolean;
 }
 
 /**
@@ -224,6 +245,7 @@ export function decideBanner(input: BannerDecisionInput): BannerDecision {
   if (!input.onboardingCompleted) return BannerDecision.None;
 
   if (input.probeState === ProbeState.Unauthenticated) {
+    if (input.credentialWarningDismissed) return BannerDecision.None;
     return input.hasLlm ? BannerDecision.KeyInvalid : BannerDecision.NoAi;
   }
 

--- a/apps/agor-ui/src/components/OnboardingBanners/bannerLogic.ts
+++ b/apps/agor-ui/src/components/OnboardingBanners/bannerLogic.ts
@@ -10,11 +10,12 @@
 import type {
   AgenticToolName,
   AuthCheckStatus,
+  ProviderResolutionPolicy,
   TenantAgenticToolName,
   TenantAgenticToolSettings,
   User,
 } from '@agor-live/client';
-import { PROVIDER_CREDENTIAL_FIELDS } from '@agor-live/client';
+import { DEFAULT_PROVIDER_RESOLUTION_POLICY, PROVIDER_CREDENTIAL_FIELDS } from '@agor-live/client';
 import { resolveAvailableUserAgenticTool } from '../AgentSelectionGrid/availableAgents';
 
 function credentialFieldsFor(tool: AgenticToolName): readonly string[] {
@@ -91,6 +92,30 @@ export function resolvedCredentialOwner(
     default:
       return hasUserCredential || !hasTenantCredential ? 'user' : 'tenant';
   }
+}
+
+export type CredentialRemediationTarget = 'user' | 'tenant' | 'workspace-admin';
+
+/**
+ * Where the caller can actually repair the selected connection.
+ *
+ * Effective ownership and remediation authority differ for a member using a
+ * workspace fallback under `user_preferred`: the current connection is tenant
+ * owned, but adding a personal credential takes precedence and is actionable.
+ */
+export function credentialRemediationTarget(
+  effectiveOwner: 'user' | 'tenant',
+  resolutionPolicy: ProviderResolutionPolicy | undefined,
+  canManageWorkspaceCredentials: boolean
+): CredentialRemediationTarget {
+  if (effectiveOwner === 'user') return 'user';
+  if (canManageWorkspaceCredentials) return 'tenant';
+  if (
+    (resolutionPolicy ?? DEFAULT_PROVIDER_RESOLUTION_POLICY) === DEFAULT_PROVIDER_RESOLUTION_POLICY
+  ) {
+    return 'user';
+  }
+  return 'workspace-admin';
 }
 
 /**

--- a/apps/agor-ui/src/components/OnboardingBanners/credentialWarningDismissal.ts
+++ b/apps/agor-ui/src/components/OnboardingBanners/credentialWarningDismissal.ts
@@ -7,7 +7,7 @@ interface CredentialWarningDismissal {
   snoozedUntil: number;
 }
 
-function storageKey(userId: string, tool: AgenticToolName): string {
+export function credentialWarningSnoozeStorageKey(userId: string, tool: AgenticToolName): string {
   return `agor:credential-warning:v1:${userId}:${tool}`;
 }
 
@@ -18,7 +18,7 @@ export function readCredentialWarningSnooze(
   tool: AgenticToolName,
   now = Date.now()
 ): number | null {
-  const key = storageKey(userId, tool);
+  const key = credentialWarningSnoozeStorageKey(userId, tool);
   try {
     const raw = storage.getItem(key);
     if (!raw) return null;
@@ -55,7 +55,7 @@ export function writeCredentialWarningSnooze(
   const snoozedUntil = now + CREDENTIAL_WARNING_SNOOZE_MS;
   try {
     storage.setItem(
-      storageKey(userId, tool),
+      credentialWarningSnoozeStorageKey(userId, tool),
       JSON.stringify({ version: 1, snoozedUntil } satisfies CredentialWarningDismissal)
     );
   } catch {
@@ -71,7 +71,7 @@ export function clearCredentialWarningSnooze(
   tool: AgenticToolName
 ): void {
   try {
-    storage.removeItem(storageKey(userId, tool));
+    storage.removeItem(credentialWarningSnoozeStorageKey(userId, tool));
   } catch {
     // Best effort only.
   }

--- a/apps/agor-ui/src/components/OnboardingBanners/credentialWarningDismissal.ts
+++ b/apps/agor-ui/src/components/OnboardingBanners/credentialWarningDismissal.ts
@@ -1,0 +1,78 @@
+import type { AgenticToolName } from '@agor-live/client';
+
+export const CREDENTIAL_WARNING_SNOOZE_MS = 24 * 60 * 60 * 1000;
+
+interface CredentialWarningDismissal {
+  version: 1;
+  snoozedUntil: number;
+}
+
+function storageKey(userId: string, tool: AgenticToolName): string {
+  return `agor:credential-warning:v1:${userId}:${tool}`;
+}
+
+/** Read one user/tool-scoped snooze, deleting malformed or expired state. */
+export function readCredentialWarningSnooze(
+  storage: Pick<Storage, 'getItem' | 'removeItem'>,
+  userId: string,
+  tool: AgenticToolName,
+  now = Date.now()
+): number | null {
+  const key = storageKey(userId, tool);
+  try {
+    const raw = storage.getItem(key);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<CredentialWarningDismissal>;
+    if (
+      parsed.version !== 1 ||
+      typeof parsed.snoozedUntil !== 'number' ||
+      !Number.isFinite(parsed.snoozedUntil) ||
+      parsed.snoozedUntil <= now
+    ) {
+      storage.removeItem(key);
+      return null;
+    }
+    return parsed.snoozedUntil;
+  } catch {
+    // Storage can be unavailable in hardened/private browser contexts. A
+    // persistence failure must not hide a real warning indefinitely.
+    try {
+      storage.removeItem(key);
+    } catch {
+      // Best effort only.
+    }
+    return null;
+  }
+}
+
+/** Snooze one user's warning for one tool. Returns the in-memory expiry. */
+export function writeCredentialWarningSnooze(
+  storage: Pick<Storage, 'setItem'>,
+  userId: string,
+  tool: AgenticToolName,
+  now = Date.now()
+): number {
+  const snoozedUntil = now + CREDENTIAL_WARNING_SNOOZE_MS;
+  try {
+    storage.setItem(
+      storageKey(userId, tool),
+      JSON.stringify({ version: 1, snoozedUntil } satisfies CredentialWarningDismissal)
+    );
+  } catch {
+    // The mounted component still honors the in-memory snooze. A reload will
+    // show the warning again rather than silently hiding it forever.
+  }
+  return snoozedUntil;
+}
+
+export function clearCredentialWarningSnooze(
+  storage: Pick<Storage, 'removeItem'>,
+  userId: string,
+  tool: AgenticToolName
+): void {
+  try {
+    storage.removeItem(storageKey(userId, tool));
+  } catch {
+    // Best effort only.
+  }
+}

--- a/docs/internal/ai-credential-status-banner-2026-08-29.md
+++ b/docs/internal/ai-credential-status-banner-2026-08-29.md
@@ -1,0 +1,269 @@
+# AI credential status banner: authority and UX contract
+
+Date: 2026-08-29
+
+## Revision inventory
+
+At investigation time:
+
+- Local `main`, `origin/main`, and the branch base were all
+  `66ed08618f241b0a28f2c0029a8634a5e3d29bda` (`fix(onboarding): prevent final
+modal reopen and restore dismissal (#2595)`).
+- `https://agor.sandbox.preset.zone/health` reported Agor `0.25.2`, build
+  `6a0074c13`, built at `2026-08-27T06:00:20.945Z`. The unambiguous repository
+  commit for that prefix is
+  `6a0074c1351f0a6d65540267dc7783b06cf7b258` (`feat(apm): trace postgres.js
+queries via Drizzle session shim (#2571)`). The deployed build was therefore
+  behind `main`.
+- The managed-environment credential hardening referenced in the report is
+  `83c5076ee4f3fac5c38250d90753e0901a769aca` (`fix(security): harden managed
+environment secrets (#2561)`).
+
+The health endpoint is authoritative for deployment/build identity, not agent
+credential health.
+
+## Credential/status authorities
+
+There is intentionally no single persisted `aiCredentialsWork` boolean.
+Authority is layered and tool-specific:
+
+| Question                                                         | Authoritative source                                                                                      | Notes                                                                                                                                                                                                      |
+| ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Which tool will a new session use?                               | `User.primary_agentic_tool`, then user/default agentic config and the session's selected agent            | `packages/core/src/types/user.ts`; `bannerLogic.ts` mirrors the app's selected-tool precedence for the shell warning.                                                                                      |
+| Is a tool deployed and enabled, and which credential owner wins? | `agentic-tool-settings` plus `TenantAgenticToolSettingsRepository`                                        | Includes deployment availability, workspace enablement, `user_*`/`tenant_*` resolution policy, and boolean-only workspace field status.                                                                    |
+| Does the user have a provider credential recorded?               | Encrypted `users.data.agentic_tools[tool]` and `agentic_auth_methods`                                     | `apps/agor-daemon/src/services/users.ts` returns field-presence booleans only. Secret fields are never returned. General `env_vars` are not a provider-credential fallback after #2561.                    |
+| What complete connection will execution receive?                 | `resolveProviderConnection` / `resolveApiKey`                                                             | `packages/core/src/config/tenant-agentic-tool-resolver.ts` chooses one complete user or workspace connection atomically and honors the selected Claude/Codex auth family.                                  |
+| Is the selected resolved credential usable now?                  | Authenticated `POST /check-auth`                                                                          | `apps/agor-daemon/src/services/check-auth.ts` resolves in trusted tenant/user context, then returns `authenticated`, `unauthenticated`, or `unknown`. It does not persist or cache a result.               |
+| What does execution really receive?                              | Executor provider-env installation                                                                        | `packages/executor/src/env-sanitizer.ts` removes ambient provider credentials; the resolved connection is installed by the executor launch path. This is the final source for task execution.              |
+| Is the daemon/process healthy?                                   | `GET /health`                                                                                             | Process/build health only. It cannot prove any user's provider authentication.                                                                                                                             |
+| How does UI state refresh?                                       | `users` and `agentic-tool-settings` realtime events, reconnect hydration, and a fresh `/check-auth` probe | `apps/agor-ui/src/hooks/useAgorData.ts`, `agorRealtimeActions.ts`, `agorStore.ts`, `App.tsx`, and `OnboardingBanners.tsx`.                                                                                 |
+| Where can the user act?                                          | User Agent Setup or workspace Agentic Tools settings                                                      | The banner routes according to the effective resolution policy and caller role. It says “open/review settings,” not “reset,” because an outage or unknown result should not encourage credential rotation. |
+
+`/check-auth` status semantics are:
+
+- **authenticated**: positive provider/native evidence (provider 2xx, valid
+  native account metadata where reliable, well-formed supported Codex native
+  login, or a runtime-managed tool);
+- **unauthenticated**: positive blocking evidence (no credential on the active
+  policy route, disabled tool, decrypt failure, provider 401/403, or a
+  positively missing/malformed native login);
+- **unknown**: the daemon could not prove either side (initial/loading state,
+  timeout, network error, provider 5xx, delegated inspection problem, or an
+  auth class without a reliable negative probe).
+
+Callers must never translate `unknown` into a definitive failure.
+
+## Root cause
+
+Claude has three supported credential fields:
+
+1. `ANTHROPIC_API_KEY` (Anthropic API key, `x-api-key`);
+2. `ANTHROPIC_AUTH_TOKEN` (Anthropic SDK bearer token, `Authorization: Bearer`);
+3. `CLAUDE_CODE_OAUTH_TOKEN` (Claude subscription/setup-token path).
+
+The atomic resolver already returned the complete connection and the executor
+already installed all three correctly. The old `check-auth` code destructured
+only `apiKey` from `resolveApiKey('ANTHROPIC_API_KEY', ...)`, then separately
+looked for the subscription token. It ignored
+`connection.ANTHROPIC_AUTH_TOKEN`. A user with a working bearer connection
+therefore received:
+
+```text
+POST /check-auth { tool: "claude-code" }
+→ unauthenticated: No usable ANTHROPIC_API_KEY ...
+```
+
+while an actual Claude task received the bearer token and succeeded. The UI
+combined the boolean presence of that bearer field with the false daemon
+verdict and produced the old global copy:
+
+```text
+Your AI credentials aren't working. Sessions will fail until you reconnect.
+```
+
+Production-safe evidence confirmed the mismatch without reading a secret:
+
+- Max's self DTO exposed only `ANTHROPIC_AUTH_TOKEN: true` for Claude;
+- the workspace Claude route exposed no configured workspace credential;
+- deployed `/check-auth` returned `unauthenticated` and specifically claimed
+  `ANTHROPIC_API_KEY` was absent;
+- a recent Claude Sonnet task for the same user/route completed successfully on
+  the deployed revision.
+
+That makes the bearer-field omission the direct root cause with high
+confidence. It also shows why checking only “configured” or only one canonical
+key name is not an execution-health verdict.
+
+The banner had secondary stale/global defects:
+
+- it probed one preferred tool but described all “AI credentials”;
+- its no-key fallback could let another agent's status decide the selected
+  agent's global result;
+- it counted legacy/general managed env-var presence even though #2561 removed
+  those values from provider resolution;
+- same-field credential rotations keep the same public `true` presence bit, so
+  the probe effect could remain stale after a realtime patch;
+- reconnect did not explicitly reset the verdict to `unknown` and re-probe;
+- workspace policy could still be loading when the first probe ran;
+- there was no dismiss control.
+
+There is no daemon auth-result cache to invalidate and no replica-local status
+record. In PostgreSQL HA the resolver reads tenant data on the serving replica;
+socket reconnect hydration plus a new stateless probe is the UI consistency
+mechanism. SQLite is a single-daemon deployment. Provider and database
+timeouts remain `unknown` rather than being cached as a rejection.
+
+### Model-history audit
+
+The global banner/copy originated in
+`a0646ced58623dec1e1953af7c1ad82281f610cf` (#1742) and its bounded native
+fallback in `e32def0b1aa245ba726eb7cc7237b8f13bf5b255` (#1862). Those assumptions
+predate the Claude setup-token flow
+(`7fdd146d1d7010fb959abe2a154974b5a91d0f99`, #1867), Codex ChatGPT import
+(`2e691849586f302b0109daae685491bafd9f9d10`, #1954), durable/HA Codex identity
+(`a44bba086dafd01a4504a8a693725ec2eaaa7bfa`, #2521, and
+`5d19fbc6d72f36c9672010396510b35f1f8afbb9`, #2575), and provider-scoped
+managed-secret hardening (#2561). The old global boolean and “reconnect AI”
+wording were therefore remnants of an older one-key model.
+
+Secure local password assignment
+(`0738c71ca612be89c90385b0bf83d4d6f447e97f`, #2538) and external/cloud Agor
+identity govern access to the daemon; they are not provider credentials and
+must not affect this banner. Delegated/cloud execution identity matters only
+when a native credential lives in that execution home. Inspection errors on
+that route remain `unknown`, not a global provider failure.
+
+## Before and after state machine
+
+### Before
+
+```mermaid
+stateDiagram-v2
+  [*] --> Loading
+  Loading --> GlobalWarning: selected probe says unauthenticated
+  Loading --> Clear: selected/fallback probe says authenticated
+  Loading --> Clear: error/timeout
+  GlobalWarning --> GlobalWarning: same presence bit or socket reconnect
+```
+
+The fallback and copy collapsed multiple tools, and no user transition existed
+out of `GlobalWarning` except a later dependency-changing probe or page reload.
+
+### After
+
+```mermaid
+stateDiagram-v2
+  [*] --> Unknown
+  Unknown --> Unknown: policy loading / disconnected / timeout / 5xx / probe error
+  Unknown --> Healthy: selected enabled tool positively authenticated
+  Unknown --> BlockedMissing: selected enabled tool positively has no active credential
+  Unknown --> BlockedRejected: selected enabled tool positively rejects configured credential
+  BlockedMissing --> Snoozed: close
+  BlockedRejected --> Snoozed: close
+  Snoozed --> Unknown: credential save / user switch / selected tool change
+  Snoozed --> BlockedMissing: 24h expires and fresh verdict is missing
+  Snoozed --> BlockedRejected: 24h expires and fresh verdict is rejected
+  BlockedMissing --> Unknown: disconnect / credential or policy event
+  BlockedRejected --> Unknown: disconnect / credential or policy event
+  Unknown --> Healthy: reconnect/realtime re-probe succeeds
+```
+
+Only the selected enabled tool is probed. Another tool's failure does not
+create this warning; another tool's success does not claim the selected tool
+can run. If the selected tool is disabled, the first enabled tool is selected;
+if no tool is available, a credential-failure banner is not shown. Workspace
+policy hydration is a prerequisite, so startup does not guess.
+
+New copy identifies the affected tool:
+
+- missing: **“Claude Code isn't connected. New Claude Code sessions won't run
+  until you configure it.”**
+- rejected: **“Claude Code rejected the configured credential. New Claude Code
+  sessions will fail until you update it.”**
+
+The action opens or reviews that tool's user/workspace settings. The close
+button has an agent-specific accessible name and snoozes the warning for 24
+hours. Persistence is local-browser, versioned, and scoped by user ID plus
+tool. Expired/malformed values are removed. A local credential save clears the
+snooze immediately; a different user or selected tool never inherits it. If
+storage is unavailable, only the current mount is snoozed, so persistence
+failure cannot hide a continuing error indefinitely.
+
+## Deterministic reproduction and request/event sequence
+
+The managed SQLite regression uses only synthetic values:
+
+1. Create a user in an isolated migrated SQLite database.
+2. Store an encrypted synthetic `ANTHROPIC_AUTH_TOKEN` in the user's
+   `claude-code` provider bucket (and separately test a synthetic workspace
+   bearer connection under `tenant_required`).
+3. Run `check-auth.create` inside a trusted tenant context.
+4. Mock only the provider boundary and assert `/v1/models` receives the same
+   Bearer authentication shape as the Anthropic SDK.
+5. Return provider 200, 401, and transport failure to prove
+   `authenticated`, `unauthenticated`, and `unknown` respectively.
+6. Assert the service result contains no synthetic credential.
+
+The UI/component sequence is:
+
+```text
+authenticate/hydrate user (boolean field status only)
+→ hydrate agentic-tool-settings
+→ choose selected enabled agent and active owner
+→ POST /check-auth for exactly that agent
+→ Unknown while in flight
+→ render only on a positive authenticated/unauthenticated verdict
+→ users patched / agentic-tool-settings patched / local save / reconnect
+→ reset Unknown and issue a fresh selected-agent probe
+```
+
+Focused component tests cover valid configured Claude, rejected/expired Claude,
+loading/unknown, another-agent-only failure, policy-loading and disabled-agent
+states, reconnect success and failure, same-field realtime rotation, logout and
+user switch, snooze persistence/expiry, and snooze invalidation after save.
+Real-browser coverage runs the warning at desktop, tablet, phone, and short
+landscape viewports and exercises keyboard focus and the close action. Synthetic
+provider hints are asserted absent from the DOM.
+
+## Security and tenancy review
+
+- Server authorization and tenant context are unchanged. `check-auth` still
+  requires the authenticated Feathers path and calls resolution under
+  `getCurrentTenantId()` / `runWithTenantDatabaseScope` with the actual user ID.
+- Credential encryption, redacted user DTOs, and provider-env sanitization are
+  unchanged.
+- No result, event, DOM text, or new log contains a credential. Provider secrets
+  exist only in the in-memory outbound provider request as before.
+- The complete connection continues to come from exactly one policy-selected
+  owner; fields are not combined across users, tenants, or credential families.
+- The new localStorage record contains only version, user ID, tool name, and an
+  expiry timestamp.
+
+## Rollout, rollback, and residual risk
+
+This is a code-only rollout with no schema/config migration. Existing browsers
+have no snooze record and will see a real selected-agent rejection normally.
+Monitor `/check-auth` status mix/provider latency and credential-related session
+start failures by tool; do not log credentials or request headers.
+
+Rollback is a normal code revert. The namespaced localStorage entries are
+harmless if old UI code ignores them and expire after 24 hours. The daemon and
+UI portions should preferably roll out together: the UI changes improve copy
+and staleness, but only the daemon change fixes Claude bearer validation.
+
+Residual risks:
+
+- a provider may change its health endpoint/auth semantics; non-401/403
+  responses deliberately remain `unknown` rather than accusing the credential;
+- Claude subscription account metadata is not a reliable negative signal, so
+  missing metadata remains `unknown` and the next real task is the ultimate
+  validation;
+- Codex ChatGPT login is intentionally not launched by the persistent shell
+  probe; its cheap result remains `unknown` until an explicit native validation
+  or task start;
+- generic `users.updated_at` is the available realtime revision, so an unrelated
+  self-profile update can cause one extra bounded probe. It is safe but could be
+  replaced later by a non-secret credential revision emitted by the daemon;
+- a provider can accept `/v1/models` and still reject a later model/task for a
+  quota or model-specific reason. That is a task error, not proof that all
+  credentials are disconnected.

--- a/docs/internal/ai-credential-status-banner-2026-08-29.md
+++ b/docs/internal/ai-credential-status-banner-2026-08-29.md
@@ -29,8 +29,8 @@ Authority is layered and tool-specific:
 
 | Question                                                         | Authoritative source                                                                                      | Notes                                                                                                                                                                                                      |
 | ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Which tool will a new session use?                               | `User.primary_agentic_tool`, then user/default agentic config and the session's selected agent            | `packages/core/src/types/user.ts`; `bannerLogic.ts` mirrors the app's selected-tool precedence for the shell warning.                                                                                      |
-| Is a tool deployed and enabled, and which credential owner wins? | `agentic-tool-settings` plus `TenantAgenticToolSettingsRepository`                                        | Includes deployment availability, workspace enablement, `user_*`/`tenant_*` resolution policy, and boolean-only workspace field status.                                                                    |
+| Which tool will a new session use?                               | `resolveUserPrimaryAgenticTool`, then `resolveAvailableUserAgenticTool` against `AVAILABLE_AGENTS`        | The New Session and navbar creation flows, picker fallback, and shell credential warning share this resolver. Stored credentials do not silently change the selected tool.                                 |
+| Is a tool deployed and enabled, and which credential owner wins? | `agentic-tool-settings` plus `TenantAgenticToolSettingsRepository`                                        | Includes deployment availability, workspace enablement, `user_*`/`tenant_*` resolution policy, boolean-only workspace field status, and a durable non-secret revision incremented on every settings patch. |
 | Does the user have a provider credential recorded?               | Encrypted `users.data.agentic_tools[tool]` and `agentic_auth_methods`                                     | `apps/agor-daemon/src/services/users.ts` returns field-presence booleans only. Secret fields are never returned. General `env_vars` are not a provider-credential fallback after #2561.                    |
 | What complete connection will execution receive?                 | `resolveProviderConnection` / `resolveApiKey`                                                             | `packages/core/src/config/tenant-agentic-tool-resolver.ts` chooses one complete user or workspace connection atomically and honors the selected Claude/Codex auth family.                                  |
 | Is the selected resolved credential usable now?                  | Authenticated `POST /check-auth`                                                                          | `apps/agor-daemon/src/services/check-auth.ts` resolves in trusted tenant/user context, then returns `authenticated`, `unauthenticated`, or `unknown`. It does not persist or cache a result.               |
@@ -103,6 +103,8 @@ The banner had secondary stale/global defects:
   those values from provider resolution;
 - same-field credential rotations keep the same public `true` presence bit, so
   the probe effect could remain stale after a realtime patch;
+- the selected-tool fallback order was independently duplicated and could drift
+  from the New Session picker;
 - reconnect did not explicitly reset the verdict to `unknown` and re-probe;
 - workspace policy could still be loading when the first probe ran;
 - there was no dismiss control.
@@ -174,6 +176,12 @@ can run. If the selected tool is disabled, the first enabled tool is selected;
 if no tool is available, a credential-failure banner is not shown. Workspace
 policy hydration is a prerequisite, so startup does not guess.
 
+“Selected” is the same effective tool as session creation: the persisted
+primary tool (or Claude default), followed by the first enabled entry in
+`AVAILABLE_AGENTS`. Credential presence and an old per-tool onboarding config
+do not silently replace that selection. This also keeps OpenCode ahead of the
+beta Cursor/Copilot fallbacks when earlier tools are disabled.
+
 New copy identifies the affected tool:
 
 - missing: **“Claude Code isn't connected. New Claude Code sessions won't run
@@ -181,13 +189,19 @@ New copy identifies the affected tool:
 - rejected: **“Claude Code rejected the configured credential. New Claude Code
   sessions will fail until you update it.”**
 
-The action opens or reviews that tool's user/workspace settings. The close
+The action opens or reviews that tool's user/workspace settings. When the
+active route is workspace-owned and the caller is not an administrator, the
+banner instead explains that a workspace admin must act and does not link to
+personal settings that the resolution policy will ignore. The close
 button has an agent-specific accessible name and snoozes the warning for 24
 hours. Persistence is local-browser, versioned, and scoped by user ID plus
 tool. Expired/malformed values are removed. A local credential save clears the
-snooze immediately; a different user or selected tool never inherits it. If
-storage is unavailable, only the current mount is snoozed, so persistence
-failure cannot hide a continuing error indefinitely.
+snooze immediately; a durable workspace revision does the same for workspace
+rotations, including same-field replacements whose public presence stays
+`true`. Storage events synchronize snooze/clear state across tabs. A different
+user or selected tool never inherits it. If storage is unavailable, only the
+current mount is snoozed, so persistence failure cannot hide a continuing error
+indefinitely.
 
 ## Deterministic reproduction and request/event sequence
 
@@ -217,10 +231,18 @@ authenticate/hydrate user (boolean field status only)
 → reset Unknown and issue a fresh selected-agent probe
 ```
 
+Every workspace agentic-tool patch increments a generation stored atomically
+with the encrypted settings JSON. The public DTO exposes only that number and
+field-presence booleans. Realtime upserts and reconnect hydration therefore
+carry the same durable revision across replicas without revealing a credential.
+An older in-flight probe is cancelled when the revision changes.
+
 Focused component tests cover valid configured Claude, rejected/expired Claude,
 loading/unknown, another-agent-only failure, policy-loading and disabled-agent
-states, reconnect success and failure, same-field realtime rotation, logout and
-user switch, snooze persistence/expiry, and snooze invalidation after save.
+states, creation-order fallback, reconnect success and failure, same-field user
+and workspace realtime rotation (settled and in-flight), logout and user switch,
+snooze persistence/expiry, cross-tab synchronization, and snooze invalidation
+after save.
 Real-browser coverage runs the warning at desktop, tablet, phone, and short
 landscape viewports and exercises keyboard focus and the close action. Synthetic
 provider hints are asserted absent from the DOM.
@@ -241,8 +263,10 @@ provider hints are asserted absent from the DOM.
 
 ## Rollout, rollback, and residual risk
 
-This is a code-only rollout with no schema/config migration. Existing browsers
-have no snooze record and will see a real selected-agent rejection normally.
+This is a code-only rollout with no schema/config migration. Legacy encrypted
+workspace settings read as revision `0`; their next patch atomically persists
+revision `1`. Existing browsers have no snooze record and will see a real
+selected-agent rejection normally.
 Monitor `/check-auth` status mix/provider latency and credential-related session
 start failures by tool; do not log credentials or request headers.
 

--- a/docs/internal/ai-credential-status-banner-2026-08-29.md
+++ b/docs/internal/ai-credential-status-banner-2026-08-29.md
@@ -191,8 +191,10 @@ New copy identifies the affected tool:
 
 The action opens or reviews that tool's user/workspace settings. When the
 active route is workspace-owned and the caller is not an administrator, the
-banner instead explains that a workspace admin must act and does not link to
-personal settings that the resolution policy will ignore. The close
+remediation follows policy rather than ownership alone: `tenant_required` and
+an active `tenant_preferred` credential explain that a workspace admin must
+act, while `user_preferred` offers personal settings because a new personal
+credential takes precedence over the rejected workspace fallback. The close
 button has an agent-specific accessible name and snoozes the warning for 24
 hours. Persistence is local-browser, versioned, and scoped by user ID plus
 tool. Expired/malformed values are removed. A local credential save clears the

--- a/packages/core/src/db/repositories/tenant-agentic-tools.test.ts
+++ b/packages/core/src/db/repositories/tenant-agentic-tools.test.ts
@@ -24,6 +24,7 @@ describe('TenantAgenticToolSettingsRepository', () => {
     });
 
     await expect(repository.find('codex')).resolves.toEqual({
+      revision: 1,
       enabled: false,
       connection: {
         OPENAI_API_KEY: 'workspace-key',
@@ -45,6 +46,7 @@ describe('TenantAgenticToolSettingsRepository', () => {
     });
 
     await expect(repository.find('claude-code')).resolves.toEqual({
+      revision: 2,
       connection: { ANTHROPIC_BASE_URL: 'https://example.invalid' },
     });
   });
@@ -58,15 +60,35 @@ describe('TenantAgenticToolSettingsRepository', () => {
         resolution_policy: 'user_required',
       });
       await expect(repository.find('codex')).resolves.toEqual({
+        revision: 1,
         resolution_policy: 'user_required',
         connection: { OPENAI_API_KEY: 'workspace-key' },
       });
 
       await repository.patch('codex', { resolution_policy: 'tenant_required' });
       await expect(repository.find('codex')).resolves.toEqual({
+        revision: 2,
         resolution_policy: 'tenant_required',
         connection: { OPENAI_API_KEY: 'workspace-key' },
       });
     }
   );
+
+  dbTest('increments a durable revision for same-presence credential rotations', async ({ db }) => {
+    const repository = new TenantAgenticToolSettingsRepository(db);
+    await repository.patch('claude-code', {
+      connection: { ANTHROPIC_AUTH_TOKEN: 'synthetic-token-one' },
+    });
+    const first = await repository.find('claude-code');
+
+    await repository.patch('claude-code', {
+      connection: { ANTHROPIC_AUTH_TOKEN: 'synthetic-token-two' },
+    });
+    const second = await repository.find('claude-code');
+
+    expect(first).toMatchObject({ revision: 1 });
+    expect(second).toMatchObject({ revision: 2 });
+    expect(Object.keys(first.connection ?? {})).toEqual(['ANTHROPIC_AUTH_TOKEN']);
+    expect(Object.keys(second.connection ?? {})).toEqual(['ANTHROPIC_AUTH_TOKEN']);
+  });
 });

--- a/packages/core/src/db/repositories/tenant-agentic-tools.ts
+++ b/packages/core/src/db/repositories/tenant-agentic-tools.ts
@@ -41,11 +41,18 @@ function parseSettings(
     throw new Error(`Invalid stored tenant agentic-tool settings for ${tool}`);
   }
   const input = parsed as {
+    revision?: unknown;
     enabled?: unknown;
     resolution_policy?: unknown;
     inline_configuration_allowed?: unknown;
     connection?: unknown;
   };
+  if (
+    input.revision !== undefined &&
+    (!Number.isSafeInteger(input.revision) || (input.revision as number) < 1)
+  ) {
+    throw new Error(`Invalid revision in tenant agentic-tool settings for ${tool}`);
+  }
   if (input.enabled !== undefined && typeof input.enabled !== 'boolean') {
     throw new Error(`Invalid enabled value in tenant agentic-tool settings for ${tool}`);
   }
@@ -79,6 +86,7 @@ function parseSettings(
   }
   const resolutionPolicy = input.resolution_policy as ProviderResolutionPolicy | undefined;
   return {
+    ...(input.revision !== undefined ? { revision: input.revision as number } : {}),
     ...(input.enabled === false ? { enabled: false } : {}),
     ...(resolutionPolicy && resolutionPolicy !== DEFAULT_PROVIDER_RESOLUTION_POLICY
       ? { resolution_policy: resolutionPolicy }
@@ -155,7 +163,12 @@ export class TenantAgenticToolSettingsRepository {
       }
       const resolutionPolicy =
         patch.resolution_policy ?? current.resolution_policy ?? DEFAULT_PROVIDER_RESOLUTION_POLICY;
+      const revision = (current.revision ?? 0) + 1;
+      if (!Number.isSafeInteger(revision)) {
+        throw new Error(`Tenant agentic-tool settings revision overflow for ${tool}`);
+      }
       const next: StoredTenantAgenticToolSettings = {
+        revision,
         ...((patch.enabled ?? current.enabled) === false ? { enabled: false } : {}),
         ...(resolutionPolicy !== DEFAULT_PROVIDER_RESOLUTION_POLICY
           ? { resolution_policy: resolutionPolicy }
@@ -166,18 +179,14 @@ export class TenantAgenticToolSettingsRepository {
         ...(Object.keys(connection).length > 0 ? { connection } : {}),
       };
 
-      if (Object.keys(next).length === 0) {
-        await variables.delete(TENANT_AGENTIC_TOOLS_NAMESPACE, tool);
-      } else {
-        await variables.set({
-          namespace: TENANT_AGENTIC_TOOLS_NAMESPACE,
-          key: tool,
-          value: JSON.stringify(next),
-          encrypted: true,
-          content_type: 'application/json',
-          updated_by: updatedBy ?? null,
-        });
-      }
+      await variables.set({
+        namespace: TENANT_AGENTIC_TOOLS_NAMESPACE,
+        key: tool,
+        value: JSON.stringify(next),
+        encrypted: true,
+        content_type: 'application/json',
+        updated_by: updatedBy ?? null,
+      });
       return next;
     };
 

--- a/packages/core/src/types/tenant-agentic-tool.ts
+++ b/packages/core/src/types/tenant-agentic-tool.ts
@@ -57,6 +57,8 @@ export const TENANT_PROVIDER_CONNECTION_FIELDS = {
 } as const satisfies Record<ProviderConnectionTool, readonly AgenticToolConfigField[]>;
 
 export interface StoredTenantAgenticToolSettings {
+  /** Durable generation incremented on every workspace settings patch. */
+  revision?: number;
   /** Omitted values inherit Agor's built-in default (enabled). */
   enabled?: boolean;
   /** Omitted values inherit Agor's built-in user-preferred policy. */
@@ -72,6 +74,8 @@ export interface TenantAgenticToolFieldStatus {
 
 export interface TenantAgenticToolSettings {
   tool: TenantAgenticToolName;
+  /** Non-secret durable generation used to invalidate client-side status probes. */
+  revision?: number;
   /** Whether the deployment operator selected and installed this tool package. */
   deployment_available: boolean;
   /** Effective workspace availability: deployment_available and not tenant-disabled. */


### PR DESCRIPTION
## Summary

- validate Claude's complete resolved provider connection, including `ANTHROPIC_AUTH_TOKEN` bearer auth, instead of reducing status to `ANTHROPIC_API_KEY`
- make the app-shell warning authoritative for exactly the agent a new-session flow will select and the active user/workspace credential route
- keep policy-loading, reconnecting, provider timeout/5xx, and other inconclusive states at `unknown` rather than claiming credentials failed
- add agent-specific copy/actions and an accessible user+agent-scoped 24-hour snooze that re-probes before reminding
- invalidate stale results on same-field user **and workspace** rotations, policy updates, reconnect, local saves, logout/user switch, agent changes, and cross-tab snooze changes

## Root cause

`resolveApiKey('ANTHROPIC_API_KEY')` returns both the named key and the complete policy-selected connection. Claude execution installs that complete connection, so a stored `ANTHROPIC_AUTH_TOKEN` works as bearer auth. `check-auth` only looked at the named `apiKey` (and a separate subscription-token lookup), ignored the bearer field, and returned `unauthenticated`. The UI combined that false verdict with the bearer field's public presence bit and showed the old global “Your AI credentials aren't working” banner even though Claude tasks succeeded.

The old banner also predated provider-scoped managed-secret hardening and the current Claude/Codex auth families, collapsed status across agents, could remain stale across same-presence updates/reconnect, and had no close control.

## Product contract

- `authenticated`: positive provider/native evidence
- `unauthenticated`: positive blocking evidence (missing active route, decrypt failure, 401/403, positively broken native login)
- `unknown`: loading, timeout/network/5xx, delegated inspection error, or an auth class without a reliable negative probe
- a warning is rendered only for an `unauthenticated` verdict on the enabled tool the creation UI will initially select
- session creation and the banner share one enabled-tool resolver and canonical fallback order
- remediation follows policy rather than ownership alone: admins can repair the active workspace route; members get contact-admin copy when workspace policy blocks personal overrides, while `user_preferred` workspace fallbacks offer personal settings because a new personal credential takes precedence
- close snoozes for 24 hours per browser/user/tool; user saves or durable workspace revisions clear it, storage events synchronize tabs, and expiry starts from `unknown` and re-probes

The full authority map, before/after state machine, deterministic reproduction, rollout/rollback, and residual risks are in `docs/internal/ai-credential-status-banner-2026-08-29.md`.

## Stale-state / HA handling

Workspace tool settings now carry a durable non-secret `revision`, stored with the encrypted workspace settings record and incremented under the existing row lock on every patch. Its public DTO contains the revision plus presence booleans only—never credential values. This lets settled and in-flight probes, snoozes, realtime consumers, reconnects, and separate daemon replicas distinguish same-presence credential rotations without component-local counters or schema changes.

Legacy rows read as revision 0; their next patch writes revision 1.

## Security / tenancy

- no auth boundary, tenant scope, resolution policy, encryption, or DTO redaction is weakened
- provider credentials remain server-side and appear only in the outbound provider request
- tests assert synthetic credentials do not enter service results or the DOM
- no schema/config migration; localStorage stores only user ID, tool name, version, and expiry
- workspace revision updates retain the existing tenant-scoped transaction, row lock, encryption, and realtime service path

## Validation

Latest branch (`8a0c5c2394e189469384c71b7e0c96da5b68282f`):

- `pnpm check` — passed (all typecheck, lint/policy, boundary, and build tasks)
- focused core workspace-settings repository suite — 5 passed
- focused daemon workspace-settings + auth suites — 28 passed
- focused banner/logic UI suite after policy-remediation follow-up — 49 passed
- focused banner/logic/agent-selection UI suites — 54 passed
- focused New Session/Navbar/agent-selection suites — 37 passed
- focused real-browser banner suite at desktop/tablet/phone/short-landscape — 4 passed
- `git diff --check` — passed

Earlier full-suite validation on the same PR:

- full browser suite — 64 passed
- full daemon run: 3,870 passed / 145 skipped; one unrelated MCP test timed out under concurrent full-suite load and passed 22/22 when rerun isolated
- full UI run: 2,097 passed; five unrelated UI tests failed/timed out under concurrent full-suite load and passed 56/56 when rerun single-worker
