### PR TITLE
fix(rbac,codex): 0095 null-board branches + Codex credential home symlink walk

### DIFF
--- a/apps/agor-daemon/src/services/branches.test.ts
+++ b/apps/agor-daemon/src/services/branches.test.ts
@@ -701,6 +701,59 @@ describe('BranchesService environment start async behavior', () => {
     );
   });
 
+  it('forwards resolved sandbox mount inputs into the env-logs executor params', async () => {
+    const { service } = createServiceHarness();
+    const branch = {
+      branch_id: 'wt-sbx' as BranchID,
+      repo_id: 'repo-1',
+      name: 'wt-sbx',
+      path: '/tmp/wt-sbx',
+      created_by: 'user-1' as UUID,
+      primary_owner_user_id: 'owner-2' as UUID,
+      branch_unique_id: 2,
+      logs_command: 'tail -n 100 dev.log',
+    };
+
+    vi.spyOn(service as never, 'ensureCanTriggerEnv').mockResolvedValue(undefined as never);
+    vi.spyOn(service, 'get').mockResolvedValue(branch as never);
+    vi.spyOn(service as never, 'resolveEnvironmentCommand').mockResolvedValue({
+      kind: 'shell',
+      command: branch.logs_command,
+    } as never);
+    // Under the fail-closed per_user sandbox this context resolves an owner
+    // home store; the executor payload MUST carry it or buildSandboxWrap
+    // refuses to spawn (the ENOTDIR-adjacent "no owner home store" failure).
+    vi.spyOn(service as never, 'resolveEnvironmentExecutorContext').mockResolvedValue({
+      env: { PATH: '/usr/bin:/bin' },
+      delegatedHomeKey: undefined,
+      executionUserId: 'owner-2',
+      branchFsAccess: 'write',
+      sandboxMounts: {
+        sandboxHomeStore: '/data/homes/owner-2',
+        sandboxWorktreesRoot: '/data/worktrees',
+        sandboxBaseRepoPath: undefined,
+      },
+    } as never);
+    mockedRequestExecutor.mockResolvedValue({
+      success: true,
+      data: { logs: 'ok', timestamp: '2026-06-19T00:00:00.000Z' },
+    });
+
+    await service.getLogs(branch.branch_id);
+
+    expect(mockedRequestExecutor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: 'environment.logs',
+        params: expect.objectContaining({
+          sandboxHomeStore: '/data/homes/owner-2',
+          sandboxWorktreesRoot: '/data/worktrees',
+          logsCommand: branch.logs_command,
+        }),
+      }),
+      expect.anything()
+    );
+  });
+
   it('resolves lifecycle credentials for the authenticated actor, not the branch creator', async () => {
     const { service } = createServiceHarness();
     const app = (service as unknown as { app: Application }).app as unknown as {

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -30,11 +30,13 @@ import {
   generateId,
   getCurrentTenantId,
   KnowledgeNamespaceRepository,
+  RepoRepository,
   runWithTenantDatabaseScope,
   runWithTenantDatabaseTransaction,
   TaskRepository,
   type TenantScopeAwareDatabase,
   type TenantScopedDatabase,
+  UsersRepository,
 } from '@agor/core/db';
 import { renderBranchSnapshot } from '@agor/core/environment/render-snapshot';
 import {
@@ -90,6 +92,7 @@ import { shouldUseCloneReferencePath } from '../utils/clone-reference.js';
 import { emitServiceEvent } from '../utils/emit-service-event.js';
 import { resolveDelegatedExecutionHomeKey } from '../utils/executor-delegated-home.js';
 import { parseLastMessageTruncationLength } from '../utils/query-params.js';
+import { resolveOwnerHomeStore, resolveSandboxStoragePaths } from '../utils/sandbox-context.js';
 import { getDaemonUrl, requestExecutor, spawnExecutor } from '../utils/spawn-executor.js';
 import { deferWithTenantContext } from '../utils/tenant-db-scope.js';
 import { isKnowledgeAdmin } from './knowledge-access.js';
@@ -457,6 +460,16 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     env: Record<string, string>;
     executionUserId: UserID;
     branchFsAccess: Exclude<BranchFsAccessLevel, 'none'>;
+    // Authoritative sandbox mount inputs for the environment executor, mirroring
+    // the session path (register-services). Empty when the fail-closed
+    // filesystem sandbox or its per_user home overlay is off. Without these,
+    // buildSandboxWrap resolves no owner home store and refuses to spawn under
+    // `home_mode: per_user` — which is what broke env logs/start/stop/nuke.
+    sandboxMounts: {
+      sandboxHomeStore?: string;
+      sandboxWorktreesRoot?: string;
+      sandboxBaseRepoPath?: string;
+    };
   }> {
     const config = this.app.get('config');
     return this.withTenantDatabase(params, async () => {
@@ -485,8 +498,42 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
         config
       );
 
+      // Resolve the per-owner home store (and worktree / base-repo mounts) the
+      // sandbox needs, keyed to the environment's execution user — the same
+      // resolution the session executor path performs. Only the fail-closed
+      // sandbox with a per_user home requires it; otherwise leave it empty.
+      const sandboxCfg = config.execution?.sandbox;
+      const sandboxMounts: {
+        sandboxHomeStore?: string;
+        sandboxWorktreesRoot?: string;
+        sandboxBaseRepoPath?: string;
+      } = {};
+      if (sandboxCfg?.enabled === true && sandboxCfg?.home_mode === 'per_user') {
+        const tenantId = params?.tenant?.tenant_id ?? getCurrentTenantId();
+        const filesystemHome =
+          (
+            await new UsersRepository(this.db).findById(executionUserId as string)
+          )?.filesystem_home?.trim() || undefined;
+        sandboxMounts.sandboxHomeStore = resolveOwnerHomeStore({
+          config,
+          tenantId,
+          ownerUserId: executionUserId,
+          filesystemHome,
+        });
+        sandboxMounts.sandboxWorktreesRoot = resolveSandboxStoragePaths(
+          config,
+          tenantId
+        ).worktreesRoot;
+        // Only linked worktrees need the shared git dir mounted; a clone-mode
+        // branch carries its own `.git` (mirrors the session executor path).
+        if (branch.storage_mode !== 'clone' && branch.repo_id) {
+          const repo = await new RepoRepository(this.db).findById(branch.repo_id);
+          sandboxMounts.sandboxBaseRepoPath = repo?.local_path ?? undefined;
+        }
+      }
+
       const env = await createUserProcessEnvironment(executionUserId, this.db);
-      return { delegatedHomeKey, env, executionUserId, branchFsAccess };
+      return { delegatedHomeKey, env, executionUserId, branchFsAccess, sandboxMounts };
     });
   }
 
@@ -502,7 +549,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     branchFsAccess: Exclude<BranchFsAccessLevel, 'none'>;
   }> {
     const { branch, action, params } = options;
-    const { delegatedHomeKey, env, executionUserId, branchFsAccess } =
+    const { delegatedHomeKey, env, executionUserId, branchFsAccess, sandboxMounts } =
       await this.resolveEnvironmentExecutorContext(branch, options.params);
     const sessionToken = await this.withTenantDatabase(params, () =>
       issueExecutorCommandToken(
@@ -526,6 +573,8 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
           branchPath: branch.path,
           cwd: branch.path,
           principalBranchAccess: branchFsAccess,
+          // Sandbox mount inputs consumed by spawn-executor → buildSandboxWrap.
+          ...sandboxMounts,
           action,
           startCommand: branch.start_command,
           stopCommand: branch.stop_command,
@@ -626,7 +675,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     logsCommand: string,
     params?: BranchParams
   ): Promise<{ stdout: string; stderr: string; truncated: boolean }> {
-    const { delegatedHomeKey, env, executionUserId, branchFsAccess } =
+    const { delegatedHomeKey, env, executionUserId, branchFsAccess, sandboxMounts } =
       await this.resolveEnvironmentExecutorContext(branch, params, 'read');
     const sessionToken = await this.withTenantDatabase(params, () =>
       issueExecutorCommandToken(this.app, 'environment-logs', executionUserId, branch.branch_id)
@@ -642,6 +691,8 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
           branchPath: branch.path,
           cwd: branch.path,
           principalBranchAccess: branchFsAccess,
+          // Sandbox mount inputs consumed by spawn-executor → buildSandboxWrap.
+          ...sandboxMounts,
           logsCommand,
         },
       },

--- a/packages/core/drizzle/postgres/0095_board_branch_capability_policies.sql
+++ b/packages/core/drizzle/postgres/0095_board_branch_capability_policies.sql
@@ -265,12 +265,18 @@ FROM board_group_grants bg JOIN boards b ON b.tenant_id=bg.tenant_id AND b.board
 WHERE bg.can<>'none' AND COALESCE(b.data->>'access_mode','shared')='shared';
 --> statement-breakpoint
 
+-- A branch may carry a stale permission_source='board' while its board_id is
+-- NULL or dangling (the board was deleted). The board_config LEFT JOIN is then
+-- unmatched, so inheriting its others_role/others_fs_access would insert NULL
+-- into NOT NULL columns. Guard every board-inheritance branch on a resolved
+-- board_config and otherwise fall back to the branch's own others_can/fs, the
+-- same path used for genuine 'override' branches.
 INSERT INTO branch_permission_configs
 SELECT br.tenant_id,gen_random_uuid()::text,NULL,br.branch_id,1,
- CASE WHEN br.permission_source='board' THEN 'shared'
+ CASE WHEN br.permission_source='board' AND board_config.config_id IS NOT NULL THEN 'shared'
   WHEN COALESCE(br.others_can,'session')<>'none' OR EXISTS(SELECT 1 FROM branch_owners bo WHERE bo.tenant_id=br.tenant_id AND bo.branch_id=br.branch_id AND bo.user_id<>br.primary_owner_user_id) OR EXISTS(SELECT 1 FROM branch_group_grants bg WHERE bg.tenant_id=br.tenant_id AND bg.branch_id=br.branch_id AND bg.can<>'none') THEN 'shared' ELSE 'private' END,
- CASE WHEN br.permission_source='board' THEN board_config.others_role ELSE CASE COALESCE(br.others_can,'session') WHEN 'none' THEN 'none' WHEN 'view' THEN 'viewer' WHEN 'all' THEN 'manager' ELSE 'collaborator' END END,
- CASE WHEN br.permission_source='board' THEN board_config.others_fs_access WHEN COALESCE(br.others_can,'session')='none' THEN 'none' ELSE COALESCE(br.others_fs_access,'read') END,
+ CASE WHEN br.permission_source='board' AND board_config.config_id IS NOT NULL THEN board_config.others_role ELSE CASE COALESCE(br.others_can,'session') WHEN 'none' THEN 'none' WHEN 'view' THEN 'viewer' WHEN 'all' THEN 'manager' ELSE 'collaborator' END END,
+ CASE WHEN br.permission_source='board' AND board_config.config_id IS NOT NULL THEN board_config.others_fs_access WHEN COALESCE(br.others_can,'session')='none' THEN 'none' ELSE COALESCE(br.others_fs_access,'read') END,
  1,br.primary_owner_user_id,COALESCE(br.created_at,now()),COALESCE(br.updated_at,br.created_at,now())
 FROM branches br
 LEFT JOIN branch_permission_configs board_config ON board_config.tenant_id=br.tenant_id AND board_config.board_id=br.board_id

--- a/packages/core/drizzle/sqlite/0098_board_branch_capability_policies.sql
+++ b/packages/core/drizzle/sqlite/0098_board_branch_capability_policies.sql
@@ -239,17 +239,22 @@ WHERE bg.`can`<>'none' AND COALESCE(json_extract(b.`data`, '$.access_mode'), 'sh
 -- Explicit branch packages. A branch that formerly used board permissions is
 -- materialized only when branch-specific authority or a distinct board owner
 -- must be preserved; its package starts as an exact copy of the board template.
+-- A branch may carry a stale permission_source='board' while its board_id is
+-- NULL or dangling (the board was deleted). The board_config LEFT JOIN is then
+-- unmatched, so inheriting its others_role/others_fs_access would insert NULL
+-- into NOT NULL columns. Guard every board-inheritance branch on a resolved
+-- board_config and otherwise fall back to the branch's own others_can/fs.
 INSERT INTO `branch_permission_configs`
 SELECT lower(hex(randomblob(4)))||'-'||lower(hex(randomblob(2)))||'-7'||substr(lower(hex(randomblob(2))),2)||'-8'||substr(lower(hex(randomblob(2))),2)||'-'||lower(hex(randomblob(6))),
   NULL, br.`branch_id`, 1,
-  CASE WHEN br.`permission_source`='board' THEN 'shared'
+  CASE WHEN br.`permission_source`='board' AND board_config.`config_id` IS NOT NULL THEN 'shared'
        WHEN COALESCE(br.`others_can`,'session')<>'none'
          OR EXISTS (SELECT 1 FROM `branch_owners` bo WHERE bo.`branch_id`=br.`branch_id` AND bo.`user_id`<>br.`primary_owner_user_id`)
          OR EXISTS (SELECT 1 FROM `branch_group_grants` bg WHERE bg.`branch_id`=br.`branch_id` AND bg.`can`<>'none')
        THEN 'shared' ELSE 'private' END,
-  CASE WHEN br.`permission_source`='board' THEN board_config.`others_role`
+  CASE WHEN br.`permission_source`='board' AND board_config.`config_id` IS NOT NULL THEN board_config.`others_role`
        ELSE CASE COALESCE(br.`others_can`,'session') WHEN 'none' THEN 'none' WHEN 'view' THEN 'viewer' WHEN 'all' THEN 'manager' ELSE 'collaborator' END END,
-  CASE WHEN br.`permission_source`='board' THEN board_config.`others_fs_access`
+  CASE WHEN br.`permission_source`='board' AND board_config.`config_id` IS NOT NULL THEN board_config.`others_fs_access`
        WHEN COALESCE(br.`others_can`,'session')='none' THEN 'none' ELSE COALESCE(br.`others_fs_access`,'read') END,
   1, br.`primary_owner_user_id`, COALESCE(br.`created_at`, unixepoch()*1000), COALESCE(br.`updated_at`, br.`created_at`, unixepoch()*1000)
 FROM `branches` br

--- a/packages/core/src/codex/credential-file.test.ts
+++ b/packages/core/src/codex/credential-file.test.ts
@@ -172,6 +172,37 @@ describe('credential file directory capability', () => {
   );
 
   it.runIf(process.platform === 'linux')(
+    'tolerates a static symlinked home but still refuses a symlinked credential leaf',
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), 'agor-credential-home-alias-'));
+      const realHome = join(root, 'real-home');
+      const codexHome = join(realHome, '.codex');
+      await mkdir(codexHome, { recursive: true });
+      await writeFile(join(codexHome, 'auth.json'), 'caller-secret');
+
+      // A static, admin-owned home alias (e.g. /home/<user> ->
+      // /var/lib/.../<user>). Reading and binding through it must succeed —
+      // the old full-path O_NOFOLLOW walk failed closed here with ENOTDIR.
+      const aliasHome = join(root, 'alias-home');
+      await symlink(realHome, aliasHome);
+      const aliasedAuth = join(aliasHome, '.codex', 'auth.json');
+      await expect(readCredentialFile(aliasedAuth)).resolves.toBe('caller-secret');
+      const handle = await openCredentialFileForBind(aliasedAuth);
+      await handle.close();
+
+      // ...but a symlinked LEAF `.codex` (the sandbox-writable component) is
+      // still rejected, preserving the anti-cross-home-symlink guarantee.
+      const swappedHome = join(root, 'swapped-home');
+      const otherCodex = join(root, 'other', '.codex');
+      await mkdir(swappedHome, { recursive: true });
+      await mkdir(otherCodex, { recursive: true });
+      await writeFile(join(otherCodex, 'auth.json'), 'other-secret');
+      await symlink(otherCodex, join(swappedHome, '.codex'));
+      await expect(readCredentialFile(join(swappedHome, '.codex', 'auth.json'))).rejects.toThrow();
+    }
+  );
+
+  it.runIf(process.platform === 'linux')(
     'keeps mutation attached to the opened directory during a path swap',
     async () => {
       const root = await mkdtemp(join(tmpdir(), 'agor-credential-swap-'));

--- a/packages/core/src/codex/credential-file.ts
+++ b/packages/core/src/codex/credential-file.ts
@@ -1,8 +1,8 @@
 import { spawn } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
 import { constants } from 'node:fs';
-import { type FileHandle, lstat, mkdir, open, rename, rm } from 'node:fs/promises';
-import { basename, dirname, join, parse, resolve, sep } from 'node:path';
+import { type FileHandle, lstat, mkdir, open, realpath, rename, rm } from 'node:fs/promises';
+import { basename, dirname, join, resolve } from 'node:path';
 import { parseCodexAuthJson } from './auth-file.js';
 
 const LOCK_WAIT_MS = 10_000;
@@ -25,11 +25,20 @@ interface CredentialLock {
 }
 
 // Keep this sensitive storage primitive's ambient filesystem authority behind
-// six narrow adapters. Besides making the operations auditable by Agor's
+// seven narrow adapters. Besides making the operations auditable by Agor's
 // daemon-filesystem boundary registry, callers cannot accidentally bypass the
 // directory-capability path with a one-off fs call.
 async function openPath(path: string, flags: string | number, mode?: number): Promise<FileHandle> {
   return open(path, flags, mode);
+}
+
+// Resolve a trusted, admin/daemon-owned anchor path to its canonical form,
+// following any STATIC symlinks in it (e.g. a root-owned `/home/<user>` ->
+// `/var/lib/.../<user>` alias on non-standard hosts). Only ever applied to the
+// credential directory's parent home, never to a component a sandboxed actor
+// can write; the leaf stays O_NOFOLLOW.
+async function resolveCanonicalDirectory(path: string): Promise<string> {
+  return realpath(path);
 }
 
 async function createDirectory(
@@ -66,31 +75,42 @@ function linuxDirectoryFlags(): number {
 }
 
 /**
- * Open each directory component relative to its already-open parent. The final
- * `/proc/self/fd` path stays attached to that inode even if a sandbox process
- * concurrently renames `.codex` and replaces it with a cross-home symlink.
+ * Open the credential directory as a race-safe capability. The credential
+ * leaf (`.codex`) is opened with `O_NOFOLLOW` relative to its already-open
+ * parent, so the final `/proc/self/fd` path stays attached to that inode even
+ * if a sandbox process concurrently renames `.codex` and replaces it with a
+ * cross-home symlink.
+ *
+ * The parent home is a distinct trust tier: it and its ancestors are admin- or
+ * daemon-owned and not writable by a sandboxed actor, and on non-standard hosts
+ * the home may be reached through a STATIC, root-owned symlink alias. We
+ * therefore canonicalize the parent (following those static links) and keep
+ * `O_NOFOLLOW` strictly for the sandbox-writable leaf, rather than walking the
+ * whole path `O_NOFOLLOW` — which would fail closed on a legitimate home alias.
  */
 async function openLinuxDirectory(
   rawDirectory: string,
   create: boolean
 ): Promise<CredentialDirectory> {
   const absolute = resolve(rawDirectory);
-  const root = parse(absolute).root;
-  let current = await openPath(root, linuxDirectoryFlags());
+  const parent = await resolveCanonicalDirectory(dirname(absolute));
+  const leaf = basename(absolute);
+  // `parent` is canonical (symlink-free) and its terminal node is not
+  // sandbox-renamable, so following it here is safe; the leaf below stays
+  // O_NOFOLLOW.
+  let current = await openPath(parent, constants.O_RDONLY | constants.O_DIRECTORY);
   try {
-    for (const component of absolute.slice(root.length).split(sep).filter(Boolean)) {
-      const child = join('/proc/self/fd', String(current.fd), component);
-      if (create) {
-        try {
-          await createDirectory(child, { mode: 0o700 });
-        } catch (error) {
-          if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
-        }
+    const child = join('/proc/self/fd', String(current.fd), leaf);
+    if (create) {
+      try {
+        await createDirectory(child, { mode: 0o700 });
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
       }
-      const next = await openPath(child, linuxDirectoryFlags());
-      await current.close();
-      current = next;
     }
+    const next = await openPath(child, linuxDirectoryFlags());
+    await current.close();
+    current = next;
     if (create) await current.chmod(0o700);
     return { handle: current, path: `/proc/self/fd/${current.fd}` };
   } catch (error) {

--- a/scripts/daemon-filesystem-exceptions.json
+++ b/scripts/daemon-filesystem-exceptions.json
@@ -1666,6 +1666,20 @@
     "operation": "call:open@openPath#1"
   },
   {
+    "id": "DAEMON-FS-CAP-237",
+    "class": "A",
+    "file": "packages/core/src/codex/credential-file.ts",
+    "import": "node:fs/promises",
+    "owner": "Codex credential authority",
+    "boundary": "canonical tenant/user credential-store capability",
+    "rationale": "Canonicalizes only the credential directory's trusted parent home — an admin/daemon-owned anchor whose ancestors are not sandbox-writable and which may legitimately be reached through a static, root-owned symlink alias on non-standard hosts. Never applied to the sandbox-writable credential leaf (.codex), which retains its no-follow open, so a concurrent path swap still cannot redirect access across homes.",
+    "reviewTarget": null,
+    "reviewDate": null,
+    "symbol": "realpath",
+    "local": "realpath",
+    "operation": "call:realpath@resolveCanonicalDirectory#1"
+  },
+  {
     "id": "DAEMON-FS-CAP-211",
     "class": "A",
     "file": "packages/core/src/codex/credential-file.ts",


### PR DESCRIPTION
Three fixes surfaced deploying the 0.25 board/branch RBAC + per-branch SDK home rollout (#2555, #2587) onto an instance with real-world dirty data, a symlinked daemon home, and the fail-closed `per_user` filesystem sandbox.

## 1. Migration `0095` (postgres) / `0098` (sqlite) — null/dangling board branches

**Symptom:** migration aborts with `23502 not-null violation` on `branch_permission_configs.others_role`.

**Cause:** a branch carrying a stale `permission_source='board'` while its `board_id` is `NULL` or points to a deleted board leaves the `board_config` `LEFT JOIN` unmatched. Inheriting its `others_role` / `others_fs_access` then inserts `NULL` into those `NOT NULL` columns.

**Fix:** guard every board-inheritance branch on a resolved `board_config` (`board_config.config_id IS NOT NULL`); otherwise fall back to the branch's own `others_can` / `others_fs_access` — the same path real `override` branches already use. Applied to both twins.

> These migrations are unreleased (not on npm), so editing them in place is safe — no deployed DB has the old hash, and drizzle keys "pending" off the journal timestamp, not file content.

## 2. Codex credential bind — `packages/core/src/codex/credential-file.ts`

**Symptom:** `ENOTDIR: not a directory, open '/proc/self/fd/N/<user>'` — **only** for Codex sessions created **after** enabling `sdk_home_mode: per_branch`. Claude Code and pre-rollout `execution_home` sessions are unaffected.

**Cause:** branch-scope Codex sessions `--bind-fd` the caller's `~/.codex/auth.json` into the branch SDK home. `openLinuxDirectory` pinned the source by walking the **entire** credential path with `O_NOFOLLOW`, which fails closed on a **static, root-owned home symlink** (e.g. `/home/<user> -> /var/lib/.../<user>`).

**Fix:** two trust tiers. Canonicalize the credential dir's **parent home** (admin/daemon-owned, ancestors not sandbox-writable, may be a static alias) via `realpath`; keep `O_NOFOLLOW` on the sandbox-writable **leaf** (`.codex`). Preserves the anti-cross-home-symlink guarantee. New test covers both the tolerated static alias and the still-rejected symlinked leaf; the four existing symlink-rejection contracts stay green.

## 3. Environment commands — `apps/agor-daemon/src/services/branches.ts`

**Symptom:** `Executor sandbox setup failed: sandbox home_mode=per_user requires an owner home store, but none was resolved. Refusing to fall back to a shared home` — on env logs/start/stop/nuke.

**Cause:** the env-command executor path resolved an `executionUserId` but never converted it into the sandbox mount inputs the session path assembles, so `buildSandboxWrap` got `ownerHomeStore=undefined` and failed closed under the forced `home_mode: per_user`. Affected **all** branches' env operations in sandbox mode.

**Fix:** `resolveEnvironmentExecutorContext` now resolves `sandboxHomeStore` (from the execution user + `filesystem_home`), `sandboxWorktreesRoot`, and `sandboxBaseRepoPath` (non-clone worktrees only), and both the lifecycle and logs payloads forward them into the executor params. Empty when the sandbox / `per_user` home is off, so non-sandbox deployments are unchanged. Regression test asserts the mounts reach the env-logs params.

🤖 Generated with [Claude Code](https://claude.com/claude-code)