### PR TITLE
fix(mcp): enter tenant DB scope for custom-method branch/repo/board creates

### DIFF
--- a/apps/agor-daemon/src/mcp/tenant-scope.ts
+++ b/apps/agor-daemon/src/mcp/tenant-scope.ts
@@ -1,9 +1,12 @@
 import type { TenantScopeAwareDatabase } from '@agor/core/db';
 import {
+  assertTenantWritable,
   bindRepositoryToTenantUnitOfWork,
   runWithTenantContext,
   runWithTenantDatabaseScope,
+  TenantWriteGateActiveError,
 } from '@agor/core/db';
+import { Unavailable } from '@agor/core/feathers';
 import type { McpServer } from '@modelcontextprotocol/server';
 import { wrapRegisterTool } from './register-tool-proxy.js';
 import type { McpContext } from './server.js';
@@ -12,6 +15,11 @@ import type { McpContext } from './server.js';
  * Custom MCP service methods bypass the Feathers around hooks that normally
  * enter the tenant database scope. Re-enter that scope when authentication
  * supplied a tenant, while preserving static/single-tenant behavior.
+ *
+ * READ-ONLY variant. For custom-method calls that MUTATE tenant data, use
+ * {@link runWithMcpTenantDatabaseWrite} so the tenant write-freeze gate is
+ * enforced too — otherwise MCP mutations would slip past the freeze that HTTP
+ * custom routes apply via `tenantWriteGateAround`.
  */
 export async function runWithMcpTenantDatabaseScope<T>(
   ctx: McpContext,
@@ -20,6 +28,37 @@ export async function runWithMcpTenantDatabaseScope<T>(
   const tenantId = ctx.baseServiceParams.tenant?.tenant_id;
   if (!tenantId) return work(ctx.db);
   return runWithTenantDatabaseScope(ctx.db, tenantId, () => work(ctx.db));
+}
+
+/**
+ * MUTATING variant of {@link runWithMcpTenantDatabaseScope}. Mirrors the HTTP
+ * custom-route pair `[tenantDatabaseScopeAround, tenantWriteGateAround]`: it
+ * enters the tenant database scope AND asserts the tenant write-freeze gate
+ * inside it before running the mutation, translating `TenantWriteGateActiveError`
+ * to `Unavailable` exactly like the route hook. Use this for MCP calls to custom
+ * (non-transport) service methods that write `this.db` directly — those bypass
+ * the Feathers `writeGateBefore` hook that guards standard methods.
+ *
+ * On SQLite/static the gate read is a no-op (`readTenantWriteGate` short-circuits
+ * for non-Postgres), so behavior there is identical to the read-only variant.
+ */
+export async function runWithMcpTenantDatabaseWrite<T>(
+  ctx: McpContext,
+  work: (db: TenantScopeAwareDatabase) => Promise<T>
+): Promise<T> {
+  const tenantId = ctx.baseServiceParams.tenant?.tenant_id;
+  if (!tenantId) return work(ctx.db);
+  return runWithTenantDatabaseScope(ctx.db, tenantId, async () => {
+    try {
+      await assertTenantWritable(ctx.db, tenantId);
+    } catch (error) {
+      if (error instanceof TenantWriteGateActiveError) {
+        throw new Unavailable(error.message);
+      }
+      throw error;
+    }
+    return work(ctx.db);
+  });
 }
 
 /** Bind a repository used by long MCP orchestration to short tenant DB units. */

--- a/apps/agor-daemon/src/mcp/tools/boards.ts
+++ b/apps/agor-daemon/src/mcp/tools/boards.ts
@@ -422,7 +422,12 @@ export function registerBoardTools(server: McpServer, ctx: McpContext): void {
     async (args) => {
       const boardId = coerceString(args.boardId)!;
       const boardsService = ctx.app.service('boards') as unknown as BoardsServiceImpl;
-      const result = await boardsService.archive(boardId, ctx.baseServiceParams);
+      // archive() is a custom (non-transport) method that reads/patches over
+      // `this.db` without an internal scope helper, so re-enter the tenant DB
+      // scope here (the HTTP archive route enters it via its around hook).
+      const result = await runWithMcpTenantDatabaseScope(ctx, () =>
+        boardsService.archive(boardId, ctx.baseServiceParams)
+      );
       return textResult({
         success: true,
         board: result,
@@ -443,7 +448,11 @@ export function registerBoardTools(server: McpServer, ctx: McpContext): void {
     async (args) => {
       const boardId = coerceString(args.boardId)!;
       const boardsService = ctx.app.service('boards') as unknown as BoardsServiceImpl;
-      const result = await boardsService.unarchive(boardId, ctx.baseServiceParams);
+      // Custom (non-transport) method — enter the tenant DB scope like the HTTP
+      // unarchive route's around hook would.
+      const result = await runWithMcpTenantDatabaseScope(ctx, () =>
+        boardsService.unarchive(boardId, ctx.baseServiceParams)
+      );
       return textResult({
         success: true,
         board: result,

--- a/apps/agor-daemon/src/mcp/tools/boards.ts
+++ b/apps/agor-daemon/src/mcp/tools/boards.ts
@@ -23,7 +23,7 @@ import {
 } from '../schema.js';
 import type { McpContext } from '../server.js';
 import { coerceString, textResult } from '../server.js';
-import { runWithMcpTenantDatabaseScope } from '../tenant-scope.js';
+import { runWithMcpTenantDatabaseScope, runWithMcpTenantDatabaseWrite } from '../tenant-scope.js';
 
 const BOARD_OBJECT_TYPES = [
   'zone',
@@ -425,7 +425,7 @@ export function registerBoardTools(server: McpServer, ctx: McpContext): void {
       // archive() is a custom (non-transport) method that reads/patches over
       // `this.db` without an internal scope helper, so re-enter the tenant DB
       // scope here (the HTTP archive route enters it via its around hook).
-      const result = await runWithMcpTenantDatabaseScope(ctx, () =>
+      const result = await runWithMcpTenantDatabaseWrite(ctx, () =>
         boardsService.archive(boardId, ctx.baseServiceParams)
       );
       return textResult({
@@ -450,7 +450,7 @@ export function registerBoardTools(server: McpServer, ctx: McpContext): void {
       const boardsService = ctx.app.service('boards') as unknown as BoardsServiceImpl;
       // Custom (non-transport) method — enter the tenant DB scope like the HTTP
       // unarchive route's around hook would.
-      const result = await runWithMcpTenantDatabaseScope(ctx, () =>
+      const result = await runWithMcpTenantDatabaseWrite(ctx, () =>
         boardsService.unarchive(boardId, ctx.baseServiceParams)
       );
       return textResult({

--- a/apps/agor-daemon/src/mcp/tools/branches.tenant-scope.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.tenant-scope.test.ts
@@ -1,0 +1,231 @@
+import {
+  createTenantScopedDatabaseProxy,
+  getCurrentTenantDatabaseScope,
+  getCurrentTenantId,
+  MissingTenantDatabaseScopeError,
+  runWithTenantContext,
+} from '@agor/core/db';
+import type { McpServer, ServerContext } from '@modelcontextprotocol/server';
+import { describe, expect, it, vi } from 'vitest';
+import { registerBranchTools } from './branches.js';
+
+/**
+ * Regression coverage for the HA/multi-tenant MCP failure:
+ * `agor_branches_create` threw `Missing tenant database scope for daemon
+ * database access` in `required_from_auth` mode.
+ *
+ * `ReposService.createBranch` is deliberately NOT a Feathers transport method,
+ * so the MCP tool calls it directly — bypassing the around hooks that enter the
+ * tenant database scope on the HTTP `/repos/:id/branches` route. Against a
+ * `requireScope`-guarded daemon-database proxy the first `this.db` touch then
+ * throws. These tests exercise the REAL guard machinery (the same
+ * `createTenantScopedDatabaseProxy` / `tenantDatabaseScope` used in production)
+ * rather than a stub, so removing the fix re-breaks them.
+ */
+
+vi.mock('../../utils/executor-delegated-home.js', () => ({
+  resolveDelegatedExecutionHomeKey: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../utils/spawn-executor.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../utils/spawn-executor.js')>();
+  return { ...actual };
+});
+
+type ToolHandler = (
+  args: Record<string, unknown>,
+  requestContext?: ServerContext
+) => Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }>;
+
+function requestContext(): ServerContext {
+  return { mcpReq: { signal: new AbortController().signal } } as ServerContext;
+}
+
+/**
+ * Build a guarded daemon-database proxy exactly like `setup/database.ts` does in
+ * hosted mode, plus a fake `createBranch` that TOUCHES that proxy — reproducing
+ * the production access that trips the guard when no scope is active.
+ */
+function makeFixture(options: {
+  tenantId?: string;
+  requireScope?: boolean;
+  branchesGet?: () => Promise<unknown>;
+}) {
+  // A `.run` marker makes `isPostgresDatabase` treat this as the SQLite-like
+  // handle, so `runWithTenantDatabaseScope` enters an identity-only tenant scope
+  // (no native transaction to fake). The scope still satisfies the guard — which
+  // is the behavior under test. The real Postgres transaction path is covered
+  // end-to-end by scripts/test-ha-mcp-branch-create.mjs.
+  const base = { __daemon: true, run: () => undefined } as Record<string, unknown>;
+  const guardedDb = createTenantScopedDatabaseProxy(base, {
+    requireScope: options.requireScope ?? true,
+    label: 'daemon database',
+  });
+
+  const observations: Array<{
+    tenantIdInContext: string | undefined;
+    scopeKind: string | undefined;
+    scopeTenantId: string | undefined;
+  }> = [];
+
+  // Mirrors ReposService.createBranch: the first thing it does is create a
+  // repository over `this.db` (the guarded proxy) and read from it. A property
+  // access on the proxy is what runs `assertDatabaseScopeAllowed`.
+  const createBranch = vi.fn(async () => {
+    // Touch the guarded proxy — throws MissingTenantDatabaseScopeError unless a
+    // tenant/system database scope is active.
+    void (guardedDb as unknown as Record<string, unknown>).select;
+    const scope = getCurrentTenantDatabaseScope();
+    observations.push({
+      tenantIdInContext: getCurrentTenantId(),
+      scopeKind: scope?.kind,
+      scopeTenantId: scope?.kind === 'tenant' ? scope.tenantId : undefined,
+    });
+    return { branch_id: 'branch-new', name: 'feature', board_id: 'board-1' };
+  });
+
+  const app = {
+    get: () => ({}),
+    service(name: string) {
+      if (name === 'repos') {
+        return {
+          get: vi.fn(async () => ({ repo_id: 'repo-1', default_branch: 'main' })),
+          createBranch,
+        };
+      }
+      if (name === 'boards') return { get: vi.fn(async () => ({ board_id: 'board-1' })) };
+      if (name === 'branches' && options.branchesGet) return { get: options.branchesGet };
+      throw new Error(`Unexpected service call: ${name}`);
+    },
+  };
+
+  const baseServiceParams = {
+    authenticated: true,
+    provider: 'mcp',
+    ...(options.tenantId ? { tenant: { tenant_id: options.tenantId } } : {}),
+    user: { user_id: 'user-1', role: 'member' },
+  };
+
+  let captured: ToolHandler | undefined;
+  const fakeServer = {
+    registerTool: (name: string, _cfg: unknown, cb: ToolHandler) => {
+      if (name === 'agor_branches_create') captured = cb;
+    },
+  } as unknown as McpServer;
+
+  registerBranchTools(fakeServer, {
+    app: app as unknown as Parameters<typeof registerBranchTools>[1]['app'],
+    db: guardedDb as unknown as Parameters<typeof registerBranchTools>[1]['db'],
+    userId: 'user-1' as Parameters<typeof registerBranchTools>[1]['userId'],
+    authenticatedUser: {
+      user_id: 'user-1',
+      email: 'user@example.test',
+      role: 'member',
+    } as Parameters<typeof registerBranchTools>[1]['authenticatedUser'],
+    baseServiceParams: baseServiceParams as Parameters<
+      typeof registerBranchTools
+    >[1]['baseServiceParams'],
+  });
+
+  if (!captured) throw new Error('agor_branches_create was not registered');
+  return { handler: captured, createBranch, observations, guardedDb };
+}
+
+const createArgs = (over: Record<string, unknown> = {}) => ({
+  repoId: 'repo-1',
+  branchName: 'feature',
+  boardId: 'board-1',
+  // Skip the auto-suffix pre-read so createBranch is the only guarded DB touch.
+  autoSuffix: false,
+  ...over,
+});
+
+describe('agor_branches_create tenant database scope (HA regression)', () => {
+  it('locks the exact guard error string the HA daemon reported', () => {
+    // The message the live HA MCP call surfaced on daemon A and B for both
+    // waitForReady modes: "Missing tenant database scope for daemon database
+    // access". If this label ever drifts, the symptom the fix targets changes.
+    expect(new MissingTenantDatabaseScopeError('daemon database').message).toBe(
+      'Missing tenant database scope for daemon database access'
+    );
+  });
+
+  it('enters the authenticated tenant database scope around createBranch (waitForReady=false)', async () => {
+    const { handler, createBranch, observations } = makeFixture({ tenantId: 'tenant-a' });
+
+    const result = await handler(createArgs({ waitForReady: false }), requestContext());
+
+    expect(result.isError).toBeFalsy();
+    expect(createBranch).toHaveBeenCalledTimes(1);
+    // Proves the fix: createBranch ran under an active tenant DB scope bound to
+    // the authenticated tenant, not merely tenant context identity.
+    expect(observations).toEqual([
+      { tenantIdInContext: 'tenant-a', scopeKind: 'tenant', scopeTenantId: 'tenant-a' },
+    ]);
+  });
+
+  it('does not hold the tenant database scope across the readiness wait (waitForReady=true)', async () => {
+    // Wait mode reads the branch through a *separate* Feathers get; the create
+    // scope must not still be open while polling. We assert the scope was active
+    // during createBranch and fully cleaned up after the tool returns.
+    const branchesGet = vi.fn(async () => ({
+      branch_id: 'branch-new',
+      name: 'feature',
+      board_id: 'board-1',
+      filesystem_status: 'ready',
+    }));
+    const { handler, observations } = makeFixture({ tenantId: 'tenant-a', branchesGet });
+
+    const result = await handler(
+      createArgs({ waitForReady: true, waitTimeoutMs: 2_000 }),
+      requestContext()
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(observations[0]).toEqual({
+      tenantIdInContext: 'tenant-a',
+      scopeKind: 'tenant',
+      scopeTenantId: 'tenant-a',
+    });
+    // Scope cleanup: nothing leaks past the tool boundary.
+    expect(getCurrentTenantDatabaseScope()).toBeUndefined();
+  });
+
+  it('keeps tenant A and tenant B on their own scopes (no cross-tenant leakage)', async () => {
+    const a = makeFixture({ tenantId: 'tenant-a' });
+    const b = makeFixture({ tenantId: 'tenant-b' });
+
+    await a.handler(createArgs({ branchName: 'a-feature' }), requestContext());
+    await b.handler(createArgs({ branchName: 'b-feature' }), requestContext());
+
+    expect(a.observations[0]?.scopeTenantId).toBe('tenant-a');
+    expect(b.observations[0]?.scopeTenantId).toBe('tenant-b');
+  });
+
+  it('rejects a tenant scope that conflicts with an active foreign tenant context (fail closed)', async () => {
+    // If ambient identity already belongs to tenant-b, a create authenticated as
+    // tenant-a must not silently switch tenants — it must fail closed.
+    const { handler } = makeFixture({ tenantId: 'tenant-a' });
+
+    await expect(
+      runWithTenantContext('tenant-b', () => handler(createArgs(), requestContext()))
+    ).rejects.toThrow(/tenant/i);
+  });
+
+  it('preserves static single-tenant behavior when no tenant is authenticated', async () => {
+    // SQLite/static mode: proxy is not scope-requiring and no tenant is present.
+    // createBranch must run without entering a tenant DB scope, exactly as today.
+    const { handler, createBranch, observations } = makeFixture({
+      tenantId: undefined,
+      requireScope: false,
+    });
+
+    const result = await handler(createArgs(), requestContext());
+
+    expect(result.isError).toBeFalsy();
+    expect(createBranch).toHaveBeenCalledTimes(1);
+    expect(observations).toEqual([
+      { tenantIdInContext: undefined, scopeKind: undefined, scopeTenantId: undefined },
+    ]);
+  });
+});

--- a/apps/agor-daemon/src/mcp/tools/branches.tenant-scope.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.tenant-scope.test.ts
@@ -27,11 +27,6 @@ vi.mock('../../utils/executor-delegated-home.js', () => ({
   resolveDelegatedExecutionHomeKey: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock('../../utils/spawn-executor.js', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../../utils/spawn-executor.js')>();
-  return { ...actual };
-});
-
 type ToolHandler = (
   args: Record<string, unknown>,
   requestContext?: ServerContext
@@ -50,6 +45,9 @@ function makeFixture(options: {
   tenantId?: string;
   requireScope?: boolean;
   branchesGet?: () => Promise<unknown>;
+  /** Runs inside createBranch's tenant scope (after the guarded-db touch,
+   *  before the observation is recorded) — used to interleave concurrent calls. */
+  onCreate?: () => Promise<void>;
 }) {
   // A `.run` marker makes `isPostgresDatabase` treat this as the SQLite-like
   // handle, so `runWithTenantDatabaseScope` enters an identity-only tenant scope
@@ -75,6 +73,8 @@ function makeFixture(options: {
     // Touch the guarded proxy — throws MissingTenantDatabaseScopeError unless a
     // tenant/system database scope is active.
     void (guardedDb as unknown as Record<string, unknown>).select;
+    // Optional interleave point (still inside the tenant scope).
+    if (options.onCreate) await options.onCreate();
     const scope = getCurrentTenantDatabaseScope();
     observations.push({
       tenantIdInContext: getCurrentTenantId(),
@@ -166,14 +166,19 @@ describe('agor_branches_create tenant database scope (HA regression)', () => {
 
   it('does not hold the tenant database scope across the readiness wait (waitForReady=true)', async () => {
     // Wait mode reads the branch through a *separate* Feathers get; the create
-    // scope must not still be open while polling. We assert the scope was active
-    // during createBranch and fully cleaned up after the tool returns.
-    const branchesGet = vi.fn(async () => ({
-      branch_id: 'branch-new',
-      name: 'feature',
-      board_id: 'board-1',
-      filesystem_status: 'ready',
-    }));
+    // scope must be closed by the time polling runs. Capture the ambient scope
+    // *inside* the poll — the assertion below would fail if polling happened
+    // while the create transaction was still open.
+    let scopeDuringPoll: unknown = 'not-called';
+    const branchesGet = vi.fn(async () => {
+      scopeDuringPoll = getCurrentTenantDatabaseScope();
+      return {
+        branch_id: 'branch-new',
+        name: 'feature',
+        board_id: 'board-1',
+        filesystem_status: 'ready',
+      };
+    });
     const { handler, observations } = makeFixture({ tenantId: 'tenant-a', branchesGet });
 
     const result = await handler(
@@ -187,19 +192,55 @@ describe('agor_branches_create tenant database scope (HA regression)', () => {
       scopeKind: 'tenant',
       scopeTenantId: 'tenant-a',
     });
-    // Scope cleanup: nothing leaks past the tool boundary.
+    // The readiness poll ran with NO create scope active...
+    expect(branchesGet).toHaveBeenCalled();
+    expect(scopeDuringPoll).toBeUndefined();
+    // ...and nothing leaks past the tool boundary either.
     expect(getCurrentTenantDatabaseScope()).toBeUndefined();
   });
 
-  it('keeps tenant A and tenant B on their own scopes (no cross-tenant leakage)', async () => {
-    const a = makeFixture({ tenantId: 'tenant-a' });
-    const b = makeFixture({ tenantId: 'tenant-b' });
+  it('keeps concurrent tenant A and tenant B requests on their own scopes (no cross-tenant leakage)', async () => {
+    // Interleave: both createBranch calls suspend inside their own tenant scope
+    // simultaneously, then each records its ambient tenant *after* the barrier.
+    // AsyncLocalStorage must keep the two concurrent contexts separate.
+    let enterA!: () => void;
+    let enterB!: () => void;
+    const aInside = new Promise<void>((resolve) => {
+      enterA = resolve;
+    });
+    const bInside = new Promise<void>((resolve) => {
+      enterB = resolve;
+    });
+    const a = makeFixture({
+      tenantId: 'tenant-a',
+      onCreate: async () => {
+        enterA();
+        await bInside;
+      },
+    });
+    const b = makeFixture({
+      tenantId: 'tenant-b',
+      onCreate: async () => {
+        enterB();
+        await aInside;
+      },
+    });
 
-    await a.handler(createArgs({ branchName: 'a-feature' }), requestContext());
-    await b.handler(createArgs({ branchName: 'b-feature' }), requestContext());
+    await Promise.all([
+      a.handler(createArgs({ branchName: 'a-feature' }), requestContext()),
+      b.handler(createArgs({ branchName: 'b-feature' }), requestContext()),
+    ]);
 
-    expect(a.observations[0]?.scopeTenantId).toBe('tenant-a');
-    expect(b.observations[0]?.scopeTenantId).toBe('tenant-b');
+    expect(a.observations[0]).toEqual({
+      tenantIdInContext: 'tenant-a',
+      scopeKind: 'tenant',
+      scopeTenantId: 'tenant-a',
+    });
+    expect(b.observations[0]).toEqual({
+      tenantIdInContext: 'tenant-b',
+      scopeKind: 'tenant',
+      scopeTenantId: 'tenant-b',
+    });
   });
 
   it('rejects a tenant scope that conflicts with an active foreign tenant context (fail closed)', async () => {

--- a/apps/agor-daemon/src/mcp/tools/branches.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.test.ts
@@ -74,7 +74,10 @@ function registerAndCaptureHandler(
 
   registerBranchTools(fakeServer, {
     app: ctx.app as Parameters<typeof registerBranchTools>[1]['app'],
-    db: {} as Parameters<typeof registerBranchTools>[1]['db'],
+    // A `.run` marker makes runWithMcpTenantDatabaseScope treat this as the
+    // SQLite-like handle (identity scope, no native transaction to fake) when a
+    // tenant is present in baseServiceParams.
+    db: { run: () => undefined } as unknown as Parameters<typeof registerBranchTools>[1]['db'],
     userId: ctx.userId as Parameters<typeof registerBranchTools>[1]['userId'],
     sessionId: ctx.sessionId as Parameters<typeof registerBranchTools>[1]['sessionId'],
     authenticatedUser: (ctx.authenticatedUser ?? {
@@ -115,7 +118,10 @@ function registerAndCaptureConfig(
 
   registerBranchTools(fakeServer, {
     app: ctx.app as Parameters<typeof registerBranchTools>[1]['app'],
-    db: {} as Parameters<typeof registerBranchTools>[1]['db'],
+    // A `.run` marker makes runWithMcpTenantDatabaseScope treat this as the
+    // SQLite-like handle (identity scope, no native transaction to fake) when a
+    // tenant is present in baseServiceParams.
+    db: { run: () => undefined } as unknown as Parameters<typeof registerBranchTools>[1]['db'],
     userId: ctx.userId as Parameters<typeof registerBranchTools>[1]['userId'],
     sessionId: ctx.sessionId as Parameters<typeof registerBranchTools>[1]['sessionId'],
     authenticatedUser: (ctx.authenticatedUser ?? {

--- a/apps/agor-daemon/src/mcp/tools/branches.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.ts
@@ -53,7 +53,7 @@ import {
 } from '../schema.js';
 import type { McpContext } from '../server.js';
 import { coerceString, sessionContextRequiredResult, textResult } from '../server.js';
-import { runWithMcpTenantDatabaseScope } from '../tenant-scope.js';
+import { runWithMcpTenantDatabaseScope, runWithMcpTenantDatabaseWrite } from '../tenant-scope.js';
 import { assertValidVariant } from './_environment-helpers.js';
 
 const BRANCH_NAME_PATTERN = /^[a-z0-9-]+$/;
@@ -977,7 +977,7 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
       // the authenticated tenant scope here so the metadata writes join one
       // tenant transaction — exactly like the HTTP route — while the readiness
       // wait below stays outside it and never holds a transaction across polls.
-      const branch = await runWithMcpTenantDatabaseScope(ctx, () =>
+      const branch = await runWithMcpTenantDatabaseWrite(ctx, () =>
         reposService.createBranch(
           repoId,
           {

--- a/apps/agor-daemon/src/mcp/tools/branches.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.ts
@@ -969,25 +969,35 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
       const storageMode = args.storage_mode as 'worktree' | 'clone' | undefined;
       const cloneDepth = typeof args.clone_depth === 'number' ? args.clone_depth : undefined;
 
-      const branch = await reposService.createBranch(
-        repoId,
-        {
-          name: branchName,
-          ref,
-          createBranch,
-          refType,
-          ...(pullLatest !== undefined ? { pullLatest } : {}),
-          ...(sourceBranch ? { sourceBranch } : {}),
-          ...(issueUrl ? { issue_url: issueUrl } : {}),
-          ...(pullRequestUrl ? { pull_request_url: pullRequestUrl } : {}),
-          boardId,
-          ...(zoneId ? { zoneId } : {}),
-          ...(variant ? { environment_variant: variant } : {}),
-          ...(storageMode ? { storage_mode: storageMode } : {}),
-          ...(cloneDepth !== undefined ? { clone_depth: cloneDepth } : {}),
-          ...(teammateConfig ? { custom_context: { teammate: teammateConfig } } : {}),
-        },
-        ctx.baseServiceParams
+      // `createBranch` is deliberately NOT a Feathers transport method (it takes
+      // `(id, data)`), so this direct call bypasses the around hooks that enter
+      // the tenant database scope for the HTTP `/repos/:id/branches` route. In
+      // `required_from_auth` mode the guarded daemon-database proxy then throws
+      // `MissingTenantDatabaseScopeError` on the first `this.db` touch. Re-enter
+      // the authenticated tenant scope here so the metadata writes join one
+      // tenant transaction — exactly like the HTTP route — while the readiness
+      // wait below stays outside it and never holds a transaction across polls.
+      const branch = await runWithMcpTenantDatabaseScope(ctx, () =>
+        reposService.createBranch(
+          repoId,
+          {
+            name: branchName,
+            ref,
+            createBranch,
+            refType,
+            ...(pullLatest !== undefined ? { pullLatest } : {}),
+            ...(sourceBranch ? { sourceBranch } : {}),
+            ...(issueUrl ? { issue_url: issueUrl } : {}),
+            ...(pullRequestUrl ? { pull_request_url: pullRequestUrl } : {}),
+            boardId,
+            ...(zoneId ? { zoneId } : {}),
+            ...(variant ? { environment_variant: variant } : {}),
+            ...(storageMode ? { storage_mode: storageMode } : {}),
+            ...(cloneDepth !== undefined ? { clone_depth: cloneDepth } : {}),
+            ...(teammateConfig ? { custom_context: { teammate: teammateConfig } } : {}),
+          },
+          ctx.baseServiceParams
+        )
       );
 
       const readinessResult = args.waitForReady
@@ -1322,9 +1332,12 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
       };
 
       if (zoneId === null) {
-        const boardObject = await boardObjectsService.findByBranchId(
-          branchId as BranchID,
-          ctx.baseServiceParams
+        // findByBranchId is a custom (non-transport) method on the board-objects
+        // service and reads `this.db` directly without an internal scope helper,
+        // so enter the tenant DB scope for this read (the surrounding patch/create
+        // are transport methods that enter it via their own hooks).
+        const boardObject = await runWithMcpTenantDatabaseScope(ctx, () =>
+          boardObjectsService.findByBranchId(branchId as BranchID, ctx.baseServiceParams)
         );
         if (!boardObject) {
           return textResult({
@@ -1365,7 +1378,9 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
       const { x: relativeX, y: relativeY } = computeZoneRelativePosition(zone as ZoneBoardObject);
 
       let boardObject: import('@agor/core/types').BoardEntityObject | null =
-        await boardObjectsService.findByBranchId(branchId as BranchID, ctx.baseServiceParams);
+        await runWithMcpTenantDatabaseScope(ctx, () =>
+          boardObjectsService.findByBranchId(branchId as BranchID, ctx.baseServiceParams)
+        );
 
       if (!boardObject) {
         // Create new board object

--- a/apps/agor-daemon/src/mcp/tools/cards.ts
+++ b/apps/agor-daemon/src/mcp/tools/cards.ts
@@ -105,7 +105,12 @@ export function registerCardTools(server: McpServer, ctx: McpContext): void {
     },
     async (args) => {
       const cardsService = ctx.app.service('cards') as unknown as CardsService;
-      const cardWithType = await cardsService.getWithType(args.cardId);
+      // getWithType() reads the card repository over `this.db` directly and is
+      // not a Feathers transport method, so enter the tenant DB scope here (the
+      // other cards custom-method calls in this file do the same).
+      const cardWithType = await runWithMcpTenantDatabaseScope(ctx, () =>
+        cardsService.getWithType(args.cardId)
+      );
       if (!cardWithType) throw new Error(`Card ${args.cardId} not found`);
       return textResult(cardWithType);
     }

--- a/apps/agor-daemon/src/mcp/tools/repos.ts
+++ b/apps/agor-daemon/src/mcp/tools/repos.ts
@@ -13,7 +13,7 @@ import {
 } from '../schema.js';
 import type { McpContext } from '../server.js';
 import { coerceString, textResult } from '../server.js';
-import { runWithMcpTenantDatabaseScope } from '../tenant-scope.js';
+import { runWithMcpTenantDatabaseWrite } from '../tenant-scope.js';
 
 export function registerRepoTools(server: McpServer, ctx: McpContext): void {
   // Tool 1: agor_repos_list
@@ -140,7 +140,7 @@ export function registerRepoTools(server: McpServer, ctx: McpContext): void {
       // scope for HTTP callers. Re-enter it here so its `this.db` reads/writes
       // join one short tenant unit — the executor clone itself is fire-and-forget
       // and runs outside this scope. See mcp/tenant-scope.ts.
-      const result = await runWithMcpTenantDatabaseScope(ctx, () =>
+      const result = await runWithMcpTenantDatabaseWrite(ctx, () =>
         reposService.cloneRepository(
           { url, slug, name, ...(defaultBranch ? { default_branch: defaultBranch } : {}) },
           ctx.baseServiceParams
@@ -239,7 +239,7 @@ export function registerRepoTools(server: McpServer, ctx: McpContext): void {
       // Custom (non-transport) method: its `this.get`/`this.patch`/`findBySlug`
       // touch the guarded daemon DB directly, so enter the tenant scope here to
       // match the HTTP route's around hook.
-      const updated = await runWithMcpTenantDatabaseScope(ctx, () =>
+      const updated = await runWithMcpTenantDatabaseWrite(ctx, () =>
         reposService.updateMetadata(repoId, patch, ctx.baseServiceParams)
       );
       return textResult(updated);

--- a/apps/agor-daemon/src/mcp/tools/repos.ts
+++ b/apps/agor-daemon/src/mcp/tools/repos.ts
@@ -13,6 +13,7 @@ import {
 } from '../schema.js';
 import type { McpContext } from '../server.js';
 import { coerceString, textResult } from '../server.js';
+import { runWithMcpTenantDatabaseScope } from '../tenant-scope.js';
 
 export function registerRepoTools(server: McpServer, ctx: McpContext): void {
   // Tool 1: agor_repos_list
@@ -134,9 +135,16 @@ export function registerRepoTools(server: McpServer, ctx: McpContext): void {
       const name = coerceString(args.name);
       const defaultBranch = coerceString(args.default_branch);
       const reposService = ctx.app.service('repos') as unknown as ReposServiceImpl;
-      const result = await reposService.cloneRepository(
-        { url, slug, name, ...(defaultBranch ? { default_branch: defaultBranch } : {}) },
-        ctx.baseServiceParams
+      // `cloneRepository` is a custom (non-transport) service method, so this
+      // direct call bypasses the around hooks that enter the tenant database
+      // scope for HTTP callers. Re-enter it here so its `this.db` reads/writes
+      // join one short tenant unit — the executor clone itself is fire-and-forget
+      // and runs outside this scope. See mcp/tenant-scope.ts.
+      const result = await runWithMcpTenantDatabaseScope(ctx, () =>
+        reposService.cloneRepository(
+          { url, slug, name, ...(defaultBranch ? { default_branch: defaultBranch } : {}) },
+          ctx.baseServiceParams
+        )
       );
       return textResult(result);
     }
@@ -163,7 +171,12 @@ export function registerRepoTools(server: McpServer, ctx: McpContext): void {
       if (!path) throw new Error('path is required');
       const slug = coerceString(args.slug);
       const reposService = ctx.app.service('repos') as unknown as ReposServiceImpl;
-      const repo = await reposService.addLocalRepository({ path, slug }, ctx.baseServiceParams);
+      // Custom (non-transport) method — re-enter the tenant DB scope like the
+      // HTTP route's around hook would. (Local repos are rejected in hosted
+      // multi-tenant mode, but the scope keeps this path correct everywhere.)
+      const repo = await runWithMcpTenantDatabaseScope(ctx, () =>
+        reposService.addLocalRepository({ path, slug }, ctx.baseServiceParams)
+      );
       return textResult(repo);
     }
   );
@@ -222,7 +235,12 @@ export function registerRepoTools(server: McpServer, ctx: McpContext): void {
       if (defaultBranch !== undefined) patch.default_branch = defaultBranch;
 
       const reposService = ctx.app.service('repos') as unknown as ReposServiceImpl;
-      const updated = await reposService.updateMetadata(repoId, patch, ctx.baseServiceParams);
+      // Custom (non-transport) method: its `this.get`/`this.patch`/`findBySlug`
+      // touch the guarded daemon DB directly, so enter the tenant scope here to
+      // match the HTTP route's around hook.
+      const updated = await runWithMcpTenantDatabaseScope(ctx, () =>
+        reposService.updateMetadata(repoId, patch, ctx.baseServiceParams)
+      );
       return textResult(updated);
     }
   );

--- a/apps/agor-daemon/src/mcp/tools/repos.ts
+++ b/apps/agor-daemon/src/mcp/tools/repos.ts
@@ -171,12 +171,13 @@ export function registerRepoTools(server: McpServer, ctx: McpContext): void {
       if (!path) throw new Error('path is required');
       const slug = coerceString(args.slug);
       const reposService = ctx.app.service('repos') as unknown as ReposServiceImpl;
-      // Custom (non-transport) method — re-enter the tenant DB scope like the
-      // HTTP route's around hook would. (Local repos are rejected in hosted
-      // multi-tenant mode, but the scope keeps this path correct everywhere.)
-      const repo = await runWithMcpTenantDatabaseScope(ctx, () =>
-        reposService.addLocalRepository({ path, slug }, ctx.baseServiceParams)
-      );
+      // Intentionally NOT wrapped in runWithMcpTenantDatabaseScope:
+      // addLocalRepository is rejected outright in `required_from_auth` mode
+      // (BadRequest before any DB touch), so the scope guard can never fire
+      // here. Wrapping would only risk holding a Postgres transaction across the
+      // method's awaited `git.repo.inspect` executor call if that guard were ever
+      // lifted. Local-repo registration stays a static/single-tenant path.
+      const repo = await reposService.addLocalRepository({ path, slug }, ctx.baseServiceParams);
       return textResult(repo);
     }
   );

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -53,7 +53,7 @@ import {
 } from '../schema.js';
 import type { McpContext } from '../server.js';
 import { sessionContextRequiredResult, textResult } from '../server.js';
-import { runWithMcpTenantDatabaseScope } from '../tenant-scope.js';
+import { runWithMcpTenantDatabaseScope, runWithMcpTenantDatabaseWrite } from '../tenant-scope.js';
 import { listAttachedMcpServers } from './mcp-servers.js';
 
 /**
@@ -1463,7 +1463,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
       // sessionRepo writes) directly and is not a Feathers transport method, so
       // enter the tenant DB scope here (the HTTP archive route enters it via its
       // around hook). The whole tree update is DB-only — no network held.
-      const result = await runWithMcpTenantDatabaseScope(ctx, () =>
+      const result = await runWithMcpTenantDatabaseWrite(ctx, () =>
         sessionsService.archive(args.sessionId, { includeChildren }, ctx.baseServiceParams)
       );
 
@@ -1497,7 +1497,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
       const includeChildren = args.includeChildren !== false;
       const sessionsService = ctx.app.service('sessions') as unknown as SessionsServiceImpl;
       // Same as archive: enter the tenant DB scope around the (DB-only) tree walk.
-      const result = await runWithMcpTenantDatabaseScope(ctx, () =>
+      const result = await runWithMcpTenantDatabaseWrite(ctx, () =>
         sessionsService.unarchive(args.sessionId, { includeChildren }, ctx.baseServiceParams)
       );
 

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -1459,10 +1459,12 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
     async (args) => {
       const includeChildren = args.includeChildren !== false;
       const sessionsService = ctx.app.service('sessions') as unknown as SessionsServiceImpl;
-      const result = await sessionsService.archive(
-        args.sessionId,
-        { includeChildren },
-        ctx.baseServiceParams
+      // archive() -> setArchiveStateForTree touches this.db (this.get,
+      // sessionRepo writes) directly and is not a Feathers transport method, so
+      // enter the tenant DB scope here (the HTTP archive route enters it via its
+      // around hook). The whole tree update is DB-only — no network held.
+      const result = await runWithMcpTenantDatabaseScope(ctx, () =>
+        sessionsService.archive(args.sessionId, { includeChildren }, ctx.baseServiceParams)
       );
 
       return textResult({
@@ -1494,10 +1496,9 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
     async (args) => {
       const includeChildren = args.includeChildren !== false;
       const sessionsService = ctx.app.service('sessions') as unknown as SessionsServiceImpl;
-      const result = await sessionsService.unarchive(
-        args.sessionId,
-        { includeChildren },
-        ctx.baseServiceParams
+      // Same as archive: enter the tenant DB scope around the (DB-only) tree walk.
+      const result = await runWithMcpTenantDatabaseScope(ctx, () =>
+        sessionsService.unarchive(args.sessionId, { includeChildren }, ctx.baseServiceParams)
       );
 
       return textResult({

--- a/apps/agor-daemon/src/mcp/tools/tenant-scope-audit.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/tenant-scope-audit.test.ts
@@ -1,0 +1,129 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Static guard against the "Missing tenant database scope" class of bug.
+ *
+ * MCP tool handlers enter only tenant *context* at the boundary
+ * (`tenantScopedToolProxy`). A daemon service's *custom* (non-Feathers-transport)
+ * method that reads/writes `this.db` therefore needs an explicit tenant *database*
+ * scope at the call site (`runWithMcpTenantDatabaseScope`), unless the method
+ * defends itself internally. Standard transport methods (find/get/create/update/
+ * patch/remove) go through Feathers hooks and are already scoped.
+ *
+ * This test scans every `mcp/tools/*.ts` file for `<x>Service.<method>(` calls to
+ * non-transport methods and fails if one is neither wrapped at the call site nor
+ * on the explicit, justified allow-list below. It scans the built AST-free source
+ * (comments stripped) and matches balanced `runWithMcpTenantDatabaseScope(...)`
+ * spans, so it handles both `() => svc.method()` and multi-statement
+ * `async (db) => { ...; return svc.method() }` wrappers.
+ *
+ * It caught `agor_cards_get` and `agor_sessions_archive`/`_unarchive` slipping
+ * through the first fix pass; keep it green.
+ */
+
+const TOOLS_DIR = __dirname;
+
+// Feathers standard transport methods — hook-scoped, never need a call-site wrap.
+const TRANSPORT_METHODS = new Set(['find', 'get', 'create', 'update', 'patch', 'remove']);
+
+/**
+ * `<serviceVar>.<method>` calls that are intentionally NOT wrapped at the MCP call
+ * site, each with the reason it is nonetheless safe. Keyed by the exact call token
+ * so an unwrapped `boardsService.unarchive` is still flagged even though
+ * `branchesService.unarchive` is allow-listed.
+ */
+const ALLOWED_UNWRAPPED: Record<string, string> = {
+  // BranchesService defends its custom methods with the private
+  // `withTenantDatabase(params, work)` short-unit helper (directly or via
+  // `loadEnvironmentForAction`), and must NOT hold a transaction across the
+  // executor/network work these env methods perform.
+  'branchesService.unarchive': 'BranchesService.withTenantDatabase (short unit)',
+  'branchesService.startEnvironment': 'loadEnvironmentForAction -> withTenantDatabase',
+  'branchesService.stopEnvironment': 'loadEnvironmentForAction -> withTenantDatabase',
+  'branchesService.nukeEnvironment': 'loadEnvironmentForAction -> withTenantDatabase',
+  'branchesService.getLogs': 'loadEnvironmentForAction -> withTenantDatabase',
+  'branchesService.renderEnvironment': 'loadEnvironmentForAction -> withTenantDatabase',
+  'branchesService.checkHealth': 'withTenantDatabase (short unit)',
+  // GatewayService is identity-only; its repositories are
+  // `bindRepositoryToTenantUnitOfWork`-bound, so each access opens its own short
+  // tenant unit.
+  'gatewayService.emitMessage': 'channelRepo bound to tenant unit of work',
+  // Rejected with BadRequest in required_from_auth BEFORE any DB touch, and it
+  // awaits a git.repo.inspect executor round-trip before its writes — wrapping
+  // would risk a transaction across network I/O. See repos.ts.
+  'reposService.addLocalRepository': 'HA-forbidden before any DB touch; intentional',
+};
+
+/** Balanced-paren spans of every `runWithMcpTenantDatabaseScope( ... )` call. */
+function scopeSpans(code: string): Array<[number, number]> {
+  const spans: Array<[number, number]> = [];
+  const opener = /runWithMcpTenantDatabaseScope\s*\(/g;
+  let m: RegExpExecArray | null;
+  // biome-ignore lint/suspicious/noAssignInExpressions: standard regex exec loop.
+  while ((m = opener.exec(code)) !== null) {
+    let depth = 0;
+    let i = m.index + m[0].length - 1; // index of the opening '('
+    for (; i < code.length; i++) {
+      if (code[i] === '(') depth++;
+      else if (code[i] === ')' && --depth === 0) break;
+    }
+    spans.push([m.index, i]);
+  }
+  return spans;
+}
+
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+function lineOf(code: string, index: number): number {
+  return code.slice(0, index).split('\n').length;
+}
+
+describe('MCP tool tenant database scope audit', () => {
+  const files = readdirSync(TOOLS_DIR).filter((f) => f.endsWith('.ts') && !f.endsWith('.test.ts'));
+
+  it('scans a non-trivial set of tool files', () => {
+    expect(files.length).toBeGreaterThan(5);
+  });
+
+  it('wraps every non-transport service-method call in runWithMcpTenantDatabaseScope (or allow-lists it)', () => {
+    const violations: string[] = [];
+
+    for (const file of files) {
+      const code = stripComments(readFileSync(join(TOOLS_DIR, file), 'utf8'));
+      const spans = scopeSpans(code);
+      const guarded = (idx: number) => spans.some(([s, e]) => idx >= s && idx <= e);
+
+      const call = /\b([a-zA-Z]+Service)\.([a-zA-Z]+)\(/g;
+      let m: RegExpExecArray | null;
+      // biome-ignore lint/suspicious/noAssignInExpressions: standard regex exec loop.
+      while ((m = call.exec(code)) !== null) {
+        const [, serviceVar, method] = m;
+        if (TRANSPORT_METHODS.has(method)) continue;
+        const token = `${serviceVar}.${method}`;
+        if (guarded(m.index)) continue;
+        if (token in ALLOWED_UNWRAPPED) continue;
+        violations.push(`${file}:${lineOf(code, m.index)}  ${token}()`);
+      }
+    }
+
+    expect(
+      violations,
+      `Unguarded MCP custom-method service calls (wrap in runWithMcpTenantDatabaseScope, or add to ALLOWED_UNWRAPPED with a reason):\n${violations.join('\n')}`
+    ).toEqual([]);
+  });
+
+  it('keeps the allow-list honest (every entry is still called somewhere)', () => {
+    const allCode = files
+      .map((f) => stripComments(readFileSync(join(TOOLS_DIR, f), 'utf8')))
+      .join('\n');
+    const stale = Object.keys(ALLOWED_UNWRAPPED).filter((token) => !allCode.includes(`${token}(`));
+    expect(
+      stale,
+      `Stale ALLOWED_UNWRAPPED entries (no longer called): ${stale.join(', ')}`
+    ).toEqual([]);
+  });
+});

--- a/apps/agor-daemon/src/mcp/tools/tenant-scope-audit.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/tenant-scope-audit.test.ts
@@ -68,10 +68,31 @@ const ALLOWED_UNWRAPPED: Record<string, string> = {
  */
 const CALL_SITE_SCOPED_SERVICES = ['repos', 'boards', 'cards', 'sessions', 'board-objects'];
 
-/** Balanced-paren spans of every `runWithMcpTenantDatabase{Scope,Write}( ... )` call. */
-function scopeSpans(code: string): Array<[number, number]> {
+/**
+ * `<serviceVar>.<method>` mutators that this PR brought onto the WRITE helper
+ * (`runWithMcpTenantDatabaseWrite`), which also enforces the tenant write-freeze
+ * gate. The read-only scope helper would silently skip the gate, so this list
+ * guards against a future edit downgrading one of them to the read helper.
+ *
+ * NOTE: this is the set with gated HTTP-route parity, not every MCP mutation.
+ * Other pre-existing MCP mutations (cards/board-object custom methods, and
+ * non-`Service.method` writes such as direct repositories / `appendSystemMessage`)
+ * still use the read helper and are the subject of the documented service-side
+ * write-gate follow-up — see docs/internal/mcp-tenant-db-scope-createbranch-2026-08-29.md.
+ */
+const MUTATION_TOKENS = new Set([
+  'reposService.createBranch',
+  'reposService.cloneRepository',
+  'reposService.updateMetadata',
+  'boardsService.archive',
+  'boardsService.unarchive',
+  'sessionsService.archive',
+  'sessionsService.unarchive',
+]);
+
+/** Balanced-paren spans of every call matching `opener`. */
+function helperSpans(code: string, opener: RegExp): Array<[number, number]> {
   const spans: Array<[number, number]> = [];
-  const opener = /runWithMcpTenantDatabase(?:Scope|Write)\s*\(/g;
   let m: RegExpExecArray | null;
   // biome-ignore lint/suspicious/noAssignInExpressions: standard regex exec loop.
   while ((m = opener.exec(code)) !== null) {
@@ -85,6 +106,12 @@ function scopeSpans(code: string): Array<[number, number]> {
   }
   return spans;
 }
+
+/** Spans of either scope helper (reads or writes) — for the "is scoped at all" check. */
+const scopeSpans = (code: string) =>
+  helperSpans(code, /runWithMcpTenantDatabase(?:Scope|Write)\s*\(/g);
+/** Spans of the WRITE helper only — for the "mutations honor the freeze gate" check. */
+const writeSpans = (code: string) => helperSpans(code, /runWithMcpTenantDatabaseWrite\s*\(/g);
 
 function stripComments(src: string): string {
   return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
@@ -126,6 +153,39 @@ describe('MCP tool tenant database scope audit', () => {
       violations,
       `Unguarded MCP custom-method service calls (wrap in runWithMcpTenantDatabaseScope, or add to ALLOWED_UNWRAPPED with a reason):\n${violations.join('\n')}`
     ).toEqual([]);
+  });
+
+  it('wraps every mutating custom-method call in the WRITE helper (freeze gate honored)', () => {
+    const violations: string[] = [];
+    for (const file of files) {
+      const code = stripComments(readFileSync(join(TOOLS_DIR, file), 'utf8'));
+      const writes = writeSpans(code);
+      const inWrite = (idx: number) => writes.some(([s, e]) => idx >= s && idx <= e);
+
+      const call = /\b([a-zA-Z]+Service)\.([a-zA-Z]+)\(/g;
+      let m: RegExpExecArray | null;
+      // biome-ignore lint/suspicious/noAssignInExpressions: standard regex exec loop.
+      while ((m = call.exec(code)) !== null) {
+        const token = `${m[1]}.${m[2]}`;
+        if (!MUTATION_TOKENS.has(token)) continue;
+        if (inWrite(m.index)) continue;
+        violations.push(`${file}:${lineOf(code, m.index)}  ${token}()`);
+      }
+    }
+    expect(
+      violations,
+      `Mutating MCP calls must use runWithMcpTenantDatabaseWrite (it enforces the tenant write-freeze gate; the read-only scope helper skips it):\n${violations.join('\n')}`
+    ).toEqual([]);
+  });
+
+  it('keeps the mutation-token list honest (every entry is still called somewhere)', () => {
+    const allCode = files
+      .map((f) => stripComments(readFileSync(join(TOOLS_DIR, f), 'utf8')))
+      .join('\n');
+    const stale = [...MUTATION_TOKENS].filter((token) => !allCode.includes(`${token}(`));
+    expect(stale, `Stale MUTATION_TOKENS entries (no longer called): ${stale.join(', ')}`).toEqual(
+      []
+    );
   });
 
   it('does not alias a call-site-scoped service to a non-<name>Service local (which would evade the scan)', () => {

--- a/apps/agor-daemon/src/mcp/tools/tenant-scope-audit.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/tenant-scope-audit.test.ts
@@ -14,10 +14,13 @@ import { describe, expect, it } from 'vitest';
  *
  * This test scans every `mcp/tools/*.ts` file for `<x>Service.<method>(` calls to
  * non-transport methods and fails if one is neither wrapped at the call site nor
- * on the explicit, justified allow-list below. It scans the built AST-free source
- * (comments stripped) and matches balanced `runWithMcpTenantDatabaseScope(...)`
- * spans, so it handles both `() => svc.method()` and multi-statement
- * `async (db) => { ...; return svc.method() }` wrappers.
+ * on the explicit, justified allow-list below. Reads use
+ * `runWithMcpTenantDatabaseScope`; MUTATIONS use `runWithMcpTenantDatabaseWrite`
+ * (which also enforces the tenant write-freeze gate) — the scan accepts either.
+ * It scans the AST-free source (comments stripped) and matches balanced
+ * `runWithMcpTenantDatabase{Scope,Write}(...)` spans, so it handles both
+ * `() => svc.method()` and multi-statement `async (db) => { ...; return
+ * svc.method() }` wrappers.
  *
  * It caught `agor_cards_get` and `agor_sessions_archive`/`_unarchive` slipping
  * through the first fix pass; keep it green.
@@ -56,10 +59,19 @@ const ALLOWED_UNWRAPPED: Record<string, string> = {
   'reposService.addLocalRepository': 'HA-forbidden before any DB touch; intentional',
 };
 
-/** Balanced-paren spans of every `runWithMcpTenantDatabaseScope( ... )` call. */
+/**
+ * Services whose custom methods rely on a call-site tenant scope (they do NOT
+ * self-scope). The scanner keys on the conventional `<name>Service` local for
+ * these; the naming convention itself is enforced by a separate test so an
+ * aliased handle (e.g. `const svc = ctx.app.service('cards')`) can't evade it.
+ * Self-scoping services (branches/gateway/artifacts) are intentionally absent.
+ */
+const CALL_SITE_SCOPED_SERVICES = ['repos', 'boards', 'cards', 'sessions', 'board-objects'];
+
+/** Balanced-paren spans of every `runWithMcpTenantDatabase{Scope,Write}( ... )` call. */
 function scopeSpans(code: string): Array<[number, number]> {
   const spans: Array<[number, number]> = [];
-  const opener = /runWithMcpTenantDatabaseScope\s*\(/g;
+  const opener = /runWithMcpTenantDatabase(?:Scope|Write)\s*\(/g;
   let m: RegExpExecArray | null;
   // biome-ignore lint/suspicious/noAssignInExpressions: standard regex exec loop.
   while ((m = opener.exec(code)) !== null) {
@@ -113,6 +125,33 @@ describe('MCP tool tenant database scope audit', () => {
     expect(
       violations,
       `Unguarded MCP custom-method service calls (wrap in runWithMcpTenantDatabaseScope, or add to ALLOWED_UNWRAPPED with a reason):\n${violations.join('\n')}`
+    ).toEqual([]);
+  });
+
+  it('does not alias a call-site-scoped service to a non-<name>Service local (which would evade the scan)', () => {
+    // The scan above keys on `<name>Service` locals. Guard the convention: a
+    // handle for a call-site-scoped service (e.g. `const svc = ctx.app.service(
+    // 'cards')`) assigned to a variable that does not end in `Service` would hide
+    // its custom-method calls. Self-scoping services (artifacts/branches/gateway)
+    // may use any alias.
+    const offenders: string[] = [];
+    const assign = /const\s+([a-zA-Z][a-zA-Z0-9]*)\s*=\s*ctx\.app\.service\(\s*'([^']+)'/g;
+    for (const file of files) {
+      const code = stripComments(readFileSync(join(TOOLS_DIR, file), 'utf8'));
+      let m: RegExpExecArray | null;
+      // biome-ignore lint/suspicious/noAssignInExpressions: standard regex exec loop.
+      while ((m = assign.exec(code)) !== null) {
+        const [, varName, serviceName] = m;
+        if (CALL_SITE_SCOPED_SERVICES.includes(serviceName) && !varName.endsWith('Service')) {
+          offenders.push(
+            `${file}:${lineOf(code, m.index)}  const ${varName} = service('${serviceName}')`
+          );
+        }
+      }
+    }
+    expect(
+      offenders,
+      `Alias a call-site-scoped service to a <name>Service local so the scope audit sees its calls:\n${offenders.join('\n')}`
     ).toEqual([]);
   });
 

--- a/apps/agor-daemon/src/mcp/tools/tenant-write-gate.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/tenant-write-gate.test.ts
@@ -1,0 +1,77 @@
+import { createTenantScopedDatabaseProxy } from '@agor/core/db';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { McpContext } from '../server.js';
+import { runWithMcpTenantDatabaseWrite } from '../tenant-scope.js';
+
+/**
+ * `runWithMcpTenantDatabaseWrite` mirrors the HTTP custom-route pair
+ * `[tenantDatabaseScopeAround, tenantWriteGateAround]`: it must reject a mutation
+ * with `Unavailable` while the tenant write-freeze gate is active, *before*
+ * running the write. Custom (non-transport) service mutators reached over MCP —
+ * `sessions.archive`/`unarchive`, `repos.cloneRepository`/`updateMetadata`,
+ * `boards.archive`/`unarchive`, `repos.createBranch` — go through this helper, so
+ * a frozen tenant can no longer slip a write past the gate on the MCP path.
+ */
+
+let gateActive = false;
+
+vi.mock('@agor/core/db', async (importActual) => {
+  const actual = await importActual<typeof import('@agor/core/db')>();
+  return {
+    ...actual,
+    // Deterministic gate we can toggle per test; throws the real error type so
+    // the helper's `instanceof` translation to `Unavailable` is exercised.
+    assertTenantWritable: vi.fn(async (_db: unknown, tenantId: string) => {
+      if (gateActive) throw new actual.TenantWriteGateActiveError(tenantId, 1);
+    }),
+  };
+});
+
+function makeCtx(tenantId?: string): McpContext {
+  // `.run` marks the handle as SQLite-like so the scope is identity-only (no
+  // native transaction to fake); the gate assertion is what's under test.
+  const base = { run: () => undefined } as Record<string, unknown>;
+  const db = createTenantScopedDatabaseProxy(base, {
+    requireScope: true,
+    label: 'daemon database',
+  });
+  return {
+    db,
+    baseServiceParams: {
+      authenticated: true,
+      provider: 'mcp',
+      ...(tenantId ? { tenant: { tenant_id: tenantId } } : {}),
+      user: { user_id: 'user-1', role: 'member' },
+    },
+  } as unknown as McpContext;
+}
+
+describe('runWithMcpTenantDatabaseWrite (tenant write-freeze gate)', () => {
+  beforeEach(() => {
+    gateActive = false;
+  });
+
+  it('rejects with Unavailable and does NOT run the write when the gate is active', async () => {
+    gateActive = true;
+    const work = vi.fn(async () => 'written');
+
+    await expect(runWithMcpTenantDatabaseWrite(makeCtx('tenant-a'), work)).rejects.toMatchObject({
+      // Feathers `Unavailable` — code 503; the raw TenantWriteGateActiveError is translated.
+      code: 503,
+    });
+    expect(work).not.toHaveBeenCalled();
+  });
+
+  it('runs the write when the gate is inactive', async () => {
+    const work = vi.fn(async () => 'written');
+    await expect(runWithMcpTenantDatabaseWrite(makeCtx('tenant-a'), work)).resolves.toBe('written');
+    expect(work).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves static single-tenant behavior (no tenant -> no gate, work runs)', async () => {
+    gateActive = true; // even with an "active" gate, a request with no tenant is unscoped
+    const work = vi.fn(async () => 'written');
+    await expect(runWithMcpTenantDatabaseWrite(makeCtx(undefined), work)).resolves.toBe('written');
+    expect(work).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/agor-daemon/src/mcp/tools/tenant-write-gate.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/tenant-write-gate.test.ts
@@ -22,7 +22,7 @@ vi.mock('@agor/core/db', async (importActual) => {
     // Deterministic gate we can toggle per test; throws the real error type so
     // the helper's `instanceof` translation to `Unavailable` is exercised.
     assertTenantWritable: vi.fn(async (_db: unknown, tenantId: string) => {
-      if (gateActive) throw new actual.TenantWriteGateActiveError(tenantId, 1);
+      if (gateActive) throw new actual.TenantWriteGateActiveError(tenantId, '1');
     }),
   };
 });

--- a/docs/internal/mcp-tenant-db-scope-createbranch-2026-08-29.md
+++ b/docs/internal/mcp-tenant-db-scope-createbranch-2026-08-29.md
@@ -1,0 +1,132 @@
+# MCP `agor_branches_create` — "Missing tenant database scope" in HA
+
+**Date:** 2026-08-29
+**Area:** multi-tenancy · MCP tool boundary · daemon services
+**Mode affected:** `execution.multi_tenancy = required_from_auth` (HA / hosted Postgres). Static SQLite/single-tenant is unaffected.
+
+## Symptom
+
+Calling the MCP tool `agor_branches_create` against an HA daemon returned:
+
+```
+Missing tenant database scope for daemon database access
+```
+
+Reproduced live against the branch's HA Compose stack (variant `ha`, ingress `:7833`,
+tenants `acme`/`globex`, two daemon replicas behind nginx) on **both** replicas and for
+**both** `waitForReady=false` and `waitForReady=true`. The equivalent REST call
+(`POST /repos/:id/branches`) **succeeded** in the same environment — proving the gap is
+specific to the MCP path, not to branch creation itself.
+
+## Root cause
+
+`MissingTenantDatabaseScopeError` is thrown by the guarded daemon-database proxy
+(`packages/core/src/db/tenant-scope.ts`, `assertDatabaseScopeAllowed`). In
+`required_from_auth` the proxy is created with `requireScope: true`
+(`apps/agor-daemon/src/setup/database.ts`), so **every** DB touch must run inside an
+active tenant **database** scope (`tenantDatabaseScope`, an `AsyncLocalStorage` set by
+`runWithTenantDatabaseScope`). Tenant **context** identity alone (`tenantContextScope`,
+set by `runWithTenantContext`) does **not** satisfy the guard.
+
+Two facts combine:
+
+1. **The MCP tool boundary enters only tenant _context_.**
+   `tenantScopedToolProxy` (`apps/agor-daemon/src/mcp/tenant-scope.ts`) wraps every tool
+   handler in `runWithTenantContext(tenantId, …)` — identity only, deliberately no
+   HTTP-long DB transaction, because many tools then do long polling / executor / provider
+   work. Each handler is expected to open a **short** tenant DB unit at the actual DB call
+   via `runWithMcpTenantDatabaseScope(ctx, …)`.
+
+2. **`ReposService.createBranch` is deliberately NOT a Feathers transport method.**
+   It takes `(id, data)` and is exposed to HTTP/CLI only through the authenticated custom
+   route `/repos/:id/branches` (`register-routes.ts`). That route is registered with the
+   standard `registerAuthenticatedRoute`, whose around chain is
+   `[tenantDatabaseScopeAround, tenantWriteGateAround]` — i.e. the whole method runs inside
+   one tenant DB transaction. `createBranch` therefore assumes an **ambient** scope: it
+   reads/writes `this.db` directly (`new BranchRepository(this.db).findActiveByRepoAndName`,
+   `resolveDelegatedExecutionHomeKey(this.db, …)`, `this.get`, `branchesService.create`,
+   `board-objects.create`) with no scope of its own.
+
+The MCP tool called `reposService.createBranch(repoId, …, ctx.baseServiceParams)`
+**directly** — a programmatic call that bypasses the Feathers around hooks — while the
+tool boundary had provided only tenant _context_. The very first `this.db` touch
+(`findActiveByRepoAndName`) tripped the guard. Nearby MCP DB touches were already correct
+(e.g. the auto-suffix pre-read at `branches.ts` uses `runWithMcpTenantDatabaseScope`); the
+`createBranch` call was the one unguarded site.
+
+`waitForReady` is irrelevant to the failure — the error is thrown during the initial
+metadata write, before the fire-and-forget executor spawn and before the readiness poll.
+
+### Why some sibling MCP calls were already fine
+
+Services differ in how they defend themselves:
+
+- **`BranchesService`** has a private `withTenantDatabase(params, work)` helper (short
+  tenant unit) that its own custom methods (`unarchive`, `startEnvironment`,
+  `nukeEnvironment`, …) use internally — so those are safe even when called directly from
+  MCP, and correctly do **not** hold a transaction across executor/network work.
+- **`SessionsService`** and **`GatewayService`** similarly scope internally
+  (`runWithTenantDatabaseScope` / `deferWithTenantContext`).
+- **`cards.ts`** already wrapped `cardsService.createWithPlacement` in
+  `runWithMcpTenantDatabaseScope`.
+
+The outliers are services whose custom methods touch `this.db` **without** an internal
+helper and rely purely on the caller's ambient scope: **`ReposService`**,
+**`BoardsService.archive/unarchive`**, and **`BoardObjectsService.findByBranchId`**.
+
+## Fix
+
+Wrap each affected direct custom-method call at the MCP call site in
+`runWithMcpTenantDatabaseScope(ctx, …)`. On Postgres this opens one short tenant
+transaction (with `agor.tenant_id` set for RLS) and joins any already-active same-tenant
+scope; on SQLite/static it is a no-op identity scope. Long readiness waits stay **outside**
+the scope, so no transaction is held across polls.
+
+Sites fixed:
+
+| File                                         | Tool                                 | Custom method                             |
+| -------------------------------------------- | ------------------------------------ | ----------------------------------------- |
+| `apps/agor-daemon/src/mcp/tools/branches.ts` | `agor_branches_create`               | `reposService.createBranch`               |
+| `apps/agor-daemon/src/mcp/tools/branches.ts` | `agor_branches_set_zone`             | `boardObjectsService.findByBranchId` (×2) |
+| `apps/agor-daemon/src/mcp/tools/repos.ts`    | `agor_repos_clone`                   | `reposService.cloneRepository`            |
+| `apps/agor-daemon/src/mcp/tools/repos.ts`    | `agor_repos_create_local`            | `reposService.addLocalRepository`         |
+| `apps/agor-daemon/src/mcp/tools/repos.ts`    | `agor_repos_update`                  | `reposService.updateMetadata`             |
+| `apps/agor-daemon/src/mcp/tools/boards.ts`   | `agor_boards_archive` / `_unarchive` | `boardsService.archive` / `unarchive`     |
+
+This matches the established codebase pattern (identity at the tool boundary, short DB
+units at the call site) and the multitenancy cheat sheet's rule: _"Long-lived work should
+carry tenant identity without holding an HTTP-long transaction; open short tenant database
+units at the actual database call."_ No scope error is caught/suppressed, and no global
+runner is reused.
+
+## Tenant / RBAC / RLS boundary preservation
+
+The fix only re-enters the caller's already-authenticated tenant. `resolveTenantBoundary`
+still rejects any cross-tenant switch, and the Postgres transaction sets `agor.tenant_id`
+transaction-locally so RLS policies enforce isolation. A tenant-B caller still cannot reach
+tenant-A repos/branches (verified: a foreign `repoId` reads as 404, indistinguishable from
+missing). Nothing weakens the existing negative boundaries.
+
+## Tests
+
+- `apps/agor-daemon/src/mcp/tools/branches.tenant-scope.test.ts` — exercises the **real**
+  guard machinery (`createTenantScopedDatabaseProxy({requireScope:true})` +
+  `tenantDatabaseScope`): locks the exact error string; proves `createBranch` now runs
+  under an active tenant DB scope bound to the authenticated tenant (`waitForReady`
+  false/true); proves scope cleanup after return; proves tenant A/B don't share a scope;
+  proves a conflicting foreign ambient tenant fails closed; and preserves static
+  single-tenant behavior (no scope, no error).
+- `scripts/test-ha-mcp-branch-create.mjs` — gated HA integration reproduction against the
+  live Compose stack (real `/mcp`, minted session token): REST control succeeds; MCP
+  create succeeds on both replicas for both wait modes; concurrent creates all succeed
+  (no scope bleed); tenant-B token cannot create against a tenant-A repo.
+
+## Durable follow-up (recommended, not done here)
+
+`ReposService`, `BoardsService`, and `BoardObjectsService` should grow the same private
+`withTenantDatabase(params, work)` helper that `BranchesService` already has, and wrap
+their custom methods internally. That makes the services defend themselves regardless of
+caller (HTTP route, MCP, gateway, scheduler) rather than relying on every call site to
+remember the wrapper — the same defense-in-depth the branches/sessions/gateway services
+already apply. The static guard in `register-services.mcp-tenant-scope.test.ts` is the
+model for a lint that would catch a new unguarded custom-method call site.

--- a/docs/internal/mcp-tenant-db-scope-createbranch-2026-08-29.md
+++ b/docs/internal/mcp-tenant-db-scope-createbranch-2026-08-29.md
@@ -72,7 +72,9 @@ Services differ in how they defend themselves:
 
 The outliers are services whose custom methods touch `this.db` **without** an internal
 helper and rely purely on the caller's ambient scope: **`ReposService`**,
-**`BoardsService.archive/unarchive`**, and **`BoardObjectsService.findByBranchId`**.
+**`BoardsService.archive/unarchive`**, **`BoardObjectsService.findByBranchId`**, and
+**`CardsService.getWithType`** (the other `cards.ts` custom-method calls were already
+wrapped; `getWithType` was the one that had been missed).
 
 ## Fix
 
@@ -89,9 +91,16 @@ Sites fixed:
 | `apps/agor-daemon/src/mcp/tools/branches.ts` | `agor_branches_create`               | `reposService.createBranch`               |
 | `apps/agor-daemon/src/mcp/tools/branches.ts` | `agor_branches_set_zone`             | `boardObjectsService.findByBranchId` (×2) |
 | `apps/agor-daemon/src/mcp/tools/repos.ts`    | `agor_repos_clone`                   | `reposService.cloneRepository`            |
-| `apps/agor-daemon/src/mcp/tools/repos.ts`    | `agor_repos_create_local`            | `reposService.addLocalRepository`         |
 | `apps/agor-daemon/src/mcp/tools/repos.ts`    | `agor_repos_update`                  | `reposService.updateMetadata`             |
 | `apps/agor-daemon/src/mcp/tools/boards.ts`   | `agor_boards_archive` / `_unarchive` | `boardsService.archive` / `unarchive`     |
+| `apps/agor-daemon/src/mcp/tools/cards.ts`    | `agor_cards_get`                     | `cardsService.getWithType`                |
+
+**Deliberately NOT wrapped: `agor_repos_create_local` (`addLocalRepository`).** That
+service method rejects with `BadRequest` in `required_from_auth` mode _before_ any DB
+touch, so the scope guard can never fire there in a scope-requiring deployment. It also
+`await`s a `git.repo.inspect` executor round-trip before its DB writes — so wrapping the
+whole call would risk holding a Postgres transaction across that network I/O if the HA
+guard were ever lifted. Local-repo registration stays a static/single-tenant path.
 
 This matches the established codebase pattern (identity at the tool boundary, short DB
 units at the call site) and the multitenancy cheat sheet's rule: _"Long-lived work should
@@ -123,10 +132,14 @@ missing). Nothing weakens the existing negative boundaries.
 
 ## Durable follow-up (recommended, not done here)
 
-`ReposService`, `BoardsService`, and `BoardObjectsService` should grow the same private
-`withTenantDatabase(params, work)` helper that `BranchesService` already has, and wrap
-their custom methods internally. That makes the services defend themselves regardless of
-caller (HTTP route, MCP, gateway, scheduler) rather than relying on every call site to
-remember the wrapper — the same defense-in-depth the branches/sessions/gateway services
-already apply. The static guard in `register-services.mcp-tenant-scope.test.ts` is the
-model for a lint that would catch a new unguarded custom-method call site.
+`ReposService`, `BoardsService`, `BoardObjectsService`, and `CardsService` should grow the
+same private `withTenantDatabase(params, work)` helper that `BranchesService` already has,
+and wrap their custom methods internally. That makes the services defend themselves
+regardless of caller (HTTP route, MCP, gateway, scheduler) rather than relying on every
+call site to remember the wrapper — the same defense-in-depth the branches/sessions/gateway
+services already apply, and it removes the drift risk that let `agor_cards_get` slip through
+this first pass. A lighter alternative is a static audit (modeled on the source-scanning
+`register-services.mcp-tenant-scope.test.ts`) over `mcp/tools/*` that flags any direct
+custom-method service call not wrapped in `runWithMcpTenantDatabaseScope`, with a small
+explicit allow-list for methods that scope internally (e.g. branches/sessions/gateway) or
+are intentionally unwrapped (e.g. `addLocalRepository`). Either closes the gap durably.

--- a/docs/internal/mcp-tenant-db-scope-createbranch-2026-08-29.md
+++ b/docs/internal/mcp-tenant-db-scope-createbranch-2026-08-29.md
@@ -72,9 +72,14 @@ Services differ in how they defend themselves:
 
 The outliers are services whose custom methods touch `this.db` **without** an internal
 helper and rely purely on the caller's ambient scope: **`ReposService`**,
-**`BoardsService.archive/unarchive`**, **`BoardObjectsService.findByBranchId`**, and
-**`CardsService.getWithType`** (the other `cards.ts` custom-method calls were already
-wrapped; `getWithType` was the one that had been missed).
+**`BoardsService.archive/unarchive`**, **`BoardObjectsService.findByBranchId`**,
+**`CardsService.getWithType`**, and **`SessionsService.archive/unarchive`** (via
+`setArchiveStateForTree`). The last two were pre-existing misses surfaced by the static
+audit test described below, not by the original report.
+
+By contrast, `SessionsService`'s _other_ DB work and `GatewayService` (identity-only, with
+`bindRepositoryToTenantUnitOfWork`-bound repos) do self-scope — only the archive tree walk
+had been left relying on an ambient scope.
 
 ## Fix
 
@@ -86,14 +91,15 @@ the scope, so no transaction is held across polls.
 
 Sites fixed:
 
-| File                                         | Tool                                 | Custom method                             |
-| -------------------------------------------- | ------------------------------------ | ----------------------------------------- |
-| `apps/agor-daemon/src/mcp/tools/branches.ts` | `agor_branches_create`               | `reposService.createBranch`               |
-| `apps/agor-daemon/src/mcp/tools/branches.ts` | `agor_branches_set_zone`             | `boardObjectsService.findByBranchId` (×2) |
-| `apps/agor-daemon/src/mcp/tools/repos.ts`    | `agor_repos_clone`                   | `reposService.cloneRepository`            |
-| `apps/agor-daemon/src/mcp/tools/repos.ts`    | `agor_repos_update`                  | `reposService.updateMetadata`             |
-| `apps/agor-daemon/src/mcp/tools/boards.ts`   | `agor_boards_archive` / `_unarchive` | `boardsService.archive` / `unarchive`     |
-| `apps/agor-daemon/src/mcp/tools/cards.ts`    | `agor_cards_get`                     | `cardsService.getWithType`                |
+| File                                         | Tool                                   | Custom method                             |
+| -------------------------------------------- | -------------------------------------- | ----------------------------------------- |
+| `apps/agor-daemon/src/mcp/tools/branches.ts` | `agor_branches_create`                 | `reposService.createBranch`               |
+| `apps/agor-daemon/src/mcp/tools/branches.ts` | `agor_branches_set_zone`               | `boardObjectsService.findByBranchId` (×2) |
+| `apps/agor-daemon/src/mcp/tools/repos.ts`    | `agor_repos_clone`                     | `reposService.cloneRepository`            |
+| `apps/agor-daemon/src/mcp/tools/repos.ts`    | `agor_repos_update`                    | `reposService.updateMetadata`             |
+| `apps/agor-daemon/src/mcp/tools/boards.ts`   | `agor_boards_archive` / `_unarchive`   | `boardsService.archive` / `unarchive`     |
+| `apps/agor-daemon/src/mcp/tools/cards.ts`    | `agor_cards_get`                       | `cardsService.getWithType`                |
+| `apps/agor-daemon/src/mcp/tools/sessions.ts` | `agor_sessions_archive` / `_unarchive` | `sessionsService.archive` / `unarchive`   |
 
 **Deliberately NOT wrapped: `agor_repos_create_local` (`addLocalRepository`).** That
 service method rejects with `BadRequest` in `required_from_auth` mode _before_ any DB
@@ -137,9 +143,15 @@ same private `withTenantDatabase(params, work)` helper that `BranchesService` al
 and wrap their custom methods internally. That makes the services defend themselves
 regardless of caller (HTTP route, MCP, gateway, scheduler) rather than relying on every
 call site to remember the wrapper — the same defense-in-depth the branches/sessions/gateway
-services already apply, and it removes the drift risk that let `agor_cards_get` slip through
-this first pass. A lighter alternative is a static audit (modeled on the source-scanning
-`register-services.mcp-tenant-scope.test.ts`) over `mcp/tools/*` that flags any direct
-custom-method service call not wrapped in `runWithMcpTenantDatabaseScope`, with a small
-explicit allow-list for methods that scope internally (e.g. branches/sessions/gateway) or
-are intentionally unwrapped (e.g. `addLocalRepository`). Either closes the gap durably.
+services already apply, and it removes the drift risk that let `agor_cards_get` and `agor_sessions_archive` slip
+through the first pass.
+
+**The static audit is now implemented** as
+`apps/agor-daemon/src/mcp/tools/tenant-scope-audit.test.ts`: it scans every `mcp/tools/*.ts`
+for `<x>Service.<method>()` calls to non-transport methods and fails unless the call is
+wrapped in `runWithMcpTenantDatabaseScope` (balanced-span aware, so multi-statement `async
+(db) => { … }` wrappers count) or is on an explicit, per-token allow-list with a documented
+reason (branches env methods + `unarchive` via `withTenantDatabase`; `gatewayService.emitMessage`
+via unit-of-work-bound repos; `reposService.addLocalRepository` as intentionally unwrapped).
+Running it during this change is what surfaced the `sessions` miss. The service-side
+`withTenantDatabase` refactor remains the heavier, more thorough follow-up.

--- a/docs/internal/mcp-tenant-db-scope-createbranch-2026-08-29.md
+++ b/docs/internal/mcp-tenant-db-scope-createbranch-2026-08-29.md
@@ -122,6 +122,24 @@ transaction-locally so RLS policies enforce isolation. A tenant-B caller still c
 tenant-A repos/branches (verified: a foreign `repoId` reads as 404, indistinguishable from
 missing). Nothing weakens the existing negative boundaries.
 
+### Write-freeze gate parity (mutations)
+
+Entering the tenant DB scope is not sufficient for **mutations**. HTTP custom routes wrap
+`[tenantDatabaseScopeAround, tenantWriteGateAround]`, so a write during a tenant freeze
+(deletion/export/import/verify window) is rejected with `Unavailable`. Standard Feathers
+methods get the same via the `writeGateBefore` hook. But a custom (non-transport) service
+method that writes `this.db` directly (`ReposService.updateMetadata` → `this.patch`,
+`SessionsService.setArchiveStateForTree` → `sessionRepo` writes, etc.) has neither on the
+MCP path. So `runWithMcpTenantDatabaseScope` alone would let an MCP mutation slip past a
+freeze that HTTP enforces.
+
+`runWithMcpTenantDatabaseWrite` closes that: it enters the scope **and** calls
+`assertTenantWritable` inside it, translating `TenantWriteGateActiveError` → `Unavailable`
+exactly like the route hook. It is used for the mutating call sites (createBranch,
+cloneRepository, updateMetadata, boards/sessions archive+unarchive); reads keep the
+read-only helper. On SQLite/static the gate read short-circuits (`readTenantWriteGate`
+returns inactive for non-Postgres), so single-tenant behavior is unchanged.
+
 ## Tests
 
 - `apps/agor-daemon/src/mcp/tools/branches.tenant-scope.test.ts` — exercises the **real**

--- a/docs/internal/mcp-tenant-db-scope-createbranch-2026-08-29.md
+++ b/docs/internal/mcp-tenant-db-scope-createbranch-2026-08-29.md
@@ -167,9 +167,23 @@ through the first pass.
 **The static audit is now implemented** as
 `apps/agor-daemon/src/mcp/tools/tenant-scope-audit.test.ts`: it scans every `mcp/tools/*.ts`
 for `<x>Service.<method>()` calls to non-transport methods and fails unless the call is
-wrapped in `runWithMcpTenantDatabaseScope` (balanced-span aware, so multi-statement `async
-(db) => { … }` wrappers count) or is on an explicit, per-token allow-list with a documented
-reason (branches env methods + `unarchive` via `withTenantDatabase`; `gatewayService.emitMessage`
-via unit-of-work-bound repos; `reposService.addLocalRepository` as intentionally unwrapped).
-Running it during this change is what surfaced the `sessions` miss. The service-side
-`withTenantDatabase` refactor remains the heavier, more thorough follow-up.
+wrapped in either `runWithMcpTenantDatabaseScope` or `runWithMcpTenantDatabaseWrite`
+(balanced-span aware, so multi-statement `async (db) => { … }` wrappers count) or is on an
+explicit, per-token allow-list with a documented reason (branches env methods + `unarchive`
+via `withTenantDatabase`; `gatewayService.emitMessage` via unit-of-work-bound repos;
+`reposService.addLocalRepository` as intentionally unwrapped). It additionally enforces a
+`MUTATION_TOKENS` list (mutations must use the WRITE helper, not the read-only one) and the
+`<name>Service` alias convention the scan relies on. Running it during this change is what
+surfaced the `sessions` miss.
+
+Two threads remain for the service-side follow-up. (1) The **write-freeze gate** should
+cover _every_ MCP-initiated tenant mutation, not only those the scanner sees as
+`Service.method` calls — direct repository writes
+(`SessionRelationshipRepository.setCallbackEnabled`), utility writes (`appendSystemMessage`
+in `widgets.ts`), and the internally-scoped env mutators (`startEnvironment` et al., which
+need the _admission_ pattern rather than a held transaction) are not yet gated on the MCP
+path. HTTP-route parity is a convenient signal, not the criterion — the criterion is "is it
+a tenant write." (2) Growing the `withTenantDatabase`/write-unit helper on
+`ReposService`/`BoardsService`/`BoardObjectsService`/`CardsService` (as `BranchesService`
+already has) would make the services defend themselves — scope _and_ gate — regardless of
+caller, retiring the per-call-site read/write helper juggling entirely.

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "test:daemon-filesystem-boundaries": "node --test scripts/check-daemon-filesystem-boundaries.test.mjs",
     "test:sandbox-migration": "node --test scripts/strict-to-sandbox-migration.test.mjs",
     "check:agentic-tool-packages": "node scripts/check-agentic-tool-packages.mjs",
-    "test:ha:docker": "node --test docker/ha/dev-launcher.test.mjs && node scripts/test-daemon-ha.mjs"
+    "test:ha:docker": "node --test docker/ha/dev-launcher.test.mjs && node scripts/test-daemon-ha.mjs && node scripts/test-ha-mcp-branch-create.mjs"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.7",

--- a/scripts/test-ha-mcp-branch-create.mjs
+++ b/scripts/test-ha-mcp-branch-create.mjs
@@ -16,6 +16,7 @@
  *   - waitForReady=false AND waitForReady=true both succeed.
  *   - Concurrent MCP creates all succeed (no tenant-scope bleed across requests).
  *   - agor_cards_get (CardsService.getWithType, same failure class) runs under scope.
+ *   - agor_sessions_archive (SessionsService.setArchiveStateForTree) runs under scope.
  *   - A tenant-B MCP token cannot create against a tenant-A repo (RLS isolation).
  *
  * Gated like scripts/test-daemon-ha.mjs — requires a running Compose stack.
@@ -376,6 +377,21 @@ assert(
 );
 assert.equal(cardGet.isError, false, `agor_cards_get failed: ${cardGet.text}`);
 console.log('ok - MCP agor_cards_get runs under tenant scope (no regression)');
+
+// agor_sessions_archive exercises SessionsService.setArchiveStateForTree — raw
+// this.db reads/writes with no internal scope, the same failure class. Archive a
+// throwaway target session.
+const targetSessionId = await createSession(daemonA, aHeaders, controlBranch.branch_id);
+const archiveRes = await mcpToolCall(daemonA, aToken, sidConcurrent, 'agor_sessions_archive', {
+  sessionId: targetSessionId,
+  includeChildren: false,
+});
+assert(
+  !/Missing tenant database scope/i.test(archiveRes.text),
+  `tenant scope regression in agor_sessions_archive: ${archiveRes.text}`
+);
+assert.equal(archiveRes.isError, false, `agor_sessions_archive failed: ${archiveRes.text}`);
+console.log('ok - MCP agor_sessions_archive runs under tenant scope (no regression)');
 
 // ---- Tenant B: cross-tenant negative ---------------------------------------
 const beatrice = await loginPersona({ tenant: 'globex', persona: 'globex-beatrice' }, daemonB);

--- a/scripts/test-ha-mcp-branch-create.mjs
+++ b/scripts/test-ha-mcp-branch-create.mjs
@@ -321,10 +321,11 @@ for (const [label, base] of [
       // (ready OR timeout — both are non-error) rather than the scope failure.
       // Materialization of a synthetic repo may legitimately time out, so we do
       // not assert `ready` specifically; we assert the wait code path ran.
-      const message = result.payload?._readiness?.message ?? '';
+      // Assert the machine-readable outcome rather than user-facing message text.
+      const outcome = result.payload?._readiness?.outcome;
       assert(
-        /ready for session creation|Timed out/i.test(message),
-        `waitForReady did not render a bounded readiness outcome on ${label}: ${result.text}`
+        outcome === 'ready' || outcome === 'timeout',
+        `waitForReady did not render a bounded readiness outcome on ${label} (outcome=${outcome}): ${result.text}`
       );
     }
   }

--- a/scripts/test-ha-mcp-branch-create.mjs
+++ b/scripts/test-ha-mcp-branch-create.mjs
@@ -15,6 +15,7 @@
  *   - MCP agor_branches_create succeeds on daemon A and daemon B (replica routing).
  *   - waitForReady=false AND waitForReady=true both succeed.
  *   - Concurrent MCP creates all succeed (no tenant-scope bleed across requests).
+ *   - agor_cards_get (CardsService.getWithType, same failure class) runs under scope.
  *   - A tenant-B MCP token cannot create against a tenant-A repo (RLS isolation).
  *
  * Gated like scripts/test-daemon-ha.mjs — requires a running Compose stack.
@@ -166,7 +167,13 @@ async function mcpCreateBranch(base, token, sid, args) {
     `tools/call returned no result at ${base}: ${JSON.stringify(res.messages).slice(0, 300)}`
   );
   const text = (result.content ?? []).map((c) => c.text).join(' ');
-  return { isError: result.isError === true, text };
+  let payload;
+  try {
+    payload = JSON.parse(text);
+  } catch {
+    payload = undefined;
+  }
+  return { isError: result.isError === true, text, payload };
 }
 
 async function registerRepo(base, headers, slug) {
@@ -212,6 +219,41 @@ async function createSession(base, headers, branchId) {
   const body = await res.text();
   assert.equal(res.status, 201, `session create failed: ${res.status} ${body}`);
   return JSON.parse(body).session_id;
+}
+
+async function createCardType(base, headers, name) {
+  const res = await fetch(`${base}/card-types`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ name }),
+  });
+  const body = await res.text();
+  assert.equal(res.status, 201, `card-type create failed: ${res.status} ${body}`);
+  return JSON.parse(body).card_type_id;
+}
+
+/** Call an arbitrary MCP tool and return { isError, text, payload }. */
+async function mcpToolCall(base, token, sid, name, args) {
+  const res = await mcpCall(
+    base,
+    token,
+    { jsonrpc: '2.0', id: 3, method: 'tools/call', params: { name, arguments: args } },
+    sid ? { 'mcp-session-id': sid } : {}
+  );
+  assert.equal(res.status, 200, `${name} HTTP status at ${base}: ${res.status}`);
+  const result = res.messages.map((m) => m.result).find(Boolean);
+  assert(
+    result,
+    `${name} returned no result at ${base}: ${JSON.stringify(res.messages).slice(0, 300)}`
+  );
+  const text = (result.content ?? []).map((c) => c.text).join(' ');
+  let payload;
+  try {
+    payload = JSON.parse(text);
+  } catch {
+    payload = undefined;
+  }
+  return { isError: result.isError === true, text, payload };
 }
 
 const stamp = Date.now();
@@ -260,17 +302,35 @@ for (const [label, base] of [
       ...(waitForReady ? { waitTimeoutMs: 8000 } : {}),
     };
     const result = await mcpCreateBranch(base, aToken, sid, args);
+    // Primary regression guard: the scope error must be gone in both modes.
+    assert(
+      !/Missing tenant database scope/i.test(result.text),
+      `tenant scope regression on ${label} (waitForReady=${waitForReady}): ${result.text}`
+    );
     assert.equal(
       result.isError,
       false,
       `MCP agor_branches_create failed on ${label} (waitForReady=${waitForReady}): ${result.text}`
     );
     assert(
-      !/Missing tenant database scope/i.test(result.text),
-      `tenant scope regression on ${label} (waitForReady=${waitForReady}): ${result.text}`
+      typeof result.payload?.branch_id === 'string',
+      `MCP agor_branches_create returned no branch on ${label} (waitForReady=${waitForReady}): ${result.text}`
     );
+    if (waitForReady) {
+      // The wait path executed and produced a *bounded* readiness outcome
+      // (ready OR timeout — both are non-error) rather than the scope failure.
+      // Materialization of a synthetic repo may legitimately time out, so we do
+      // not assert `ready` specifically; we assert the wait code path ran.
+      const message = result.payload?._readiness?.message ?? '';
+      assert(
+        /ready for session creation|Timed out/i.test(message),
+        `waitForReady did not render a bounded readiness outcome on ${label}: ${result.text}`
+      );
+    }
   }
-  console.log(`ok - MCP agor_branches_create succeeds on ${label} for waitForReady false and true`);
+  console.log(
+    `ok - MCP agor_branches_create runs with no scope regression on ${label} (waitForReady false and true)`
+  );
 }
 
 // Concurrent creates share the pooled Postgres connections; each must open and
@@ -290,6 +350,31 @@ for (const [i, result] of concurrent.entries()) {
   assert.equal(result.isError, false, `concurrent create ${i} failed: ${result.text}`);
 }
 console.log('ok - concurrent MCP branch creates all succeed with no tenant-scope bleed');
+
+// agor_cards_get exercises CardsService.getWithType — a custom, non-transport
+// method that reads the card repository over `this.db` directly, the same
+// failure class as branch create. It must also run under an active tenant scope.
+const aCardTypeId = await createCardType(daemonA, aHeaders, `ha-type-${stamp}`);
+// Cards must be created via createWithPlacement (already wrapped) — use the MCP
+// tool so this stays a pure MCP-path check.
+const cardCreate = await mcpToolCall(daemonA, aToken, sidConcurrent, 'agor_cards_create', {
+  boardId: aBoardId,
+  cardTypeId: aCardTypeId,
+  title: `ha-card-${stamp}`,
+});
+assert.equal(cardCreate.isError, false, `agor_cards_create failed: ${cardCreate.text}`);
+const aCardId = cardCreate.payload?.card?.card_id;
+assert(typeof aCardId === 'string', `agor_cards_create returned no card id: ${cardCreate.text}`);
+
+const cardGet = await mcpToolCall(daemonA, aToken, sidConcurrent, 'agor_cards_get', {
+  cardId: aCardId,
+});
+assert(
+  !/Missing tenant database scope/i.test(cardGet.text),
+  `tenant scope regression in agor_cards_get: ${cardGet.text}`
+);
+assert.equal(cardGet.isError, false, `agor_cards_get failed: ${cardGet.text}`);
+console.log('ok - MCP agor_cards_get runs under tenant scope (no regression)');
 
 // ---- Tenant B: cross-tenant negative ---------------------------------------
 const beatrice = await loginPersona({ tenant: 'globex', persona: 'globex-beatrice' }, daemonB);

--- a/scripts/test-ha-mcp-branch-create.mjs
+++ b/scripts/test-ha-mcp-branch-create.mjs
@@ -1,0 +1,339 @@
+#!/usr/bin/env node
+
+/**
+ * HA regression for the multi-tenant MCP branch-create failure.
+ *
+ * Before the fix, `agor_branches_create` (and other ReposService/BoardsService
+ * custom-method MCP calls) threw "Missing tenant database scope for daemon
+ * database access" under `required_from_auth`, because the MCP tool boundary
+ * enters only tenant *context* while those custom methods touch the guarded
+ * daemon DB directly. See docs/internal/mcp-tenant-db-scope-createbranch-2026-08-29.md.
+ *
+ * This exercises the real `/mcp` endpoint on both HA replicas, with a minted
+ * session MCP token, and asserts:
+ *   - REST /repos/:id/branches control path succeeds (baseline).
+ *   - MCP agor_branches_create succeeds on daemon A and daemon B (replica routing).
+ *   - waitForReady=false AND waitForReady=true both succeed.
+ *   - Concurrent MCP creates all succeed (no tenant-scope bleed across requests).
+ *   - A tenant-B MCP token cannot create against a tenant-A repo (RLS isolation).
+ *
+ * Gated like scripts/test-daemon-ha.mjs — requires a running Compose stack.
+ */
+
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+
+if (process.env.AGOR_HA_INTEGRATION !== '1') {
+  console.log('SKIP: set AGOR_HA_INTEGRATION=1 to exercise the HA MCP branch-create path');
+  process.exit(0);
+}
+
+// biome-ignore lint/suspicious/noUndeclaredEnvVars: HA test secret supplied by the Compose stack env, not a checked-in .env.
+const JWT_SECRET = process.env.AGOR_JWT_SECRET;
+assert(JWT_SECRET, 'AGOR_JWT_SECRET is required (must match the HA daemon JWT secret)');
+
+const ingress = process.env.HA_URL ?? `http://127.0.0.1:${process.env.HA_PORT ?? '3030'}`;
+const daemonA = `http://127.0.0.1:${process.env.HA_DAEMON_A_PORT ?? '13031'}`;
+const daemonB = `http://127.0.0.1:${process.env.HA_DAEMON_B_PORT ?? '13032'}`;
+
+// Mirrors packages/core/src/types/mcp.ts MCP_TOKEN_AUDIENCE / MCP_TOKEN_ISSUER
+// and the HS256 claim shape minted by mcp/tokens.ts generateSessionToken.
+const MCP_TOKEN_AUDIENCE = 'agor:mcp:internal';
+const MCP_TOKEN_ISSUER = 'agor';
+
+const b64url = (input) =>
+  Buffer.from(typeof input === 'string' ? input : JSON.stringify(input)).toString('base64url');
+
+function mintMcpToken({ sessionId, userId, tenantId }) {
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: 'HS256', typ: 'JWT' };
+  const payload = {
+    sub: sessionId,
+    uid: userId,
+    tid: tenantId,
+    aud: MCP_TOKEN_AUDIENCE,
+    iss: MCP_TOKEN_ISSUER,
+    iat: now,
+    exp: now + 3600,
+    jti: crypto.randomUUID(),
+  };
+  const data = `${b64url(header)}.${b64url(payload)}`;
+  const sig = crypto.createHmac('sha256', JWT_SECRET).update(data).digest('base64url');
+  return `${data}.${sig}`;
+}
+
+async function loginPersona({ tenant, persona }, base = daemonA) {
+  const selected = await fetch(`${ingress}/dev-auth/select`, {
+    method: 'POST',
+    redirect: 'manual',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({ tenant, persona, return_to: '/ui/' }),
+  });
+  assert.equal(selected.status, 303, `persona selection failed: ${selected.status}`);
+  const launchCode = new URL(selected.headers.get('location')).searchParams.get('launch_code');
+  assert(launchCode, 'persona selection did not return a launch code');
+  const response = await fetch(`${base}/auth/launch`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ launchCode }),
+  });
+  assert.equal(response.status, 201, `persona launch failed: ${response.status}`);
+  return response.json();
+}
+
+function parseMcpBody(text) {
+  // The endpoint may answer with a single JSON body or an SSE stream.
+  if (text.includes('data:')) {
+    return text
+      .split('\n')
+      .filter((line) => line.startsWith('data:'))
+      .map((line) => {
+        try {
+          return JSON.parse(line.slice(5).trim());
+        } catch {
+          return null;
+        }
+      })
+      .filter(Boolean);
+  }
+  try {
+    return [JSON.parse(text)];
+  } catch {
+    return [];
+  }
+}
+
+async function mcpCall(base, token, body, extraHeaders = {}) {
+  const res = await fetch(`${base}/mcp`, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json, text/event-stream',
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+      ...extraHeaders,
+    },
+    body: JSON.stringify(body),
+  });
+  return {
+    status: res.status,
+    sid: res.headers.get('mcp-session-id'),
+    messages: parseMcpBody(await res.text()),
+  };
+}
+
+async function mcpInitialize(base, token) {
+  const init = await mcpCall(base, token, {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2025-03-26',
+      capabilities: {},
+      clientInfo: { name: 'agor-ha-mcp-branch-create', version: '1.0.0' },
+    },
+  });
+  assert.equal(init.status, 200, `MCP initialize failed at ${base}: ${init.status}`);
+  if (init.sid) {
+    await mcpCall(
+      base,
+      token,
+      { jsonrpc: '2.0', method: 'notifications/initialized' },
+      {
+        'mcp-session-id': init.sid,
+      }
+    );
+  }
+  return init.sid;
+}
+
+/** Call agor_branches_create and return the tool result payload (parsed). */
+async function mcpCreateBranch(base, token, sid, args) {
+  const res = await mcpCall(
+    base,
+    token,
+    {
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: { name: 'agor_branches_create', arguments: args },
+    },
+    sid ? { 'mcp-session-id': sid } : {}
+  );
+  assert.equal(res.status, 200, `tools/call HTTP status at ${base}: ${res.status}`);
+  const result = res.messages.map((m) => m.result).find(Boolean);
+  assert(
+    result,
+    `tools/call returned no result at ${base}: ${JSON.stringify(res.messages).slice(0, 300)}`
+  );
+  const text = (result.content ?? []).map((c) => c.text).join(' ');
+  return { isError: result.isError === true, text };
+}
+
+async function registerRepo(base, headers, slug) {
+  // A remote row is enough for branch metadata creation; the clone itself is a
+  // fire-and-forget executor step and is not what this test exercises.
+  const res = await fetch(`${base}/repos`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      slug,
+      name: slug,
+      repo_type: 'remote',
+      remote_url: 'https://github.com/octocat/Hello-World.git',
+      default_branch: 'master',
+      clone_status: 'ready',
+      local_path: `/home/agor/.agor/repos/${slug}`,
+    }),
+  });
+  const body = await res.text();
+  assert.equal(res.status, 201, `repo registration failed: ${res.status} ${body}`);
+  return JSON.parse(body).repo_id;
+}
+
+async function firstBoardId(base, headers) {
+  const res = await fetch(`${base}/boards`, { headers });
+  assert.equal(res.status, 200, `board list failed: ${res.status}`);
+  const body = await res.json();
+  const boards = body.data ?? body;
+  assert(boards.length > 0, 'tenant has no board to place branches on');
+  return boards[0].board_id;
+}
+
+async function createSession(base, headers, branchId) {
+  const res = await fetch(`${base}/sessions`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({
+      branch_id: branchId,
+      title: 'ha-mcp-regression',
+      agentic_tool: 'claude-code',
+    }),
+  });
+  const body = await res.text();
+  assert.equal(res.status, 201, `session create failed: ${res.status} ${body}`);
+  return JSON.parse(body).session_id;
+}
+
+const stamp = Date.now();
+
+// ---- Tenant A: full REST + MCP round-trip ----------------------------------
+const alice = await loginPersona({ tenant: 'acme', persona: 'acme-alice' });
+const aHeaders = {
+  authorization: `Bearer ${alice.accessToken}`,
+  'content-type': 'application/json',
+};
+const aUserId = alice.user.user_id;
+const aBoardId = await firstBoardId(daemonA, aHeaders);
+const aRepoId = await registerRepo(daemonA, aHeaders, `ha-mcp-${stamp}`);
+
+// REST control: this path enters the tenant DB scope via the route around hook.
+const restRes = await fetch(`${daemonA}/repos/${aRepoId}/branches`, {
+  method: 'POST',
+  headers: aHeaders,
+  body: JSON.stringify({
+    name: `rest-control-${stamp}`,
+    boardId: aBoardId,
+    createBranch: true,
+    ref: `rest-control-${stamp}`,
+    sourceBranch: 'master',
+  }),
+});
+assert.equal(restRes.status, 201, `REST control branch create failed: ${restRes.status}`);
+const controlBranch = await restRes.json();
+console.log('ok - REST /repos/:id/branches control path creates a branch under tenant scope');
+
+const aSessionId = await createSession(daemonA, aHeaders, controlBranch.branch_id);
+const aToken = mintMcpToken({ sessionId: aSessionId, userId: aUserId, tenantId: 'acme' });
+
+// MCP create on BOTH replicas, BOTH wait modes.
+for (const [label, base] of [
+  ['daemon-a', daemonA],
+  ['daemon-b', daemonB],
+]) {
+  const sid = await mcpInitialize(base, aToken);
+  for (const waitForReady of [false, true]) {
+    const args = {
+      repoId: aRepoId,
+      branchName: `mcp-${label}-${waitForReady ? 'wait' : 'nowait'}-${stamp}`,
+      boardId: aBoardId,
+      waitForReady,
+      ...(waitForReady ? { waitTimeoutMs: 8000 } : {}),
+    };
+    const result = await mcpCreateBranch(base, aToken, sid, args);
+    assert.equal(
+      result.isError,
+      false,
+      `MCP agor_branches_create failed on ${label} (waitForReady=${waitForReady}): ${result.text}`
+    );
+    assert(
+      !/Missing tenant database scope/i.test(result.text),
+      `tenant scope regression on ${label} (waitForReady=${waitForReady}): ${result.text}`
+    );
+  }
+  console.log(`ok - MCP agor_branches_create succeeds on ${label} for waitForReady false and true`);
+}
+
+// Concurrent creates share the pooled Postgres connections; each must open and
+// clean up its own tenant scope without bleeding into a sibling request.
+const sidConcurrent = await mcpInitialize(daemonA, aToken);
+const concurrent = await Promise.all(
+  Array.from({ length: 5 }, (_unused, i) =>
+    mcpCreateBranch(daemonA, aToken, sidConcurrent, {
+      repoId: aRepoId,
+      branchName: `mcp-concurrent-${i}-${stamp}`,
+      boardId: aBoardId,
+      waitForReady: false,
+    })
+  )
+);
+for (const [i, result] of concurrent.entries()) {
+  assert.equal(result.isError, false, `concurrent create ${i} failed: ${result.text}`);
+}
+console.log('ok - concurrent MCP branch creates all succeed with no tenant-scope bleed');
+
+// ---- Tenant B: cross-tenant negative ---------------------------------------
+const beatrice = await loginPersona({ tenant: 'globex', persona: 'globex-beatrice' }, daemonB);
+const bHeaders = {
+  authorization: `Bearer ${beatrice.accessToken}`,
+  'content-type': 'application/json',
+};
+const bUserId = beatrice.user.user_id;
+const bBoardId = await firstBoardId(daemonB, bHeaders);
+const bRepoId = await registerRepo(daemonB, bHeaders, `ha-mcp-b-${stamp}`);
+const bBranchRes = await fetch(`${daemonB}/repos/${bRepoId}/branches`, {
+  method: 'POST',
+  headers: bHeaders,
+  body: JSON.stringify({
+    name: `b-control-${stamp}`,
+    boardId: bBoardId,
+    createBranch: true,
+    ref: `b-control-${stamp}`,
+    sourceBranch: 'master',
+  }),
+});
+assert.equal(bBranchRes.status, 201, `tenant B control branch failed: ${bBranchRes.status}`);
+const bSessionId = await createSession(daemonB, bHeaders, (await bBranchRes.json()).branch_id);
+const bToken = mintMcpToken({ sessionId: bSessionId, userId: bUserId, tenantId: 'globex' });
+
+const sidB = await mcpInitialize(daemonB, bToken);
+const crossTenant = await mcpCreateBranch(daemonB, bToken, sidB, {
+  // tenant-A repo id, tenant-B credentials — RLS must hide it.
+  repoId: aRepoId,
+  branchName: `cross-tenant-${stamp}`,
+  boardId: bBoardId,
+  waitForReady: false,
+});
+assert.equal(
+  crossTenant.isError,
+  true,
+  'tenant B unexpectedly created a branch against a tenant A repo'
+);
+assert(
+  !/Missing tenant database scope/i.test(crossTenant.text),
+  `cross-tenant denial must be a tenant-isolation error, not a scope bug: ${crossTenant.text}`
+);
+console.log(
+  'ok - tenant B MCP token cannot create a branch against a tenant A repo (RLS isolation)'
+);
+
+console.log('PASS: HA MCP branch-create tenant scope regression');


### PR DESCRIPTION
## Problem

In `required_from_auth` (HA / hosted Postgres) mode, the MCP tool `agor_branches_create` failed with:

```
Missing tenant database scope for daemon database access
```

Reproduced **live** against the branch's HA Compose stack (variant `ha`, ingress `:7833`, tenants `acme`/`globex`, two daemon replicas behind nginx) on **both** replicas and for **both** `waitForReady=false` and `true`. The equivalent REST call (`POST /repos/:id/branches`) **succeeded** in the same environment — the gap is specific to the MCP path.

## Root cause

The MCP tool boundary (`tenantScopedToolProxy`) enters only tenant **context** (identity), by design — many tools then do long polling/executor/provider work and must not hold an HTTP-long transaction. Each handler is expected to open a **short** tenant **database** unit at its DB call via `runWithMcpTenantDatabaseScope`.

`ReposService.createBranch` is deliberately **not** a Feathers transport method; it is exposed to HTTP/CLI only via the `/repos/:id/branches` route, whose around chain (`tenantDatabaseScopeAround`) wraps the whole method in a tenant transaction. `createBranch` therefore reads/writes `this.db` directly and relies on that **ambient** scope. The MCP tool called it directly (bypassing hooks) with only tenant context present, so the guarded daemon-DB proxy (`requireScope: true`) threw on the first `this.db` touch.

## Fix

Wrap the affected direct custom (non-transport) service-method calls in `runWithMcpTenantDatabaseScope`, matching the established `cards.ts` pattern and the HTTP route's per-request tenant transaction. Readiness waits stay **outside** the scope — no transaction is held across polls. Tenant/RBAC/RLS boundaries are unchanged (cross-tenant switches still fail closed; RLS still isolates).

Sites fixed:

| Tool | Custom method |
| --- | --- |
| `agor_branches_create` | `reposService.createBranch` |
| `agor_branches_set_zone` | `boardObjectsService.findByBranchId` (×2) |
| `agor_repos_clone` / `_create_local` / `_update` | `cloneRepository` / `addLocalRepository` / `updateMetadata` |
| `agor_boards_archive` / `_unarchive` | `boardsService.archive` / `unarchive` |

Sibling services that already scope internally (`BranchesService.withTenantDatabase`, `SessionsService`, `GatewayService`, and `cards.ts`) were audited and left unchanged.

## Tests

- **`branches.tenant-scope.test.ts`** — exercises the *real* guard machinery (`createTenantScopedDatabaseProxy({requireScope:true})` + `tenantDatabaseScope`): exact error string; scope entry bound to the authenticated tenant for both wait modes; scope cleanup after return; tenant A/B isolation; fail-closed on a conflicting foreign tenant; preserved static single-tenant behavior.
- **`scripts/test-ha-mcp-branch-create.mjs`** — gated HA integration reproduction over the real `/mcp` endpoint on both replicas: REST control, both wait modes, concurrent creates (no scope bleed), tenant-B token cannot create against a tenant-A repo.

## Verification

- Reproduced the exact error live on both replicas before the fix.
- Rebuilt the HA daemon image with the fix → the HA regression script passes on both replicas (all wait modes, concurrent, cross-tenant negative).
- `branches.tenant-scope.test.ts` + existing MCP tool tests: 59 passing; `pnpm check:multitenancy-boundaries` clean; biome clean.

Design note: `docs/internal/mcp-tenant-db-scope-createbranch-2026-08-29.md` (includes a recommended durable follow-up: give `ReposService`/`BoardsService`/`BoardObjectsService` the same internal `withTenantDatabase` helper `BranchesService` has).

🤖 Generated with [Claude Code](https://claude.com/claude-code)