### PR TITLE
fix(kb): stop memory append from republishing private documents

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/knowledge-memory-append.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/knowledge-memory-append.test.ts
@@ -1,0 +1,391 @@
+import type { McpServer } from '@modelcontextprotocol/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `agor_teammate_memory_append` must never restate document governance.
+ *
+ * Appending a memory bullet is a content operation. Re-sending creation
+ * defaults (visibility / edit_policy / status / title / kind) on every append
+ * silently republished a document its owner had made private.
+ *
+ * These tests drive the real MCP handler against a fake `kb/documents` service
+ * whose `putDocument` reproduces the production write semantics:
+ *   - update: `deepMerge(current, updates)` skips `undefined`, so an omitted
+ *     field is preserved (packages/core/src/db/repositories/merge-utils.ts)
+ *   - create: `documentToInsert` supplies the column defaults
+ *     (packages/core/src/db/repositories/knowledge.ts)
+ *
+ * Asserting on stored document state — not just on the call payload — is what
+ * makes these bite: a regression has to survive the same merge production uses.
+ */
+
+vi.mock('@agor/core/db', () => ({
+  BranchRepository: class FakeBranchRepository {},
+  KnowledgeNamespaceRepository: class FakeKnowledgeNamespaceRepository {},
+  shortId: (value: string) => value.slice(0, 8),
+}));
+
+vi.mock('@agor/core/feathers', () => ({
+  NotFound: class NotFound extends Error {},
+}));
+
+vi.mock('../../utils/branch-workspace-path.js', () => ({
+  resolveBranchWorkspacePath: vi.fn(),
+  ensureBranchWorkspaceAccess: vi.fn(),
+}));
+vi.mock('../../utils/executor-delegated-home.js', () => ({
+  resolveDelegatedExecutionHomeKey: vi.fn(async () => undefined),
+}));
+vi.mock('../../utils/spawn-executor.js', () => ({
+  getDaemonUrl: vi.fn(() => 'http://daemon.test'),
+  requestExecutor: vi.fn(),
+}));
+vi.mock('../../services/session-token-service.js', () => ({
+  issueExecutorCommandToken: vi.fn(async () => 'token'),
+}));
+vi.mock('../resolve-ids.js', () => ({
+  resolveBranchId: vi.fn(),
+}));
+
+vi.mock('../server.js', () => ({
+  coerceJsonRecord: (value: unknown) => value,
+  coerceString: (value: unknown) => {
+    if (typeof value !== 'string') return undefined;
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  },
+  sessionContextRequiredResult: () => ({
+    content: [{ type: 'text', text: '{"error":"session required"}' }],
+  }),
+  textResult: (data: unknown) => ({ content: [{ type: 'text', text: JSON.stringify(data) }] }),
+}));
+
+vi.mock('../tenant-scope.js', () => ({
+  runWithMcpTenantDatabaseScope: async (_ctx: unknown, fn: (db: unknown) => unknown) => fn({}),
+}));
+
+vi.mock('../../services/knowledge-access.js', () => ({
+  resolveKnowledgeNamespacePermission: vi.fn(async () => 'write'),
+  hasKnowledgeNamespacePermission: vi.fn(() => true),
+}));
+
+const MEMORY_PATH = 'memory/2026-03-04.md';
+const MEMORY_DATE = '2026-03-04';
+
+type StoredDocument = {
+  document_id: string;
+  path: string;
+  title: string;
+  kind: string;
+  visibility: string;
+  status: string;
+  edit_policy: string;
+  content: string;
+  version_id: string;
+  metadata: Record<string, unknown>;
+};
+
+class NotFoundLikeError extends Error {
+  readonly code = 404;
+}
+
+/** Mirrors KnowledgeDocumentRepository.documentToInsert's column defaults. */
+const CREATE_DEFAULTS = {
+  kind: 'doc',
+  visibility: 'public',
+  status: 'published',
+  edit_policy: 'owner',
+} as const;
+
+const GOVERNANCE_FIELDS = ['title', 'kind', 'visibility', 'status', 'edit_policy'] as const;
+
+function createFakeDocumentsService(seed?: Partial<StoredDocument>) {
+  const store = new Map<string, StoredDocument>();
+  let versionCounter = 0;
+
+  if (seed) {
+    versionCounter += 1;
+    store.set(MEMORY_PATH, {
+      document_id: 'doc-fixture',
+      path: MEMORY_PATH,
+      title: 'Seeded title',
+      kind: 'memory',
+      visibility: 'public',
+      status: 'published',
+      edit_policy: 'public',
+      content: `# ${MEMORY_DATE}\n`,
+      version_id: `version-${versionCounter}`,
+      metadata: {},
+      ...seed,
+    });
+  }
+
+  const getDocument = vi.fn(async (data: Record<string, unknown>) => {
+    const doc = store.get(String(data.path));
+    if (!doc) throw new NotFoundLikeError('Knowledge document not found');
+    return { ...doc, current_version: { version_id: doc.version_id } };
+  });
+
+  const putDocument = vi.fn(async (data: Record<string, unknown>) => {
+    const docPath = String(data.path);
+    const existing = store.get(docPath);
+    versionCounter += 1;
+
+    if (existing) {
+      // deepMerge(current, updates): a key whose value is `undefined` (or that
+      // is absent entirely) leaves the current value untouched.
+      const next: StoredDocument = { ...existing };
+      for (const field of GOVERNANCE_FIELDS) {
+        const value = data[field];
+        if (value !== undefined) next[field] = String(value);
+      }
+      if (typeof data.content_text === 'string') {
+        next.content = data.content_text;
+        next.version_id = `version-${versionCounter}`;
+      }
+      next.metadata = {
+        ...existing.metadata,
+        ...((data.metadata as Record<string, unknown> | undefined) ?? {}),
+      };
+      store.set(docPath, next);
+      return next;
+    }
+
+    const created: StoredDocument = {
+      document_id: 'doc-created',
+      path: docPath,
+      title: (data.title as string | undefined) ?? 'Untitled',
+      kind: (data.kind as string | undefined) ?? CREATE_DEFAULTS.kind,
+      visibility: (data.visibility as string | undefined) ?? CREATE_DEFAULTS.visibility,
+      status: (data.status as string | undefined) ?? CREATE_DEFAULTS.status,
+      edit_policy: (data.edit_policy as string | undefined) ?? CREATE_DEFAULTS.edit_policy,
+      content: typeof data.content_text === 'string' ? data.content_text : '',
+      version_id: `version-${versionCounter}`,
+      metadata: (data.metadata as Record<string, unknown> | undefined) ?? {},
+    };
+    store.set(docPath, created);
+    return created;
+  });
+
+  return {
+    service: { getDocument, putDocument },
+    getDocument,
+    putDocument,
+    read: () => store.get(MEMORY_PATH),
+  };
+}
+
+async function captureAppendHandler(options: {
+  documents: { getDocument: unknown; putDocument: unknown };
+  defaultVisibility?: string;
+  namespaceVisibilityDefault?: string;
+}) {
+  const { registerKnowledgeTools } = await import('./knowledge.js');
+
+  const branch = {
+    branch_id: 'branch-fixture',
+    custom_context: {
+      teammate: {
+        kind: 'teammate',
+        displayName: 'Fixture Teammate',
+        kb: {
+          primary_namespace_id: 'namespace-fixture',
+          primary_namespace_slug: 'fixture-space',
+          ...(options.defaultVisibility ? { default_visibility: options.defaultVisibility } : {}),
+        },
+      },
+    },
+  };
+
+  const services: Record<string, unknown> = {
+    sessions: { get: vi.fn(async () => ({ branch_id: 'branch-fixture' })) },
+    branches: { get: vi.fn(async () => branch) },
+    'kb/namespaces': {
+      get: vi.fn(async () => ({
+        namespace_id: 'namespace-fixture',
+        slug: 'fixture-space',
+        archived: false,
+        visibility_default: options.namespaceVisibilityDefault ?? 'public',
+      })),
+    },
+    'kb/documents': options.documents,
+  };
+
+  const captured: Record<string, (args: Record<string, unknown>) => Promise<unknown>> = {};
+  const fakeServer = {
+    registerTool: (
+      name: string,
+      _cfg: unknown,
+      handler: (args: Record<string, unknown>) => Promise<unknown>
+    ) => {
+      captured[name] = handler;
+    },
+  } as unknown as McpServer;
+
+  registerKnowledgeTools(fakeServer, {
+    app: { services, service: (path: string) => services[path] ?? {} },
+    db: {},
+    userId: 'user-fixture',
+    sessionId: 'session-fixture',
+    authenticatedUser: { user_id: 'user-fixture', role: 'member' },
+    baseServiceParams: {},
+  } as never);
+
+  const handler = captured.agor_teammate_memory_append;
+  if (!handler) throw new Error('agor_teammate_memory_append was not registered');
+  return handler;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('agor_teammate_memory_append governance preservation', () => {
+  it('keeps an owner-restricted document private and owner-edited across an append', async () => {
+    const documents = createFakeDocumentsService({
+      visibility: 'private',
+      edit_policy: 'owner',
+    });
+    // Defaults deliberately differ from the stored values: if the handler
+    // recomputes them, the document flips to public/public.
+    const append = await captureAppendHandler({
+      documents: documents.service,
+      defaultVisibility: 'public',
+      namespaceVisibilityDefault: 'public',
+    });
+
+    await append({ bullets: 'Prefers fixture data in tests', date: MEMORY_DATE });
+
+    const stored = documents.read();
+    expect(stored?.visibility).toBe('private');
+    expect(stored?.edit_policy).toBe('owner');
+
+    // The append must not even attempt a governance change.
+    const payload = documents.putDocument.mock.calls[0][0] as Record<string, unknown>;
+    expect(payload).not.toHaveProperty('visibility');
+    expect(payload).not.toHaveProperty('edit_policy');
+
+    // ...and the bullet still landed.
+    expect(stored?.content).toContain('Prefers fixture data in tests');
+  });
+
+  it('keeps an owner-chosen title, kind and draft status across an append', async () => {
+    const documents = createFakeDocumentsService({
+      title: 'Renamed by owner',
+      kind: 'doc',
+      status: 'draft',
+    });
+    const append = await captureAppendHandler({ documents: documents.service });
+
+    await append({ bullets: 'Second fixture bullet', date: MEMORY_DATE });
+
+    const stored = documents.read();
+    expect(stored?.title).toBe('Renamed by owner');
+    expect(stored?.kind).toBe('doc');
+    expect(stored?.status).toBe('draft');
+
+    const payload = documents.putDocument.mock.calls[0][0] as Record<string, unknown>;
+    expect(payload).not.toHaveProperty('title');
+    expect(payload).not.toHaveProperty('kind');
+    expect(payload).not.toHaveProperty('status');
+  });
+
+  it('still applies creation defaults when the memory document does not exist yet', async () => {
+    const documents = createFakeDocumentsService();
+    const append = await captureAppendHandler({
+      documents: documents.service,
+      defaultVisibility: 'private',
+      namespaceVisibilityDefault: 'public',
+    });
+
+    await append({ bullets: 'First bullet of a brand new day', date: MEMORY_DATE });
+
+    const stored = documents.read();
+    // Teammate default wins over the namespace default on first write.
+    expect(stored?.visibility).toBe('private');
+    expect(stored?.kind).toBe('memory');
+    expect(stored?.status).toBe('published');
+    expect(stored?.edit_policy).toBe('public');
+    expect(stored?.title).toBe(MEMORY_DATE);
+    // Guards against the fields being dropped and silently falling back to the
+    // repository column defaults rather than the memory-document defaults.
+    expect(stored?.kind).not.toBe(CREATE_DEFAULTS.kind);
+    expect(stored?.edit_policy).not.toBe(CREATE_DEFAULTS.edit_policy);
+    expect(stored?.content).toContain('First bullet of a brand new day');
+  });
+
+  it('falls back to the namespace default visibility when the teammate sets none', async () => {
+    const documents = createFakeDocumentsService();
+    const append = await captureAppendHandler({
+      documents: documents.service,
+      namespaceVisibilityDefault: 'private',
+    });
+
+    await append({ bullets: 'Namespace-defaulted bullet', date: MEMORY_DATE });
+
+    expect(documents.read()?.visibility).toBe('private');
+  });
+
+  it('does not drift over repeated appends to a private document', async () => {
+    const documents = createFakeDocumentsService({
+      visibility: 'private',
+      edit_policy: 'owner',
+      title: 'Renamed by owner',
+      status: 'draft',
+    });
+    const append = await captureAppendHandler({
+      documents: documents.service,
+      defaultVisibility: 'public',
+      namespaceVisibilityDefault: 'public',
+    });
+
+    for (const bullet of ['bullet alpha', 'bullet beta', 'bullet gamma', 'bullet delta']) {
+      await append({ bullets: bullet, date: MEMORY_DATE });
+      const snapshot = documents.read();
+      expect(snapshot?.visibility).toBe('private');
+      expect(snapshot?.edit_policy).toBe('owner');
+      expect(snapshot?.title).toBe('Renamed by owner');
+      expect(snapshot?.status).toBe('draft');
+    }
+
+    expect(documents.putDocument).toHaveBeenCalledTimes(4);
+    const final = documents.read();
+    for (const bullet of ['bullet alpha', 'bullet beta', 'bullet gamma', 'bullet delta']) {
+      expect(final?.content).toContain(bullet);
+    }
+  });
+
+  it('still passes the optimistic-concurrency token and memory metadata', async () => {
+    const documents = createFakeDocumentsService({
+      visibility: 'private',
+      edit_policy: 'owner',
+      version_id: 'version-seeded',
+    });
+    const append = await captureAppendHandler({ documents: documents.service });
+
+    await append({ bullets: 'Concurrency-checked bullet', date: MEMORY_DATE });
+
+    const payload = documents.putDocument.mock.calls[0][0] as Record<string, unknown>;
+    expect(payload.expected_version).toBe('version-seeded');
+    expect(payload.metadata).toMatchObject({
+      teammate_memory: true,
+      teammate_branch_id: 'branch-fixture',
+      memory_date: MEMORY_DATE,
+    });
+  });
+
+  it('does not write at all when every bullet is already recorded', async () => {
+    const documents = createFakeDocumentsService({
+      visibility: 'private',
+      edit_policy: 'owner',
+    });
+    const append = await captureAppendHandler({ documents: documents.service });
+
+    await append({ bullets: 'Deduped bullet', date: MEMORY_DATE, idempotencyKey: 'fixture-key' });
+    expect(documents.putDocument).toHaveBeenCalledTimes(1);
+
+    await append({ bullets: 'Deduped bullet', date: MEMORY_DATE, idempotencyKey: 'fixture-key' });
+    expect(documents.putDocument).toHaveBeenCalledTimes(1);
+    expect(documents.read()?.visibility).toBe('private');
+  });
+});

--- a/apps/agor-daemon/src/mcp/tools/knowledge.ts
+++ b/apps/agor-daemon/src/mcp/tools/knowledge.ts
@@ -1036,6 +1036,7 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
 
     let existingContent = `# ${date}\n`;
     let expectedVersion: string | number | undefined;
+    let documentExists = false;
     try {
       const existing = (await callCustomMethod(
         docsService,
@@ -1048,6 +1049,7 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
         mcpParams(ctx)
       )) as HydratedKnowledgeDocumentResult | undefined;
       if (existing) {
+        documentExists = true;
         existingContent = typeof existing.content === 'string' ? existing.content : existingContent;
         expectedVersion = existing.current_version?.version_id;
       }
@@ -1092,11 +1094,20 @@ export function registerKnowledgeTools(server: McpServer, ctx: McpContext): void
         {
           namespace_slug: namespace.slug,
           path: docPath,
-          title: date,
-          kind: 'memory',
-          visibility: teammate?.kb?.default_visibility ?? namespace.visibility_default,
-          edit_policy: 'public',
-          status: 'published',
+          // Appending is a content operation, so it must not restate document
+          // governance. Creation defaults apply only on first write: replaying
+          // them on every append silently republished a memory document its
+          // owner had set to private/owner, and undid retitles and drafting.
+          // Omitted fields are preserved by the repository's merge on update.
+          ...(documentExists
+            ? {}
+            : {
+                title: date,
+                kind: 'memory',
+                visibility: teammate?.kb?.default_visibility ?? namespace.visibility_default,
+                edit_policy: 'public',
+                status: 'published',
+              }),
           content_text: nextContent,
           expected_version: expectedVersion,
           metadata: {


### PR DESCRIPTION
## Summary

`agor_teammate_memory_append` silently reset the visibility and edit policy of an existing memory document on every append. A document its owner had made private was republished as public without any indication.

## Reproduction

1. Set a teammate memory document to `visibility: private`, `edit_policy: owner` (via `agor_kb_put` or the Knowledge UI).
2. Append a bullet with `agor_teammate_memory_append`.
3. The bullet lands correctly — and the document comes back `visibility: public`, `edit_policy: public`.

Restoring the setting works until the next append, which stamps it back. Reproduced on two independent teammates, so it is not specific to one namespace's configuration.

## Cause

The append path sent `visibility`, `edit_policy`, `title`, `kind` and `status` on every call. `visibility` was recomputed from the teammate/namespace defaults; `edit_policy` was a hardcoded `'public'` that consulted no default at all. The stored values were never read, so each append overwrote the owner's choices. The handler already fetched the document to read its content and version — it just ignored the fields that mattered.

A second symptom followed from the same line: because `assertCanChangeGovernance` rejects a governance change from a non-owner, appending to a private document *failed* with `Forbidden` for collaborators.

## Fix

Appending a bullet is a content operation and must not restate document governance. Creation defaults now apply only when the document does not yet exist. For an existing document the handler sends content, `expected_version` and metadata only.

Omission (rather than passing the fetched values back) is deliberate: `deepMerge` skips `undefined`, so an omitted field is preserved on update, and omitting means no governance change is *attempted* — it cannot revert a concurrent change made between the read and the write, and it does not trip the governance permission check for non-owners. This matches what `agor_kb_edit` already does.

First-write behavior is unchanged, including the `edit_policy: 'public'` default that keeps a new memory document collaboratively editable.

## Tests

Seven tests drive the real handler against a fake documents service reproducing production merge semantics (undefined-skip on update, column defaults on create), asserting resulting document state rather than call payloads:

- a `private`/`owner` document keeps both across an append, and the bullet still lands
- an owner's title, kind and `draft` status survive an append
- a new memory document still gets its defaults (teammate default visibility, `kind: memory`, `status: published`)
- namespace default visibility is still the fallback when the teammate sets none
- four consecutive appends produce no drift
- `expected_version` and memory metadata are still sent; idempotent re-appends still write nothing

Each assertion was mutation-tested: re-introducing the hardcoded `edit_policy`, the default-derived `visibility`, or the `title`/`kind`/`status` fields fails the corresponding test, as does dropping the creation defaults.

`pnpm typecheck` and the full daemon suite (3945 passing) are clean.
