### PR TITLE
fix(opencode): make reasoning effort a per-model capability

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/sessions.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.test.ts
@@ -1758,10 +1758,18 @@ describe('agor_models_list', () => {
     expect(claudeIds).toContain('claude-opus-4-6');
     expect(claudeIds).toContain('claude-sonnet-5');
     expect(parsed.opencode).toMatchObject({
-      default: null,
-      models: [],
-      note: expect.stringContaining('provider-specific'),
+      default: { providerId: 'opencode', modelId: 'big-pickle' },
+      runtimeVersion: '1.14.33',
+      providers: expect.any(Array),
+      models: expect.any(Array),
+      note: expect.stringContaining('model-specific'),
     });
+    expect(
+      parsed.opencode.models.find(
+        (model: { provider: string; id: string }) =>
+          model.provider === 'opencode-go' && model.id === 'qwen3.8-flash'
+      )
+    ).toMatchObject({ reasoningEffortLevels: [] });
   });
 
   it('filters to a single agenticTool when requested', async () => {
@@ -1794,6 +1802,50 @@ describe('agor_models_list', () => {
       status: 'known',
       availability: 'provider-dependent',
     });
+  });
+
+  it('returns authoritative branch-scoped OpenCode effort metadata when requested', async () => {
+    const find = vi.fn(async () => ({
+      runtime: 'available',
+      runtimeVersion: '1.14.33',
+      suggestedSelection: { providerId: 'opencode-go', modelId: 'qwen3.8-flash' },
+      providers: [
+        {
+          id: 'opencode-go',
+          name: 'OpenCode Go',
+          runtimeAvailable: true,
+          credentialPresence: 'present',
+          authMethods: [],
+          models: [
+            {
+              id: 'qwen3.8-flash',
+              name: 'Qwen3.8 Flash',
+              status: 'active',
+              reasoningEffortLevels: [],
+            },
+          ],
+        },
+      ],
+    }));
+    const app = makeFakeApp({ '/opencode-auth': { find } });
+    const { agor_models_list } = await registerAndCaptureHandlers(
+      { app, userId: 'user-1', sessionId: 'sess-1' },
+      ['agor_models_list']
+    );
+
+    const result = await agor_models_list({ agenticTool: 'opencode', branchId: 'branch-1' });
+    const parsed = JSON.parse(result.content[0].text);
+
+    expect(find).toHaveBeenCalledWith(
+      expect.objectContaining({ query: { branch_id: 'branch-1' } })
+    );
+    expect(parsed.opencode.models).toEqual([
+      expect.objectContaining({
+        provider: 'opencode-go',
+        id: 'qwen3.8-flash',
+        reasoningEffortLevels: [],
+      }),
+    ]);
   });
 });
 

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -1,3 +1,4 @@
+import { createOpenCodeKnownModelCatalog, OPENCODE_VERSION } from '@agor/agentic-tool-opencode';
 import { AGENTIC_TOOL_CAPABILITIES } from '@agor/agentic-tools';
 import {
   BranchRepository,
@@ -96,7 +97,9 @@ const modelConfigObjectSchema = z.object({
   effort: z
     .enum(['low', 'medium', 'high', 'xhigh', 'max'])
     .optional()
-    .describe('Reasoning effort level (default: high)'),
+    .describe(
+      'Reasoning effort override. For OpenCode, omit it to inherit the selected model/runtime default and use agor_models_list to inspect exact-pair support.'
+    ),
   advisorModel: mcpOptionalString(
     'modelConfig.advisorModel',
     "Claude Code advisor model override (e.g. 'opus', 'sonnet', 'fable', or a full model ID)."
@@ -1705,9 +1708,30 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
           .enum(AGENTIC_TOOL_NAMES)
           .optional()
           .describe('Filter to a single agentic tool. Omit to return all tools.'),
+        branchId: mcpOptionalId(
+          'branchId',
+          'Branch',
+          'Optional branch scope for authoritative live OpenCode provider/model effort discovery.'
+        ),
       }),
     },
     async (args) => {
+      let openCodeCatalog = null;
+      if (args.agenticTool === undefined || args.agenticTool === 'opencode') {
+        try {
+          openCodeCatalog = args.branchId
+            ? await ctx.app.service('/opencode-auth').find({
+                ...ctx.baseServiceParams,
+                query: { branch_id: await resolveBranchId(ctx, args.branchId) },
+              })
+            : await ctx.app.service('/opencode-models').find(ctx.baseServiceParams);
+        } catch {
+          openCodeCatalog = {
+            runtimeVersion: OPENCODE_VERSION,
+            ...createOpenCodeKnownModelCatalog(null),
+          };
+        }
+      }
       const claudeModels = AVAILABLE_CLAUDE_MODEL_ALIASES.map((m) => ({
         id: m.id,
         displayName: m.displayName,
@@ -1757,9 +1781,20 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
           note: 'Gemini models are normally fetched live from the Google API per-user. This is the static fallback list — newer models may exist.',
         },
         opencode: {
-          default: null,
-          models: [],
-          note: 'OpenCode models are provider-specific and are discovered after selecting a provider. Pass both modelConfig.provider and modelConfig.model from the OpenCode provider catalog.',
+          default: openCodeCatalog?.suggestedSelection ?? null,
+          runtimeVersion: openCodeCatalog?.runtimeVersion ?? OPENCODE_VERSION,
+          providers: openCodeCatalog?.providers ?? [],
+          models:
+            openCodeCatalog?.providers.flatMap((provider) =>
+              provider.models.map((model) => ({
+                provider: provider.id,
+                id: model.id,
+                displayName: model.name,
+                status: model.status,
+                reasoningEffortLevels: model.reasoningEffortLevels,
+              }))
+            ) ?? [],
+          note: 'OpenCode requires an exact provider/model pair. reasoningEffortLevels is model-specific: [] means omit modelConfig.effort, while a missing field means the value is unknown and will be validated at runtime. Live session-owner and branch configuration remains authoritative.',
         },
         copilot: {
           default: DEFAULT_COPILOT_MODEL,
@@ -1779,7 +1814,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         },
       } satisfies Record<
         AgenticToolName,
-        { default: string | null; models: unknown[]; note: string }
+        { default: unknown; models: unknown[]; note: string; [key: string]: unknown }
       >;
 
       if (args.agenticTool) {

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -24,6 +24,8 @@ import {
   type AgenticToolName,
   type Board,
   getSessionType,
+  type OpenCodeModelCatalog,
+  type OpenCodeProviderSettings,
   type Session,
   type SessionType,
   type ZoneBoardObject,
@@ -1685,9 +1687,9 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
   // Tool 13: agor_models_list
   //
   // Discovery tool so MCP-driven agents can find valid `model` strings without
-  // having to scrape tool descriptions. Sourced from the same in-process model
-  // registries the UI uses (packages/core/src/models/*). This reads the
-  // registry loaded by the running daemon; it is not provider discovery.
+  // having to scrape tool descriptions. Most tools use the same in-process
+  // registries as the UI. OpenCode also returns its safe provider/model catalog
+  // and can perform owner-scoped live discovery when a branch is supplied.
   //
   // Caveats:
   //   - Gemini's authoritative list is fetched live from the Google API per
@@ -1695,8 +1697,8 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
   //     best-effort starter list.
   //   - Copilot and Cursor have dynamic discovery exposed via /copilot-models
   //     and /cursor-models in the daemon. Static fallbacks are exposed here.
-  //   - OpenCode is a provider+model matrix and doesn't have a single static
-  //     list. Its entry explains that discovery happens after provider choice.
+  //   - OpenCode is a provider+model matrix. Its entry includes flattened exact
+  //     pairs plus the provider groups and model-specific effort metadata.
   server.registerTool(
     'agor_models_list',
     {
@@ -1716,7 +1718,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
       }),
     },
     async (args) => {
-      let openCodeCatalog = null;
+      let openCodeCatalog: OpenCodeModelCatalog | OpenCodeProviderSettings | null = null;
       if (args.agenticTool === undefined || args.agenticTool === 'opencode') {
         try {
           openCodeCatalog = args.branchId

--- a/apps/agor-docs/content/guide/sessions.mdx
+++ b/apps/agor-docs/content/guide/sessions.mdx
@@ -224,6 +224,12 @@ All of this is changeable at any point. You don't have to start a new session to
 
 _Session Settings modal: model, effort, permissions, MCP, env vars, callbacks, all editable mid-session for supported runtimes._
 
+For OpenCode, reasoning effort is an exact provider/model capability rather than a tool-wide
+default. The selector shows the native effort names known for the chosen model. An empty list means
+the runtime exposes no compatible explicit effort, so leave the field inherited; models entered
+manually without known metadata are validated against the session owner's live, branch-scoped
+OpenCode configuration before any prompt is submitted.
+
 Forks and spawned children copy selection names for continuity, never stored values. Each child
 resolves the copied names against its attributed owner. When a collaborator forks or spawns from a
 shared branch-scoped session, the child is attributed to that collaborator, so a copied name cannot

--- a/apps/agor-ui/src/components/AgenticConfigChipRow/AgenticConfigChipRow.test.tsx
+++ b/apps/agor-ui/src/components/AgenticConfigChipRow/AgenticConfigChipRow.test.tsx
@@ -29,10 +29,16 @@ vi.mock('../ModelSelector', async () => {
     ModelSelector: ({
       onChange,
       onCommit,
+      onReasoningEffortLevelsChange,
       agentic_tool,
     }: {
       onChange: (v: unknown) => void;
-      onCommit?: () => void;
+      onCommit?: (value: { mode: 'exact'; provider: string; model: string }) => void;
+      onReasoningEffortLevelsChange?: (availability: {
+        provider: string;
+        model: string;
+        levels: readonly string[] | undefined;
+      }) => void;
       agentic_tool?: AgenticToolName;
     }) => (
       <>
@@ -41,7 +47,11 @@ vi.mock('../ModelSelector', async () => {
           data-testid="model-change"
           onClick={() => {
             onChange({ mode: 'alias', model: 'claude-haiku-4-5' });
-            onCommit?.();
+            onCommit?.({
+              mode: 'exact',
+              provider: 'anthropic',
+              model: 'claude-haiku-4-5',
+            });
           }}
         >
           change model
@@ -54,15 +64,37 @@ vi.mock('../ModelSelector', async () => {
           type exact model
         </button>
         {agentic_tool === 'opencode' && (
-          <button
-            type="button"
-            data-testid="model-suggest"
-            onClick={() =>
-              onChange({ mode: 'exact', provider: 'openai', model: 'suggested-model' })
-            }
-          >
-            suggest model
-          </button>
+          <>
+            <button
+              type="button"
+              data-testid="model-suggest"
+              onClick={() =>
+                onChange({ mode: 'exact', provider: 'openai', model: 'suggested-model' })
+              }
+            >
+              suggest model
+            </button>
+            <button
+              type="button"
+              data-testid="model-qwen"
+              onClick={() => {
+                const next = {
+                  mode: 'exact' as const,
+                  provider: 'opencode-go',
+                  model: 'qwen3.8-flash',
+                };
+                onChange(next);
+                onReasoningEffortLevelsChange?.({
+                  provider: next.provider,
+                  model: next.model,
+                  levels: [],
+                });
+                onCommit?.(next);
+              }}
+            >
+              choose qwen
+            </button>
+          </>
         )}
       </>
     ),
@@ -137,6 +169,7 @@ function Harness({
   tool = 'claude-code',
   collapsibleChips,
   validateModelSelection,
+  initialValues,
 }: {
   user: User;
   client?: AgorClient | null;
@@ -144,10 +177,11 @@ function Harness({
   tool?: AgenticToolName;
   collapsibleChips?: boolean;
   validateModelSelection?: boolean;
+  initialValues?: Record<string, unknown>;
 }) {
   const [form] = Form.useForm();
   return (
-    <Form form={form} initialValues={{ agenticToolPresetId: initialSource }}>
+    <Form form={form} initialValues={{ agenticToolPresetId: initialSource, ...initialValues }}>
       <AgenticConfigChipRow
         tool={tool}
         client={client}
@@ -376,6 +410,43 @@ describe('AgenticConfigChipRow', () => {
     render(<Harness user={{ user_id: 'gemini-user' } as User} tool="gemini" />);
     await screen.findByTestId('permission-chip');
     expect(screen.queryByTestId('effort-chip')).not.toBeInTheDocument();
+  });
+
+  it('uses per-model OpenCode effort levels and clears an incompatible effort on model commit', async () => {
+    render(
+      <Harness
+        user={{ user_id: 'opencode-user' } as User}
+        client={null}
+        tool="opencode"
+        initialSource="__inline__"
+        initialValues={{
+          modelConfig: {
+            mode: 'exact',
+            provider: 'opencode-go',
+            model: 'gpt-5.6-luna',
+          },
+          effort: 'high',
+        }}
+      />
+    );
+
+    expect(await screen.findByTestId('effort-chip')).toHaveTextContent('Effort: High');
+    fireEvent.click(screen.getByTestId('model-chip'));
+    fireEvent.click(await screen.findByTestId('model-qwen'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('effort-chip')).toHaveTextContent('Effort: Inherited')
+    );
+    expect(JSON.parse(screen.getByTestId('state').textContent || '{}')).toMatchObject({
+      model: 'qwen3.8-flash',
+    });
+    expect(JSON.parse(screen.getByTestId('state').textContent || '{}')).not.toHaveProperty(
+      'effort'
+    );
+
+    fireEvent.click(screen.getByTestId('effort-chip'));
+    expect(await screen.findByText(/no explicit effort.*use inherited/i)).toBeInTheDocument();
+    expect(screen.getByTestId('effort-select').textContent).toBe('Inherited|clearable|');
   });
 
   it('collapses the chip row behind a one-line summary when collapsibleChips is set', async () => {

--- a/apps/agor-ui/src/components/AgenticConfigChipRow/AgenticConfigChipRow.tsx
+++ b/apps/agor-ui/src/components/AgenticConfigChipRow/AgenticConfigChipRow.tsx
@@ -3,6 +3,7 @@ import {
   agenticToolRequiresModelSelection,
   getAgenticToolModelSelectionError,
 } from '@agor/agentic-tools';
+import { useAgenticToolReasoningEffortLevels } from '@agor/agentic-tools/ui';
 import type {
   AgenticToolName,
   AgorClient,
@@ -29,10 +30,11 @@ import {
   Form,
   Popover,
   Select,
+  Space,
   Typography,
   theme,
 } from 'antd';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { mapToArray } from '@/utils/mapHelpers';
 import {
   INLINE_AGENTIC_CONFIGURATION,
@@ -136,8 +138,8 @@ export const AgenticConfigChipRow: React.FC<AgenticConfigChipRowProps> = ({
   const form = Form.useFormInstance();
   const isClaude = CLAUDE_TOOLS.has(tool);
   const toolCapabilities = AGENTIC_TOOL_CAPABILITIES[tool];
-  const effortLevels = toolCapabilities.reasoningEffortLevels;
-  const supportsEffort = showEffort && Boolean(effortLevels?.length);
+  const toolEffortLevels = toolCapabilities.reasoningEffortLevels;
+  const supportsEffort = showEffort && Boolean(toolEffortLevels?.length);
   const {
     inlineAllowed,
     loading,
@@ -175,28 +177,47 @@ export const AgenticConfigChipRow: React.FC<AgenticConfigChipRowProps> = ({
 
   const resolved = configForSource(source);
   const resolvedModelConfig = resolved.modelConfig as ModelConfig | undefined;
+  const modelEffortLevels = useAgenticToolReasoningEffortLevels({
+    tool,
+    selection:
+      resolvedModelConfig?.provider && resolvedModelConfig.model
+        ? { provider: resolvedModelConfig.provider, model: resolvedModelConfig.model }
+        : undefined,
+    client,
+    branchId,
+    catalogEnabled,
+  });
+  const modelEffortMetadataKnown = tool === 'opencode' && modelEffortLevels !== undefined;
+  const effortLevels = modelEffortMetadataKnown ? modelEffortLevels : toolEffortLevels;
   const modelSelectionError = validateModelSelection
     ? getAgenticToolModelSelectionError(tool, resolvedModelConfig)
     : undefined;
-  const configError = getSourceError(source) ?? modelSelectionError;
+  const resolvedModel = resolved.modelConfig?.model || getDefaultModelForTool(tool) || '';
+  const resolvedPermission = resolved.permissionMode || getDefaultPermissionMode(tool);
+  const explicitEffort = isInline ? formEffort : resolved.modelConfig?.effort;
+  const effortSelectionError =
+    modelEffortMetadataKnown && explicitEffort && !modelEffortLevels.includes(explicitEffort)
+      ? modelEffortLevels.length > 0
+        ? `Choose a supported effort: ${modelEffortLevels.join(', ')}`
+        : 'This model has no explicit effort in the configured OpenCode runtime; use inherited.'
+      : undefined;
+  const configError = getSourceError(source) ?? modelSelectionError ?? effortSelectionError;
   const configResolvable = !configError;
+  const correctionError = modelSelectionError ?? effortSelectionError;
   const [chipsExpanded, setChipsExpanded] = useState(false);
-  const disclosureExpanded = Boolean(modelSelectionError) || chipsExpanded;
+  const disclosureExpanded = Boolean(correctionError) || chipsExpanded;
 
-  // Invalid required model configuration forces the corrective controls open.
+  // Invalid model/effort configuration forces the corrective controls open.
   // Latch that open state so an automatic suggestion or user correction does
   // not make the controls disappear as soon as the error clears.
   useEffect(() => {
-    if (modelSelectionError) setChipsExpanded(true);
-  }, [modelSelectionError]);
+    if (correctionError) setChipsExpanded(true);
+  }, [correctionError]);
 
   useEffect(() => {
     onConfigValidityChange?.(configResolvable, configError);
   }, [configError, configResolvable, onConfigValidityChange]);
 
-  const resolvedModel = resolved.modelConfig?.model || getDefaultModelForTool(tool) || '';
-  const resolvedPermission = resolved.permissionMode || getDefaultPermissionMode(tool);
-  const explicitEffort = isInline ? formEffort : resolved.modelConfig?.effort;
   const resolvedEffort = explicitEffort ?? toolCapabilities.defaultReasoningEffort;
   const advisorModel = resolved.modelConfig?.advisorModel;
   const mcpCount = formMcp?.length ?? 0;
@@ -277,6 +298,14 @@ export const AgenticConfigChipRow: React.FC<AgenticConfigChipRowProps> = ({
   const permissionMeta = getPermissionModeMeta(tool, resolvedPermission);
   const permissionColor =
     permissionMeta?.tone === 'warning' ? getPermissionModeColor('warning', token) : undefined;
+  const modelEffortAvailabilityRef = useRef<
+    | {
+        provider: string;
+        model: string;
+        levels: readonly EffortLevel[] | undefined;
+      }
+    | undefined
+  >(undefined);
 
   const managedNote = (
     <Typography.Text type="secondary">
@@ -330,12 +359,30 @@ export const AgenticConfigChipRow: React.FC<AgenticConfigChipRowProps> = ({
             <ModelSelector
               value={resolved.modelConfig as ModelConfig | undefined}
               onChange={onModelChange}
-              onCommit={close}
               agentic_tool={tool}
               client={client}
               branchId={branchId}
               catalogEnabled={catalogEnabled}
               showAdvisor={false}
+              onReasoningEffortLevelsChange={(availability) => {
+                modelEffortAvailabilityRef.current = availability;
+              }}
+              onCommit={(next) => {
+                const availability = modelEffortAvailabilityRef.current;
+                const currentEffort = form.getFieldValue('effort') as EffortLevel | undefined;
+                if (
+                  tool === 'opencode' &&
+                  currentEffort &&
+                  availability !== undefined &&
+                  availability.provider === next.provider &&
+                  availability.model === next.model &&
+                  availability.levels !== undefined &&
+                  !availability.levels.includes(currentEffort)
+                ) {
+                  form.setFieldValue('effort', undefined);
+                }
+                close();
+              }}
             />
           )}
         />
@@ -370,20 +417,37 @@ export const AgenticConfigChipRow: React.FC<AgenticConfigChipRowProps> = ({
           title="Reasoning effort"
           editable={inlineAllowed}
           managedNote={managedNote}
+          color={effortSelectionError ? token.colorError : undefined}
           width={300}
           testid="effort-chip"
           renderContent={(close) => (
-            <EffortSelector
-              value={resolvedEffort}
-              levels={effortLevels}
-              fallbackValue={toolCapabilities.defaultReasoningEffort}
-              allowInherited={!toolCapabilities.defaultReasoningEffort}
-              onChange={(effort) => {
-                onEffortChange(effort);
-                close();
-              }}
-              fullWidth
-            />
+            <Space orientation="vertical" size={8} style={{ width: '100%' }}>
+              {tool === 'opencode' &&
+                modelEffortMetadataKnown &&
+                modelEffortLevels.length === 0 && (
+                  <Typography.Text type={effortSelectionError ? 'danger' : 'secondary'}>
+                    This model has no explicit effort in the configured OpenCode runtime. Use
+                    inherited.
+                  </Typography.Text>
+                )}
+              {tool === 'opencode' && !modelEffortMetadataKnown && (
+                <Typography.Text type="secondary">
+                  Available efforts are unknown for this exact model and will be validated at
+                  runtime.
+                </Typography.Text>
+              )}
+              <EffortSelector
+                value={resolvedEffort}
+                levels={effortLevels}
+                fallbackValue={toolCapabilities.defaultReasoningEffort}
+                allowInherited={!toolCapabilities.defaultReasoningEffort}
+                onChange={(effort) => {
+                  onEffortChange(effort);
+                  close();
+                }}
+                fullWidth
+              />
+            </Space>
           )}
         />
       )}
@@ -471,9 +535,9 @@ export const AgenticConfigChipRow: React.FC<AgenticConfigChipRowProps> = ({
           activeKey={disclosureExpanded ? ['chips'] : []}
           onChange={(activeKeys) => {
             // AntD may still report a requested key change for a disabled
-            // header. Keep the forced-open latch intact until the required
-            // model selection is valid.
-            if (modelSelectionError) return;
+            // header. Keep the forced-open latch intact until the invalid
+            // model/effort selection is corrected.
+            if (correctionError) return;
             const keys = Array.isArray(activeKeys) ? activeKeys : [activeKeys];
             setChipsExpanded(keys.includes('chips'));
           }}
@@ -492,13 +556,15 @@ export const AgenticConfigChipRow: React.FC<AgenticConfigChipRowProps> = ({
           items={[
             {
               key: 'chips',
-              collapsible: modelSelectionError ? 'disabled' : 'header',
+              collapsible: correctionError ? 'disabled' : 'header',
               label: (
                 <Typography.Text
                   aria-label={`Session configuration: ${chipSummary}${
                     modelSelectionError
                       ? '. Complete the required model selection before collapsing.'
-                      : ''
+                      : effortSelectionError
+                        ? '. Correct the invalid reasoning effort before collapsing.'
+                        : ''
                   }`}
                   type="secondary"
                   ellipsis={{ tooltip: chipSummary }}

--- a/apps/agor-ui/src/components/AgenticToolConfigForm/AgenticToolConfigForm.test.tsx
+++ b/apps/agor-ui/src/components/AgenticToolConfigForm/AgenticToolConfigForm.test.tsx
@@ -1,10 +1,50 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { Form } from 'antd';
+import { useEffect } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { AgenticToolConfigForm } from './AgenticToolConfigForm';
 
 vi.mock('../ModelSelector', () => ({
-  ModelSelector: () => <div data-testid="model-selector" />,
+  ModelSelector: ({
+    value,
+    onChange,
+    onCommit,
+    onReasoningEffortLevelsChange,
+  }: {
+    value?: { provider?: string; model?: string };
+    onChange?: (value: { mode: 'exact'; provider: string; model: string }) => void;
+    onCommit?: (value: { mode: 'exact'; provider: string; model: string }) => void;
+    onReasoningEffortLevelsChange?: (availability: {
+      provider: string;
+      model: string;
+      levels: readonly string[] | undefined;
+    }) => void;
+  }) => {
+    useEffect(() => {
+      if (!value?.provider || !value.model) return;
+      onReasoningEffortLevelsChange?.({
+        provider: value.provider,
+        model: value.model,
+        levels: value.model === 'qwen3.8-flash' ? [] : ['low', 'medium', 'high'],
+      });
+    }, [onReasoningEffortLevelsChange, value?.model, value?.provider]);
+    const selectQwen = () => {
+      const next = {
+        mode: 'exact' as const,
+        provider: 'opencode-go',
+        model: 'qwen3.8-flash',
+      };
+      onChange?.(next);
+      onCommit?.(next);
+    };
+    return (
+      <div data-testid="model-selector">
+        <button type="button" onClick={selectQwen}>
+          Select Qwen
+        </button>
+      </div>
+    );
+  },
 }));
 vi.mock('../PermissionModeSelector', () => ({
   CODEX_APPROVAL_POLICIES: [],
@@ -68,5 +108,58 @@ describe('AgenticToolConfigForm reasoning effort', () => {
 
     expect(await screen.findByText(/exact OpenCode provider and model/i)).toBeInTheDocument();
     await waitFor(() => expect(onFinish).not.toHaveBeenCalled());
+  });
+
+  it('shows inherited only and rejects a stored effort for a known-empty OpenCode model', async () => {
+    const onFinish = vi.fn();
+    render(
+      <Form
+        initialValues={{
+          modelConfig: { mode: 'exact', provider: 'opencode-go', model: 'qwen3.8-flash' },
+          effort: 'high',
+        }}
+        onFinish={onFinish}
+      >
+        <AgenticToolConfigForm agenticTool="opencode" />
+        <button type="submit">Save</button>
+      </Form>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('effort-selector').textContent).toBe('|inherited')
+    );
+    expect(screen.getByText(/no explicit effort.*use inherited/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(onFinish).not.toHaveBeenCalled());
+  });
+
+  it('clears an incompatible stale effort after an explicit model change', async () => {
+    const onFinish = vi.fn();
+    render(
+      <Form
+        initialValues={{
+          modelConfig: { mode: 'exact', provider: 'openai', model: 'gpt-test' },
+          effort: 'high',
+        }}
+        onFinish={onFinish}
+      >
+        <AgenticToolConfigForm agenticTool="opencode" />
+        <button type="submit">Save</button>
+      </Form>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select Qwen' }));
+    await waitFor(() =>
+      expect(screen.getByTestId('effort-selector').textContent).toBe('|inherited')
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() =>
+      expect(onFinish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          modelConfig: expect.objectContaining({ model: 'qwen3.8-flash' }),
+          effort: undefined,
+        })
+      )
+    );
   });
 });

--- a/apps/agor-ui/src/components/AgenticToolConfigForm/AgenticToolConfigForm.tsx
+++ b/apps/agor-ui/src/components/AgenticToolConfigForm/AgenticToolConfigForm.tsx
@@ -16,9 +16,10 @@
 
 import { AGENTIC_TOOL_CAPABILITIES, getAgenticToolModelSelectionError } from '@agor/agentic-tools';
 import { getAgenticToolUIIntegration } from '@agor/agentic-tools/ui';
-import type { AgenticToolName, AgorClient } from '@agor-live/client';
+import type { AgenticToolName, AgorClient, EffortLevel } from '@agor-live/client';
 import { DEFAULT_CLAUDE_MODEL } from '@agor-live/client';
 import { Form, Select } from 'antd';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { CodexNetworkAccessToggle } from '../CodexNetworkAccessToggle';
 import { EffortSelector } from '../EffortSelector';
 import { ModelSelector } from '../ModelSelector';
@@ -75,10 +76,54 @@ export const AgenticToolConfigForm: React.FC<AgenticToolConfigFormProps> = ({
   branchId,
   showAdvisor = true,
 }) => {
+  const form = Form.useFormInstance();
+  const selectedModel = Form.useWatch('modelConfig', form) as
+    | { provider?: string; model?: string }
+    | undefined;
+  const selectedEffort = Form.useWatch('effort', form) as EffortLevel | undefined;
   const modelLabel = modelLabelForTool(agenticTool);
   const showCodexFields = agenticTool === 'codex' && !compact;
   const toolCapabilities = AGENTIC_TOOL_CAPABILITIES[agenticTool];
-  const effortLevels = toolCapabilities.reasoningEffortLevels;
+  const toolEffortLevels = toolCapabilities.reasoningEffortLevels;
+  const [openCodeEffortAvailability, setOpenCodeEffortAvailability] = useState<{
+    provider: string;
+    model: string;
+    levels: readonly EffortLevel[] | undefined;
+  }>();
+  const modelSelectionCommittedRef = useRef(false);
+  const onReasoningEffortLevelsChange = useCallback(
+    (availability: {
+      provider: string;
+      model: string;
+      levels: readonly EffortLevel[] | undefined;
+    }) => setOpenCodeEffortAvailability(availability),
+    []
+  );
+  const selectedPairMatchesAvailability =
+    agenticTool === 'opencode' &&
+    openCodeEffortAvailability?.provider === selectedModel?.provider &&
+    openCodeEffortAvailability?.model === selectedModel?.model;
+  const modelEffortLevels = selectedPairMatchesAvailability
+    ? openCodeEffortAvailability?.levels
+    : undefined;
+  const modelEffortMetadataKnown =
+    selectedPairMatchesAvailability && modelEffortLevels !== undefined;
+  const effortLevels = modelEffortMetadataKnown ? modelEffortLevels : toolEffortLevels;
+  const effortIncompatible = Boolean(
+    modelEffortMetadataKnown && selectedEffort && !modelEffortLevels.includes(selectedEffort)
+  );
+
+  useEffect(() => {
+    if (agenticTool !== 'opencode') {
+      modelSelectionCommittedRef.current = false;
+      return;
+    }
+    if (!modelSelectionCommittedRef.current || !modelEffortMetadataKnown) return;
+    if (selectedEffort && !modelEffortLevels?.includes(selectedEffort)) {
+      form.setFieldValue('effort', undefined);
+    }
+    modelSelectionCommittedRef.current = false;
+  }, [agenticTool, form, modelEffortLevels, modelEffortMetadataKnown, selectedEffort]);
 
   return (
     <>
@@ -104,6 +149,10 @@ export const AgenticToolConfigForm: React.FC<AgenticToolConfigFormProps> = ({
           client={client}
           branchId={branchId}
           showAdvisor={showAdvisor}
+          onCommit={() => {
+            modelSelectionCommittedRef.current = true;
+          }}
+          onReasoningEffortLevelsChange={onReasoningEffortLevelsChange}
         />
       </Form.Item>
 
@@ -115,16 +164,39 @@ export const AgenticToolConfigForm: React.FC<AgenticToolConfigFormProps> = ({
         <PermissionModeSelector agentic_tool={agenticTool} compact={compact} fullWidth />
       </Form.Item>
 
-      {effortLevels && (
+      {toolEffortLevels && (
         <Form.Item
           name="effort"
           label="Reasoning Effort"
+          rules={[
+            {
+              validator: (_, value: EffortLevel | undefined) =>
+                modelEffortMetadataKnown && value && !modelEffortLevels?.includes(value)
+                  ? Promise.reject(
+                      new Error(
+                        (modelEffortLevels?.length ?? 0) > 0
+                          ? `Choose a supported effort: ${modelEffortLevels?.join(', ')}`
+                          : 'This model has no explicit effort in the configured OpenCode runtime; use inherited.'
+                      )
+                    )
+                  : Promise.resolve(),
+            },
+          ]}
+          validateStatus={effortIncompatible ? 'error' : undefined}
           help={
-            showHelpText
-              ? toolCapabilities.defaultReasoningEffort
-                ? 'Control how much reasoning the agent applies'
-                : 'Control how much reasoning the agent applies; inherited uses the runtime configuration'
-              : undefined
+            effortIncompatible
+              ? (modelEffortLevels?.length ?? 0) > 0
+                ? `Choose a supported effort: ${modelEffortLevels?.join(', ')}`
+                : 'This model has no explicit effort in the configured OpenCode runtime; use inherited.'
+              : showHelpText
+                ? agenticTool === 'opencode' && !modelEffortMetadataKnown
+                  ? 'Available efforts are unknown for this exact model and will be validated at runtime; inherited uses the model default.'
+                  : agenticTool === 'opencode' && modelEffortLevels?.length === 0
+                    ? 'This model has no explicit effort in the configured OpenCode runtime; use inherited.'
+                    : toolCapabilities.defaultReasoningEffort
+                      ? 'Control how much reasoning the agent applies'
+                      : 'Control how much reasoning the agent applies; inherited uses the runtime configuration'
+                : undefined
           }
         >
           <EffortSelector

--- a/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
+++ b/apps/agor-ui/src/components/ModelSelector/ModelSelector.tsx
@@ -8,6 +8,7 @@ import {
   CURSOR_MODEL_METADATA,
   DEFAULT_CODEX_MODEL,
   DEFAULT_COPILOT_MODEL,
+  type EffortLevel,
   GEMINI_MODELS,
   type GeminiModel,
 } from '@agor-live/client';
@@ -38,6 +39,11 @@ export interface ModelSelectorProps {
   onChange?: (config: ModelConfig) => void;
   /** Fired after an explicit user selection or completed exact-model edit. */
   onCommit?: (config: ModelConfig) => void;
+  onReasoningEffortLevelsChange?: (availability: {
+    provider: string;
+    model: string;
+    levels: readonly EffortLevel[] | undefined;
+  }) => void;
   agent?: AgenticToolName; // Kept as 'agent' for backwards compat in prop name
   agentic_tool?: AgenticToolName;
   /**
@@ -140,6 +146,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
   value,
   onChange,
   onCommit,
+  onReasoningEffortLevelsChange,
   agent,
   agentic_tool,
   client,
@@ -342,6 +349,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
             provider: selection.provider,
           });
         }}
+        onReasoningEffortLevelsChange={onReasoningEffortLevelsChange}
       />
     );
   }

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.test.tsx
@@ -19,8 +19,11 @@ vi.mock('../ModelSelector', () => ({
   ModelSelector: () => <div data-testid="model-selector-stub" />,
 }));
 vi.mock('../EffortSelector', () => ({
-  EffortSelector: ({ value }: { value?: EffortLevel }) => (
-    <div data-testid="effort-selector-stub">{value ?? 'Inherited'}</div>
+  EffortSelector: ({ value, levels }: { value?: EffortLevel; levels?: readonly EffortLevel[] }) => (
+    <div data-testid="effort-selector-stub">
+      <span>{value ?? 'Inherited'}</span>
+      <span data-testid="effort-levels-stub">{levels?.join(',') ?? 'unknown'}</span>
+    </div>
   ),
 }));
 
@@ -506,6 +509,40 @@ describe('SessionFooter', () => {
     const overflowOptions = await screen.findByRole('group', { name: 'More options' });
     expect(within(overflowOptions).getByText('Effort')).toBeInTheDocument();
     expect(within(overflowOptions).getByText('Inherited')).toBeInTheDocument();
+  });
+
+  it('uses the exact OpenCode model effort set in the footer', async () => {
+    render(
+      <SessionFooter
+        {...baseProps}
+        currentUserId="opencode-owner"
+        session={
+          {
+            ...baseSession,
+            branch_id: 'branch-1',
+            created_by: 'opencode-owner',
+            agentic_tool: 'opencode',
+            model_config: {
+              mode: 'exact',
+              provider: 'opencode-go',
+              model: 'qwen3.8-flash',
+            },
+          } as Session
+        }
+        modelConfig={{
+          mode: 'exact',
+          provider: 'opencode-go',
+          model: 'qwen3.8-flash',
+        }}
+        toolCaps={AGENTIC_TOOL_CAPABILITIES.opencode}
+      />,
+      { wrapper: Wrapper }
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'More options' }));
+    const overflowOptions = await screen.findByRole('group', { name: 'More options' });
+    expect(within(overflowOptions).getByText('Effort')).toBeInTheDocument();
+    expect(within(overflowOptions).getByTestId('effort-levels-stub')).toBeEmptyDOMElement();
   });
 });
 

--- a/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionFooter.tsx
@@ -1,3 +1,4 @@
+import { useAgenticToolReasoningEffortLevels } from '@agor/agentic-tools/ui';
 import type {
   AgenticToolCapabilities,
   AgenticToolName,
@@ -98,7 +99,7 @@ export interface SessionFooterProps {
   modelLabel?: string;
   modelConfig?: ModelConfig;
   // Handlers
-  onModelConfigCommit: (config: ModelConfig) => void;
+  onModelConfigCommit: (config: ModelConfig, options?: { clearEffort?: boolean }) => void;
   onOpenSessionSettings?: (sessionId: string) => void;
   onSendPrompt: () => void;
   onStop: () => void;
@@ -162,6 +163,46 @@ const SessionFooterInner: React.FC<SessionFooterProps> = ({
 }) => {
   const managedByPreset = Boolean(session.agentic_tool_preset_id);
   const supportsLiveEffort = Boolean(toolCaps?.reasoningEffortLevels?.length);
+  const modelEffortLevels = useAgenticToolReasoningEffortLevels({
+    tool: session.agentic_tool,
+    selection:
+      modelConfig?.provider && modelConfig.model
+        ? { provider: modelConfig.provider, model: modelConfig.model }
+        : undefined,
+    client,
+    branchId: session.branch_id,
+    catalogEnabled: session.created_by === currentUserId,
+  });
+  const modelEffortMetadataKnown =
+    session.agentic_tool === 'opencode' && modelEffortLevels !== undefined;
+  const effectiveEffortLevels = modelEffortMetadataKnown
+    ? modelEffortLevels
+    : toolCaps?.reasoningEffortLevels;
+  const modelEffortAvailabilityRef = React.useRef<
+    | {
+        provider: string;
+        model: string;
+        levels: readonly EffortLevel[] | undefined;
+      }
+    | undefined
+  >(undefined);
+  const handleModelConfigCommit = React.useCallback(
+    (next: ModelConfig) => {
+      const availability = modelEffortAvailabilityRef.current;
+      const clearEffort = Boolean(
+        session.agentic_tool === 'opencode' &&
+          effortLevel &&
+          availability !== undefined &&
+          availability.provider === next.provider &&
+          availability.model === next.model &&
+          availability.levels !== undefined &&
+          !availability.levels.includes(effortLevel)
+      );
+      if (clearEffort) onModelConfigCommit(next, { clearEffort: true });
+      else onModelConfigCommit(next);
+    },
+    [effortLevel, onModelConfigCommit, session.agentic_tool]
+  );
   const { token } = theme.useToken();
   const [moreOpen, setMoreOpen] = React.useState(false);
   const moreContentRef = React.useRef<HTMLFieldSetElement>(null);
@@ -336,7 +377,10 @@ const SessionFooterInner: React.FC<SessionFooterProps> = ({
           <ModelSelector
             key={session.session_id}
             value={modelConfig}
-            onCommit={onModelConfigCommit}
+            onCommit={handleModelConfigCommit}
+            onReasoningEffortLevelsChange={(availability) => {
+              modelEffortAvailabilityRef.current = availability;
+            }}
             agentic_tool={session.agentic_tool}
             client={client}
             branchId={session.branch_id}
@@ -374,7 +418,7 @@ const SessionFooterInner: React.FC<SessionFooterProps> = ({
             <EffortSelector
               value={effortLevel}
               onChange={onEffortChange}
-              levels={toolCaps.reasoningEffortLevels}
+              levels={effectiveEffortLevels}
               fallbackValue={toolCaps.defaultReasoningEffort}
               allowInherited={!toolCaps.defaultReasoningEffort}
               size="small"
@@ -1417,7 +1461,10 @@ const SessionFooterInner: React.FC<SessionFooterProps> = ({
                       <ModelSelector
                         key={session.session_id}
                         value={modelConfig}
-                        onCommit={onModelConfigCommit}
+                        onCommit={handleModelConfigCommit}
+                        onReasoningEffortLevelsChange={(availability) => {
+                          modelEffortAvailabilityRef.current = availability;
+                        }}
                         agentic_tool={session.agentic_tool}
                         client={client}
                         branchId={session.branch_id}

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -935,7 +935,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   // lifetime-stable wrappers that delegate to the latest implementations via
   // a ref (re-pointed each render, right where the impls are defined).
   const footerHandlersRef = React.useRef<{
-    onModelConfigCommit: (config: ModelConfig) => void;
+    onModelConfigCommit: (config: ModelConfig, options?: { clearEffort?: boolean }) => void;
     onSendPrompt: () => void;
     onStop: () => void;
     onFork: () => void;
@@ -949,8 +949,8 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
   } | null>(null);
   const stableFooterHandlers = React.useMemo(
     () => ({
-      onModelConfigCommit: (config: ModelConfig) =>
-        footerHandlersRef.current?.onModelConfigCommit(config),
+      onModelConfigCommit: (config: ModelConfig, options?: { clearEffort?: boolean }) =>
+        footerHandlersRef.current?.onModelConfigCommit(config, options),
       onSendPrompt: () => footerHandlersRef.current?.onSendPrompt(),
       onStop: () => footerHandlersRef.current?.onStop(),
       onFork: () => footerHandlersRef.current?.onFork(),
@@ -1554,7 +1554,7 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     }
   };
 
-  const handleModelConfigCommit = (newConfig: ModelConfig) => {
+  const handleModelConfigCommit = (newConfig: ModelConfig, options?: { clearEffort?: boolean }) => {
     if (session && onUpdateSession) {
       const nextConfig: NonNullable<Session['model_config']> = {
         ...session.model_config,
@@ -1571,6 +1571,10 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
         nextConfig.advisorModel = newConfig.advisorModel;
       } else {
         delete nextConfig.advisorModel;
+      }
+      if (options?.clearEffort) {
+        delete nextConfig.effort;
+        setEffortLevel(undefined);
       }
       onUpdateSession(session.session_id, { model_config: nextConfig });
     }

--- a/docs/plans/opencode-go-effort-availability.md
+++ b/docs/plans/opencode-go-effort-availability.md
@@ -1,6 +1,6 @@
 # Plan: OpenCode Go effort availability
 
-**Status:** investigation and implementation plan only. This branch must not contain the fix.
+**Status:** implemented on this branch for PR #2619.
 
 ## Symptom and concrete reproduction
 
@@ -333,11 +333,9 @@ pre-prompt runtime validation remains the authoritative fail-closed boundary.
   its catalog addition is not duplicated or lost during rebase onto current
   main.
 
-## Explicitly out of scope
+## Implementation boundaries
 
-- No production-code, catalog, UI, MCP, runtime, or test implementation on this
-  planning branch.
-- No commit, push, PR, deployment, or modification of the failing session.
+- No deployment or modification of the original failing session.
 - No automatic effort mapping, silent fallback, or change to the shared five
   `EffortLevel` values.
 - No OpenCode CLI/SDK upgrade or adoption of newer model-catalog semantics.

--- a/docs/plans/opencode-go-effort-availability.md
+++ b/docs/plans/opencode-go-effort-availability.md
@@ -1,0 +1,346 @@
+# Plan: OpenCode Go effort availability
+
+**Status:** investigation and implementation plan only. This branch must not contain the fix.
+
+## Symptom and concrete reproduction
+
+The failing Agor session is `01a051ab-93b0-76d2-a592-ae211b36efdc` (parent
+`01a05196-64ea-720f-8283-a8c840388f65`) with:
+
+```json
+{
+  "agentic_tool": "opencode",
+  "model_config": {
+    "mode": "exact",
+    "provider": "opencode-go",
+    "model": "qwen3.8-flash",
+    "effort": "high"
+  }
+}
+```
+
+Task `01a051ab-93c4-74df-8ca1-ab287da89d3f` failed in about 62 seconds with
+`tool_use_count: 0` and exactly:
+
+> The selected OpenCode reasoning effort is not available for this session
+> owner's provider/model and branch configuration; choose a supported effort or
+> leave it unset
+
+The executor connected, started the pinned OpenCode `1.14.33` server, and read
+`/config/providers` and `/provider`. It did not create an OpenCode session or
+submit an LLM prompt. This places the failure in Agor's pre-prompt availability
+check rather than in an OpenCode Go inference request.
+
+An otherwise equivalent session, `01a051ad-1406-7311-b7de-deceb3d28fe2`, used
+the same owner, branch, exact `opencode-go/qwen3.8-flash` pair, and no effort.
+Task `01a051ad-1418-7762-acd2-51ea5eacb996` created an OpenCode session and made
+LLM calls before later failing with an unrelated `fetch failed`. That is direct
+evidence that leaving effort unset passes Agor's model/effort admission and that
+the provider/model pair itself resolves.
+
+The repro branch contains no project `opencode.json`, `opencode.jsonc`, or
+`.opencode` configuration. A branch-local variant override is therefore not the
+cause in this repro.
+
+## Current-main failure path
+
+All repository citations in this section refer to this planning branch at
+`384733b4b` (the current-main snapshot supplied for this investigation).
+
+1. Agor's shared `EffortLevel` is `low | medium | high | xhigh | max`, and the
+   selected value is persisted under `session.model_config.effort`
+   (`packages/core/src/types/session.ts:3-7`, `packages/core/src/types/session.ts:341-360`).
+2. The OpenCode integration advertises all five values as a **tool-wide**
+   capability, without considering provider or model
+   (`packages/agentic-tool-opencode/src/shared/index.ts:18-25`).
+3. `AgenticToolConfigForm` passes that tool-wide list directly to
+   `EffortSelector`; the selector only filters against the supplied global list
+   (`apps/agor-ui/src/components/AgenticToolConfigForm/AgenticToolConfigForm.tsx:78-82`,
+   `apps/agor-ui/src/components/AgenticToolConfigForm/AgenticToolConfigForm.tsx:118-135`,
+   `apps/agor-ui/src/components/EffortSelector/EffortSelector.tsx:32-58`,
+   `apps/agor-ui/src/components/EffortSelector/EffortSelector.tsx:63-77`). Thus
+   the UI offers `high` for every OpenCode model.
+4. The standalone form field is folded into `model_config` and sent on session
+   creation (`apps/agor-ui/src/components/AgenticToolConfigForm/agenticConfigHelpers.ts:38-47`,
+   `apps/agor-ui/src/hooks/useSessionActions.ts:85-101`). MCP behaves similarly:
+   its common schema accepts any of the five efforts and `coerceModelConfig`
+   passes the object through (`apps/agor-daemon/src/mcp/tools/sessions.ts:59-135`).
+5. Session creation only performs special model validation for Codex. OpenCode
+   is checked for a complete exact provider/model pair, not whether that pair
+   exposes the requested effort
+   (`apps/agor-daemon/src/services/sessions.ts:279-286`,
+   `packages/agentic-tool-opencode/src/shared/model-configuration.ts:19-31`).
+6. The executor forwards the persisted provider, model, and effort unchanged
+   (`packages/executor/src/handlers/sdk/opencode.ts:147-159`).
+7. After starting OpenCode, `OpenCodeTool` calls
+   `assertExplicitModelAvailable` **before** resolving/creating an OpenCode
+   session (`packages/agentic-tool-opencode/src/runtime/opencode-tool.ts:743-758`).
+   The check finds the exact provider/model in live OpenCode discovery and, when
+   effort is set, requires `selectedModel.variants` to contain that exact key
+   (`packages/agentic-tool-opencode/src/runtime/opencode-tool.ts:867-915`). The
+   reported string is thrown at lines 910-913. If admitted, the same value is
+   sent as OpenCode's `variant` at lines 1020-1032.
+
+The validator deliberately checks both candidate map keys and each model's
+reported `id` (`packages/agentic-tool-opencode/src/runtime/opencode-tool.ts:886-891`).
+The repro is consequently neither an exact-mode/alias mismatch nor a missing
+provider/model pair. It is the requested variant key that is absent.
+
+## Root cause
+
+### Contract mismatch
+
+Agor exposes effort as a tool-global five-value control, while the pinned
+OpenCode runtime exposes reasoning as a provider/model-specific `variants` map
+and Agor correctly enforces that live map at execution time. Neither the
+server-free catalog nor live catalog projection carries variant names:
+
+- `OpenCodeCatalogModel` only has `id`, `name`, and `status`
+  (`packages/core/src/types/opencode-models.ts:8-12`).
+- The known-model helper constructs only those fields
+  (`packages/agentic-tool-opencode/src/shared/known-models.ts:14-19`).
+- Live discovery also projects models down to `id`, `name`, and `status`,
+  discarding `variants` (`packages/agentic-tool-opencode/src/runtime/auth-handler.ts:177-270`,
+  especially lines 228-235).
+- The model selector only selects provider/model and has no model-effort
+  contract (`packages/agentic-tool-opencode/src/ui/useOpenCodeModelCatalog.ts:23-26`,
+  `packages/agentic-tool-opencode/src/ui/OpenCodeModelSelector.tsx:45-96`).
+- `agor_models_list` returns an empty model list for OpenCode and tells MCP
+  callers to use a provider catalog that the MCP response does not expose
+  (`apps/agor-daemon/src/mcp/tools/sessions.ts:1682-1701`,
+  `apps/agor-daemon/src/mcp/tools/sessions.ts:1759-1763`).
+
+The UI and MCP can therefore persist a combination that looks supported from
+Agor's public capability metadata but is rejected by Agor's more accurate live
+runtime check. The roughly one-minute delay is runtime startup/discovery, not
+reasoning or tool use.
+
+### Why `qwen3.8-flash + high` is rejected
+
+Agor pins both the OpenCode SDK/package and managed CLI to `1.14.33`
+(`packages/agentic-tool-opencode/src/shared/known-models.ts:7`,
+`packages/agentic-tool-opencode/package.json:53-56`,
+`packages/agentic-tool-opencode/src/runtime/binary.ts:61-99`). In that OpenCode
+release, the provider transform returns no variants for model IDs containing
+`qwen`; it also lacks the newer model-catalog schema needed to consume
+`reasoning_options`. See the exact upstream implementation in
+[OpenCode 1.14.33's variant transform](https://github.com/anomalyco/opencode/blob/v1.14.33/packages/opencode/src/provider/transform.ts#L427-L457)
+and [provider model conversion](https://github.com/anomalyco/opencode/blob/v1.14.33/packages/opencode/src/provider/provider.ts#L989-L1037),
+together with that release's [accepted model-catalog schema](https://github.com/anomalyco/opencode/blob/v1.14.33/packages/opencode/src/provider/models.ts#L27-L78).
+The live `qwen3.8-flash` model therefore has no `variants.high` key (in fact, no
+native variants at all) and the exact runtime check rejects it. The
+[models.dev catalog](https://models.dev/api.json) observed on 2026-08-30
+described low/medium/xhigh reasoning choices for this model, but the pinned
+runtime cannot use that newer metadata; moreover, `high` is not one of those
+declared choices, so silently mapping or forcing it would still be wrong.
+
+### OpenCode Go model inventory
+
+Current main does not curate `opencode-go`, so a credential-backed provider is
+shown with zero known models
+(`packages/agentic-tool-opencode/src/shared/known-models.ts:127-135`). PR #2605
+proposes 25 active models. Applying OpenCode `1.14.33`'s provider conversion to
+the `opencode-go` metadata observed for those exact entries on 2026-08-30 gives
+the following Agor-selectable variant keys (excluding OpenCode-only names such
+as `none` or `minimal`):
+
+| Agor effort keys exposed by pinned runtime | Proposed #2605 models                                                                                                                                                                                               | Count |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----: |
+| `low, medium, high, xhigh`                 | `gpt-5.6-luna`, `muse-spark-1.2-contributor`                                                                                                                                                                        |     2 |
+| `low, medium, high, max`                   | `deepseek-v4-flash`, `deepseek-v4-flash-vision-exp`, `deepseek-v4-pro`                                                                                                                                              |     3 |
+| `low, medium, high`                        | `hy3`, `hy4-preview`, `longcat-2.0`, `mimo-v2.5`, `mimo-v2.5-pro`                                                                                                                                                   |     5 |
+| none                                       | `glm-5.1`, `glm-5.2`, `glm-5.3`, `glm-5.3-flash`, `grok-4.6`, `kimi-k2.6`, `kimi-k2.7-code`, `kimi-k3`, `minimax-m2.7`, `minimax-m3`, `qwen3.6-plus`, `qwen3.7-max`, `qwen3.7-plus`, `qwen3.8-flash`, `qwen3.8-max` |    15 |
+
+Thus 15 of the 25 proposed models reject **every** explicit Agor effort under
+the pinned runtime; only 10 expose any compatible key. This substantiates the
+report that the problem affects “most” OpenCode Go models. The catalog's lack
+of model-level effort metadata is the Agor product bug; the empty native variant
+sets are also a limitation/behavior of the pinned upstream runtime.
+
+## Relationship to PR #2605
+
+The related worktree is at commit `b3f95e956` (`feat(opencode): add OpenCode Go
+provider and surface runtime-unavailable errors`), based on older main
+`66ed08618`; the reviewed local diff is 12 files, +243/-8. It:
+
+- adds `opencode-go` to the curated known-provider catalog with the 25 models
+  enumerated above and suggested model `gpt-5.6-luna`;
+- propagates an environment marker used by credential/provider discovery; and
+- makes OpenCode binary/runtime-unavailable failures visible in provider
+  settings, with tests for those behaviors.
+
+It does **not** change `OpenCodeCatalogModel`, retain live `variants`, change
+the global `reasoningEffortLevels`, make `EffortSelector` model-aware, change
+the MCP model/effort contract, or alter `assertExplicitModelAvailable`. Its
+new models still contain only `id`/`name`/`status`, and its tests do not cover
+effort. There is no separate plan/design document in that commit.
+
+Therefore #2605 is adjacent but does not fix this bug. It makes the affected
+models selectable and thereby exposes the pre-existing mismatch more often.
+The mismatch predates that PR (the current validator and global effort
+capability were introduced independently). Relevant drift from #2605's base to
+current main includes newer agentic-integration/config-home capability plumbing,
+but no change that resolves OpenCode effort behavior. The implementation should
+either extend #2605 before merge or land immediately after it from a current-main
+rebase; duplicating its 25-model catalog addition on this planning branch would
+be wrong.
+
+## Recommended fix
+
+Keep runtime validation strict, but make the selectable effort values
+model-aware and expose the same safe metadata to UI and MCP callers. This is the
+smallest correct Agor-style fix because it prevents known-invalid choices while
+retaining the live, branch-aware check as the final authority.
+
+1. **Add a model-level safe effort read model.** Extend
+   `OpenCodeCatalogModel` with an optional field such as
+   `reasoningEffortLevels?: EffortLevel[]`. Preserve the semantic distinction
+   between “unknown/not discovered” and “known to have no Agor-compatible
+   variants”; an explicit empty array must not be collapsed into missing data.
+   Store only variant key names intersected with the shared `EffortLevel` enum,
+   never OpenCode's variant option bodies.
+2. **Populate the curated OpenCode Go models alongside #2605.** Add the exact
+   pinned-runtime values in the table above to #2605's 25 entries. Centralize a
+   pure filtering/helper function so known-catalog tests, live projection, MCP,
+   and runtime diagnostics use the same set of Agor-recognized keys. Record the
+   OpenCode version used to derive the static data; the catalog already exposes
+   `runtimeVersion`.
+3. **Retain safe live variant names during authenticated discovery.** Extend the
+   existing owner/tenant/branch-scoped discovery projection in
+   `runtime/auth-handler.ts` to include filtered variant names. Live discovery
+   should override static advice when available because project configuration
+   may add, remove, or alter variants. Continue to discard all variant option
+   bodies and provider configuration so the endpoint remains a safe read model.
+4. **Make effort selection follow the selected exact model.** Have the package-
+   owned OpenCode selector/integration provide the selected model's effective
+   effort list to `AgenticToolConfigForm`, rather than always using the tool-wide
+   five-value list. For a known empty list, show only inherited/unset (with copy
+   that this model has no explicit effort in the configured runtime). For
+   unknown metadata, preserve an explicit “validated at runtime” state rather
+   than falsely treating it as unsupported. When the user changes provider or
+   model, clear an incompatible stale effort or surface immediate form
+   validation before saving; do not silently persist it.
+5. **Expose the same discovery to MCP.** Make `agor_models_list` return OpenCode
+   provider/model entries with `reasoningEffortLevels`, or add a narrowly scoped
+   read-only OpenCode catalog tool if changing the generic shape would be
+   incompatible. Document that an empty list means omit `modelConfig.effort`,
+   missing metadata is runtime-validated, and live branch configuration remains
+   authoritative. Keep the common five-value input enum; validity depends on
+   the exact pair. Also correct its “default: high” description for OpenCode:
+   unset means inherit the runtime/model default, not force `high`.
+6. **Improve, but do not weaken, the final runtime diagnostic.** Continue to
+   reject before prompt submission when live `selectedModel.variants` lacks the
+   requested key. Include the requested value and filtered supported values in
+   the error; if there are none, explicitly say to leave effort unset. Never
+   include variant payloads or provider configuration in the error.
+
+Do not add a static hard rejection to generic session creation. The live model
+map is owner-, provider-, and branch-dependent; manual exact pairs and branch
+variant overrides can legitimately differ from the server-free catalog. Static
+metadata should prevent bad choices and improve guidance, while the existing
+pre-prompt runtime validation remains the authoritative fail-closed boundary.
+
+## Alternatives considered
+
+| Alternative                                               | Why reject it                                                                                                                                                                                |
+| --------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Silently ignore/strip an unsupported effort               | The persisted session would claim a setting the runtime did not apply, making runs irreproducible and hiding user error.                                                                     |
+| Map `high` to another variant                             | OpenCode exposes named native variants, not an ordered compatibility contract. `qwen3.8-flash`'s newer declared values do not even include `high`; there is no defensible universal mapping. |
+| Add only the 25 model names from #2605                    | That is exactly what #2605 does; names/status alone cannot drive effort availability.                                                                                                        |
+| Globally remove effort for OpenCode                       | Ten of the 25 proposed OpenCode Go models expose useful supported effort keys, and other providers/models also support variants.                                                             |
+| Send the unknown variant and let upstream decide          | It lies in UI/state and removes Agor's useful fail-fast guarantee; pinned OpenCode's variant contract is the live source of truth.                                                           |
+| Hard-reject from the static catalog during session create | It would reject valid manual or branch-overridden configurations and cannot reflect owner-specific live provider state.                                                                      |
+| Upgrade OpenCode as the sole fix                          | An upgrade is a broader SDK/binary/catalog change and does not remove per-model differences. Even newer metadata does not make `high` valid for every model. It can be evaluated separately. |
+
+## Test plan
+
+### Catalog and filtering
+
+- Extend `known-models.test.ts` to assert all 25 #2605 models and their explicit
+  effort metadata, including `qwen3.8-flash: []`, positive GPT/DeepSeek cases,
+  and unchanged credential-gated visibility.
+- Unit-test the shared filter: accept only `low|medium|high|xhigh|max`, discard
+  `none`, `minimal`, arbitrary names, and option values; distinguish unknown
+  metadata from a known empty list.
+- Pin expectations to OpenCode `1.14.33` so a runtime upgrade forces deliberate
+  review rather than silently making the UI stale.
+
+### Live discovery and security
+
+- Extend `auth-handler.integration.test.ts` so discovered models contain safe
+  variant key names only, branch-added/removed variants are reflected, and
+  variant option bodies/secrets are never returned.
+- Preserve current credential gating and authenticated subject resolution.
+  Because this is tenant/user/branch-owned discovery, add proportional negative
+  coverage proving one user/tenant cannot inspect another owner's provider or
+  variant metadata.
+
+### UI
+
+- Replace the current OpenCode form expectation that always exposes all five
+  levels with model-specific tests.
+- Cover a supported model, a known-empty model, unknown/manual exact metadata,
+  inherited/unset behavior, and switching from a supported model with a saved
+  effort to an incompatible model.
+- Verify Codex and other tool behavior remains unchanged.
+- Verify a collaborator who cannot read the session owner's private provider
+  catalog does not accidentally substitute the collaborator's own catalog for
+  the stored exact pair; leave final validation to the owner-scoped runtime.
+
+### MCP and service behavior
+
+- Add MCP tests for OpenCode provider/model/effort discovery and for accurate
+  unset/inherited guidance.
+- Verify create/spawn/prompt preserve an omitted effort, while the shared input
+  schema still accepts all five values for pairs that support them.
+- Do not add false static rejection for manual exact or branch-overridden pairs.
+
+### Runtime
+
+- Extend `opencode-tool.test.ts` with: `qwen3.8-flash + high` rejected before
+  session creation; the same pair unset admitted; a supported exact variant
+  admitted and sent; and a branch-provided supported variant admitted.
+- Assert the revised error lists only filtered safe keys and never serializes
+  variant payloads or provider configuration.
+- Manually repeat the concrete repro: the UI/MCP discovery must prevent or warn
+  about `qwen3.8-flash + high`; unset must reach OpenCode prompt submission; a
+  listed supported pair must still pass.
+- Run scoped core/OpenCode package, daemon MCP, and UI tests plus typecheck/lint.
+  Do not start dev servers or run a workspace build for this change.
+
+## Risks and open questions
+
+- **Catalog drift:** OpenCode `1.14.33` can consume a refreshed external model
+  catalog while Agor's curated metadata is static. Decide whether static values
+  are generated at release time or maintained manually, and make the pin/drift
+  visible in tests. Live discovery must remain authoritative.
+- **Known empty versus unknown:** This distinction controls whether UI disables
+  effort or allows a runtime-validated advanced choice. It needs an explicit
+  type/API contract, not truthiness.
+- **Branch overrides:** Server-free metadata cannot see project variants. The
+  UI should prefer authenticated branch discovery when available and degrade to
+  advisory static metadata without introducing a static daemon rejection.
+- **Existing invalid sessions:** Opening an already stored incompatible effort
+  should show a warning and an unset path. Do not mutate persisted configuration
+  merely by rendering the form.
+- **Private owner catalogs:** Session collaborators may not be entitled to the
+  owner's provider details. Reuse existing authenticated subject/tenant
+  boundaries and do not expose credentials or variant bodies.
+- **Runtime upgrade:** Newer OpenCode releases may understand
+  `reasoning_options`, changing the 15/25 count and valid values. Treat upgrading
+  the exact CLI/SDK pair as separate, reviewed work with regenerated metadata.
+- **#2605 sequencing:** Coordinate the model metadata with the older-base PR so
+  its catalog addition is not duplicated or lost during rebase onto current
+  main.
+
+## Explicitly out of scope
+
+- No production-code, catalog, UI, MCP, runtime, or test implementation on this
+  planning branch.
+- No commit, push, PR, deployment, or modification of the failing session.
+- No automatic effort mapping, silent fallback, or change to the shared five
+  `EffortLevel` values.
+- No OpenCode CLI/SDK upgrade or adoption of newer model-catalog semantics.
+- No change to OpenCode Go credentials, billing, rate limits, or unrelated
+  runtime-unavailable error handling from #2605.
+- No retroactive mutation of stored sessions or branch configuration.

--- a/packages/agentic-tool-opencode/src/runtime/auth-handler.integration.test.ts
+++ b/packages/agentic-tool-opencode/src/runtime/auth-handler.integration.test.ts
@@ -191,6 +191,10 @@ describe('opencode.auth executor command', () => {
                 name: 'GPT Next',
                 status: 'active',
                 options: { apiKey: 'must-not-cross' },
+                variants: {
+                  high: { apiKey: 'must-not-cross' },
+                  minimal: { apiKey: 'must-not-cross' },
+                },
               },
             },
           },
@@ -237,7 +241,14 @@ describe('opencode.auth executor command', () => {
             credentialPresence: 'present',
             authMethods: [],
             suggestedModel: 'gpt-next',
-            models: [{ id: 'gpt-next', name: 'GPT Next', status: 'active' }],
+            models: [
+              {
+                id: 'gpt-next',
+                name: 'GPT Next',
+                status: 'active',
+                reasoningEffortLevels: ['high'],
+              },
+            ],
           },
         ],
       },

--- a/packages/agentic-tool-opencode/src/runtime/auth-handler.integration.test.ts
+++ b/packages/agentic-tool-opencode/src/runtime/auth-handler.integration.test.ts
@@ -186,6 +186,11 @@ describe('opencode.auth executor command', () => {
             name: 'OpenAI',
             key: 'must-not-cross',
             models: {
+              'custom-unknown': {
+                id: 'custom-unknown',
+                name: 'Custom Unknown',
+                status: 'active',
+              },
               'gpt-next': {
                 id: 'gpt-next',
                 name: 'GPT Next',
@@ -195,6 +200,12 @@ describe('opencode.auth executor command', () => {
                   high: { apiKey: 'must-not-cross' },
                   minimal: { apiKey: 'must-not-cross' },
                 },
+              },
+              'qwen-empty': {
+                id: 'qwen-empty',
+                name: 'Qwen Empty',
+                status: 'active',
+                variants: {},
               },
             },
           },
@@ -243,10 +254,21 @@ describe('opencode.auth executor command', () => {
             suggestedModel: 'gpt-next',
             models: [
               {
+                id: 'custom-unknown',
+                name: 'Custom Unknown',
+                status: 'active',
+              },
+              {
                 id: 'gpt-next',
                 name: 'GPT Next',
                 status: 'active',
                 reasoningEffortLevels: ['high'],
+              },
+              {
+                id: 'qwen-empty',
+                name: 'Qwen Empty',
+                status: 'active',
+                reasoningEffortLevels: [],
               },
             ],
           },

--- a/packages/agentic-tool-opencode/src/runtime/auth-handler.ts
+++ b/packages/agentic-tool-opencode/src/runtime/auth-handler.ts
@@ -228,15 +228,17 @@ async function readConfigurationSnapshot(
           : {}),
         models: modelProvider
           ? Object.values(modelProvider.models)
-              .map((model) => ({
-                id: model.id,
-                name: model.name,
-                status: model.status,
-                reasoningEffortLevels:
-                  filterOpenCodeReasoningEffortLevels(
-                    (model as { variants?: Record<string, unknown> }).variants ?? {}
-                  ) ?? [],
-              }))
+              .map((model) => {
+                const reasoningEffortLevels = filterOpenCodeReasoningEffortLevels(
+                  (model as { variants?: Record<string, unknown> }).variants
+                );
+                return {
+                  id: model.id,
+                  name: model.name,
+                  status: model.status,
+                  ...(reasoningEffortLevels !== undefined ? { reasoningEffortLevels } : {}),
+                };
+              })
               .sort((left, right) => left.id.localeCompare(right.id))
           : [],
       };

--- a/packages/agentic-tool-opencode/src/runtime/auth-handler.ts
+++ b/packages/agentic-tool-opencode/src/runtime/auth-handler.ts
@@ -10,6 +10,7 @@ import type {
 } from '@agor/core/types';
 import type { createOpencodeClient } from '@opencode-ai/sdk/v2';
 import { createOpenCodeKnownModelCatalog } from '../shared/known-models.js';
+import { filterOpenCodeReasoningEffortLevels } from '../shared/reasoning-effort.js';
 import type { OpenCodeAuthPayload } from './auth-payload.js';
 import {
   ensureOpenCodeDataHome as defaultEnsureOpenCodeDataHome,
@@ -231,6 +232,10 @@ async function readConfigurationSnapshot(
                 id: model.id,
                 name: model.name,
                 status: model.status,
+                reasoningEffortLevels:
+                  filterOpenCodeReasoningEffortLevels(
+                    (model as { variants?: Record<string, unknown> }).variants ?? {}
+                  ) ?? [],
               }))
               .sort((left, right) => left.id.localeCompare(right.id))
           : [],

--- a/packages/agentic-tool-opencode/src/runtime/opencode-tool.test.ts
+++ b/packages/agentic-tool-opencode/src/runtime/opencode-tool.test.ts
@@ -218,7 +218,18 @@ describe('OpenCodeTool prompt variants', () => {
 
     expect(error).toBeInstanceOf(Error);
     expect((error as Error).message).toMatch(/reasoning effort.*not available/i);
+    expect((error as Error).message).toContain('high');
+    expect((error as Error).message).toContain('max');
     expect((error as Error).message).not.toContain('must-not-cross');
+  });
+
+  it('directs models without compatible native variants to leave effort unset', async () => {
+    const error = await assertExplicitModelAvailable({ id: 'qwen3.8-flash' }, 'high').catch(
+      (failure: unknown) => failure
+    );
+
+    expect((error as Error).message).toContain('"high"');
+    expect((error as Error).message).toMatch(/no supported explicit efforts.*leave it unset/i);
   });
 
   it('omits the native prompt variant but still submits the Agor system prompt when effort is unset', async () => {

--- a/packages/agentic-tool-opencode/src/runtime/opencode-tool.ts
+++ b/packages/agentic-tool-opencode/src/runtime/opencode-tool.ts
@@ -26,6 +26,7 @@ import {
 } from '@agor/core/types';
 import type { createOpencodeClient } from '@opencode-ai/sdk';
 import { OPENCODE_MODEL_CONFIG_PAIR_ERROR } from '../shared/index.js';
+import { filterOpenCodeReasoningEffortLevels } from '../shared/reasoning-effort.js';
 import type { OpenCodeCommand } from './binary.js';
 import {
   createOpenCodeEventTranslator,
@@ -877,6 +878,7 @@ export class OpenCodeTool {
   ): Promise<void> {
     let modelAvailable = false;
     let effortAvailable = !effort;
+    let supportedEfforts: EffortLevel[] = [];
     try {
       const query = { directory };
       const [catalogResponse, runtimeResponse] = await Promise.all([
@@ -897,7 +899,8 @@ export class OpenCodeTool {
       if (modelAvailable && effort) {
         // OpenCode returns native variants here; the generated SDK model type currently omits them.
         const variants = (selectedModel as { variants?: Record<string, unknown> }).variants;
-        effortAvailable = Boolean(variants && Object.hasOwn(variants, effort));
+        supportedEfforts = filterOpenCodeReasoningEffortLevels(variants ?? {}) ?? [];
+        effortAvailable = supportedEfforts.includes(effort);
       }
     } catch {
       // Public failure stays independent of raw provider objects and SDK details.
@@ -908,8 +911,12 @@ export class OpenCodeTool {
       );
     }
     if (!effortAvailable) {
+      const guidance =
+        supportedEfforts.length > 0
+          ? `choose one of: ${supportedEfforts.join(', ')}, or leave it unset`
+          : 'this model exposes no supported explicit efforts; leave it unset';
       throw new Error(
-        "The selected OpenCode reasoning effort is not available for this session owner's provider/model and branch configuration; choose a supported effort or leave it unset"
+        `The selected OpenCode reasoning effort "${effort}" is not available for this session owner's ${providerId}/${modelId} branch configuration; ${guidance}`
       );
     }
   }

--- a/packages/agentic-tool-opencode/src/shared/index.ts
+++ b/packages/agentic-tool-opencode/src/shared/index.ts
@@ -4,7 +4,6 @@ export {
   parseOpenCodeExecutorContext,
 } from './executor-context.js';
 export { createOpenCodeKnownModelCatalog, OPENCODE_VERSION } from './known-models.js';
-
 export {
   hasCompleteOpenCodeModelConfig,
   OPENCODE_MODEL_CONFIG_PAIR_ERROR,
@@ -12,8 +11,13 @@ export {
   resolveOpenCodeCatalogFallback,
   resolveOpenCodeModelConfig,
 } from './model-configuration.js';
+export {
+  filterOpenCodeReasoningEffortLevels,
+  OPENCODE_AGOR_EFFORT_LEVELS,
+} from './reasoning-effort.js';
 
 import { OPENCODE_MODEL_CONFIGURATION } from './model-configuration.js';
+import { OPENCODE_AGOR_EFFORT_LEVELS } from './reasoning-effort.js';
 
 export const OPENCODE_INTEGRATION = Object.freeze({
   name: 'opencode',
@@ -21,7 +25,7 @@ export const OPENCODE_INTEGRATION = Object.freeze({
   capabilities: {
     supportsSessionFork: false,
     supportsChildSpawn: true,
-    reasoningEffortLevels: ['low', 'medium', 'high', 'xhigh', 'max'],
+    reasoningEffortLevels: OPENCODE_AGOR_EFFORT_LEVELS,
   },
   authentication: 'runtime-managed',
   sdkVersion: '@opencode-ai/sdk@1.14.33',

--- a/packages/agentic-tool-opencode/src/shared/known-models.test.ts
+++ b/packages/agentic-tool-opencode/src/shared/known-models.test.ts
@@ -115,5 +115,40 @@ describe('OpenCode known model catalog', () => {
     expect(provider?.models.find(({ id }) => id === 'qwen3.8-flash')).toMatchObject({
       reasoningEffortLevels: [],
     });
+    expect(
+      Object.fromEntries(
+        Object.entries(
+          Object.groupBy(
+            provider?.models ?? [],
+            (model) => model.reasoningEffortLevels?.join(',') || 'none'
+          )
+        ).map(([levels, models]) => [levels, models?.map(({ id }) => id)])
+      )
+    ).toEqual({
+      'low,medium,high,xhigh': ['gpt-5.6-luna', 'muse-spark-1.2-contributor'],
+      'low,medium,high,max': [
+        'deepseek-v4-flash',
+        'deepseek-v4-flash-vision-exp',
+        'deepseek-v4-pro',
+      ],
+      'low,medium,high': ['hy3', 'hy4-preview', 'longcat-2.0', 'mimo-v2.5', 'mimo-v2.5-pro'],
+      none: [
+        'glm-5.1',
+        'glm-5.2',
+        'glm-5.3',
+        'glm-5.3-flash',
+        'grok-4.6',
+        'kimi-k2.6',
+        'kimi-k2.7-code',
+        'kimi-k3',
+        'minimax-m2.7',
+        'minimax-m3',
+        'qwen3.6-plus',
+        'qwen3.7-max',
+        'qwen3.7-plus',
+        'qwen3.8-flash',
+        'qwen3.8-max',
+      ],
+    });
   });
 });

--- a/packages/agentic-tool-opencode/src/shared/known-models.test.ts
+++ b/packages/agentic-tool-opencode/src/shared/known-models.test.ts
@@ -92,4 +92,28 @@ describe('OpenCode known model catalog', () => {
       ]),
     });
   });
+
+  it('pins OpenCode Go model effort metadata to the packaged runtime', () => {
+    const disconnected = createOpenCodeKnownModelCatalog(new Set());
+    const configured = createOpenCodeKnownModelCatalog(new Set(['opencode-go']));
+    const provider = configured.providers.find(({ id }) => id === 'opencode-go');
+
+    expect(disconnected.providers.find(({ id }) => id === 'opencode-go')).toMatchObject({
+      availableForSelection: false,
+    });
+    expect(configured.suggestedSelection).toEqual({
+      providerId: 'opencode-go',
+      modelId: 'gpt-5.6-luna',
+    });
+    expect(provider?.models).toHaveLength(25);
+    expect(provider?.models.find(({ id }) => id === 'gpt-5.6-luna')).toMatchObject({
+      reasoningEffortLevels: ['low', 'medium', 'high', 'xhigh'],
+    });
+    expect(provider?.models.find(({ id }) => id === 'deepseek-v4-pro')).toMatchObject({
+      reasoningEffortLevels: ['low', 'medium', 'high', 'max'],
+    });
+    expect(provider?.models.find(({ id }) => id === 'qwen3.8-flash')).toMatchObject({
+      reasoningEffortLevels: [],
+    });
+  });
 });

--- a/packages/agentic-tool-opencode/src/shared/known-models.ts
+++ b/packages/agentic-tool-opencode/src/shared/known-models.ts
@@ -15,8 +15,22 @@ interface KnownProvider {
 }
 
 const activeModels = (
-  models: ReadonlyArray<readonly [id: string, name: string]>
-): OpenCodeCatalogModel[] => models.map(([id, name]) => ({ id, name, status: 'active' }));
+  models: ReadonlyArray<
+    readonly [
+      id: string,
+      name: string,
+      reasoningEffortLevels?: OpenCodeCatalogModel['reasoningEffortLevels'],
+    ]
+  >
+): OpenCodeCatalogModel[] =>
+  models.map(([id, name, reasoningEffortLevels]) => ({
+    id,
+    name,
+    status: 'active',
+    ...(reasoningEffortLevels !== undefined
+      ? { reasoningEffortLevels: [...reasoningEffortLevels] }
+      : {}),
+  }));
 
 /** Curated against the OpenCode version pinned by this package. */
 const KNOWN_PROVIDERS = [
@@ -77,6 +91,49 @@ const KNOWN_PROVIDERS = [
       ['claude-opus-4-5', 'Claude Opus 4.5'],
       ['claude-sonnet-4-5', 'Claude Sonnet 4.5'],
       ['claude-haiku-4-5', 'Claude Haiku 4.5'],
+    ]),
+  },
+  {
+    // Active lineup and native variant keys captured from the OpenCode
+    // 1.14.33 post-connect catalog on 2026-08-30.
+    id: 'opencode-go',
+    name: 'OpenCode Go',
+    availableWithoutCredentials: false,
+    suggestedModel: 'gpt-5.6-luna',
+    models: activeModels([
+      ['gpt-5.6-luna', 'GPT-5.6 Luna', ['low', 'medium', 'high', 'xhigh']],
+      ['deepseek-v4-flash', 'DeepSeek V4 Flash', ['low', 'medium', 'high', 'max']],
+      [
+        'deepseek-v4-flash-vision-exp',
+        'DeepSeek V4 Flash Vision Exp',
+        ['low', 'medium', 'high', 'max'],
+      ],
+      ['deepseek-v4-pro', 'DeepSeek V4 Pro (New)', ['low', 'medium', 'high', 'max']],
+      ['glm-5.1', 'GLM-5.1', []],
+      ['glm-5.2', 'GLM-5.2', []],
+      ['glm-5.3', 'GLM-5.3', []],
+      ['glm-5.3-flash', 'GLM-5.3-Flash (2x usage)', []],
+      ['grok-4.6', 'Grok 4.6', []],
+      ['hy3', 'Hy3 (8x usage)', ['low', 'medium', 'high']],
+      ['hy4-preview', 'Hy4 preview', ['low', 'medium', 'high']],
+      ['kimi-k2.6', 'Kimi K2.6', []],
+      ['kimi-k2.7-code', 'Kimi K2.7 Code', []],
+      ['kimi-k3', 'Kimi K3', []],
+      ['longcat-2.0', 'LongCat-2.0', ['low', 'medium', 'high']],
+      ['mimo-v2.5', 'MiMo V2.5', ['low', 'medium', 'high']],
+      ['mimo-v2.5-pro', 'MiMo V2.5 Pro', ['low', 'medium', 'high']],
+      ['minimax-m2.7', 'MiniMax-M2.7', []],
+      ['minimax-m3', 'MiniMax-M3', []],
+      [
+        'muse-spark-1.2-contributor',
+        'Muse Spark 1.2 Contributor',
+        ['low', 'medium', 'high', 'xhigh'],
+      ],
+      ['qwen3.6-plus', 'Qwen3.6 Plus', []],
+      ['qwen3.7-max', 'Qwen3.7 Max', []],
+      ['qwen3.7-plus', 'Qwen3.7 Plus', []],
+      ['qwen3.8-flash', 'Qwen3.8 Flash', []],
+      ['qwen3.8-max', 'Qwen3.8 Max', []],
     ]),
   },
   {

--- a/packages/agentic-tool-opencode/src/shared/reasoning-effort.test.ts
+++ b/packages/agentic-tool-opencode/src/shared/reasoning-effort.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { filterOpenCodeReasoningEffortLevels } from './reasoning-effort.js';
+
+describe('filterOpenCodeReasoningEffortLevels', () => {
+  it('returns recognized variant keys in canonical order without reading their values', () => {
+    expect(
+      filterOpenCodeReasoningEffortLevels({
+        max: { apiKey: 'must-not-cross' },
+        minimal: {},
+        low: false,
+        none: {},
+        arbitrary: {},
+      })
+    ).toEqual(['low', 'max']);
+  });
+
+  it('distinguishes unknown input from a known empty variant map', () => {
+    expect(filterOpenCodeReasoningEffortLevels(undefined)).toBeUndefined();
+    expect(filterOpenCodeReasoningEffortLevels(null)).toBeUndefined();
+    expect(filterOpenCodeReasoningEffortLevels([])).toBeUndefined();
+    expect(filterOpenCodeReasoningEffortLevels({ none: {}, minimal: {} })).toEqual([]);
+  });
+});

--- a/packages/agentic-tool-opencode/src/shared/reasoning-effort.ts
+++ b/packages/agentic-tool-opencode/src/shared/reasoning-effort.ts
@@ -1,0 +1,20 @@
+import type { EffortLevel } from '@agor/core/types';
+
+export const OPENCODE_AGOR_EFFORT_LEVELS = [
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+] as const satisfies readonly EffortLevel[];
+
+/**
+ * Projects OpenCode's native variant map to the only names Agor may expose.
+ * Variant bodies are deliberately ignored because they may contain provider
+ * configuration. Missing/non-map input remains unknown; an empty map becomes
+ * a known empty list.
+ */
+export function filterOpenCodeReasoningEffortLevels(variants: unknown): EffortLevel[] | undefined {
+  if (!variants || typeof variants !== 'object' || Array.isArray(variants)) return undefined;
+  return OPENCODE_AGOR_EFFORT_LEVELS.filter((level) => Object.hasOwn(variants, level));
+}

--- a/packages/agentic-tool-opencode/src/ui/OpenCodeModelSelector.test.tsx
+++ b/packages/agentic-tool-opencode/src/ui/OpenCodeModelSelector.test.tsx
@@ -36,12 +36,14 @@ const nativeScaleCatalog = {
   })),
 };
 
-function clientWithCatalog(result: unknown = catalog) {
+function clientWithCatalog(result: unknown = catalog, liveResult: unknown = null) {
   const find = vi.fn().mockResolvedValue(result);
+  const liveFind = vi.fn().mockResolvedValue(liveResult);
   return {
     find,
+    liveFind,
     client: {
-      service: vi.fn(() => ({ find })),
+      service: vi.fn((path: string) => ({ find: path === 'opencode-auth' ? liveFind : find })),
     },
   };
 }
@@ -83,6 +85,68 @@ describe('OpenCodeModelSelector', () => {
     expect(onChange).toHaveBeenLastCalledWith({ provider: 'openai', model: 'gpt-5' });
     expect(onCommit).toHaveBeenCalledOnce();
     expect(onCommit).toHaveBeenLastCalledWith({ provider: 'openai', model: 'gpt-5' });
+  });
+
+  it('prefers safe branch-scoped live effort metadata over static catalog advice', async () => {
+    const onReasoningEffortLevelsChange = vi.fn();
+    const staticCatalog = {
+      ...catalog,
+      providers: [
+        {
+          ...catalog.providers[0],
+          models: [
+            {
+              id: 'gpt-5',
+              name: 'GPT-5',
+              status: 'active',
+              reasoningEffortLevels: ['high'],
+            },
+          ],
+        },
+      ],
+    };
+    const liveConfiguration = {
+      runtime: 'available',
+      runtimeVersion: '1.14.33',
+      providers: [
+        {
+          id: 'openai',
+          name: 'OpenAI',
+          runtimeAvailable: true,
+          credentialPresence: 'present',
+          authMethods: [],
+          models: [
+            {
+              id: 'gpt-5',
+              name: 'GPT-5',
+              status: 'active',
+              reasoningEffortLevels: [],
+            },
+          ],
+        },
+      ],
+    };
+    const { client, liveFind } = clientWithCatalog(staticCatalog, liveConfiguration);
+
+    render(
+      <OpenCodeModelSelector
+        value={{ provider: 'openai', model: 'gpt-5' }}
+        client={client as never}
+        branchId="branch-1"
+        onReasoningEffortLevelsChange={onReasoningEffortLevelsChange}
+      />
+    );
+
+    await waitFor(() =>
+      expect(liveFind).toHaveBeenCalledWith({ query: { branch_id: 'branch-1' } })
+    );
+    await waitFor(() =>
+      expect(onReasoningEffortLevelsChange).toHaveBeenLastCalledWith({
+        provider: 'openai',
+        model: 'gpt-5',
+        levels: [],
+      })
+    );
   });
 
   it('keeps immediate catalog entries unselectable until availability resolves', async () => {

--- a/packages/agentic-tool-opencode/src/ui/OpenCodeModelSelector.test.tsx
+++ b/packages/agentic-tool-opencode/src/ui/OpenCodeModelSelector.test.tsx
@@ -273,18 +273,20 @@ describe('OpenCodeModelSelector', () => {
   });
 
   it('keeps a foreign owner stored compact pair private without calling it unavailable', () => {
-    const { client, find } = clientWithCatalog();
+    const { client, find, liveFind } = clientWithCatalog();
 
     render(
       <OpenCodeModelSelector
         value={{ provider: 'private-provider', model: 'private-model' }}
         client={client as never}
+        branchId="private-branch"
         catalogEnabled={false}
         compact
       />
     );
 
     expect(find).not.toHaveBeenCalled();
+    expect(liveFind).not.toHaveBeenCalled();
     expect(screen.getByText('private-provider/private-model')).toBeInTheDocument();
     expect(screen.queryByText(/\(unavailable\)/i)).not.toBeInTheDocument();
   });

--- a/packages/agentic-tool-opencode/src/ui/OpenCodeModelSelector.tsx
+++ b/packages/agentic-tool-opencode/src/ui/OpenCodeModelSelector.tsx
@@ -1,9 +1,5 @@
 import type { AgorClient } from '@agor/core/client';
-import type {
-  EffortLevel,
-  OpenCodeModelCatalog,
-  OpenCodeProviderDiscovery,
-} from '@agor/core/types';
+import type { EffortLevel, OpenCodeModelCatalog } from '@agor/core/types';
 import {
   InfoCircleOutlined,
   ReloadOutlined,
@@ -11,8 +7,9 @@ import {
   WarningOutlined,
 } from '@ant-design/icons';
 import { Alert, Button, Flex, Input, Popover, Select, Space, Tooltip, Typography } from 'antd';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useOpenCodeModelCatalog } from './useOpenCodeModelCatalog';
+import { useOpenCodeReasoningEffortLevels } from './useOpenCodeReasoningEffortLevels';
 
 const { Text } = Typography;
 
@@ -226,12 +223,27 @@ export const OpenCodeModelSelector: React.FC<OpenCodeModelSelectorProps> = ({
   const [model, setModel] = useState(value?.model ?? '');
   const [manualOpen, setManualOpen] = useState(!catalogEnabled && !compact);
   const [compactManualOpen, setCompactManualOpen] = useState(false);
-  const [liveEffortLevels, setLiveEffortLevels] = useState<
-    Map<string, readonly EffortLevel[]> | undefined
-  >();
   const appliedSuggestionRef = useRef<string | null>(null);
   const { catalog, availabilityResolved, loading, refreshFailed, refresh } =
     useOpenCodeModelCatalog({ client, catalogEnabled });
+  const {
+    levels: selectedReasoningEffortLevels,
+    resolve: resolveReasoningEffortLevels,
+    liveLoading,
+    liveFailed,
+    retry: retryLiveDiscovery,
+  } = useOpenCodeReasoningEffortLevels({
+    client,
+    branchId,
+    catalogEnabled,
+    provider,
+    model,
+  });
+  const refreshAll = useCallback(async () => {
+    await Promise.all([refresh(), retryLiveDiscovery()]);
+  }, [refresh, retryLiveDiscovery]);
+  const discoveryLoading = loading || liveLoading;
+  const discoveryFailed = refreshFailed || liveFailed;
 
   useEffect(() => {
     setProvider(value?.provider ?? '');
@@ -242,31 +254,6 @@ export const OpenCodeModelSelector: React.FC<OpenCodeModelSelectorProps> = ({
     if (!catalogEnabled) setManualOpen(!compact);
   }, [catalogEnabled, compact]);
 
-  useEffect(() => {
-    setLiveEffortLevels(undefined);
-    if (!client || !catalogEnabled || !branchId) return;
-    let cancelled = false;
-    void client
-      .service('opencode-auth')
-      .find({ query: { branch_id: branchId } })
-      .then((configuration: OpenCodeProviderDiscovery) => {
-        if (cancelled || configuration.runtime !== 'available') return;
-        const levels = new Map<string, readonly EffortLevel[]>();
-        for (const entry of configuration.providers) {
-          for (const candidate of entry.models) {
-            if (candidate.reasoningEffortLevels !== undefined) {
-              levels.set(modelPairValue(entry.id, candidate.id), candidate.reasoningEffortLevels);
-            }
-          }
-        }
-        setLiveEffortLevels(levels);
-      })
-      .catch(() => undefined);
-    return () => {
-      cancelled = true;
-    };
-  }, [branchId, catalogEnabled, client]);
-
   const storedCatalogState = useMemo<StoredCatalogState>(() => {
     if (!value || !catalog) return 'unknown';
     const storedProvider = catalog.providers.find((entry) => entry.id === value.provider);
@@ -276,15 +263,6 @@ export const OpenCodeModelSelector: React.FC<OpenCodeModelSelectorProps> = ({
     if (!availabilityResolved) return 'unknown';
     return storedProvider.availableForSelection ? 'available' : 'unavailable';
   }, [availabilityResolved, catalog, value]);
-
-  const selectedReasoningEffortLevels = useMemo(() => {
-    if (!catalogEnabled || !provider || !model) return undefined;
-    const liveLevels = liveEffortLevels?.get(modelPairValue(provider, model));
-    if (liveLevels !== undefined) return liveLevels;
-    return catalog?.providers
-      .find((entry) => entry.id === provider)
-      ?.models.find((candidate) => candidate.id === model)?.reasoningEffortLevels;
-  }, [catalog, catalogEnabled, liveEffortLevels, model, provider]);
 
   useEffect(() => {
     if (!provider || !model) return;
@@ -307,11 +285,16 @@ export const OpenCodeModelSelector: React.FC<OpenCodeModelSelectorProps> = ({
 
   const selectPair = (nextProvider: string, nextModel: string) => {
     const selection = { provider: nextProvider, model: nextModel };
+    const reasoningEffortLevels = resolveReasoningEffortLevels(nextProvider, nextModel);
     setProvider(nextProvider);
     setModel(nextModel);
     setManualOpen(false);
     setCompactManualOpen(false);
     onChange?.(selection);
+    onReasoningEffortLevelsChange?.({
+      ...selection,
+      levels: reasoningEffortLevels,
+    });
     onCommit?.(selection);
   };
 
@@ -397,14 +380,14 @@ export const OpenCodeModelSelector: React.FC<OpenCodeModelSelectorProps> = ({
         catalog={catalog}
         catalogEnabled={catalogEnabled}
         client={client}
-        loading={loading}
+        loading={discoveryLoading}
         availabilityResolved={availabilityResolved}
-        refreshFailed={refreshFailed}
+        refreshFailed={discoveryFailed}
         storedCatalogState={storedCatalogState}
         manualFields={manualFields}
         manualOpen={compactManualOpen}
         setManualOpen={setCompactManualOpen}
-        refresh={refresh}
+        refresh={refreshAll}
         selectPair={selectPair}
         getPopupContainer={getPopupContainer}
       />
@@ -422,14 +405,14 @@ export const OpenCodeModelSelector: React.FC<OpenCodeModelSelectorProps> = ({
         />
       )}
 
-      {refreshFailed && (
+      {discoveryFailed && (
         <Alert
           type="warning"
           showIcon
           title="Could not load configured OpenCode providers"
           description="The stored selection was not changed. Retry or enter an exact provider/model pair manually."
           action={
-            <Button size="small" loading={loading} onClick={() => void refresh()}>
+            <Button size="small" loading={discoveryLoading} onClick={() => void refreshAll()}>
               Retry
             </Button>
           }

--- a/packages/agentic-tool-opencode/src/ui/OpenCodeModelSelector.tsx
+++ b/packages/agentic-tool-opencode/src/ui/OpenCodeModelSelector.tsx
@@ -1,5 +1,9 @@
 import type { AgorClient } from '@agor/core/client';
-import type { OpenCodeModelCatalog } from '@agor/core/types';
+import type {
+  EffortLevel,
+  OpenCodeModelCatalog,
+  OpenCodeProviderDiscovery,
+} from '@agor/core/types';
 import {
   InfoCircleOutlined,
   ReloadOutlined,
@@ -24,6 +28,11 @@ export interface OpenCodeModelSelectorProps {
   onChange?: (config: OpenCodeModelConfig | undefined) => void;
   /** Fired for an explicit catalog or exact-ID selection, never an automatic suggestion. */
   onCommit?: (config: OpenCodeModelConfig) => void;
+  onReasoningEffortLevelsChange?: (availability: {
+    provider: string;
+    model: string;
+    levels: readonly EffortLevel[] | undefined;
+  }) => void;
   client?: AgorClient | null;
   branchId?: string;
   /**
@@ -206,6 +215,7 @@ export const OpenCodeModelSelector: React.FC<OpenCodeModelSelectorProps> = ({
   value,
   onChange,
   onCommit,
+  onReasoningEffortLevelsChange,
   client,
   branchId,
   catalogEnabled = true,
@@ -216,6 +226,9 @@ export const OpenCodeModelSelector: React.FC<OpenCodeModelSelectorProps> = ({
   const [model, setModel] = useState(value?.model ?? '');
   const [manualOpen, setManualOpen] = useState(!catalogEnabled && !compact);
   const [compactManualOpen, setCompactManualOpen] = useState(false);
+  const [liveEffortLevels, setLiveEffortLevels] = useState<
+    Map<string, readonly EffortLevel[]> | undefined
+  >();
   const appliedSuggestionRef = useRef<string | null>(null);
   const { catalog, availabilityResolved, loading, refreshFailed, refresh } =
     useOpenCodeModelCatalog({ client, catalogEnabled });
@@ -229,6 +242,31 @@ export const OpenCodeModelSelector: React.FC<OpenCodeModelSelectorProps> = ({
     if (!catalogEnabled) setManualOpen(!compact);
   }, [catalogEnabled, compact]);
 
+  useEffect(() => {
+    setLiveEffortLevels(undefined);
+    if (!client || !catalogEnabled || !branchId) return;
+    let cancelled = false;
+    void client
+      .service('opencode-auth')
+      .find({ query: { branch_id: branchId } })
+      .then((configuration: OpenCodeProviderDiscovery) => {
+        if (cancelled || configuration.runtime !== 'available') return;
+        const levels = new Map<string, readonly EffortLevel[]>();
+        for (const entry of configuration.providers) {
+          for (const candidate of entry.models) {
+            if (candidate.reasoningEffortLevels !== undefined) {
+              levels.set(modelPairValue(entry.id, candidate.id), candidate.reasoningEffortLevels);
+            }
+          }
+        }
+        setLiveEffortLevels(levels);
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [branchId, catalogEnabled, client]);
+
   const storedCatalogState = useMemo<StoredCatalogState>(() => {
     if (!value || !catalog) return 'unknown';
     const storedProvider = catalog.providers.find((entry) => entry.id === value.provider);
@@ -238,6 +276,24 @@ export const OpenCodeModelSelector: React.FC<OpenCodeModelSelectorProps> = ({
     if (!availabilityResolved) return 'unknown';
     return storedProvider.availableForSelection ? 'available' : 'unavailable';
   }, [availabilityResolved, catalog, value]);
+
+  const selectedReasoningEffortLevels = useMemo(() => {
+    if (!catalogEnabled || !provider || !model) return undefined;
+    const liveLevels = liveEffortLevels?.get(modelPairValue(provider, model));
+    if (liveLevels !== undefined) return liveLevels;
+    return catalog?.providers
+      .find((entry) => entry.id === provider)
+      ?.models.find((candidate) => candidate.id === model)?.reasoningEffortLevels;
+  }, [catalog, catalogEnabled, liveEffortLevels, model, provider]);
+
+  useEffect(() => {
+    if (!provider || !model) return;
+    onReasoningEffortLevelsChange?.({
+      provider,
+      model,
+      levels: selectedReasoningEffortLevels,
+    });
+  }, [model, onReasoningEffortLevelsChange, provider, selectedReasoningEffortLevels]);
 
   useEffect(() => {
     if (

--- a/packages/agentic-tool-opencode/src/ui/index.ts
+++ b/packages/agentic-tool-opencode/src/ui/index.ts
@@ -9,6 +9,7 @@ export {
 } from './OpenCodeModelSelector.js';
 export { OpenCodeProviderSettings } from './OpenCodeProviderSettings.js';
 export { OpenCodeReadiness } from './OpenCodeReadiness.js';
+export { useOpenCodeReasoningEffortLevels } from './useOpenCodeReasoningEffortLevels.js';
 
 export const OPENCODE_UI_CONTRIBUTION = {
   name: 'opencode',

--- a/packages/agentic-tool-opencode/src/ui/useOpenCodeReasoningEffortLevels.ts
+++ b/packages/agentic-tool-opencode/src/ui/useOpenCodeReasoningEffortLevels.ts
@@ -1,0 +1,202 @@
+import type { AgorClient } from '@agor/core/client';
+import type {
+  EffortLevel,
+  OpenCodeModelCatalog,
+  OpenCodeProviderDiscovery,
+} from '@agor/core/types';
+import { useCallback, useEffect, useSyncExternalStore } from 'react';
+import { useOpenCodeModelCatalog } from './useOpenCodeModelCatalog.js';
+
+interface DiscoveryState {
+  discovery: OpenCodeProviderDiscovery | null;
+  loading: boolean;
+  failed: boolean;
+}
+
+interface DiscoveryEntry {
+  client: AgorClient;
+  authentication: unknown;
+  branchId: string;
+  state: DiscoveryState;
+  request?: Promise<void>;
+  revision: number;
+  listeners: Set<() => void>;
+}
+
+const EMPTY_DISCOVERY_STATE: DiscoveryState = {
+  discovery: null,
+  loading: false,
+  failed: false,
+};
+const discoveryResources = new WeakMap<AgorClient, Map<unknown, Map<string, DiscoveryEntry>>>();
+
+function publish(entry: DiscoveryEntry, state: DiscoveryState): void {
+  entry.state = state;
+  for (const listener of entry.listeners) listener();
+}
+
+function resourcesFor(client: AgorClient): Map<unknown, Map<string, DiscoveryEntry>> {
+  let resources = discoveryResources.get(client);
+  if (resources) return resources;
+  resources = new Map();
+  discoveryResources.set(client, resources);
+  client.on?.('authenticated', () => {
+    for (const entries of resources?.values() ?? []) {
+      for (const entry of entries.values()) {
+        entry.revision += 1;
+        publish(entry, EMPTY_DISCOVERY_STATE);
+      }
+    }
+    resources?.clear();
+  });
+  return resources;
+}
+
+function entryFor(client: AgorClient, branchId: string): DiscoveryEntry {
+  const authentication = client.get?.('authentication');
+  const resources = resourcesFor(client);
+  let entries = resources.get(authentication);
+  if (!entries) {
+    entries = new Map();
+    resources.set(authentication, entries);
+  }
+  let entry = entries.get(branchId);
+  if (!entry) {
+    entry = {
+      client,
+      authentication,
+      branchId,
+      state: EMPTY_DISCOVERY_STATE,
+      revision: 0,
+      listeners: new Set(),
+    };
+    entries.set(branchId, entry);
+  }
+  return entry;
+}
+
+async function load(entry: DiscoveryEntry, force = false): Promise<void> {
+  if (entry.client.get?.('authentication') !== entry.authentication) return;
+  if (entry.request) return entry.request;
+  if (!force && (entry.state.discovery || entry.state.failed)) return;
+
+  publish(entry, { ...entry.state, loading: true, failed: false });
+  const revision = entry.revision;
+  const request = (async () => {
+    try {
+      const discovery = await entry.client
+        .service('opencode-auth')
+        .find({ query: { branch_id: entry.branchId } });
+      if (
+        entry.revision === revision &&
+        entry.client.get?.('authentication') === entry.authentication
+      ) {
+        publish(entry, { discovery, loading: false, failed: false });
+      }
+    } catch {
+      if (
+        entry.revision === revision &&
+        entry.client.get?.('authentication') === entry.authentication
+      ) {
+        publish(entry, { discovery: null, loading: false, failed: true });
+      }
+    } finally {
+      entry.request = undefined;
+    }
+  })();
+  entry.request = request;
+  return request;
+}
+
+function useOpenCodeBranchDiscovery(input: {
+  client?: AgorClient | null;
+  branchId?: string;
+  enabled: boolean;
+}): DiscoveryState & { retry: () => Promise<void> } {
+  const { client, branchId, enabled } = input;
+  const entry = client && branchId && enabled ? entryFor(client, branchId) : null;
+  const state = useSyncExternalStore(
+    useCallback(
+      (listener) => {
+        if (!entry) return () => undefined;
+        entry.listeners.add(listener);
+        return () => entry.listeners.delete(listener);
+      },
+      [entry]
+    ),
+    useCallback(() => entry?.state ?? EMPTY_DISCOVERY_STATE, [entry]),
+    () => EMPTY_DISCOVERY_STATE
+  );
+
+  useEffect(() => {
+    if (entry) void load(entry);
+  }, [entry]);
+
+  const retry = useCallback(async () => {
+    if (entry) await load(entry, true);
+  }, [entry]);
+
+  return { ...state, retry };
+}
+
+function levelsFromCatalog(
+  catalog: OpenCodeModelCatalog | null,
+  provider: string,
+  model: string
+): readonly EffortLevel[] | undefined {
+  return catalog?.providers
+    ?.find((entry) => entry.id === provider)
+    ?.models.find((candidate) => candidate.id === model)?.reasoningEffortLevels;
+}
+
+function levelsFromDiscovery(
+  discovery: OpenCodeProviderDiscovery,
+  provider: string,
+  model: string
+): readonly EffortLevel[] | undefined {
+  return discovery.providers
+    ?.find((entry) => entry.id === provider)
+    ?.models.find((candidate) => candidate.id === model)?.reasoningEffortLevels;
+}
+
+/**
+ * Resolves safe effort names for an exact pair. Authenticated branch discovery
+ * wins whenever it succeeds; otherwise the server-free catalog remains useful
+ * advisory metadata. Missing metadata stays distinct from a known empty list.
+ */
+export function useOpenCodeReasoningEffortLevels(input: {
+  client?: AgorClient | null;
+  branchId?: string;
+  catalogEnabled: boolean;
+  provider?: string;
+  model?: string;
+}) {
+  const { client, branchId, catalogEnabled, provider, model } = input;
+  const { catalog } = useOpenCodeModelCatalog({ client, catalogEnabled });
+  const {
+    discovery,
+    loading: liveLoading,
+    failed: liveFailed,
+    retry,
+  } = useOpenCodeBranchDiscovery({
+    client,
+    branchId,
+    enabled: catalogEnabled,
+  });
+  const resolve = useCallback(
+    (nextProvider: string, nextModel: string): readonly EffortLevel[] | undefined => {
+      if (!catalogEnabled) return undefined;
+      if (discovery) return levelsFromDiscovery(discovery, nextProvider, nextModel);
+      return levelsFromCatalog(catalog, nextProvider, nextModel);
+    },
+    [catalog, catalogEnabled, discovery]
+  );
+
+  return {
+    levels: provider && model ? resolve(provider, model) : undefined,
+    resolve,
+    liveLoading,
+    liveFailed,
+    retry,
+  };
+}

--- a/packages/agentic-tools/src/ui.ts
+++ b/packages/agentic-tools/src/ui.ts
@@ -1,6 +1,6 @@
 import { OPENCODE_UI_CONTRIBUTION } from '@agor/agentic-tool-opencode/ui';
 import type { AgorClient } from '@agor/core/client';
-import type { AgenticToolName, PermissionMode } from '@agor/core/types';
+import type { AgenticToolName, EffortLevel, PermissionMode } from '@agor/core/types';
 import type { ComponentType, ReactNode } from 'react';
 
 export interface AgenticToolModelSelection {
@@ -13,6 +13,12 @@ export interface AgenticToolModelSelectorProps {
   onChange?: (config: AgenticToolModelSelection | undefined) => void;
   /** Fired only when the user finishes selecting a provider/model pair. */
   onCommit?: (config: AgenticToolModelSelection) => void;
+  /** Reports advisory model-level effort support; undefined means runtime-validated. */
+  onReasoningEffortLevelsChange?: (availability: {
+    provider: string;
+    model: string;
+    levels: readonly EffortLevel[] | undefined;
+  }) => void;
   client?: AgorClient | null;
   branchId?: string;
   catalogEnabled?: boolean;

--- a/packages/agentic-tools/src/ui.ts
+++ b/packages/agentic-tools/src/ui.ts
@@ -1,4 +1,7 @@
-import { OPENCODE_UI_CONTRIBUTION } from '@agor/agentic-tool-opencode/ui';
+import {
+  OPENCODE_UI_CONTRIBUTION,
+  useOpenCodeReasoningEffortLevels,
+} from '@agor/agentic-tool-opencode/ui';
 import type { AgorClient } from '@agor/core/client';
 import type { AgenticToolName, EffortLevel, PermissionMode } from '@agor/core/types';
 import type { ComponentType, ReactNode } from 'react';
@@ -79,4 +82,27 @@ export function getAgenticToolUIIntegration(
   tool: AgenticToolName
 ): AgenticToolUIIntegration | undefined {
   return UI_INTEGRATIONS[tool];
+}
+
+/**
+ * Returns exact-model effort metadata owned by an agent integration. Missing
+ * means the tool has no model-level contract, or the exact pair must be
+ * validated by the runtime; an empty list is an authoritative unsupported set.
+ */
+export function useAgenticToolReasoningEffortLevels(input: {
+  tool: AgenticToolName;
+  selection?: AgenticToolModelSelection;
+  client?: AgorClient | null;
+  branchId?: string;
+  catalogEnabled?: boolean;
+}): readonly EffortLevel[] | undefined {
+  const { tool, selection, client, branchId, catalogEnabled = true } = input;
+  const { levels } = useOpenCodeReasoningEffortLevels({
+    client,
+    branchId,
+    catalogEnabled: tool === 'opencode' && catalogEnabled,
+    provider: selection?.provider,
+    model: selection?.model,
+  });
+  return tool === 'opencode' ? levels : undefined;
 }

--- a/packages/core/src/types/opencode-models.ts
+++ b/packages/core/src/types/opencode-models.ts
@@ -1,3 +1,5 @@
+import type { EffortLevel } from './session';
+
 export type OpenCodeModelStatus = 'alpha' | 'beta' | 'deprecated' | 'active';
 
 export interface OpenCodeModelPair {
@@ -9,6 +11,12 @@ export interface OpenCodeCatalogModel {
   id: string;
   name: string;
   status: OpenCodeModelStatus;
+  /**
+   * Safe native variant names supported by this exact model. Missing means
+   * unknown/runtime-validated; an empty array means no explicit Agor effort is
+   * supported and callers must leave the override unset.
+   */
+  reasoningEffortLevels?: EffortLevel[];
 }
 
 export interface OpenCodeCatalogProvider {


### PR DESCRIPTION
## Summary

OpenCode advertised all five Agor effort levels (`low`/`medium`/`high`/`xhigh`/`max`) as a tool-wide capability, but the runtime only accepts an effort when the exact live provider/model exposes a matching native variant. This allowed the UI and MCP to persist combinations that failed during Agor's pre-prompt admission check, before any LLM call.

Concrete repro: `opencode-go/qwen3.8-flash` + `effort: high` fails, while the same pair with effort unset reaches OpenCode. On pinned OpenCode `1.14.33`, 15 of the 25 OpenCode Go models expose no Agor-compatible explicit effort.

This PR makes reasoning effort a per-model capability, keeps owner- and branch-scoped live variants authoritative, and retains strict runtime rejection as the final fail-closed boundary.

## Changes

- **Safe model contract**
  - Adds optional `reasoningEffortLevels` to `OpenCodeCatalogModel`.
  - Semantics are explicit: missing means unknown/runtime-validated; `[]` means no explicit Agor effort is supported.
  - Centralizes filtering of native variant keys to `low|medium|high|xhigh|max`; variant bodies/provider configuration never cross the boundary.
- **Catalog and live discovery**
  - Pins OpenCode Go effort metadata to packaged runtime `1.14.33`.
  - Preserves safe live variant names from authenticated discovery, including the distinction between missing metadata and a known-empty map.
  - Shares/caches branch-scoped discovery across UI controls, retries transient failures, and never queries a collaborator's catalog for a foreign-owned session.
- **UI**
  - Makes the config form, current chip-row session flows, and session footer model-aware.
  - Known-empty models expose inherited/unset only with corrective copy.
  - Existing incompatible values are shown as invalid rather than mutated on render; explicit model changes clear a now-incompatible effort in the same save path.
  - Unknown/manual exact pairs retain all advanced choices with runtime-validation guidance.
- **MCP**
  - `agor_models_list` now returns OpenCode provider/model entries with per-model `reasoningEffortLevels`.
  - Optional `branchId` enables authoritative caller/branch-scoped live discovery.
  - Guidance now accurately says that unset OpenCode effort inherits the model/runtime default.
- **Runtime diagnostics**
  - Keeps pre-prompt rejection strict.
  - Errors name the requested effort and exact pair, list only safe supported names, or explicitly direct the user to leave effort unset.
- **Docs and plan**
  - Documents exact-model effort semantics in the sessions guide.
  - Keeps the investigation, alternatives, risks, and test plan in `docs/plans/opencode-go-effort-availability.md`.

## Relationship to #2605

#2605 adds the OpenCode Go provider lineup and runtime-unavailable reporting, but does not add model-level effort metadata or change UI/MCP/runtime effort behavior. The OpenCode Go catalog portion will need normal conflict resolution/rebasing depending on which PR lands first; live effort validation remains independent and authoritative.

## Validation

- `pnpm --filter @agor/agentic-tool-opencode test` — 19 files / 149 tests
- `pnpm --filter @agor/agentic-tools test` — 2 files / 24 tests
- `pnpm --filter @agor/agentic-tools typecheck`
- `pnpm --filter @agor/daemon exec vitest run src/mcp/tools/sessions.test.ts` — 48 tests
- Focused config/chip/footer UI suites — 57 tests
- `pnpm --filter agor-ui test` — 287 files / 2,111 tests
- `pnpm check:multitenancy-boundaries`
- Touched-file Biome, Prettier, and `git diff --check`
