### PR TITLE
fix(log): downgrade routine WebSocket auth rejections from error+stack to warn

### DIFF
--- a/apps/agor-daemon/src/setup/socketio.ts
+++ b/apps/agor-daemon/src/setup/socketio.ts
@@ -760,7 +760,31 @@ export function createSocketIOConfig(
         );
         next();
       } catch (error) {
-        console.error(`❌ WebSocket authentication failed for ${socket.id}:`, error);
+        // An expired/invalid token on a (re)connecting socket is routine: the
+        // client refreshes on the 401 we return below and retries. Log it as a
+        // terse warning without a stack. Reserve the loud error+stack for
+        // genuinely unexpected failures (absent/revoked authority, tenant drift,
+        // or another invariant violation) that warrant investigation.
+        const err = error as {
+          code?: number;
+          className?: string;
+          message?: string;
+          data?: { name?: string };
+        };
+        const expected =
+          err?.code === 401 ||
+          err?.className === 'not-authenticated' ||
+          err?.data?.name === 'TokenExpiredError' ||
+          /jwt expired|token expired/i.test(err?.message ?? '');
+        if (expected) {
+          const reason =
+            err?.data?.name === 'TokenExpiredError'
+              ? 'token expired'
+              : (err?.message ?? 'not authenticated');
+          console.warn(`WebSocket auth rejected for ${socket.id}: ${reason}`);
+        } else {
+          console.error(`❌ WebSocket authentication failed for ${socket.id}:`, error);
+        }
         authenticationFailures = Math.min(authenticationFailures + 1, Number.MAX_SAFE_INTEGER);
         retireSocketConnectionAuthority(app, fs.feathers);
         const publicError = new Error('Invalid or expired authentication token') as Error & {


### PR DESCRIPTION
## Problem

WebSocket auth failures were logged as a red ❌ `console.error` with the full error object — a ~20-line stack trace — for what is almost always a routine expired JWT:

```
❌ WebSocket authentication failed for XWc3hHfmcYJ6_MwNAAAf: NotAuthenticated: jwt expired
    at AuthenticationService.verifyAccessToken (...)
    ... 15+ more lines ...
  data: { name: 'TokenExpiredError', expiredAt: 2026-08-30T04:36:45.000Z }
```

A client's token ages out while a socket is connected (or on reconnect), it re-auths with the stale token, gets the 401, refreshes, and retries. That's expected churn — not an incident — but the stack-trace spam reads like one and buries real signal.

## Change

In the socket-auth `catch` (`apps/agor-daemon/src/setup/socketio.ts`), classify the failure:

- **Expected** (Feathers `401` / `not-authenticated`, `TokenExpiredError`, or a `jwt/token expired` message — including the mid-setup expiry throws) → one terse `console.warn` line, no stack.
- **Unexpected** (absent/revoked connection authority, tenant-authority drift, other invariant violations thrown earlier in the handler) → keep the loud `console.error` + stack for investigation.

No behavior change: the same generic `401` with refresh-safe `data` is still returned to the client; only server-side log volume drops.

## Note on root cause

The volume is expected — long-lived sockets outliving a shorter JWT TTL, with clients refreshing on the 401. If the frequency still seems high after this, worth a separate look at the JWT/session token TTL vs. socket lifetime, but that's config, not this code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)