### PR TITLE
fix(ha): preserve tenant scope through session Stop

### DIFF
--- a/apps/agor-daemon/src/register-routes.stop-scope.test.ts
+++ b/apps/agor-daemon/src/register-routes.stop-scope.test.ts
@@ -30,6 +30,9 @@ describe('Stop route transaction scope', () => {
       'runInFreshTenantWriteDatabase: runInFreshTerminationTenantWriteDatabase'
     );
     expect(stop).toContain('runInTenantDatabaseScope: inCurrentTenantDatabaseScope');
+    expect(stop).toContain("body.expected_task_id === 'string'");
+    expect(stop).toContain('{ reason: stopReason, expectedTaskId }');
+    expect(stop).toContain("outcome: 'force_failed' as const");
     expect(stop).toMatch(
       /const failedTask = await runInFreshTerminationTenantWriteDatabase\(\(\) =>\s+forceFailUnverifiedTask\(\{/
     );

--- a/apps/agor-daemon/src/register-routes.stop-scope.test.ts
+++ b/apps/agor-daemon/src/register-routes.stop-scope.test.ts
@@ -18,9 +18,18 @@ describe('Stop route transaction scope', () => {
 
     expect(stop).toContain('resolveSessionPromptAccess({');
     expect(stop).toContain('body.force_unverified !== true');
+    const stopAccessScope = stop.slice(
+      stop.indexOf('const access = await inCurrentTenantDatabaseScope'),
+      stop.indexOf(
+        'if (!access)',
+        stop.indexOf('const access = await inCurrentTenantDatabaseScope')
+      )
+    );
+    expect(stopAccessScope).toContain('resolveSessionPromptAccess({');
     expect(stop).toContain(
       'runInFreshTenantWriteDatabase: runInFreshTerminationTenantWriteDatabase'
     );
+    expect(stop).toContain('runInTenantDatabaseScope: inCurrentTenantDatabaseScope');
     expect(stop).toMatch(
       /const failedTask = await runInFreshTerminationTenantWriteDatabase\(\(\) =>\s+forceFailUnverifiedTask\(\{/
     );

--- a/apps/agor-daemon/src/register-routes.stop-scope.test.ts
+++ b/apps/agor-daemon/src/register-routes.stop-scope.test.ts
@@ -30,11 +30,11 @@ describe('Stop route transaction scope', () => {
       'runInFreshTenantWriteDatabase: runInFreshTerminationTenantWriteDatabase'
     );
     expect(stop).toContain('runInTenantDatabaseScope: inCurrentTenantDatabaseScope');
-    expect(stop).toContain("body.expected_task_id === 'string'");
+    expect(stop).toContain('!isCanonicalFullUuid(body.expected_task_id)');
     expect(stop).toContain('{ reason: stopReason, expectedTaskId }');
     expect(stop).toContain("outcome: 'force_failed' as const");
     expect(stop).toMatch(
-      /const failedTask = await runInFreshTerminationTenantWriteDatabase\(\(\) =>\s+forceFailUnverifiedTask\(\{/
+      /const forceFail = await runInFreshTerminationTenantWriteDatabase\(\(\) =>\s+forceFailUnverifiedTask\(\{/
     );
   });
 

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -3081,17 +3081,18 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
             const branch = await branchRepository.findById(session.branch_id);
             if (!branch) return null;
             const branchAccess = await branchRepository.resolveUserAccess(branch, stopUserId);
-            return { branch, branchAccess };
+            const { allowed: hasPromptAuthority } = await resolveSessionPromptAccess({
+              branchRepository,
+              branch,
+              session,
+              userId: stopUserId,
+            });
+            return { branchAccess, hasPromptAuthority };
           });
           if (!access) {
             throw new NotFound(`Branch ${session.branch_id} not found`);
           }
-          const { allowed: hasPromptAuthority } = await resolveSessionPromptAccess({
-            branchRepository,
-            branch: access.branch,
-            session,
-            userId: stopUserId,
-          });
+          const { hasPromptAuthority } = access;
           const isManager = access.branchAccess.can === 'all';
           const isGlobalSuperadmin =
             superadminOpts.allowSuperadmin && hasMinimumRole(params.user?.role, ROLES.SUPERADMIN);
@@ -3161,10 +3162,8 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
               app,
               taskRepo: stopRouteRepositories.taskRepo,
               sessionsService: sessionsServiceWithHooks,
-              findActiveTasks: (stopApp, sessionId, stopParams) =>
-                inCurrentTenantDatabaseScope(() =>
-                  findActiveTasksForSession(stopApp, sessionId, stopParams)
-                ),
+              findActiveTasks: findActiveTasksForSession,
+              runInTenantDatabaseScope: inCurrentTenantDatabaseScope,
               runInFreshTenantWriteDatabase: runInFreshTerminationTenantWriteDatabase,
             },
             id as SessionID,

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -85,6 +85,7 @@ import type {
   SessionMCPServer,
   StreamingEventType,
   Task,
+  TaskID,
   TaskMetadata,
   User,
   UserID,
@@ -3147,6 +3148,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
             );
             return {
               success: true,
+              outcome: 'force_failed' as const,
               status: failedTask.status,
               stoppedTaskId: failedTask.task_id,
             };
@@ -3156,6 +3158,8 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         }
 
         const stopReason = typeof body.reason === 'string' ? body.reason : undefined;
+        const expectedTaskId =
+          typeof body.expected_task_id === 'string' ? (body.expected_task_id as TaskID) : undefined;
         const result = await withSessionTurnLock(sessionTurnLocks, id as SessionID, async () =>
           stopSessionPreserveQueue(
             {
@@ -3168,7 +3172,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
             },
             id as SessionID,
             params,
-            { reason: stopReason }
+            { reason: stopReason, expectedTaskId }
           )
         );
 

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -83,6 +83,7 @@ import type {
   Session,
   SessionID,
   SessionMCPServer,
+  SessionStopResult,
   StreamingEventType,
   Task,
   TaskID,
@@ -95,6 +96,7 @@ import {
   boardCommentZoneParentObjectKey,
   hasMinimumRole,
   isBranchArchiveOrDeleteOptions,
+  isCanonicalFullUuid,
   isTaskPendingDispatch,
   MCP_MEMBER_POLICIES,
   MCP_MEMBER_POLICY_CHANGED_EVENT,
@@ -3048,7 +3050,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     app,
     '/sessions/:id/stop',
     {
-      async create(data: unknown, params: RouteParams) {
+      async create(data: unknown, params: RouteParams): Promise<SessionStopResult> {
         const id = params.route?.id;
         if (!id) throw new Error('Session ID required');
         const body = data && typeof data === 'object' ? (data as Record<string, unknown>) : {};
@@ -3137,7 +3139,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
                   stopRouteRepositories.branchRepo.isOwner(branchId, userId),
               });
             });
-            const failedTask = await runInFreshTerminationTenantWriteDatabase(() =>
+            const forceFail = await runInFreshTerminationTenantWriteDatabase(() =>
               forceFailUnverifiedTask({
                 app,
                 taskId: target.task.task_id,
@@ -3146,11 +3148,19 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
                 params,
               })
             );
+            if (forceFail.outcome === 'already_terminal') {
+              return {
+                success: false as const,
+                outcome: 'condition_changed' as const,
+                reason: 'Task completed before force-fail could be applied.',
+                stoppedTaskId: forceFail.task.task_id,
+              };
+            }
             return {
-              success: true,
+              success: true as const,
               outcome: 'force_failed' as const,
-              status: failedTask.status,
-              stoppedTaskId: failedTask.task_id,
+              status: TaskStatus.FAILED,
+              stoppedTaskId: forceFail.task.task_id,
             };
           });
           triggerPreservedQueue();
@@ -3158,8 +3168,10 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
         }
 
         const stopReason = typeof body.reason === 'string' ? body.reason : undefined;
-        const expectedTaskId =
-          typeof body.expected_task_id === 'string' ? (body.expected_task_id as TaskID) : undefined;
+        if (body.expected_task_id !== undefined && !isCanonicalFullUuid(body.expected_task_id)) {
+          throw new BadRequest('expected_task_id must be a canonical Task ID.');
+        }
+        const expectedTaskId = body.expected_task_id as TaskID | undefined;
         const result = await withSessionTurnLock(sessionTurnLocks, id as SessionID, async () =>
           stopSessionPreserveQueue(
             {

--- a/apps/agor-daemon/src/termination-coordinator.test.ts
+++ b/apps/agor-daemon/src/termination-coordinator.test.ts
@@ -562,12 +562,14 @@ describe('termination coordinator', () => {
       })
     ).rejects.toThrow('termination state changed');
     state.settle(task(TaskStatus.FAILED));
-    await forceFailUnverifiedTask({
-      app: state.app,
-      taskId,
-      terminationRequestedAt: '2026-01-01T00:00:01.000Z',
-      confirmation: 'STOP',
-    });
+    await expect(
+      forceFailUnverifiedTask({
+        app: state.app,
+        taskId,
+        terminationRequestedAt: '2026-01-01T00:00:01.000Z',
+        confirmation: 'STOP',
+      })
+    ).resolves.toMatchObject({ outcome: 'force_failed', task: { status: TaskStatus.FAILED } });
     expect(state.settleTermination).toHaveBeenCalledTimes(2);
     expect(state.settleTermination).toHaveBeenLastCalledWith(
       expect.objectContaining({
@@ -576,5 +578,29 @@ describe('termination coordinator', () => {
       }),
       expect.objectContaining({ suppressTerminalQueueProcessing: true })
     );
+  });
+
+  it('reports a concurrent terminal settlement instead of claiming force-fail won', async () => {
+    const state = appDouble();
+    state.setCurrent(
+      task(TaskStatus.STOPPING, {
+        termination_request: stopping('user_stop').termination_request,
+        sdk_failure: { termination: 'unverified' },
+      })
+    );
+    state.settle(task(TaskStatus.STOPPED), 'terminal');
+    const securityLog = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    await expect(
+      forceFailUnverifiedTask({
+        app: state.app,
+        taskId,
+        terminationRequestedAt: '2026-01-01T00:00:01.000Z',
+        confirmation: 'STOP',
+      })
+    ).resolves.toMatchObject({ outcome: 'already_terminal', task: { status: TaskStatus.STOPPED } });
+    expect(securityLog).not.toHaveBeenCalled();
+    expect(untrackExecutorProcess).toHaveBeenCalledWith(sessionId, taskId, state.app);
+    securityLog.mockRestore();
   });
 });

--- a/apps/agor-daemon/src/termination-coordinator.test.ts
+++ b/apps/agor-daemon/src/termination-coordinator.test.ts
@@ -384,11 +384,31 @@ describe('termination coordinator', () => {
     state.claim({ ...stopping('heartbeat_lost'), executor_mode: 'local' });
 
     await expect(request(state.app, 'heartbeat_lost')).resolves.toMatchObject({
-      status: 'unverified',
+      status: 'pending',
       task: { status: TaskStatus.STOPPING },
+      pendingCode: 'non_owner_replica',
       reason: expect.stringContaining('owns the local executor process handle'),
     });
     expect(state.claimTerminationCoordination).not.toHaveBeenCalled();
+    expect(containExecutorProcess).not.toHaveBeenCalled();
+    expect(state.settleTermination).not.toHaveBeenCalled();
+  });
+
+  it('reports a durable containment lease as structured coordination pending', async () => {
+    const state = appDouble();
+    const requested = stopping('user_stop');
+    state.claim(requested);
+    state.claimTerminationCoordination.mockResolvedValueOnce({
+      outcome: 'pending',
+      task: requested,
+    });
+
+    await expect(request(state.app, 'user_stop')).resolves.toMatchObject({
+      status: 'pending',
+      task: { status: TaskStatus.STOPPING },
+      pendingCode: 'coordination_in_progress',
+      reason: expect.stringContaining('Another daemon'),
+    });
     expect(containExecutorProcess).not.toHaveBeenCalled();
     expect(state.settleTermination).not.toHaveBeenCalled();
   });

--- a/apps/agor-daemon/src/termination-coordinator.ts
+++ b/apps/agor-daemon/src/termination-coordinator.ts
@@ -5,6 +5,7 @@ import type {
   Params,
   PersistedAgenticToolName,
   SdkFailure,
+  SessionStopPendingCode,
   Task,
   TaskID,
   TerminationCause,
@@ -20,9 +21,10 @@ import {
 } from './executor-tracking.js';
 
 export interface TerminationResult {
-  status: 'terminal' | 'unverified' | 'condition_changed';
+  status: 'terminal' | 'pending' | 'unverified' | 'condition_changed';
   task: Task;
   reason?: string;
+  pendingCode?: SessionStopPendingCode;
 }
 
 export interface TerminationInput {
@@ -303,7 +305,13 @@ async function claimContainmentCoordination(
   task: Task
 ): Promise<
   | { outcome: 'claimed'; task: Task; token: string }
-  | { outcome: 'pending' | 'condition_changed'; task: Task; reason?: string }
+  | {
+      outcome: 'pending';
+      task: Task;
+      reason: string;
+      pendingCode: SessionStopPendingCode;
+    }
+  | { outcome: 'condition_changed'; task: Task }
 > {
   const localMode = task.executor_mode !== 'templated';
   const ownsLocalHandle = !!getTrackedExecutor(task.session_id, input.app);
@@ -317,6 +325,7 @@ async function claimContainmentCoordination(
       outcome: 'pending',
       task,
       reason: 'Waiting for the daemon that owns the local executor process handle.',
+      pendingCode: 'non_owner_replica',
     };
   }
 
@@ -349,6 +358,7 @@ async function claimContainmentCoordination(
     outcome: 'pending',
     task: claim.task,
     reason: 'Another daemon currently coordinates executor containment.',
+    pendingCode: 'coordination_in_progress',
   };
 }
 
@@ -373,7 +383,12 @@ export async function requestExecutorTermination(
     if (coordination.outcome === 'condition_changed') {
       return { status: 'condition_changed', task: coordination.task };
     }
-    return { status: 'unverified', task: coordination.task, reason: coordination.reason };
+    return {
+      status: 'pending',
+      task: coordination.task,
+      reason: coordination.reason,
+      pendingCode: coordination.pendingCode,
+    };
   }
   return startContainment(input, coordination.task, tool, coordination.token);
 }

--- a/apps/agor-daemon/src/termination-coordinator.ts
+++ b/apps/agor-daemon/src/termination-coordinator.ts
@@ -5,10 +5,10 @@ import type {
   Params,
   PersistedAgenticToolName,
   SdkFailure,
-  SessionStopPendingCode,
   Task,
   TaskID,
   TerminationCause,
+  TerminationCoordinationPendingCode,
 } from '@agor/core/types';
 import { isAgenticToolName, isTerminalTaskStatus, TaskStatus } from '@agor/core/types';
 import type { TasksServiceImpl } from './declarations.js';
@@ -20,12 +20,15 @@ import {
   untrackExecutorProcess,
 } from './executor-tracking.js';
 
-export interface TerminationResult {
-  status: 'terminal' | 'pending' | 'unverified' | 'condition_changed';
-  task: Task;
-  reason?: string;
-  pendingCode?: SessionStopPendingCode;
-}
+export type TerminationResult =
+  | { status: 'terminal' | 'condition_changed'; task: Task }
+  | { status: 'unverified'; task: Task; reason: string }
+  | {
+      status: 'pending';
+      task: Task;
+      reason: string;
+      pendingCode: TerminationCoordinationPendingCode;
+    };
 
 export interface TerminationInput {
   app: Application;
@@ -309,7 +312,7 @@ async function claimContainmentCoordination(
       outcome: 'pending';
       task: Task;
       reason: string;
-      pendingCode: SessionStopPendingCode;
+      pendingCode: TerminationCoordinationPendingCode;
     }
   | { outcome: 'condition_changed'; task: Task }
 > {

--- a/apps/agor-daemon/src/termination-coordinator.ts
+++ b/apps/agor-daemon/src/termination-coordinator.ts
@@ -438,13 +438,17 @@ export async function beginExecutorTermination(input: TerminationInput): Promise
   return coordination.task;
 }
 
+export type ForceFailUnverifiedResult =
+  | { outcome: 'force_failed'; task: Task }
+  | { outcome: 'already_terminal'; task: Task };
+
 export async function forceFailUnverifiedTask(input: {
   app: Application;
   taskId: TaskID | string;
   terminationRequestedAt: string;
   confirmation: string;
   params?: Params;
-}): Promise<Task> {
+}): Promise<ForceFailUnverifiedResult> {
   const tasks = input.app.service('tasks') as unknown as TasksServiceImpl;
   const current = await tasks.get(input.taskId, input.params);
   if (input.confirmation !== 'STOP') {
@@ -460,9 +464,6 @@ export async function forceFailUnverifiedTask(input: {
       'The Task termination state changed. Review the current Task before force-failing.'
     );
   }
-  console.warn(
-    `[SECURITY] Force-failing Task ${shortId(current.task_id)} without verified executor termination`
-  );
   const settlement = await tasks.settleTermination(
     {
       taskId: current.task_id,
@@ -472,9 +473,19 @@ export async function forceFailUnverifiedTask(input: {
     },
     { ...internalParams(input.params), suppressTerminalQueueProcessing: true } as Params
   );
-  if (settlement.outcome !== 'transitioned' && settlement.outcome !== 'terminal') {
+  if (settlement.outcome === 'terminal') {
+    untrackExecutorProcess(settlement.task.session_id, settlement.task.task_id, input.app);
+    return { outcome: 'already_terminal', task: settlement.task };
+  }
+  if (settlement.outcome !== 'transitioned') {
     throw new Conflict('Task termination state changed before force-fail could be applied.');
   }
+  if (settlement.task.status !== TaskStatus.FAILED) {
+    throw new Conflict('Task termination state changed before force-fail could be applied.');
+  }
+  console.warn(
+    `[SECURITY] Force-failing Task ${shortId(current.task_id)} without verified executor termination`
+  );
   untrackExecutorProcess(settlement.task.session_id, settlement.task.task_id, input.app);
-  return settlement.task;
+  return { outcome: 'force_failed', task: settlement.task };
 }

--- a/apps/agor-daemon/src/utils/session-stop.test.ts
+++ b/apps/agor-daemon/src/utils/session-stop.test.ts
@@ -421,6 +421,51 @@ describe('stopSessionPreserveQueue', () => {
     expect(requestTermination).not.toHaveBeenCalled();
   });
 
+  it('does not describe a terminal settlement race as a still-stopping unverified result', async () => {
+    const sessionId = 'session-terminal-race';
+    const runningTask = {
+      task_id: 'task-terminal-race',
+      session_id: sessionId,
+      status: 'running',
+      created_at: '2026-01-01T00:00:00.000Z',
+    };
+    const requestTermination = vi.fn().mockResolvedValue({
+      status: 'unverified',
+      task: { ...runningTask, status: 'stopped' },
+      reason: 'Containment could not be verified after the Task settled.',
+    });
+
+    await expect(
+      stopSessionPreserveQueue(
+        {
+          app: {} as never,
+          taskRepo: { findQueued: vi.fn().mockResolvedValue([]) } as never,
+          sessionsService: {
+            get: vi.fn().mockResolvedValue({
+              session_id: sessionId,
+              agentic_tool: 'codex',
+              status: 'running',
+              ready_for_prompt: false,
+              tasks: [runningTask.task_id],
+            }),
+            patch: vi.fn(),
+          } as never,
+          findActiveTasks: vi.fn().mockResolvedValue([runningTask]) as never,
+          requestTermination: requestTermination as never,
+          runInTenantDatabaseScope,
+          runInFreshTenantWriteDatabase,
+        },
+        sessionId as never
+      )
+    ).resolves.toEqual({
+      success: false,
+      outcome: 'condition_changed',
+      reason: 'Containment could not be verified after the Task settled.',
+      stoppedTaskId: runningTask.task_id,
+      queuedTasksPreserved: 0,
+    });
+  });
+
   it('does not silently report success if the session idle patch fails after stopping the task', async () => {
     const sessionId = 'session-patch-fails';
     const runningTask = {

--- a/apps/agor-daemon/src/utils/session-stop.test.ts
+++ b/apps/agor-daemon/src/utils/session-stop.test.ts
@@ -11,6 +11,7 @@ const findActiveTasks = async (app: any, sessionId: string, params: unknown) => 
 };
 
 const runInFreshTenantWriteDatabase = <T>(work: () => Promise<T>): Promise<T> => work();
+const runInTenantDatabaseScope = <T>(work: () => Promise<T>): Promise<T> => work();
 
 describe('markStoppedSessionPromptableNoDrain', () => {
   it('marks the session promptable without triggering queue processing', async () => {
@@ -53,6 +54,70 @@ describe('markStoppedSessionPromptableNoDrain', () => {
 });
 
 describe('stopSessionPreserveQueue', () => {
+  it('keeps nested reads and the idle repair inside explicit tenant database units', async () => {
+    let readScopeDepth = 0;
+    let writeScopeDepth = 0;
+    const requireScope = (kind: 'read' | 'write') => {
+      if (readScopeDepth === 0 && writeScopeDepth === 0) {
+        throw new Error(`missing tenant ${kind} scope`);
+      }
+    };
+    const runInTenantDatabaseScope = vi.fn(async <T>(work: () => Promise<T>) => {
+      readScopeDepth += 1;
+      try {
+        return await work();
+      } finally {
+        readScopeDepth -= 1;
+      }
+    });
+    const runInFreshTenantWriteDatabase = vi.fn(async <T>(work: () => Promise<T>) => {
+      writeScopeDepth += 1;
+      try {
+        return await work();
+      } finally {
+        writeScopeDepth -= 1;
+      }
+    });
+    const sessionsService = {
+      get: vi.fn(async () => {
+        requireScope('read');
+        return {
+          session_id: 'session-scoped',
+          agentic_tool: 'codex',
+          status: 'running',
+          ready_for_prompt: false,
+          tasks: [],
+        };
+      }),
+      patch: vi.fn(async (_id, data) => {
+        requireScope('write');
+        return data;
+      }),
+    };
+    const findActiveTasks = vi.fn(async () => {
+      requireScope('read');
+      return [];
+    });
+
+    await expect(
+      stopSessionPreserveQueue(
+        {
+          app: {} as never,
+          taskRepo: { findQueued: vi.fn().mockResolvedValue([]) } as never,
+          sessionsService: sessionsService as never,
+          findActiveTasks: findActiveTasks as never,
+          runInTenantDatabaseScope,
+          runInFreshTenantWriteDatabase,
+        },
+        'session-scoped' as never
+      )
+    ).resolves.toMatchObject({ success: true, outcome: 'stopped', status: 'idle' });
+
+    expect(runInTenantDatabaseScope).toHaveBeenCalledTimes(2);
+    expect(runInFreshTenantWriteDatabase).toHaveBeenCalledOnce();
+    expect(sessionsService.patch).toHaveBeenCalledOnce();
+  });
+
   it('treats an already-idle session as an idempotent successful Stop', async () => {
     const findQueued = vi.fn().mockResolvedValue([{ task_id: 'queued-task' }]);
     const requestTermination = vi.fn();
@@ -66,12 +131,14 @@ describe('stopSessionPreserveQueue', () => {
             patch: vi.fn(),
           } as never,
           requestTermination: requestTermination as never,
+          runInTenantDatabaseScope,
           runInFreshTenantWriteDatabase,
         },
         'session-idle' as never
       )
     ).resolves.toEqual({
       success: true,
+      outcome: 'already_idle',
       status: 'idle',
       reason: 'Session is already idle',
       queuedTasksPreserved: 1,
@@ -105,6 +172,7 @@ describe('stopSessionPreserveQueue', () => {
           findActiveTasks: findActiveTasks as never,
           sessionsService: { get: vi.fn().mockResolvedValue(session), patch: vi.fn() } as never,
           requestTermination: requestTermination as never,
+          runInTenantDatabaseScope,
           runInFreshTenantWriteDatabase,
         } as never,
         session.session_id as never
@@ -167,6 +235,7 @@ describe('stopSessionPreserveQueue', () => {
         findActiveTasks: findActiveTasks as never,
         sessionsService: sessionsService as never,
         requestTermination: requestTermination as never,
+        runInTenantDatabaseScope,
         runInFreshTenantWriteDatabase: withTenantDatabase,
       },
       sessionId as never,
@@ -234,6 +303,7 @@ describe('stopSessionPreserveQueue', () => {
         findActiveTasks: findActiveTasks as never,
         sessionsService: sessionsService as never,
         requestTermination: requestTermination as never,
+        runInTenantDatabaseScope,
         runInFreshTenantWriteDatabase,
       },
       sessionId as never,
@@ -250,6 +320,62 @@ describe('stopSessionPreserveQueue', () => {
     expect(requestTermination).toHaveBeenCalledWith(
       expect.objectContaining({ taskId: awaitingInputTask.task_id, cause: 'user_stop' })
     );
+  });
+
+  it('surfaces an accepted non-owner Stop as structured pending without a second claim', async () => {
+    const sessionId = 'session-non-owner';
+    const runningTask = {
+      task_id: 'task-running-elsewhere',
+      session_id: sessionId,
+      status: 'running',
+      created_at: '2026-01-01T00:00:00.000Z',
+    };
+    const requestTermination = vi.fn().mockResolvedValue({
+      status: 'pending',
+      task: {
+        ...runningTask,
+        status: 'stopping',
+        termination_request: {
+          cause: 'user_stop',
+          requested_at: '2026-01-01T00:00:01.000Z',
+        },
+      },
+      pendingCode: 'non_owner_replica',
+      reason: 'Waiting for the daemon that owns the local executor process handle.',
+    });
+
+    await expect(
+      stopSessionPreserveQueue(
+        {
+          app: {} as never,
+          taskRepo: { findQueued: vi.fn().mockResolvedValue([]) } as never,
+          sessionsService: {
+            get: vi.fn().mockResolvedValue({
+              session_id: sessionId,
+              agentic_tool: 'codex',
+              status: 'running',
+              ready_for_prompt: false,
+              tasks: [runningTask.task_id],
+            }),
+            patch: vi.fn(),
+          } as never,
+          findActiveTasks: vi.fn().mockResolvedValue([runningTask]) as never,
+          requestTermination: requestTermination as never,
+          runInTenantDatabaseScope,
+          runInFreshTenantWriteDatabase,
+        },
+        sessionId as never
+      )
+    ).resolves.toEqual({
+      success: false,
+      outcome: 'pending',
+      status: 'stopping',
+      reason: 'Waiting for the daemon that owns the local executor process handle.',
+      stoppedTaskId: runningTask.task_id,
+      queuedTasksPreserved: 0,
+      pendingCode: 'non_owner_replica',
+    });
+    expect(requestTermination).toHaveBeenCalledOnce();
   });
 
   it('does not silently report success if the session idle patch fails after stopping the task', async () => {
@@ -298,6 +424,7 @@ describe('stopSessionPreserveQueue', () => {
           findActiveTasks: findActiveTasks as never,
           sessionsService: sessionsService as never,
           requestTermination: requestTermination as never,
+          runInTenantDatabaseScope,
           runInFreshTenantWriteDatabase,
         },
         sessionId as never,

--- a/apps/agor-daemon/src/utils/session-stop.test.ts
+++ b/apps/agor-daemon/src/utils/session-stop.test.ts
@@ -378,6 +378,49 @@ describe('stopSessionPreserveQueue', () => {
     expect(requestTermination).toHaveBeenCalledOnce();
   });
 
+  it('does not claim a successor task when the expected execution generation changed', async () => {
+    const sessionId = 'session-generation-changed';
+    const runningTask = {
+      task_id: 'task-successor',
+      session_id: sessionId,
+      status: 'running',
+      created_at: '2026-01-01T00:00:01.000Z',
+    };
+    const requestTermination = vi.fn();
+
+    await expect(
+      stopSessionPreserveQueue(
+        {
+          app: {} as never,
+          taskRepo: { findQueued: vi.fn().mockResolvedValue([]) } as never,
+          sessionsService: {
+            get: vi.fn().mockResolvedValue({
+              session_id: sessionId,
+              agentic_tool: 'codex',
+              status: 'running',
+              ready_for_prompt: false,
+              tasks: [runningTask.task_id],
+            }),
+            patch: vi.fn(),
+          } as never,
+          findActiveTasks: vi.fn().mockResolvedValue([runningTask]) as never,
+          requestTermination: requestTermination as never,
+          runInTenantDatabaseScope,
+          runInFreshTenantWriteDatabase,
+        },
+        sessionId as never,
+        {},
+        { expectedTaskId: 'task-original' as never }
+      )
+    ).resolves.toEqual({
+      success: false,
+      outcome: 'condition_changed',
+      reason: 'Execution changed before Stop could be claimed. Review the current state and retry.',
+      queuedTasksPreserved: 0,
+    });
+    expect(requestTermination).not.toHaveBeenCalled();
+  });
+
   it('does not silently report success if the session idle patch fails after stopping the task', async () => {
     const sessionId = 'session-patch-fails';
     const runningTask = {

--- a/apps/agor-daemon/src/utils/session-stop.ts
+++ b/apps/agor-daemon/src/utils/session-stop.ts
@@ -1,6 +1,6 @@
 import { shortId, type TaskRepository } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
-import type { Params, SessionID } from '@agor/core/types';
+import type { Params, SessionID, SessionStopResult } from '@agor/core/types';
 import { isSessionExecuting, SessionStatus } from '@agor/core/types';
 import type { SessionsServiceImpl } from '../declarations.js';
 import {
@@ -11,20 +11,14 @@ import {
 import { requireActiveAgenticTool } from './agentic-tool-runtime.js';
 import type { findActiveTasksForSession } from './session-tasks.js';
 
-export interface StopSessionResult {
-  success: boolean;
-  status?: typeof SessionStatus.IDLE;
-  reason?: string;
-  stoppedTaskId?: string;
-  queuedTasksPreserved?: number;
-}
-
 export interface StopSessionDeps {
   app: Application;
   taskRepo: Pick<TaskRepository, 'findQueued'>;
   sessionsService: Pick<SessionsServiceImpl, 'get' | 'patch'>;
   findActiveTasks: typeof findActiveTasksForSession;
   requestTermination?: typeof requestExecutorTermination;
+  /** Opens a required tenant database scope for nested service reads. */
+  runInTenantDatabaseScope: <T>(work: () => Promise<T>) => Promise<T>;
   /**
    * Opens one fresh, write-gated tenant database unit for each durable
    * termination step. The Stop route itself deliberately has no route-wide
@@ -75,8 +69,10 @@ export async function stopSessionPreserveQueue(
   sessionId: SessionID,
   params: Params = {},
   options: { reason?: string } = {}
-): Promise<StopSessionResult> {
-  const session = await deps.sessionsService.get(sessionId, params);
+): Promise<SessionStopResult> {
+  const session = await deps.runInTenantDatabaseScope(() =>
+    deps.sessionsService.get(sessionId, params)
+  );
 
   // Stop is idempotent across retries and the per-session turn lock. A
   // concurrent caller can observe the first caller's already-committed idle
@@ -85,6 +81,7 @@ export async function stopSessionPreserveQueue(
     const queuedTasks = await deps.taskRepo.findQueued(sessionId);
     return {
       success: true,
+      outcome: 'already_idle',
       status: SessionStatus.IDLE,
       reason: 'Session is already idle',
       queuedTasksPreserved: queuedTasks.length,
@@ -94,20 +91,26 @@ export async function stopSessionPreserveQueue(
   if (!isSessionExecuting(session)) {
     return {
       success: false,
+      outcome: 'not_stoppable',
       reason: `Session cannot be stopped (status: ${session.status})`,
     };
   }
 
-  const targetTasksArray = await deps.findActiveTasks(deps.app, sessionId, params);
+  const targetTasksArray = await deps.runInTenantDatabaseScope(() =>
+    deps.findActiveTasks(deps.app, sessionId, params)
+  );
   const queuedTasks = await deps.taskRepo.findQueued(sessionId);
 
   if (targetTasksArray.length === 0) {
     console.warn(
       `⚠️  [Stop] No active tasks for session ${shortId(sessionId)}, resetting to IDLE${options.reason ? ` (reason: ${options.reason})` : ''}`
     );
-    await markStoppedSessionPromptableNoDrain(deps.sessionsService, sessionId, params);
+    await deps.runInFreshTenantWriteDatabase(() =>
+      markStoppedSessionPromptableNoDrain(deps.sessionsService, sessionId, params)
+    );
     return {
       success: true,
+      outcome: 'stopped',
       status: SessionStatus.IDLE,
       reason: 'No active tasks found, session reset to idle',
       queuedTasksPreserved: queuedTasks.length,
@@ -134,17 +137,25 @@ export async function stopSessionPreserveQueue(
   if (termination.status !== 'terminal') {
     return {
       success: false,
+      outcome: termination.status,
+      ...(termination.status === 'pending' || termination.status === 'unverified'
+        ? { status: SessionStatus.STOPPING }
+        : {}),
       reason:
-        termination.task.error_message ??
-        termination.reason ??
-        'Task state changed before Stop could be completed.',
+        termination.status === 'pending'
+          ? (termination.reason ?? 'Stop was accepted and is awaiting HA coordination.')
+          : (termination.task.error_message ??
+            termination.reason ??
+            'Task state changed before Stop could be completed.'),
       stoppedTaskId: latestTask.task_id,
       queuedTasksPreserved: queuedTasks.length,
+      ...(termination.status === 'pending' ? { pendingCode: termination.pendingCode } : {}),
     };
   }
 
   return {
     success: true,
+    outcome: 'stopped',
     status: SessionStatus.IDLE,
     stoppedTaskId: latestTask.task_id,
     queuedTasksPreserved: queuedTasks.length,

--- a/apps/agor-daemon/src/utils/session-stop.ts
+++ b/apps/agor-daemon/src/utils/session-stop.ts
@@ -1,6 +1,6 @@
 import { shortId, type TaskRepository } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
-import type { Params, SessionID, SessionStopResult } from '@agor/core/types';
+import type { Params, SessionID, SessionStopResult, TaskID } from '@agor/core/types';
 import { isSessionExecuting, SessionStatus } from '@agor/core/types';
 import type { SessionsServiceImpl } from '../declarations.js';
 import {
@@ -68,7 +68,7 @@ export async function stopSessionPreserveQueue(
   deps: StopSessionDeps,
   sessionId: SessionID,
   params: Params = {},
-  options: { reason?: string } = {}
+  options: { reason?: string; expectedTaskId?: TaskID } = {}
 ): Promise<SessionStopResult> {
   const session = await deps.runInTenantDatabaseScope(() =>
     deps.sessionsService.get(sessionId, params)
@@ -118,6 +118,14 @@ export async function stopSessionPreserveQueue(
   }
 
   const latestTask = targetTasksArray[0];
+  if (options.expectedTaskId && latestTask.task_id !== options.expectedTaskId) {
+    return {
+      success: false,
+      outcome: 'condition_changed',
+      reason: 'Execution changed before Stop could be claimed. Review the current state and retry.',
+      queuedTasksPreserved: queuedTasks.length,
+    };
+  }
 
   console.log(
     `🛑 [Stop] Stopping task ${shortId(latestTask.task_id)} for session ${shortId(sessionId)}${options.reason ? ` (reason: ${options.reason})` : ''}`
@@ -134,22 +142,35 @@ export async function stopSessionPreserveQueue(
     params,
     runInFreshTenantWriteDatabase: deps.runInFreshTenantWriteDatabase,
   });
-  if (termination.status !== 'terminal') {
+  if (termination.status === 'pending') {
     return {
       success: false,
-      outcome: termination.status,
-      ...(termination.status === 'pending' || termination.status === 'unverified'
-        ? { status: SessionStatus.STOPPING }
-        : {}),
-      reason:
-        termination.status === 'pending'
-          ? (termination.reason ?? 'Stop was accepted and is awaiting HA coordination.')
-          : (termination.task.error_message ??
-            termination.reason ??
-            'Task state changed before Stop could be completed.'),
+      outcome: 'pending',
+      status: SessionStatus.STOPPING,
+      reason: termination.reason,
       stoppedTaskId: latestTask.task_id,
       queuedTasksPreserved: queuedTasks.length,
-      ...(termination.status === 'pending' ? { pendingCode: termination.pendingCode } : {}),
+      pendingCode: termination.pendingCode,
+    };
+  }
+  if (termination.status === 'unverified') {
+    return {
+      success: false,
+      outcome: 'unverified',
+      status: SessionStatus.STOPPING,
+      reason: termination.task.error_message ?? termination.reason,
+      stoppedTaskId: latestTask.task_id,
+      queuedTasksPreserved: queuedTasks.length,
+    };
+  }
+  if (termination.status === 'condition_changed') {
+    return {
+      success: false,
+      outcome: 'condition_changed',
+      reason:
+        termination.task.error_message ?? 'Task state changed before Stop could be completed.',
+      stoppedTaskId: latestTask.task_id,
+      queuedTasksPreserved: queuedTasks.length,
     };
   }
 

--- a/apps/agor-daemon/src/utils/session-stop.ts
+++ b/apps/agor-daemon/src/utils/session-stop.ts
@@ -1,7 +1,7 @@
 import { shortId, type TaskRepository } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import type { Params, SessionID, SessionStopResult, TaskID } from '@agor/core/types';
-import { isSessionExecuting, SessionStatus } from '@agor/core/types';
+import { isSessionExecuting, isTerminalTaskStatus, SessionStatus } from '@agor/core/types';
 import type { SessionsServiceImpl } from '../declarations.js';
 import {
   requestExecutorTermination,
@@ -154,6 +154,15 @@ export async function stopSessionPreserveQueue(
     };
   }
   if (termination.status === 'unverified') {
+    if (isTerminalTaskStatus(termination.task.status)) {
+      return {
+        success: false,
+        outcome: 'condition_changed',
+        reason: termination.reason,
+        stoppedTaskId: latestTask.task_id,
+        queuedTasksPreserved: queuedTasks.length,
+      };
+    }
     return {
       success: false,
       outcome: 'unverified',

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
@@ -131,6 +131,14 @@ describe('SessionFooter', () => {
     expect(screen.getByRole('button', { name: /stop/i })).toBeInTheDocument();
   });
 
+  it('disables Stop while the daemon connection is unavailable', () => {
+    const { container } = render(
+      <SessionFooter {...baseProps} isRunning={true} connectionDisabled={true} />,
+      { wrapper: Wrapper }
+    );
+    expect(container.querySelector('button.ant-btn-dangerous')).toBeDisabled();
+  });
+
   it('shows stopping feedback immediately while the Stop request is in flight', () => {
     const { container } = render(
       <SessionFooter {...baseProps} isRunning={true} stopRequestInFlight={true} />,

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
@@ -1302,11 +1302,13 @@ const SessionFooterInner: React.FC<SessionFooterProps> = ({
     </fieldset>
   );
 
-  const stopTooltip = stopRequestInFlight
-    ? 'Stopping...'
-    : isStopping
-      ? 'Stopping... (Click again to retry if stuck)'
-      : 'Stop Execution';
+  const stopTooltip = connectionDisabled
+    ? 'Disconnected from daemon'
+    : stopRequestInFlight
+      ? 'Stopping...'
+      : isStopping
+        ? 'Stopping... (Click again to retry if stuck)'
+        : 'Stop Execution';
 
   const showStop = isRunning || stopRequestInFlight;
 
@@ -1717,7 +1719,7 @@ const SessionFooterInner: React.FC<SessionFooterProps> = ({
                     stopRequestInFlight || isStopping ? <Spin size="small" /> : <StopOutlined />
                   }
                   onClick={onStop}
-                  disabled={!isRunning || stopRequestInFlight}
+                  disabled={connectionDisabled || !isRunning || stopRequestInFlight}
                 >
                   Stop
                 </Button>

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.test.tsx
@@ -106,6 +106,16 @@ const branch = {
   archived: false,
 } as unknown as Branch;
 
+function stopIo() {
+  const socket = {
+    connected: true,
+    timeout: vi.fn(() => socket),
+    once: vi.fn(),
+    off: vi.fn(),
+  };
+  return socket;
+}
+
 function renderPanel({
   onOpenTerminal = vi.fn(),
   onChooseAgenticTool,
@@ -296,12 +306,14 @@ describe('SessionPanel historical runtime handling and terminal actions', () => 
         status: 'running',
       } as Task,
     ];
-    const create = vi.fn().mockRejectedValue(new Error('database scope missing'));
+    const create = vi
+      .fn()
+      .mockRejectedValue(Object.assign(new Error('database scope missing'), { code: 500 }));
     const get = vi.fn().mockRejectedValue(new Error('task read unavailable'));
     vi.spyOn(console, 'error').mockImplementation(() => undefined);
     renderPanel({
       client: {
-        io: { connected: true },
+        io: stopIo(),
         service: (path: string) =>
           path === 'tasks'
             ? ({ get, on: vi.fn(), off: vi.fn() } as never)
@@ -317,7 +329,12 @@ describe('SessionPanel historical runtime handling and terminal actions', () => 
 
     fireEvent.click(await screen.findByRole('button', { name: /stop/i }));
 
-    await waitFor(() => expect(create).toHaveBeenCalledWith({}));
+    await waitFor(() =>
+      expect(create).toHaveBeenCalledWith({
+        expected_task_id: '018f0000-0000-7000-8000-000000000010',
+      })
+    );
+    expect(get).not.toHaveBeenCalled();
     expect(await screen.findByText('Failed to stop execution. You can try again.')).toBeVisible();
   });
 
@@ -343,7 +360,7 @@ describe('SessionPanel historical runtime handling and terminal actions', () => 
     vi.spyOn(console, 'error').mockImplementation(() => undefined);
     renderPanel({
       client: {
-        io: { connected: true },
+        io: stopIo(),
         service: (path: string) =>
           path === 'tasks'
             ? ({ get, on: vi.fn(), off: vi.fn() } as never)
@@ -358,6 +375,7 @@ describe('SessionPanel historical runtime handling and terminal actions', () => 
       await screen.findByText('Stop was accepted; waiting for executor termination.')
     ).toBeVisible();
     expect(create).toHaveBeenCalledOnce();
+    expect(create).toHaveBeenCalledWith({ expected_task_id: taskId });
     expect(get).toHaveBeenCalledWith(taskId);
     expect(
       screen.queryByText('Failed to stop execution. You can try again.')
@@ -378,6 +396,7 @@ describe('SessionPanel historical runtime handling and terminal actions', () => 
     });
     renderPanel({
       client: {
+        io: stopIo(),
         service: () => ({
           create,
           find: vi.fn().mockResolvedValue({ data: [] }),

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.test.tsx
@@ -297,15 +297,20 @@ describe('SessionPanel historical runtime handling and terminal actions', () => 
       } as Task,
     ];
     const create = vi.fn().mockRejectedValue(new Error('database scope missing'));
+    const get = vi.fn().mockRejectedValue(new Error('task read unavailable'));
     vi.spyOn(console, 'error').mockImplementation(() => undefined);
     renderPanel({
       client: {
-        service: () => ({
-          create,
-          find: vi.fn().mockResolvedValue({ data: [] }),
-          on: vi.fn(),
-          off: vi.fn(),
-        }),
+        io: { connected: true },
+        service: (path: string) =>
+          path === 'tasks'
+            ? ({ get, on: vi.fn(), off: vi.fn() } as never)
+            : ({
+                create,
+                find: vi.fn().mockResolvedValue({ data: [] }),
+                on: vi.fn(),
+                off: vi.fn(),
+              } as never),
       } as unknown as AgorClient,
       activeSession: { ...session, status: 'running', agentic_tool: 'codex' },
     });
@@ -314,6 +319,49 @@ describe('SessionPanel historical runtime handling and terminal actions', () => 
 
     await waitFor(() => expect(create).toHaveBeenCalledWith({}));
     expect(await screen.findByText('Failed to stop execution. You can try again.')).toBeVisible();
+  });
+
+  it('reconciles a committed Stop when the Socket.IO acknowledgement is lost without retrying', async () => {
+    const taskId = '018f0000-0000-7000-8000-000000000012';
+    reactive.tasks = [
+      {
+        task_id: taskId,
+        session_id: session.session_id,
+        status: 'running',
+      } as Task,
+    ];
+    const create = vi.fn().mockRejectedValue(new Error('socket disconnected before ack'));
+    const get = vi.fn().mockResolvedValue({
+      task_id: taskId,
+      session_id: session.session_id,
+      status: 'stopping',
+      termination_request: {
+        cause: 'user_stop',
+        requested_at: '2026-08-29T00:00:00.000Z',
+      },
+    } as Task);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    renderPanel({
+      client: {
+        io: { connected: true },
+        service: (path: string) =>
+          path === 'tasks'
+            ? ({ get, on: vi.fn(), off: vi.fn() } as never)
+            : ({ create, on: vi.fn(), off: vi.fn() } as never),
+      } as unknown as AgorClient,
+      activeSession: { ...session, status: 'running', agentic_tool: 'codex' },
+    });
+
+    fireEvent.click(await screen.findByRole('button', { name: /stop/i }));
+
+    expect(
+      await screen.findByText('Stop was accepted; waiting for executor termination.')
+    ).toBeVisible();
+    expect(create).toHaveBeenCalledOnce();
+    expect(get).toHaveBeenCalledWith(taskId);
+    expect(
+      screen.queryByText('Failed to stop execution. You can try again.')
+    ).not.toBeInTheDocument();
   });
 
   it('distinguishes accepted-but-pending Stop from an initial request failure', async () => {

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -9,6 +9,7 @@ import type {
   PermissionMode,
   Session,
   SessionID,
+  SessionStopResult,
   SpawnConfig,
   Task,
   User,
@@ -100,6 +101,7 @@ import { SessionAttachmentTray } from './SessionAttachmentTray';
 import { SessionComposerDropZone } from './SessionComposerDropZone';
 import { SessionFooter } from './SessionFooter';
 import { SessionPanelContent } from './SessionPanelContent';
+import { reconcileStopTransportFailure } from './stopReconciliation';
 import { useComposerAttachments } from './useComposerAttachments';
 
 // Re-export PermissionMode from SDK for convenience
@@ -609,6 +611,8 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   const [advancedUploadInitialFiles, setAdvancedUploadInitialFiles] = React.useState<File[]>([]);
   const [composerDropActive, setComposerDropActive] = React.useState(false);
   const [stopRequestInFlight, setStopRequestInFlight] = React.useState(false);
+  const currentClientRef = React.useRef(client);
+  currentClientRef.current = client;
   const [forceFailTarget, setForceFailTarget] = React.useState<{
     taskId: string;
     terminationRequestedAt: string;
@@ -1305,7 +1309,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   };
 
   const handleStop = async () => {
-    if (!session || !client || stopRequestInFlight) return;
+    if (!session || !client || connectionDisabled || stopRequestInFlight) return;
 
     const unverifiedTask = [...tasks]
       .reverse()
@@ -1328,17 +1332,38 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     }
 
     setStopRequestInFlight(true);
+    const stopSessionId = session.session_id;
+    const stopTarget = [...tasks]
+      .reverse()
+      .find(
+        (task) =>
+          task.status === TaskStatus.DISPATCHING ||
+          task.status === TaskStatus.RUNNING ||
+          task.status === TaskStatus.STOPPING ||
+          task.status === TaskStatus.AWAITING_PERMISSION ||
+          task.status === TaskStatus.AWAITING_INPUT
+      );
     try {
-      const result = (await client.service(`sessions/${session.session_id}/stop`).create({})) as {
-        success?: boolean;
-        reason?: string;
-      };
+      const result = (await client
+        .service(`sessions/${stopSessionId}/stop`)
+        .create({})) as SessionStopResult;
       if (result.success === false) {
         showInfo(result.reason ?? 'Stop requested; waiting for executor termination.');
       }
     } catch (error) {
       console.error('Failed to stop execution:', error);
-      showError('Failed to stop execution. You can try again.');
+      const reconciliation = stopTarget
+        ? await reconcileStopTransportFailure(
+            () => currentClientRef.current,
+            stopSessionId,
+            stopTarget.task_id
+          )
+        : { outcome: 'unresolved' as const };
+      if (reconciliation.outcome === 'accepted' || reconciliation.outcome === 'ended') {
+        showInfo(reconciliation.reason);
+      } else {
+        showError('Failed to stop execution. You can try again.');
+      }
     } finally {
       setStopRequestInFlight(false);
     }

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -101,7 +101,11 @@ import { SessionAttachmentTray } from './SessionAttachmentTray';
 import { SessionComposerDropZone } from './SessionComposerDropZone';
 import { SessionFooter } from './SessionFooter';
 import { SessionPanelContent } from './SessionPanelContent';
-import { reconcileStopTransportFailure } from './stopReconciliation';
+import {
+  isStopTransportAmbiguous,
+  reconcileStopTransportFailure,
+  requestSessionStop,
+} from './stopReconciliation';
 import { useComposerAttachments } from './useComposerAttachments';
 
 // Re-export PermissionMode from SDK for convenience
@@ -1331,7 +1335,6 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
       showInfo('Retrying stop request...');
     }
 
-    setStopRequestInFlight(true);
     const stopSessionId = session.session_id;
     const stopTarget = [...tasks]
       .reverse()
@@ -1343,16 +1346,24 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
           task.status === TaskStatus.AWAITING_PERMISSION ||
           task.status === TaskStatus.AWAITING_INPUT
       );
+    if (!stopTarget) {
+      showError('Execution state is still syncing. Try again.');
+      return;
+    }
+
+    setStopRequestInFlight(true);
     try {
-      const result = (await client
-        .service(`sessions/${stopSessionId}/stop`)
-        .create({})) as SessionStopResult;
+      const result: SessionStopResult = await requestSessionStop(
+        client,
+        stopSessionId,
+        stopTarget.task_id
+      );
       if (result.success === false) {
         showInfo(result.reason ?? 'Stop requested; waiting for executor termination.');
       }
     } catch (error) {
       console.error('Failed to stop execution:', error);
-      const reconciliation = stopTarget
+      const reconciliation = isStopTransportAmbiguous(error)
         ? await reconcileStopTransportFailure(
             () => currentClientRef.current,
             stopSessionId,

--- a/apps/agor-ui/src/components/SessionPanel/stopReconciliation.test.ts
+++ b/apps/agor-ui/src/components/SessionPanel/stopReconciliation.test.ts
@@ -1,0 +1,77 @@
+import type { AgorClient, Task } from '@agor-live/client';
+import { describe, expect, it, vi } from 'vitest';
+import { reconcileStopTransportFailure } from './stopReconciliation';
+
+const sessionId = '018f0000-0000-7000-8000-000000000001' as never;
+const taskId = '018f0000-0000-7000-8000-000000000002' as never;
+
+function clientWithTask(task: Task, connected = true) {
+  const get = vi.fn().mockResolvedValue(task);
+  const client = {
+    io: { connected },
+    service: () => ({ get }),
+  } as unknown as AgorClient;
+  return { client, get };
+}
+
+describe('reconcileStopTransportFailure', () => {
+  it('recognizes a durably accepted Stop after its Socket.IO acknowledgement is lost', async () => {
+    const { client, get } = clientWithTask({
+      task_id: taskId,
+      session_id: sessionId,
+      status: 'stopping',
+      termination_request: {
+        cause: 'user_stop',
+        requested_at: '2026-08-29T00:00:00.000Z',
+      },
+    } as Task);
+
+    await expect(
+      reconcileStopTransportFailure(() => client, sessionId, taskId, 50)
+    ).resolves.toEqual({
+      outcome: 'accepted',
+      reason: 'Stop was accepted; waiting for executor termination.',
+    });
+    expect(get).toHaveBeenCalledWith(taskId);
+  });
+
+  it('reconciles through the replacement client after a token reconnect', async () => {
+    let current = {
+      io: { connected: false },
+      service: vi.fn(),
+    } as unknown as AgorClient;
+    const replacement = clientWithTask({
+      task_id: taskId,
+      session_id: sessionId,
+      status: 'stopped',
+      termination_request: {
+        cause: 'user_stop',
+        requested_at: '2026-08-29T00:00:00.000Z',
+      },
+    } as Task);
+    setTimeout(() => {
+      current = replacement.client;
+    }, 10);
+
+    await expect(
+      reconcileStopTransportFailure(() => current, sessionId, taskId, 200)
+    ).resolves.toEqual({ outcome: 'accepted', reason: 'Stop completed.' });
+    expect(replacement.get).toHaveBeenCalledOnce();
+  });
+
+  it('does not treat another session task as proof that Stop committed', async () => {
+    const { client } = clientWithTask({
+      task_id: taskId,
+      session_id: 'another-session',
+      status: 'stopping',
+      termination_request: {
+        cause: 'user_stop',
+        requested_at: '2026-08-29T00:00:00.000Z',
+      },
+    } as Task);
+
+    await expect(
+      reconcileStopTransportFailure(() => client, sessionId, taskId, 50)
+    ).resolves.toEqual({ outcome: 'unresolved' });
+  });
+});

--- a/apps/agor-ui/src/components/SessionPanel/stopReconciliation.test.ts
+++ b/apps/agor-ui/src/components/SessionPanel/stopReconciliation.test.ts
@@ -1,6 +1,11 @@
+import { EventEmitter } from 'node:events';
 import type { AgorClient, Task } from '@agor-live/client';
 import { describe, expect, it, vi } from 'vitest';
-import { reconcileStopTransportFailure } from './stopReconciliation';
+import {
+  isStopTransportAmbiguous,
+  reconcileStopTransportFailure,
+  requestSessionStop,
+} from './stopReconciliation';
 
 const sessionId = '018f0000-0000-7000-8000-000000000001' as never;
 const taskId = '018f0000-0000-7000-8000-000000000002' as never;
@@ -73,5 +78,46 @@ describe('reconcileStopTransportFailure', () => {
     await expect(
       reconcileStopTransportFailure(() => client, sessionId, taskId, 50)
     ).resolves.toEqual({ outcome: 'unresolved' });
+  });
+});
+
+describe('requestSessionStop', () => {
+  function stopClient(create: ReturnType<typeof vi.fn>) {
+    const socket = Object.assign(new EventEmitter(), {
+      connected: true,
+      timeout: vi.fn(),
+    });
+    socket.timeout.mockReturnValue(socket);
+    const client = {
+      io: socket,
+      service: () => ({ create }),
+    } as unknown as AgorClient;
+    return { client, socket };
+  }
+
+  it('rejects a sent Stop as transport-ambiguous when Socket.IO disconnects before ack', async () => {
+    const create = vi.fn(() => new Promise(() => undefined));
+    const { client, socket } = stopClient(create);
+
+    const request = requestSessionStop(client, sessionId, taskId, 100);
+    socket.emit('disconnect', 'transport close');
+
+    const error = await request.catch((caught) => caught);
+    expect(isStopTransportAmbiguous(error)).toBe(true);
+    expect(create).toHaveBeenCalledOnce();
+    expect(create).toHaveBeenCalledWith({ expected_task_id: taskId });
+    expect(socket.timeout).toHaveBeenCalledWith(100);
+  });
+
+  it('does not classify a definite Feathers error response as transport-ambiguous', async () => {
+    const responseError = Object.assign(new Error('Forbidden'), { code: 403 });
+    const create = vi.fn().mockRejectedValue(responseError);
+    const { client } = stopClient(create);
+
+    const error = await requestSessionStop(client, sessionId, taskId, 100).catch(
+      (caught) => caught
+    );
+    expect(error).toBe(responseError);
+    expect(isStopTransportAmbiguous(error)).toBe(false);
   });
 });

--- a/apps/agor-ui/src/components/SessionPanel/stopReconciliation.ts
+++ b/apps/agor-ui/src/components/SessionPanel/stopReconciliation.ts
@@ -1,4 +1,11 @@
-import type { AgorClient, SessionID, SessionStopResult, Task, TaskID } from '@agor-live/client';
+import type {
+  AgorClient,
+  SessionID,
+  SessionStopRequest,
+  SessionStopResult,
+  Task,
+  TaskID,
+} from '@agor-live/client';
 import { isTerminalTaskStatus, TaskStatus } from '@agor-live/client';
 
 export type StopTransportReconciliation =
@@ -73,9 +80,10 @@ export function requestSessionStop(
       // error-aware acknowledgement callback. This also lets Socket.IO retire
       // the callback if the server never acknowledges.
       socket.timeout(timeoutMs);
+      const request: SessionStopRequest = { expected_task_id: expectedTaskId };
       void client
         .service(`sessions/${sessionId}/stop`)
-        .create({ expected_task_id: expectedTaskId })
+        .create(request)
         .then(
           (result) => finish(() => resolve(result as SessionStopResult)),
           (error) => {

--- a/apps/agor-ui/src/components/SessionPanel/stopReconciliation.ts
+++ b/apps/agor-ui/src/components/SessionPanel/stopReconciliation.ts
@@ -1,0 +1,65 @@
+import type { AgorClient, SessionID, Task, TaskID } from '@agor-live/client';
+import { isTerminalTaskStatus, TaskStatus } from '@agor-live/client';
+
+export type StopTransportReconciliation =
+  | { outcome: 'accepted'; reason: string }
+  | { outcome: 'ended'; reason: string }
+  | { outcome: 'unresolved' };
+
+const RECONNECT_POLL_MS = 25;
+
+async function waitForConnectedClient(
+  getClient: () => AgorClient | null,
+  timeoutMs: number
+): Promise<AgorClient | null> {
+  const deadline = Date.now() + timeoutMs;
+  do {
+    const client = getClient();
+    if (client?.io.connected) return client;
+    await new Promise<void>((resolve) => setTimeout(resolve, RECONNECT_POLL_MS));
+  } while (Date.now() < deadline);
+  return null;
+}
+
+/**
+ * A Socket.IO acknowledgement can be lost after the Stop claim commits. Never
+ * retry the mutation from this path: reconnect and reconcile the exact durable
+ * task generation instead, so one click cannot create duplicate side effects.
+ */
+export async function reconcileStopTransportFailure(
+  getClient: () => AgorClient | null,
+  sessionId: SessionID,
+  taskId: TaskID,
+  reconnectTimeoutMs = 2_000
+): Promise<StopTransportReconciliation> {
+  const client = await waitForConnectedClient(getClient, reconnectTimeoutMs);
+  if (!client) return { outcome: 'unresolved' };
+
+  try {
+    const task = (await client.service('tasks').get(taskId)) as Task;
+    if (task.task_id !== taskId || task.session_id !== sessionId) {
+      return { outcome: 'unresolved' };
+    }
+
+    if (task.termination_request?.cause === 'user_stop') {
+      if (task.status === TaskStatus.STOPPING) {
+        return {
+          outcome: 'accepted',
+          reason: 'Stop was accepted; waiting for executor termination.',
+        };
+      }
+      if (isTerminalTaskStatus(task.status)) {
+        return { outcome: 'accepted', reason: 'Stop completed.' };
+      }
+    }
+
+    if (isTerminalTaskStatus(task.status)) {
+      return { outcome: 'ended', reason: 'Execution already ended.' };
+    }
+  } catch {
+    // The durable read may still fail after reconnect (for example an
+    // authority change or tenant-safe NotFound). Preserve the original
+    // retryable error without weakening authorization or guessing success.
+  }
+  return { outcome: 'unresolved' };
+}

--- a/apps/agor-ui/src/components/SessionPanel/stopReconciliation.ts
+++ b/apps/agor-ui/src/components/SessionPanel/stopReconciliation.ts
@@ -1,4 +1,4 @@
-import type { AgorClient, SessionID, Task, TaskID } from '@agor-live/client';
+import type { AgorClient, SessionID, SessionStopResult, Task, TaskID } from '@agor-live/client';
 import { isTerminalTaskStatus, TaskStatus } from '@agor-live/client';
 
 export type StopTransportReconciliation =
@@ -7,6 +7,90 @@ export type StopTransportReconciliation =
   | { outcome: 'unresolved' };
 
 const RECONNECT_POLL_MS = 25;
+export const STOP_ACK_TIMEOUT_MS = 20_000;
+
+export class StopTransportAmbiguousError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'StopTransportAmbiguousError';
+  }
+}
+
+export function isStopTransportAmbiguous(error: unknown): boolean {
+  return error instanceof StopTransportAmbiguousError;
+}
+
+function hasFeathersResponseCode(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    typeof (error as { code?: unknown }).code === 'number'
+  );
+}
+
+/**
+ * Stop may wait for cooperative executor quiescence, so the browser cannot use
+ * a short global Socket.IO acknowledgement timeout. Bound this one mutation,
+ * and fail early on disconnect, so a lost acknowledgement reaches durable
+ * reconciliation instead of leaving the footer permanently in-flight.
+ */
+export function requestSessionStop(
+  client: AgorClient,
+  sessionId: SessionID,
+  expectedTaskId: TaskID,
+  timeoutMs = STOP_ACK_TIMEOUT_MS
+): Promise<SessionStopResult> {
+  const socket = client.io;
+  if (!socket.connected) {
+    return Promise.reject(new StopTransportAmbiguousError('Socket disconnected before Stop.'));
+  }
+
+  return new Promise<SessionStopResult>((resolve, reject) => {
+    let settled = false;
+    const finish = (work: () => void) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      socket.off('disconnect', onDisconnect);
+      work();
+    };
+    const rejectTransport = (message: string, cause?: unknown) =>
+      finish(() =>
+        reject(
+          new StopTransportAmbiguousError(message, cause === undefined ? undefined : { cause })
+        )
+      );
+    const onDisconnect = () =>
+      rejectTransport('Socket disconnected before the Stop acknowledgement.');
+    const timeout = setTimeout(
+      () => rejectTransport('Timed out waiting for the Stop acknowledgement.'),
+      timeoutMs
+    );
+
+    socket.once('disconnect', onDisconnect);
+    try {
+      // Feathers detects the Socket.IO timeout flag and installs the
+      // error-aware acknowledgement callback. This also lets Socket.IO retire
+      // the callback if the server never acknowledges.
+      socket.timeout(timeoutMs);
+      void client
+        .service(`sessions/${sessionId}/stop`)
+        .create({ expected_task_id: expectedTaskId })
+        .then(
+          (result) => finish(() => resolve(result as SessionStopResult)),
+          (error) => {
+            if (hasFeathersResponseCode(error)) {
+              finish(() => reject(error));
+            } else {
+              rejectTransport('The Stop acknowledgement was not received.', error);
+            }
+          }
+        );
+    } catch (error) {
+      rejectTransport('The Stop request could not be sent.', error);
+    }
+  });
+}
 
 async function waitForConnectedClient(
   getClient: () => AgorClient | null,

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -35,6 +35,38 @@ export const SessionStatus = {
 
 export type SessionStatus = (typeof SessionStatus)[keyof typeof SessionStatus];
 
+/** Durable outcome reported by the authenticated Session Stop endpoint. */
+export const SESSION_STOP_OUTCOMES = [
+  'stopped',
+  'already_idle',
+  'pending',
+  'unverified',
+  'condition_changed',
+  'not_stoppable',
+] as const;
+
+export type SessionStopOutcome = (typeof SESSION_STOP_OUTCOMES)[number];
+
+/** Why an accepted Stop is waiting for a different HA coordination step. */
+export const SESSION_STOP_PENDING_CODES = [
+  'non_owner_replica',
+  'coordination_in_progress',
+] as const;
+
+export type SessionStopPendingCode = (typeof SESSION_STOP_PENDING_CODES)[number];
+
+export interface SessionStopResult {
+  /** True only when the requested idle postcondition is already durable. */
+  success: boolean;
+  /** Machine-readable result; pending means the Stop claim was durably accepted. */
+  outcome: SessionStopOutcome;
+  status?: SessionStatus;
+  reason?: string;
+  stoppedTaskId?: string;
+  queuedTasksPreserved?: number;
+  pendingCode?: SessionStopPendingCode;
+}
+
 /**
  * Permission mode controls how agentic tools handle execution approvals
  *

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -49,6 +49,25 @@ export const SESSION_STOP_OUTCOMES = [
 
 export type SessionStopOutcome = (typeof SESSION_STOP_OUTCOMES)[number];
 
+/** Authenticated Session Stop endpoint request. */
+export type SessionStopRequest =
+  | {
+      force_unverified?: false;
+      reason?: string;
+      expected_task_id?: TaskID;
+      task_id?: never;
+      termination_requested_at?: never;
+      confirmation?: never;
+    }
+  | {
+      force_unverified: true;
+      task_id: TaskID;
+      termination_requested_at: string;
+      confirmation: string;
+      reason?: never;
+      expected_task_id?: never;
+    };
+
 interface SessionStopResultBase {
   reason?: string;
   stoppedTaskId?: TaskID;

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -21,6 +21,7 @@ import type { AgenticToolConfigurationReference } from './agentic-tool-preset';
 import type { ContextFilePath } from './context';
 import type { BoardID, BranchID, SessionID, SessionRelationshipID, TaskID, UserID } from './id';
 import type { ScheduleID } from './schedule';
+import type { TaskStatus, TerminationCoordinationPendingCode } from './task';
 
 export const SessionStatus = {
   IDLE: 'idle',
@@ -43,29 +44,53 @@ export const SESSION_STOP_OUTCOMES = [
   'unverified',
   'condition_changed',
   'not_stoppable',
+  'force_failed',
 ] as const;
 
 export type SessionStopOutcome = (typeof SESSION_STOP_OUTCOMES)[number];
 
-/** Why an accepted Stop is waiting for a different HA coordination step. */
-export const SESSION_STOP_PENDING_CODES = [
-  'non_owner_replica',
-  'coordination_in_progress',
-] as const;
-
-export type SessionStopPendingCode = (typeof SESSION_STOP_PENDING_CODES)[number];
-
-export interface SessionStopResult {
-  /** True only when the requested idle postcondition is already durable. */
-  success: boolean;
-  /** Machine-readable result; pending means the Stop claim was durably accepted. */
-  outcome: SessionStopOutcome;
-  status?: SessionStatus;
+interface SessionStopResultBase {
   reason?: string;
-  stoppedTaskId?: string;
+  stoppedTaskId?: TaskID;
   queuedTasksPreserved?: number;
-  pendingCode?: SessionStopPendingCode;
 }
+
+/** Result returned by the authenticated Session Stop endpoint. */
+export type SessionStopResult =
+  | (SessionStopResultBase & {
+      success: true;
+      outcome: 'stopped' | 'already_idle';
+      status: typeof SessionStatus.IDLE;
+    })
+  | (SessionStopResultBase & {
+      /** The Stop claim is durable; a different HA coordination step owns containment. */
+      success: false;
+      outcome: 'pending';
+      status: typeof SessionStatus.STOPPING;
+      reason: string;
+      stoppedTaskId: TaskID;
+      pendingCode: TerminationCoordinationPendingCode;
+    })
+  | (SessionStopResultBase & {
+      success: false;
+      outcome: 'unverified';
+      status: typeof SessionStatus.STOPPING;
+      reason: string;
+      stoppedTaskId: TaskID;
+    })
+  | (SessionStopResultBase & {
+      success: false;
+      outcome: 'condition_changed' | 'not_stoppable';
+      status?: SessionStatus;
+      reason: string;
+    })
+  | {
+      /** Explicit owner/admin recovery; does not prove executor containment. */
+      success: true;
+      outcome: 'force_failed';
+      status: typeof TaskStatus.FAILED;
+      stoppedTaskId: TaskID;
+    };
 
 /**
  * Permission mode controls how agentic tools handle execution approvals

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -85,6 +85,15 @@ export type TerminationCause =
   | 'heartbeat_lost'
   | 'sdk_health_failure';
 
+/** Why a durable termination request is waiting for another HA coordinator. */
+export const TERMINATION_COORDINATION_PENDING_CODES = [
+  'non_owner_replica',
+  'coordination_in_progress',
+] as const;
+
+export type TerminationCoordinationPendingCode =
+  (typeof TERMINATION_COORDINATION_PENDING_CODES)[number];
+
 /**
  * Expiring, database-fenced ownership of one containment attempt.
  *


### PR DESCRIPTION
## Summary

Fixes the HA Session Stop regression without weakening authorization, tenant isolation, or executor containment.

- keep every nested Stop authorization/read/idle-repair database operation inside an explicit tenant unit of work
- report accepted HA coordination as structured `pending` (`non_owner_replica` / `coordination_in_progress`) instead of conflating it with unverified executor containment
- bound the UI Stop mutation with a Stop-specific Socket.IO acknowledgement timeout/disconnect signal so a lost acknowledgement cannot leave the footer pending forever
- fence each Stop claim and ambiguous-outcome reconciliation to the exact durable Task generation; never retry the mutation automatically
- disable Stop while the UI connection is disabled

## Real HA reproduction before code changes

Environment: branch `ha` variant, two daemon replicas behind ingress, disposable dev-auth Acme user/repo/branch/session only.

### Cross-replica HTTP

Prompt sent directly to daemon A, Stop directly to daemon B:

- prompt: HTTP 201 in 178 ms; Task `01a04f9a-ea34-771c-a444-c61be654208a` was `dispatching`
- Stop: HTTP 500 in 56 ms:
  `Missing tenant database scope for daemon database access`
- immediate durable reconciliation: Session remained `running`, Task remained `dispatching`, and there was no `termination_request`

This proves the request was rejected before the durable Stop claim committed. The executor/coordinator path was never reached.

### UI-equivalent Socket.IO/Feathers path

A WebSocket client using the same Feathers service call as the UI reproduced the same failure on the owner replica:

```text
+23 ms   socket connected (websocket)
+99 ms   Task patched -> dispatching
+150 ms  prompt response HTTP 201
+183 ms  Stop error MissingTenantDatabaseScopeError
```

No Stop/coordinator log or durable termination claim appeared. Because this also failed on the executor-owner replica, non-owner routing, a lost acknowledgement, and executor containment were not the primary cause.

## Root cause

The long authenticated Stop route intentionally carries tenant identity without a route-wide transaction (the endpoint may wait for executor quiescence). Changes after #2326 introduced/strengthened short tenant database units and fail-closed database guards. #2469 scoped the route's first Session lookup and durable writes, but two later nested read paths remained outside a database unit:

1. `resolveSessionPromptAccess`, including its sharing/RBAC repository reads
2. `stopSessionPreserveQueue`'s nested Session and active-Task service reads (plus the no-active-task idle repair)

The first guarded access aborted the request before the Stop claim. During HA verification, fixing the lifecycle helper first exposed the second, earlier RBAC access; both are now scoped. This is consistent with the HA/realtime hardening in #2520 and #2542 making the latent scope omission deterministic rather than allowing ambient scope.

## Changes

### Daemon

- Scope Stop RBAC/prompt-authority resolution in a required current-tenant database unit.
- Inject a required tenant database runner into `stopSessionPreserveQueue` and scope nested reads; use a fresh tenant write unit for the idle repair.
- Preserve the existing durable claim, generation fencing, coordination lease, and process-local dedupe from #2326.
- Fence the server claim with the caller's `expected_task_id`; a successor generation returns `condition_changed` without any termination side effect.
- Model termination-coordination pending codes in the Task domain and expose canonical, discriminated `SessionStopRequest` / `SessionStopResult` contracts with branded Task IDs, including force-fail. The route validates `expected_task_id` as a canonical full UUID and its return type is compiler-enforced.
- Distinguish a force-fail that actually transitions the Task from a concurrent terminal settlement; only the winning transition emits the security audit log and `force_failed` response. Terminal/unverified settlement races return `condition_changed` rather than falsely asserting a stopping or forced-failed lifecycle.
- Return `outcome: pending` with a stable pending code when another replica owns the local process or a containment lease is already held. Genuine containment failures remain `unverified`.

### UI

- Treat structured pending responses as accepted/waiting information rather than a generic failure.
- Send the captured active Task as `expected_task_id`, apply a 20-second Stop-specific Socket.IO acknowledgement timeout, and classify disconnect/timeout/no-response failures as transport-ambiguous. Definite Feathers errors do not reconcile.
- On an ambiguous transport exception, wait for the current or replacement connected client and read the exact captured Task ID. A matching `user_stop` claim in `stopping`/terminal state is shown as accepted/completed.
- Do not automatically issue a second Stop, preventing duplicate side effects.
- Keep tenant-safe NotFound/authorization/read failures unresolved and show the existing retryable error.
- Disable Stop during `connectionDisabled`/token reconnect windows.

## Final HA validation

Final production-source HA rebuild completed and both replicas were healthy.

### Non-owner replica

Prompt on daemon A, Stop on daemon B:

```text
+440 ms  prompt HTTP 201, Task dispatching
+701 ms  Stop HTTP 201 (261 ms)
         success=false, outcome=pending, status=stopping
         pendingCode=non_owner_replica
+1943 ms durable reconciliation:
         Task stopped with cause=user_stop and executor_quiesced_at
         Session idle, ready_for_prompt=true
```

Daemon B logged the Stop; daemon A observed the durable request, aborted the provider, committed executor quiescence, and exited the executor. Neither daemon logged a missing tenant scope error.

### Final generation-fence rebuild (review follow-up)

After the review changes, the HA production-source image was rebuilt again. Prompting daemon A produced Task `01a04fdf-bd36-74f0-8fef-d248541beeb5`. On daemon B:

- Stop with a different `expected_task_id`: HTTP 201, `outcome=condition_changed`; no claim was created for the successor
- Stop with the exact Task ID: HTTP 201, `outcome=pending`, `pendingCode=non_owner_replica`
- durable read after 2 seconds: exact Task `stopped`, `termination_request.cause=user_stop`, `executor_quiesced_at` present

Daemon B logged `request_committed`; daemon A logged `executor_quiescence_committed` and `settled outcome=stopped`.

### Ambiguous response

With a deliberate 5-second Socket.IO acknowledgement timeout, an owner-replica Stop timed out after the durable claim while Task events already showed `stopping` with `cause=user_stop`. Reading the exact Task reconciled the accepted request. The disposable sandbox then produced a genuine `unverified` containment result, which remained fail-closed and was explicitly force-failed only for cleanup.

### Cross-tenant negative

A disposable Globex admin attempting to GET or Stop the Acme Session received tenant-safe 403 `Session not found` responses. The Acme Session remained `idle` and `ready_for_prompt=true` afterward.

## Validation

- `pnpm i` — lockfile unchanged; dependencies installed
- `pnpm check` — all typechecks, Biome/lint, short-ID, multitenancy, daemon-filesystem, realtime boundary checks, and builds passed
- `pnpm --filter @agor/daemon exec vitest run src/register-routes.stop-scope.test.ts src/utils/session-stop.test.ts src/termination-coordinator.test.ts --reporter=dot` — 37 passed
- `pnpm --filter agor-ui exec vitest run src/components/SessionPanel/stopReconciliation.test.ts src/components/SessionPanel/SessionPanel.test.tsx src/hooks/useAgorClient.test.tsx --reporter=dot` — 30 passed
- pre-commit lint-staged hook passed for both commits
- HA production-source build/package-artifact validation and live two-replica tests above

## Residual risks

- The Stop acknowledgement is bounded to 20 seconds (longer than the 15-second cooperative grace); post-failure UI reconciliation is intentionally bounded to 2 seconds and the exact active Task captured at click time. If reconnect/read takes longer, authorization changes, or that Task is unavailable, the UI retains the retryable error instead of guessing success.
- Remote/delegated executor containment and the existing force-fail contract are unchanged.
- This does not make a non-owner replica contain a local process; it exposes the durable pending state while the owning replica/executor observes the fenced Stop request.
