### PR TITLE
feat(files): VSCode-style git status colors on the branch Files tab

### DIFF
--- a/apps/agor-daemon/src/services/file.test.ts
+++ b/apps/agor-daemon/src/services/file.test.ts
@@ -79,6 +79,43 @@ describe('FileService executor failures', () => {
     ).rejects.toThrow('Failed to browse files: executor unavailable');
   });
 
+  it('passes the requested git snapshot to file previews', async () => {
+    vi.mocked(requestExecutor).mockResolvedValue({
+      success: true,
+      data: {
+        file: {
+          path: 'added.txt',
+          title: 'added.txt',
+          size: 6,
+          lastModified: '',
+          isText: true,
+          gitStatus: 'added',
+          content: 'staged',
+          encoding: 'utf-8',
+        },
+      },
+    });
+    const service = new FileService(createBranchRepo(), { run: vi.fn() } as never, createApp());
+
+    await runWithTenantContext('tenant-a', () =>
+      service.get('added.txt', {
+        query: { branch_id: 'branch-1', git_status_source: 'staged' },
+        user: { user_id: 'user-1', email: 'member@example.com', role: 'member' },
+      })
+    );
+
+    expect(requestExecutor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: 'branch.files.read',
+        params: expect.objectContaining({
+          filePath: 'added.txt',
+          gitStatusSource: 'staged',
+        }),
+      }),
+      expect.anything()
+    );
+  });
+
   it.each([
     {
       operation: 'listing',

--- a/apps/agor-daemon/src/services/file.ts
+++ b/apps/agor-daemon/src/services/file.ts
@@ -7,11 +7,12 @@ import {
   runWithTenantDatabaseScope,
   type TenantScopeAwareDatabase,
 } from '@agor/core/db';
-import { type Application, NotAuthenticated } from '@agor/core/feathers';
+import { type Application, BadRequest, NotAuthenticated } from '@agor/core/feathers';
 import type {
   AuthenticatedParams,
   FileDetail,
   FileListItem,
+  GitFileStatusSource,
   Id,
   QueryParams,
   RBACParams,
@@ -30,7 +31,17 @@ import { resolveDelegatedExecutionHomeKey } from '../utils/executor-delegated-ho
 import { getDaemonUrl, requestExecutor } from '../utils/spawn-executor.js';
 import { issueExecutorCommandToken } from './session-token-service.js';
 
-export type FileParams = QueryParams<{ branch_id?: string }> & Partial<AuthenticatedParams>;
+export type FileParams = QueryParams<{
+  branch_id?: string;
+  git_status_source?: GitFileStatusSource;
+}> &
+  Partial<AuthenticatedParams>;
+
+function resolveGitStatusSource(value: unknown): GitFileStatusSource {
+  if (value === undefined) return 'combined';
+  if (value === 'combined' || value === 'workingTree' || value === 'staged') return value;
+  throw new BadRequest('git_status_source must be combined, workingTree, or staged');
+}
 
 function extractFiles(data: unknown): FileListItem[] {
   if (!data || typeof data !== 'object') return [];
@@ -80,6 +91,7 @@ export class FileService
     ensureMinimumRole(params, ROLES.MEMBER, 'read file');
     const branchId = params?.query?.branch_id;
     if (!branchId) throw new Error('branch_id query parameter is required');
+    const gitStatusSource = resolveGitStatusSource(params?.query?.git_status_source);
     const resolved = await this.resolveBranchRead(branchId, params);
 
     const result = await this.runCommand(
@@ -92,6 +104,7 @@ export class FileService
       resolved.sandboxMounts,
       {
         filePath: id.toString(),
+        gitStatusSource,
       }
     );
     if (!result.success) {

--- a/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.height.browser.test.tsx
+++ b/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.height.browser.test.tsx
@@ -250,21 +250,26 @@ it.each([
       ...makeGatewaySessions(gatewayCount),
     ]);
     const scrollers = () => [...container.querySelectorAll<HTMLElement>('.ant-tree-list-holder')];
-    await waitFor(() => {
-      expect(scrollers()).toHaveLength(2);
-      for (const [index, count] of [manualCount, gatewayCount].entries()) {
-        const tree = scrollers()[index];
-        if (count <= 2) {
-          const section = tree.closest('.ant-collapse')!;
-          // Only the Collapse body padding may follow the rendered short tree.
-          expect(
-            section.getBoundingClientRect().bottom - tree.getBoundingClientRect().bottom
-          ).toBeLessThan(20);
-        } else {
-          expect(tree.clientHeight).toBeGreaterThan(500);
+    // The initial ResizeObserver allocation can settle after Testing Library's
+    // default timeout when all browser projects are competing for CI resources.
+    await waitFor(
+      () => {
+        expect(scrollers()).toHaveLength(2);
+        for (const [index, count] of [manualCount, gatewayCount].entries()) {
+          const tree = scrollers()[index];
+          if (count <= 2) {
+            const section = tree.closest('.ant-collapse')!;
+            // Only the Collapse body padding may follow the rendered short tree.
+            expect(
+              section.getBoundingClientRect().bottom - tree.getBoundingClientRect().bottom
+            ).toBeLessThan(20);
+          } else {
+            expect(tree.clientHeight).toBeGreaterThan(500);
+          }
         }
-      }
-    });
+      },
+      { timeout: 5_000 }
+    );
     // Realtime growth must remove the short-tree cap; later shrink must restore it.
     await act(async () => {
       agorStore.setState({

--- a/apps/agor-ui/src/components/BranchModal/tabs/FilesTab.test.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/FilesTab.test.tsx
@@ -25,7 +25,6 @@ vi.mock('../../FileCollection/FileCollection', () => ({
 }));
 
 vi.mock('../../CodePreviewModal/CodePreviewModal', () => ({ CodePreviewModal: () => null }));
-vi.mock('../../MarkdownModal/MarkdownModal', () => ({ MarkdownModal: () => null }));
 
 import { FilesTab } from './FilesTab';
 

--- a/apps/agor-ui/src/components/BranchModal/tabs/FilesTab.test.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/FilesTab.test.tsx
@@ -14,13 +14,32 @@ vi.mock('../../../utils/message', () => ({
 }));
 
 vi.mock('../../FileCollection/FileCollection', () => ({
-  FileCollection: ({ onDownload }: { onDownload: (file: unknown) => Promise<void> }) => (
-    <button
-      type="button"
-      onClick={() => onDownload({ path: 'archive.bin', size: 7, isText: false })}
-    >
-      Download fixture
-    </button>
+  FileCollection: ({
+    files,
+    onDownload,
+    onFileClick,
+    gitStatusSource,
+  }: {
+    files: Array<{ path?: string }>;
+    onDownload: (file: unknown) => Promise<void>;
+    onFileClick: (file: unknown) => Promise<void>;
+    gitStatusSource?: string;
+  }) => (
+    <section data-testid={`file-collection-${gitStatusSource ?? 'combined'}`}>
+      <span>{files.length} files</span>
+      <span>{files.map((file) => file.path).join(',')}</span>
+      {files.map((file) => (
+        <button key={file.path} type="button" onClick={() => onFileClick(file)}>
+          Open {file.path}
+        </button>
+      ))}
+      <button
+        type="button"
+        onClick={() => onDownload({ path: 'archive.bin', size: 7, isText: false })}
+      >
+        Download fixture
+      </button>
+    </section>
   ),
 }));
 
@@ -28,7 +47,7 @@ vi.mock('../../CodePreviewModal/CodePreviewModal', () => ({ CodePreviewModal: ()
 
 import { FilesTab } from './FilesTab';
 
-describe('FilesTab download messages', () => {
+describe('FilesTab', () => {
   const get = vi.fn();
   const findAll = vi.fn().mockResolvedValue([]);
   const client = {
@@ -42,7 +61,8 @@ describe('FilesTab download messages', () => {
       fn.mockReset();
     });
     get.mockReset();
-    findAll.mockClear();
+    findAll.mockReset();
+    findAll.mockResolvedValue([]);
     Object.defineProperty(URL, 'createObjectURL', {
       value: vi.fn(() => 'blob:test'),
       configurable: true,
@@ -84,5 +104,109 @@ describe('FilesTab download messages', () => {
     });
     expect(messageApi.showSuccess).toHaveBeenCalledWith('Downloaded!', { key: 'download' });
     expect(consoleError).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes the files and git statuses without remounting the tab', async () => {
+    findAll
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        { path: 'changed.ts', title: 'changed.ts', size: 12, gitStatus: 'modified' },
+      ]);
+
+    render(<FilesTab branch={branch} client={client} />);
+
+    await waitFor(() => expect(findAll).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText('0 files')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh files' }));
+
+    await waitFor(() => expect(findAll).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText('1 files')).toBeInTheDocument();
+    expect(findAll).toHaveBeenLastCalledWith({
+      query: { branch_id: branch.branch_id },
+    });
+  });
+
+  it('shows only unstaged or staged files in the corresponding sub-tabs', async () => {
+    get.mockResolvedValue({
+      path: 'added-then-deleted.ts',
+      title: 'added-then-deleted.ts',
+      size: 10,
+      lastModified: '',
+      isText: true,
+      gitStatus: 'added',
+      content: 'staged content',
+      encoding: 'utf-8',
+      gitDiff: { baseContent: '' },
+    });
+    findAll.mockResolvedValueOnce([
+      { path: 'clean.ts', title: 'clean.ts', size: 1 },
+      {
+        path: 'working.ts',
+        title: 'working.ts',
+        size: 2,
+        gitStatus: 'modified',
+        gitWorkingTreeStatus: 'modified',
+      },
+      {
+        path: 'staged.ts',
+        title: 'staged.ts',
+        size: 3,
+        gitStatus: 'added',
+        gitStagedStatus: 'added',
+      },
+      {
+        path: 'both.ts',
+        title: 'both.ts',
+        size: 4,
+        gitStatus: 'modified',
+        gitWorkingTreeStatus: 'modified',
+        gitStagedStatus: 'modified',
+      },
+      {
+        path: 'ignored.log',
+        title: 'ignored.log',
+        size: 5,
+        gitStatus: 'ignored',
+        gitWorkingTreeStatus: 'ignored',
+      },
+      {
+        path: 'added-then-deleted.ts',
+        title: 'added-then-deleted.ts',
+        size: 0,
+        isText: true,
+        gitStatus: 'deleted',
+        gitWorkingTreeStatus: 'deleted',
+        gitStagedStatus: 'added',
+      },
+    ]);
+
+    render(<FilesTab branch={branch} client={client} />);
+
+    expect(await screen.findByRole('tab', { name: 'All files' })).toBeInTheDocument();
+    expect(screen.getByTestId('file-collection-combined')).not.toHaveTextContent(
+      'added-then-deleted.ts'
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Changes (3)' }));
+    const changes = await screen.findByTestId('file-collection-workingTree');
+    expect(changes).toHaveTextContent('working.ts,both.ts,added-then-deleted.ts');
+    expect(changes).not.toHaveTextContent('clean.ts');
+    expect(changes).not.toHaveTextContent('ignored.log');
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Staged changes (3)' }));
+    const staged = await screen.findByTestId('file-collection-staged');
+    expect(staged).toHaveTextContent('staged.ts,both.ts,added-then-deleted.ts');
+    expect(staged).not.toHaveTextContent('working.ts');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open added-then-deleted.ts' }));
+    await waitFor(() =>
+      expect(get).toHaveBeenCalledWith('added-then-deleted.ts', {
+        query: {
+          branch_id: branch.branch_id,
+          git_status_source: 'staged',
+        },
+      })
+    );
   });
 });

--- a/apps/agor-ui/src/components/BranchModal/tabs/FilesTab.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/FilesTab.tsx
@@ -5,7 +5,6 @@ import { useThemedMessage } from '../../../utils/message';
 import { CodePreviewModal } from '../../CodePreviewModal/CodePreviewModal';
 import type { FileItem } from '../../FileCollection/FileCollection';
 import { FileCollection } from '../../FileCollection/FileCollection';
-import { MarkdownModal } from '../../MarkdownModal/MarkdownModal';
 
 const MAX_FILES = 50000;
 
@@ -65,6 +64,11 @@ const FilesTabInner: React.FC<FilesTabProps> = ({ branch, client }) => {
     async (file: FileItem) => {
       const currentClient = clientRef.current;
       if (!currentClient) return;
+
+      if (file.gitStatus === 'deleted') {
+        showError('This file was deleted in the working tree');
+        return;
+      }
 
       try {
         showLoading('Downloading file...', { key: 'download' });
@@ -151,7 +155,6 @@ const FilesTabInner: React.FC<FilesTabProps> = ({ branch, client }) => {
     setSelectedFile(null);
   }, []);
 
-  const isMarkdown = selectedFile?.path.endsWith('.md');
   const isTruncated = files.length >= MAX_FILES;
 
   return (
@@ -185,22 +188,12 @@ const FilesTabInner: React.FC<FilesTabProps> = ({ branch, client }) => {
           emptyMessage="No files found in branch"
         />
 
-        {isMarkdown ? (
-          <MarkdownModal
-            open={modalOpen}
-            title={selectedFile?.title || ''}
-            content={selectedFile?.content || ''}
-            filePath={selectedFile?.path || ''}
-            onClose={handleModalClose}
-          />
-        ) : (
-          <CodePreviewModal
-            file={selectedFile}
-            open={modalOpen}
-            onClose={handleModalClose}
-            loading={loadingDetail}
-          />
-        )}
+        <CodePreviewModal
+          file={selectedFile}
+          open={modalOpen}
+          onClose={handleModalClose}
+          loading={loadingDetail}
+        />
       </Space>
     </div>
   );

--- a/apps/agor-ui/src/components/BranchModal/tabs/FilesTab.tsx
+++ b/apps/agor-ui/src/components/BranchModal/tabs/FilesTab.tsx
@@ -1,6 +1,13 @@
-import type { AgorClient, Branch, FileDetail, FileListItem } from '@agor-live/client';
-import { Alert, Space } from 'antd';
-import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import type {
+  AgorClient,
+  Branch,
+  FileDetail,
+  FileListItem,
+  GitFileStatusSource,
+} from '@agor-live/client';
+import { ReloadOutlined } from '@ant-design/icons';
+import { Alert, Button, Space, Tabs } from 'antd';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useThemedMessage } from '../../../utils/message';
 import { CodePreviewModal } from '../../CodePreviewModal/CodePreviewModal';
 import type { FileItem } from '../../FileCollection/FileCollection';
@@ -16,7 +23,9 @@ interface FilesTabProps {
 const FilesTabInner: React.FC<FilesTabProps> = ({ branch, client }) => {
   const [files, setFiles] = useState<FileListItem[]>([]);
   const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const fileRequestIdRef = useRef(0);
 
   // Modal state
   const [selectedFile, setSelectedFile] = useState<FileDetail | null>(null);
@@ -32,32 +41,61 @@ const FilesTabInner: React.FC<FilesTabProps> = ({ branch, client }) => {
 
   const { showLoading, showSuccess, showError } = useThemedMessage();
 
-  // Fetch files when tab is opened
-  useEffect(() => {
-    if (!client) {
-      setLoading(false);
-      return;
-    }
+  // The endpoint reads the worktree and git status on every request, so the
+  // same operation handles both the initial load and an in-place refresh.
+  const fetchFiles = useCallback(
+    async (initialLoad = false) => {
+      const requestId = ++fileRequestIdRef.current;
 
-    const fetchFiles = async () => {
-      try {
+      if (!client) {
+        setLoading(false);
+        setRefreshing(false);
+        return;
+      }
+
+      if (initialLoad) {
         setLoading(true);
-        setError(null);
+      } else {
+        setRefreshing(true);
+      }
+      setError(null);
 
+      try {
         const data = await client.service('file').findAll({
           query: { branch_id: branch.branch_id },
         });
-        setFiles(data as FileListItem[]);
+
+        if (fileRequestIdRef.current === requestId) {
+          setFiles(data as FileListItem[]);
+        }
       } catch (err) {
         console.error('Failed to fetch files:', err);
-        setError(err instanceof Error ? err.message : String(err));
+        if (fileRequestIdRef.current === requestId) {
+          setError(err instanceof Error ? err.message : String(err));
+        }
       } finally {
-        setLoading(false);
+        if (fileRequestIdRef.current === requestId) {
+          setLoading(false);
+          setRefreshing(false);
+        }
       }
-    };
+    },
+    [client, branch.branch_id]
+  );
 
-    fetchFiles();
-  }, [client, branch.branch_id]);
+  // Fetch files when tab is opened or switches to a different branch.
+  useEffect(() => {
+    void fetchFiles(true);
+
+    return () => {
+      // Ignore a response from a branch that is no longer being displayed.
+      fileRequestIdRef.current += 1;
+    };
+  }, [fetchFiles]);
+
+  const handleRefresh = useCallback(() => {
+    void fetchFiles();
+  }, [fetchFiles]);
 
   // Download file (handles both UTF-8 text and base64 binary)
   const downloadFile = useCallback(
@@ -118,7 +156,7 @@ const FilesTabInner: React.FC<FilesTabProps> = ({ branch, client }) => {
 
   // Handle file click - preview text files or download others - stable callback
   const handleFileClick = useCallback(
-    async (file: FileItem) => {
+    async (file: FileItem, gitStatusSource: GitFileStatusSource = 'combined') => {
       const currentClient = clientRef.current;
       if (!currentClient) return;
 
@@ -130,7 +168,10 @@ const FilesTabInner: React.FC<FilesTabProps> = ({ branch, client }) => {
 
           // Fetch full file detail with content
           const detail = await currentClient.service('file').get(file.path, {
-            query: { branch_id: branchIdRef.current },
+            query: {
+              branch_id: branchIdRef.current,
+              git_status_source: gitStatusSource,
+            },
           });
 
           setSelectedFile(detail as FileDetail);
@@ -149,6 +190,15 @@ const FilesTabInner: React.FC<FilesTabProps> = ({ branch, client }) => {
     [downloadFile, showError]
   );
 
+  const handleWorkingTreeFileClick = useCallback(
+    (file: FileItem) => handleFileClick(file, 'workingTree'),
+    [handleFileClick]
+  );
+  const handleStagedFileClick = useCallback(
+    (file: FileItem) => handleFileClick(file, 'staged'),
+    [handleFileClick]
+  );
+
   // Handle modal close - stable callback
   const handleModalClose = useCallback(() => {
     setModalOpen(false);
@@ -156,6 +206,21 @@ const FilesTabInner: React.FC<FilesTabProps> = ({ branch, client }) => {
   }, []);
 
   const isTruncated = files.length >= MAX_FILES;
+  const visibleFiles = useMemo(
+    // Deleted entries are synthesized by the executor for source-control
+    // views; the regular file browser mirrors the actual worktree instead.
+    () => files.filter((file) => file.gitStatus !== 'deleted'),
+    [files]
+  );
+  const workingTreeChanges = useMemo(
+    () =>
+      files.filter((file) => file.gitWorkingTreeStatus && file.gitWorkingTreeStatus !== 'ignored'),
+    [files]
+  );
+  const stagedChanges = useMemo(
+    () => files.filter((file) => file.gitStagedStatus !== undefined),
+    [files]
+  );
 
   return (
     <div style={{ width: '100%', maxHeight: '70vh', overflowY: 'auto' }}>
@@ -180,12 +245,63 @@ const FilesTabInner: React.FC<FilesTabProps> = ({ branch, client }) => {
 
         {error && <Alert title="Error" description={error} type="error" showIcon />}
 
-        <FileCollection
-          files={files}
-          loading={loading}
-          onFileClick={handleFileClick}
-          onDownload={downloadFile}
-          emptyMessage="No files found in branch"
+        <Tabs
+          destroyOnHidden
+          tabBarStyle={{ marginInline: 24 }}
+          tabBarExtraContent={
+            <Button
+              icon={<ReloadOutlined />}
+              aria-label="Refresh files"
+              loading={refreshing}
+              disabled={!client || loading}
+              onClick={handleRefresh}
+            >
+              Refresh
+            </Button>
+          }
+          items={[
+            {
+              key: 'all-files',
+              label: 'All files',
+              children: (
+                <FileCollection
+                  files={visibleFiles}
+                  loading={loading}
+                  onFileClick={handleFileClick}
+                  onDownload={downloadFile}
+                  emptyMessage="No files found in branch"
+                />
+              ),
+            },
+            {
+              key: 'changes',
+              label: `Changes (${workingTreeChanges.length})`,
+              children: (
+                <FileCollection
+                  files={workingTreeChanges}
+                  loading={loading}
+                  onFileClick={handleWorkingTreeFileClick}
+                  onDownload={downloadFile}
+                  emptyMessage="No unstaged changes"
+                  gitStatusSource="workingTree"
+                />
+              ),
+            },
+            {
+              key: 'staged-changes',
+              label: `Staged changes (${stagedChanges.length})`,
+              children: (
+                <FileCollection
+                  files={stagedChanges}
+                  loading={loading}
+                  onFileClick={handleStagedFileClick}
+                  onDownload={downloadFile}
+                  emptyMessage="No staged changes"
+                  gitStatusSource="staged"
+                />
+              ),
+            },
+          ]}
         />
 
         <CodePreviewModal

--- a/apps/agor-ui/src/components/CodePreviewModal/CodePreviewModal.test.tsx
+++ b/apps/agor-ui/src/components/CodePreviewModal/CodePreviewModal.test.tsx
@@ -1,0 +1,75 @@
+import type { FileDetail } from '@agor-live/client';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/utils/message', () => ({
+  useThemedMessage: () => ({ showSuccess: vi.fn() }),
+}));
+
+vi.mock('@/components/ThemedSyntaxHighlighter', () => ({
+  ThemedSyntaxHighlighter: ({ children }: { children: string }) => (
+    <pre data-testid="file-content">{children}</pre>
+  ),
+}));
+
+vi.mock('../ToolUseRenderer/renderers/DiffBlock', () => ({
+  DiffBlock: ({
+    oldContent,
+    newContent,
+    operationType,
+  }: {
+    oldContent: string;
+    newContent: string;
+    operationType: string;
+  }) => (
+    <div data-testid="file-diff">
+      {operationType}:{oldContent}:{newContent}
+    </div>
+  ),
+}));
+
+import { CodePreviewModal } from './CodePreviewModal';
+
+const modifiedFile: FileDetail = {
+  path: 'src/example.ts',
+  title: 'example.ts',
+  size: 20,
+  lastModified: '2026-08-30T00:00:00.000Z',
+  isText: true,
+  gitStatus: 'modified',
+  content: 'const value = 2;\n',
+  encoding: 'utf-8',
+  gitDiff: { baseContent: 'const value = 1;\n' },
+};
+
+describe('CodePreviewModal git changes', () => {
+  it('lets a user switch from the current file to its HEAD diff', () => {
+    render(<CodePreviewModal file={modifiedFile} open onClose={vi.fn()} />);
+
+    expect(screen.getByTestId('file-content')).toHaveTextContent('const value = 2;');
+
+    fireEvent.click(screen.getByText('Changes'));
+
+    expect(screen.getByTestId('file-diff')).toHaveTextContent(
+      'edit:const value = 1; :const value = 2;'
+    );
+  });
+
+  it('opens a deleted file directly in diff mode', () => {
+    render(
+      <CodePreviewModal
+        file={{
+          ...modifiedFile,
+          path: 'src/deleted.ts',
+          gitStatus: 'deleted',
+          content: '',
+        }}
+        open
+        onClose={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('file-diff')).toHaveTextContent('delete:const value = 1; :');
+    expect(screen.queryByTestId('file-content')).not.toBeInTheDocument();
+  });
+});

--- a/apps/agor-ui/src/components/CodePreviewModal/CodePreviewModal.test.tsx
+++ b/apps/agor-ui/src/components/CodePreviewModal/CodePreviewModal.test.tsx
@@ -17,13 +17,15 @@ vi.mock('../ToolUseRenderer/renderers/DiffBlock', () => ({
     oldContent,
     newContent,
     operationType,
+    rawContentKind,
   }: {
     oldContent: string;
     newContent: string;
     operationType: string;
+    rawContentKind?: string;
   }) => (
     <div data-testid="file-diff">
-      {operationType}:{oldContent}:{newContent}
+      {operationType}:{rawContentKind}:{oldContent}:{newContent}
     </div>
   ),
 }));
@@ -51,7 +53,7 @@ describe('CodePreviewModal git changes', () => {
     fireEvent.click(screen.getByText('Changes'));
 
     expect(screen.getByTestId('file-diff')).toHaveTextContent(
-      'edit:const value = 1; :const value = 2;'
+      'edit:full-file:const value = 1; :const value = 2;'
     );
   });
 
@@ -69,7 +71,9 @@ describe('CodePreviewModal git changes', () => {
       />
     );
 
-    expect(screen.getByTestId('file-diff')).toHaveTextContent('delete:const value = 1; :');
+    expect(screen.getByTestId('file-diff')).toHaveTextContent(
+      'delete:full-file:const value = 1; :'
+    );
     expect(screen.queryByTestId('file-content')).not.toBeInTheDocument();
   });
 });

--- a/apps/agor-ui/src/components/CodePreviewModal/CodePreviewModal.tsx
+++ b/apps/agor-ui/src/components/CodePreviewModal/CodePreviewModal.tsx
@@ -1,10 +1,13 @@
 import type { FileDetail } from '@agor-live/client';
 import { CopyOutlined } from '@ant-design/icons';
-import { Button, Modal, Spin } from 'antd';
+import { Button, Empty, Modal, Segmented, Spin } from 'antd';
+import { useEffect, useState } from 'react';
 import { ThemedSyntaxHighlighter } from '@/components/ThemedSyntaxHighlighter';
 import { copyToClipboard } from '@/utils/clipboard';
 import { getLanguageFromPath } from '@/utils/language';
 import { useThemedMessage } from '@/utils/message';
+import { MarkdownRenderer } from '../MarkdownRenderer';
+import { DiffBlock } from '../ToolUseRenderer/renderers/DiffBlock';
 
 export interface CodePreviewModalProps {
   file: FileDetail | null;
@@ -15,10 +18,25 @@ export interface CodePreviewModalProps {
 
 export const CodePreviewModal = ({ file, open, onClose, loading }: CodePreviewModalProps) => {
   const { showSuccess } = useThemedMessage();
+  const [mode, setMode] = useState<'file' | 'changes'>('file');
+
+  useEffect(() => {
+    if (open && file) {
+      setMode(file.gitStatus === 'deleted' ? 'changes' : 'file');
+    }
+  }, [file, open]);
 
   if (!file) return null;
 
   const language = getLanguageFromPath(file.path);
+  const hasDiff = file.gitDiff !== undefined;
+  const isMarkdown = file.path.toLowerCase().endsWith('.md');
+  const operationType =
+    file.gitStatus === 'deleted'
+      ? 'delete'
+      : file.gitStatus === 'added' || file.gitStatus === 'untracked'
+        ? 'create'
+        : 'edit';
 
   const handleCopyContent = async () => {
     await copyToClipboard(file.content);
@@ -62,9 +80,41 @@ export const CodePreviewModal = ({ file, open, onClose, loading }: CodePreviewMo
       {loading ? (
         <Spin style={{ display: 'block', padding: '2rem' }} description="Loading file…" />
       ) : (
-        <ThemedSyntaxHighlighter language={language} showLineNumbers>
-          {file.content}
-        </ThemedSyntaxHighlighter>
+        <>
+          {hasDiff && (
+            <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 16 }}>
+              <Segmented<'file' | 'changes'>
+                aria-label="File preview mode"
+                value={mode}
+                onChange={setMode}
+                options={[
+                  { label: 'File', value: 'file', disabled: file.gitStatus === 'deleted' },
+                  { label: 'Changes', value: 'changes' },
+                ]}
+              />
+            </div>
+          )}
+
+          {hasDiff && mode === 'changes' ? (
+            file.gitDiff?.baseContent === file.content ? (
+              <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No content changes" />
+            ) : (
+              <DiffBlock
+                filePath={file.path}
+                operationType={operationType}
+                oldContent={file.gitDiff?.baseContent}
+                newContent={file.content}
+                forceExpanded
+              />
+            )
+          ) : isMarkdown ? (
+            <MarkdownRenderer content={file.content} />
+          ) : (
+            <ThemedSyntaxHighlighter language={language} showLineNumbers>
+              {file.content}
+            </ThemedSyntaxHighlighter>
+          )}
+        </>
       )}
     </Modal>
   );

--- a/apps/agor-ui/src/components/CodePreviewModal/CodePreviewModal.tsx
+++ b/apps/agor-ui/src/components/CodePreviewModal/CodePreviewModal.tsx
@@ -105,6 +105,7 @@ export const CodePreviewModal = ({ file, open, onClose, loading }: CodePreviewMo
                 oldContent={file.gitDiff?.baseContent}
                 newContent={file.content}
                 forceExpanded
+                rawContentKind="full-file"
               />
             )
           ) : isMarkdown ? (

--- a/apps/agor-ui/src/components/FileCollection/FileCollection.tsx
+++ b/apps/agor-ui/src/components/FileCollection/FileCollection.tsx
@@ -13,6 +13,7 @@
  * - Supports all file types (text and binary)
  */
 
+import type { GitFileStatus } from '@agor-live/client';
 import {
   CopyOutlined,
   DownloadOutlined,
@@ -20,7 +21,8 @@ import {
   FileOutlined,
   FolderOutlined,
 } from '@ant-design/icons';
-import { Button, Empty, Input, Spin, Tooltip, Tree } from 'antd';
+import type { GlobalToken } from 'antd';
+import { Button, Empty, Input, Spin, Tooltip, Tree, theme } from 'antd';
 import type React from 'react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { copyToClipboard } from '../../utils/clipboard';
@@ -38,6 +40,45 @@ export type FileItem = {
   lastModified: string;
   isText?: boolean;
   mimeType?: string;
+  gitStatus?: GitFileStatus;
+};
+
+/** VSCode-style badge letter + theme color for each git status. */
+interface GitStatusMeta {
+  color: string;
+  letter: string;
+  label: string;
+}
+
+/**
+ * Map each git status to a theme-token color + single-letter badge, matching
+ * the VSCode / IDE source-control vocabulary. Colors come from `theme.useToken()`
+ * so they adapt to light and dark automatically.
+ */
+function buildGitStatusMeta(token: GlobalToken): Record<GitFileStatus, GitStatusMeta> {
+  return {
+    added: { color: token.colorSuccess, letter: 'A', label: 'Added' },
+    untracked: { color: token.colorSuccess, letter: 'U', label: 'Untracked' },
+    copied: { color: token.colorSuccess, letter: 'C', label: 'Copied' },
+    modified: { color: token.colorWarning, letter: 'M', label: 'Modified' },
+    renamed: { color: token.colorInfo, letter: 'R', label: 'Renamed' },
+    deleted: { color: token.colorError, letter: 'D', label: 'Deleted' },
+    conflicted: { color: token.colorError, letter: '!', label: 'Conflicted' },
+    ignored: { color: token.colorTextTertiary, letter: 'I', label: 'Ignored' },
+  };
+}
+
+// Folder tint severity: a directory is colored by its most significant
+// descendant change. `ignored` is excluded so ignored subtrees stay neutral.
+const GIT_STATUS_SEVERITY: Record<GitFileStatus, number> = {
+  conflicted: 7,
+  deleted: 6,
+  modified: 5,
+  renamed: 4,
+  added: 3,
+  copied: 2,
+  untracked: 1,
+  ignored: 0,
 };
 
 export interface FileCollectionProps {
@@ -76,6 +117,7 @@ interface TreeNode {
 function buildTree(
   files: FileItem[],
   searchQuery: string,
+  statusMeta: Record<GitFileStatus, GitStatusMeta>,
   onDownload?: (file: FileItem) => void,
   onCopyPath?: (file: FileItem) => void
 ): TreeNode[] {
@@ -87,6 +129,21 @@ function buildTree(
           f.path.toLowerCase().includes(searchQuery.toLowerCase())
       )
     : files;
+
+  // Aggregate each directory's most-significant descendant change so folders
+  // containing edits can be tinted like an IDE explorer. `ignored` is skipped.
+  const dirStatus = new Map<string, GitFileStatus>();
+  for (const file of filteredFiles) {
+    if (!file.gitStatus || file.gitStatus === 'ignored') continue;
+    const parts = file.path.split('/');
+    for (let i = 1; i < parts.length; i++) {
+      const dir = parts.slice(0, i).join('/');
+      const current = dirStatus.get(dir);
+      if (!current || GIT_STATUS_SEVERITY[file.gitStatus] > GIT_STATUS_SEVERITY[current]) {
+        dirStatus.set(dir, file.gitStatus);
+      }
+    }
+  }
 
   // Group files by directory
   const tree: Map<string, TreeNode> = new Map();
@@ -105,10 +162,14 @@ function buildTree(
 
       // Create directory node if it doesn't exist
       if (!tree.has(currentPath)) {
+        const folderStatus = dirStatus.get(currentPath);
+        const folderColor = folderStatus ? statusMeta[folderStatus].color : undefined;
         tree.set(currentPath, {
           key: currentPath,
           title: (
-            <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>
+            <span
+              style={{ display: 'inline-flex', alignItems: 'center', gap: 8, color: folderColor }}
+            >
               <FolderOutlined />
               <strong>{part}</strong>
             </span>
@@ -141,7 +202,11 @@ function buildTree(
     };
 
     const fileSize = formatSize(file.size);
-    const tooltipText = `${file.path} (${fileSize})`;
+    const meta = file.gitStatus ? statusMeta[file.gitStatus] : undefined;
+    const isDeleted = file.gitStatus === 'deleted';
+    const tooltipText = meta
+      ? `${file.path} — ${meta.label}${isDeleted ? '' : ` (${fileSize})`}`
+      : `${file.path} (${fileSize})`;
 
     const fileNode: TreeNode = {
       key: file.path,
@@ -156,10 +221,42 @@ function buildTree(
             }}
           >
             <span
-              style={{ flex: 1, minWidth: 0, display: 'inline-flex', alignItems: 'center', gap: 8 }}
+              style={{
+                flex: 1,
+                minWidth: 0,
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 8,
+                color: meta?.color,
+                textDecoration: isDeleted ? 'line-through' : undefined,
+              }}
             >
               <FileIcon />
-              {fileName}
+              <span
+                style={{
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {fileName}
+              </span>
+              {meta && (
+                <span
+                  role="img"
+                  aria-label={meta.label}
+                  style={{
+                    color: meta.color,
+                    fontFamily: 'monospace',
+                    fontWeight: 600,
+                    fontSize: 12,
+                    lineHeight: 1,
+                    textDecoration: 'none',
+                  }}
+                >
+                  {meta.letter}
+                </span>
+              )}
             </span>
             <span style={{ marginLeft: 8, whiteSpace: 'nowrap', display: 'inline-flex', gap: 4 }}>
               <Tooltip title="Copy path">
@@ -253,6 +350,8 @@ const FileCollectionInner: React.FC<FileCollectionProps> = ({
   const [searchInput, setSearchInput] = useState('');
   const [expandedKeys, setExpandedKeys] = useState<string[]>([]);
   const { showSuccess } = useThemedMessage();
+  const { token } = theme.useToken();
+  const statusMeta = useMemo(() => buildGitStatusMeta(token), [token]);
 
   // Use refs to store stable callback references
   const onDownloadRef = useRef(onDownload);
@@ -281,10 +380,11 @@ const FileCollectionInner: React.FC<FileCollectionProps> = ({
     onDownloadRef.current?.(file);
   }, []);
 
-  // Build tree structure - only depends on files, searchQuery, and stable callbacks
+  // Build tree structure - only depends on files, searchQuery, status colors,
+  // and stable callbacks
   const treeData = useMemo(
-    () => buildTree(files, searchQuery, stableOnDownload, handleCopyPath),
-    [files, searchQuery, stableOnDownload, handleCopyPath]
+    () => buildTree(files, searchQuery, statusMeta, stableOnDownload, handleCopyPath),
+    [files, searchQuery, statusMeta, stableOnDownload, handleCopyPath]
   );
 
   // Handle node selection - stable callback using ref

--- a/apps/agor-ui/src/components/FileCollection/FileCollection.tsx
+++ b/apps/agor-ui/src/components/FileCollection/FileCollection.tsx
@@ -13,7 +13,7 @@
  * - Supports all file types (text and binary)
  */
 
-import type { GitFileStatus } from '@agor-live/client';
+import type { FileListItem, GitFileStatus, GitFileStatusSource } from '@agor-live/client';
 import {
   CopyOutlined,
   DownloadOutlined,
@@ -33,15 +33,7 @@ const { Search } = Input;
 // Debounce delay for live search (milliseconds)
 const SEARCH_DEBOUNCE_MS = 300;
 
-export type FileItem = {
-  path: string;
-  title: string;
-  size: number;
-  lastModified: string;
-  isText?: boolean;
-  mimeType?: string;
-  gitStatus?: GitFileStatus;
-};
+export type FileItem = FileListItem;
 
 /** VSCode-style badge letter + theme color for each git status. */
 interface GitStatusMeta {
@@ -96,6 +88,18 @@ export interface FileCollectionProps {
 
   /** Message to show when no files found */
   emptyMessage?: string;
+
+  /** Which git status dimension supplies file and folder badges. */
+  gitStatusSource?: GitFileStatusSource;
+}
+
+function getDisplayedGitStatus(
+  file: FileItem,
+  source: GitFileStatusSource
+): GitFileStatus | undefined {
+  if (source === 'workingTree') return file.gitWorkingTreeStatus;
+  if (source === 'staged') return file.gitStagedStatus;
+  return file.gitStatus;
 }
 
 /**
@@ -118,6 +122,7 @@ function buildTree(
   files: FileItem[],
   searchQuery: string,
   statusMeta: Record<GitFileStatus, GitStatusMeta>,
+  gitStatusSource: GitFileStatusSource,
   onDownload?: (file: FileItem) => void,
   onCopyPath?: (file: FileItem) => void
 ): TreeNode[] {
@@ -134,13 +139,14 @@ function buildTree(
   // containing edits can be tinted like an IDE explorer. `ignored` is skipped.
   const dirStatus = new Map<string, GitFileStatus>();
   for (const file of filteredFiles) {
-    if (!file.gitStatus || file.gitStatus === 'ignored') continue;
+    const status = getDisplayedGitStatus(file, gitStatusSource);
+    if (!status || status === 'ignored') continue;
     const parts = file.path.split('/');
     for (let i = 1; i < parts.length; i++) {
       const dir = parts.slice(0, i).join('/');
       const current = dirStatus.get(dir);
-      if (!current || GIT_STATUS_SEVERITY[file.gitStatus] > GIT_STATUS_SEVERITY[current]) {
-        dirStatus.set(dir, file.gitStatus);
+      if (!current || GIT_STATUS_SEVERITY[status] > GIT_STATUS_SEVERITY[current]) {
+        dirStatus.set(dir, status);
       }
     }
   }
@@ -202,8 +208,9 @@ function buildTree(
     };
 
     const fileSize = formatSize(file.size);
-    const meta = file.gitStatus ? statusMeta[file.gitStatus] : undefined;
-    const isDeleted = file.gitStatus === 'deleted';
+    const displayedStatus = getDisplayedGitStatus(file, gitStatusSource);
+    const meta = displayedStatus ? statusMeta[displayedStatus] : undefined;
+    const isDeleted = displayedStatus === 'deleted';
     const tooltipText = meta
       ? `${file.path} — ${meta.label}${isDeleted ? '' : ` (${fileSize})`}`
       : `${file.path} (${fileSize})`;
@@ -345,6 +352,7 @@ const FileCollectionInner: React.FC<FileCollectionProps> = ({
   onDownload,
   loading = false,
   emptyMessage = 'No files found',
+  gitStatusSource = 'combined',
 }) => {
   const [searchQuery, setSearchQuery] = useState('');
   const [searchInput, setSearchInput] = useState('');
@@ -383,8 +391,9 @@ const FileCollectionInner: React.FC<FileCollectionProps> = ({
   // Build tree structure - only depends on files, searchQuery, status colors,
   // and stable callbacks
   const treeData = useMemo(
-    () => buildTree(files, searchQuery, statusMeta, stableOnDownload, handleCopyPath),
-    [files, searchQuery, statusMeta, stableOnDownload, handleCopyPath]
+    () =>
+      buildTree(files, searchQuery, statusMeta, gitStatusSource, stableOnDownload, handleCopyPath),
+    [files, searchQuery, statusMeta, gitStatusSource, stableOnDownload, handleCopyPath]
   );
 
   // Handle node selection - stable callback using ref
@@ -531,6 +540,7 @@ export const FileCollection = memo(FileCollectionInner, (prevProps, nextProps) =
   return (
     prevProps.loading === nextProps.loading &&
     prevProps.emptyMessage === nextProps.emptyMessage &&
+    prevProps.gitStatusSource === nextProps.gitStatusSource &&
     prevProps.files === nextProps.files
     // Note: we intentionally don't compare onFileClick and onDownload
     // since we use refs internally to always get the latest callback

--- a/apps/agor-ui/src/components/ToolUseRenderer/renderers/DiffBlock/DiffBlock.test.tsx
+++ b/apps/agor-ui/src/components/ToolUseRenderer/renderers/DiffBlock/DiffBlock.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/utils/message', () => ({
+  useThemedMessage: () => ({ showSuccess: vi.fn(), showWarning: vi.fn() }),
+}));
+
+import { DiffBlock } from './DiffBlock';
+
+describe('DiffBlock computation limit', () => {
+  it('shows a useful fallback when a raw diff exceeds the synchronous budget', () => {
+    const before = Array.from({ length: 1001 }, (_, index) => `before ${index}`).join('\n');
+    const after = Array.from({ length: 1001 }, (_, index) => `after ${index}`).join('\n');
+
+    render(
+      <DiffBlock
+        filePath="large.txt"
+        operationType="edit"
+        oldContent={before}
+        newContent={after}
+        rawContentKind="full-file"
+        forceExpanded
+      />
+    );
+
+    expect(screen.getByText('Diff preview limited')).toBeInTheDocument();
+    expect(screen.getByText(/too complex to compute safely/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Copy diff' })).not.toBeInTheDocument();
+  });
+});

--- a/apps/agor-ui/src/components/ToolUseRenderer/renderers/DiffBlock/DiffBlock.tsx
+++ b/apps/agor-ui/src/components/ToolUseRenderer/renderers/DiffBlock/DiffBlock.tsx
@@ -3,13 +3,14 @@
  *
  * Two rendering tiers:
  * 1. Rich: With structuredPatch from executor (line numbers + context)
- * 2. Fallback: Client-side diffLines from old/new strings (no line numbers)
+ * 2. Fallback: Client-side diffLines from bounded raw old/new strings. Complete
+ *    files have line numbers; unknown-position fragments do not.
  *
  * Collapsed by default for large diffs (>10 lines), expanded for small ones.
  */
 
 import { CopyOutlined, DownOutlined, RightOutlined } from '@ant-design/icons';
-import { Tooltip, Typography, theme } from 'antd';
+import { Alert, Button, Tooltip, Typography, theme } from 'antd';
 import { createPatch } from 'diff';
 import type React from 'react';
 import { useState } from 'react';
@@ -17,7 +18,14 @@ import { copyToClipboard } from '@/utils/clipboard';
 import { useThemedMessage } from '@/utils/message';
 import { isDarkTheme } from '@/utils/theme';
 import { getDiffPalette } from './diffPalette';
-import { type DiffLine, type StructuredPatchHunk, useDiff, type WordSegment } from './useDiff';
+import {
+  type DiffLine,
+  RAW_DIFF_LIMITS,
+  type RawContentKind,
+  type StructuredPatchHunk,
+  useDiff,
+  type WordSegment,
+} from './useDiff';
 
 /** Lines of diff output before we collapse by default */
 const COLLAPSE_THRESHOLD = 10;
@@ -35,6 +43,8 @@ export interface DiffBlockProps {
   errorMessage?: string;
   /** Override the default expand/collapse heuristic */
   forceExpanded?: boolean;
+  /** Whether raw old/new strings are complete files or unknown-position fragments. */
+  rawContentKind?: RawContentKind;
 }
 
 /** Shorten an absolute file path for display */
@@ -79,14 +89,16 @@ export const DiffBlock: React.FC<DiffBlockProps> = ({
   isError,
   errorMessage,
   forceExpanded,
+  rawContentKind,
 }) => {
   const { token } = theme.useToken();
-  const { showSuccess } = useThemedMessage();
+  const { showSuccess, showWarning } = useThemedMessage();
   const isDark = isDarkTheme(token);
-  const diff = useDiff(oldContent, newContent, structuredPatch);
+  const diff = useDiff(oldContent, newContent, structuredPatch, rawContentKind);
 
   const defaultExpanded =
-    forceExpanded ?? (diff.totalLines <= COLLAPSE_THRESHOLD && diff.totalLines > 0);
+    forceExpanded ??
+    (diff.limited || (diff.totalLines <= COLLAPSE_THRESHOLD && diff.totalLines > 0));
   const [expanded, setExpanded] = useState(defaultExpanded);
   const [showAll, setShowAll] = useState(false);
 
@@ -113,14 +125,28 @@ export const DiffBlock: React.FC<DiffBlockProps> = ({
     );
   }
 
-  if (diff.totalLines === 0) return null;
+  if (diff.totalLines === 0 && !diff.limited) return null;
 
   const handleCopyDiff = async () => {
     let diffText: string;
     if (oldContent !== undefined && newContent !== undefined) {
-      diffText = createPatch(filePath, oldContent, newContent);
+      const patch = createPatch(filePath, oldContent, newContent, undefined, undefined, {
+        ...RAW_DIFF_LIMITS,
+      });
+      if (!patch) {
+        showWarning('Diff is too complex to copy safely');
+        return;
+      }
+      diffText = patch;
     } else if (newContent !== undefined) {
-      diffText = createPatch(filePath, '', newContent);
+      const patch = createPatch(filePath, '', newContent, undefined, undefined, {
+        ...RAW_DIFF_LIMITS,
+      });
+      if (!patch) {
+        showWarning('Diff is too complex to copy safely');
+        return;
+      }
+      diffText = patch;
     } else {
       // Reconstruct from lines
       diffText = diff.lines
@@ -334,7 +360,17 @@ export const DiffBlock: React.FC<DiffBlockProps> = ({
             overflow: 'hidden',
           }}
         >
-          <div style={{ overflowX: 'auto' }}>{visibleLines.map(renderLine)}</div>
+          {diff.limited ? (
+            <Alert
+              type="warning"
+              showIcon
+              title="Diff preview limited"
+              description="This change is too complex to compute safely in the browser. Open the file or use local Git to inspect the complete diff."
+              style={{ borderRadius: 0 }}
+            />
+          ) : (
+            <div style={{ overflowX: 'auto' }}>{visibleLines.map(renderLine)}</div>
+          )}
 
           {/* Truncation notice */}
           {needsTruncation && (
@@ -358,30 +394,33 @@ export const DiffBlock: React.FC<DiffBlockProps> = ({
           )}
 
           {/* Actions bar */}
-          <div
-            style={{
-              display: 'flex',
-              justifyContent: 'flex-end',
-              padding: `3px ${token.sizeUnit}px`,
-              borderTop: `1px solid ${token.colorBorderSecondary}`,
-              background: token.colorBgLayout,
-            }}
-          >
-            <Tooltip title="Copy diff">
-              <CopyOutlined
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleCopyDiff();
-                }}
-                style={{
-                  fontSize: 12,
-                  color: token.colorTextTertiary,
-                  cursor: 'pointer',
-                  padding: 4,
-                }}
-              />
-            </Tooltip>
-          </div>
+          {!diff.limited && (
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'flex-end',
+                padding: `3px ${token.sizeUnit}px`,
+                borderTop: `1px solid ${token.colorBorderSecondary}`,
+                background: token.colorBgLayout,
+              }}
+            >
+              <Tooltip title="Copy diff">
+                <Button
+                  type="text"
+                  size="small"
+                  aria-label="Copy diff"
+                  icon={<CopyOutlined />}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleCopyDiff();
+                  }}
+                  style={{
+                    color: token.colorTextTertiary,
+                  }}
+                />
+              </Tooltip>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/apps/agor-ui/src/components/ToolUseRenderer/renderers/DiffBlock/useDiff.test.ts
+++ b/apps/agor-ui/src/components/ToolUseRenderer/renderers/DiffBlock/useDiff.test.ts
@@ -1,0 +1,34 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useDiff } from './useDiff';
+
+describe('useDiff', () => {
+  it('assigns old and new line numbers to client-computed file diffs', () => {
+    const { result } = renderHook(() => useDiff('alpha\nbefore\nomega\n', 'alpha\nafter\nomega\n'));
+
+    expect(result.current.hasLineNumbers).toBe(true);
+    expect(result.current.lines).toMatchObject([
+      { type: 'context', content: 'alpha', oldLineNumber: 1, newLineNumber: 1 },
+      { type: 'remove', content: 'before', oldLineNumber: 2 },
+      { type: 'add', content: 'after', newLineNumber: 2 },
+      { type: 'context', content: 'omega', oldLineNumber: 3, newLineNumber: 3 },
+    ]);
+  });
+
+  it('folds distant unchanged lines while keeping the edited hunk visible', () => {
+    const before = Array.from({ length: 20 }, (_, index) => `line ${index + 1}`);
+    const after = [...before];
+    after[9] = 'changed line';
+
+    const { result } = renderHook(() => useDiff(`${before.join('\n')}\n`, `${after.join('\n')}\n`));
+
+    expect(result.current.lines.some((line) => line.content === '...')).toBe(true);
+    expect(result.current.lines).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'remove', content: 'line 10', oldLineNumber: 10 }),
+        expect.objectContaining({ type: 'add', content: 'changed line', newLineNumber: 10 }),
+      ])
+    );
+    expect(result.current.lines).toHaveLength(10);
+  });
+});

--- a/apps/agor-ui/src/components/ToolUseRenderer/renderers/DiffBlock/useDiff.test.ts
+++ b/apps/agor-ui/src/components/ToolUseRenderer/renderers/DiffBlock/useDiff.test.ts
@@ -4,7 +4,9 @@ import { useDiff } from './useDiff';
 
 describe('useDiff', () => {
   it('assigns old and new line numbers to client-computed file diffs', () => {
-    const { result } = renderHook(() => useDiff('alpha\nbefore\nomega\n', 'alpha\nafter\nomega\n'));
+    const { result } = renderHook(() =>
+      useDiff('alpha\nbefore\nomega\n', 'alpha\nafter\nomega\n', undefined, 'full-file')
+    );
 
     expect(result.current.hasLineNumbers).toBe(true);
     expect(result.current.lines).toMatchObject([
@@ -20,7 +22,9 @@ describe('useDiff', () => {
     const after = [...before];
     after[9] = 'changed line';
 
-    const { result } = renderHook(() => useDiff(`${before.join('\n')}\n`, `${after.join('\n')}\n`));
+    const { result } = renderHook(() =>
+      useDiff(`${before.join('\n')}\n`, `${after.join('\n')}\n`, undefined, 'full-file')
+    );
 
     expect(result.current.lines.some((line) => line.content === '...')).toBe(true);
     expect(result.current.lines).toEqual(
@@ -30,5 +34,75 @@ describe('useDiff', () => {
       ])
     );
     expect(result.current.lines).toHaveLength(10);
+  });
+
+  it('does not invent file line numbers for unknown-position fragments', () => {
+    const { result } = renderHook(() => useDiff('before', 'after'));
+
+    expect(result.current.hasLineNumbers).toBe(false);
+    expect(result.current.lines).toMatchObject([
+      { type: 'remove', content: 'before' },
+      { type: 'add', content: 'after' },
+    ]);
+    expect(result.current.lines[0]).not.toHaveProperty('oldLineNumber');
+    expect(result.current.lines[1]).not.toHaveProperty('newLineNumber');
+  });
+
+  it('uses authoritative line numbers from structured patches', () => {
+    const { result } = renderHook(() =>
+      useDiff(undefined, undefined, [
+        {
+          oldStart: 40,
+          oldLines: 1,
+          newStart: 40,
+          newLines: 1,
+          lines: ['-before', '+after'],
+        },
+      ])
+    );
+
+    expect(result.current.hasLineNumbers).toBe(true);
+    expect(result.current.lines).toMatchObject([
+      { type: 'remove', oldLineNumber: 40 },
+      { type: 'add', newLineNumber: 40 },
+    ]);
+  });
+
+  it('returns a limited result when a raw diff exceeds its edit budget', () => {
+    const before = Array.from({ length: 1001 }, (_, index) => `before ${index}`).join('\n');
+    const after = Array.from({ length: 1001 }, (_, index) => `after ${index}`).join('\n');
+    const { result } = renderHook(() => useDiff(before, after, undefined, 'full-file'));
+
+    expect(result.current).toMatchObject({
+      limited: true,
+      lines: [],
+      totalLines: 0,
+    });
+  });
+
+  it('limits high-line-count input before expanding it into render rows', () => {
+    const before = `${'same\n'.repeat(20000)}before`;
+    const after = `${'same\n'.repeat(20000)}after`;
+    const { result } = renderHook(() => useDiff(before, after, undefined, 'full-file'));
+
+    expect(result.current.limited).toBe(true);
+    expect(result.current.lines).toEqual([]);
+  });
+
+  it('recognizes identical content without applying the complexity fallback', () => {
+    const content = 'same\n'.repeat(20000);
+    const { result } = renderHook(() => useDiff(content, content, undefined, 'full-file'));
+
+    expect(result.current).toMatchObject({ limited: false, lines: [], totalLines: 0 });
+  });
+
+  it('skips word-level diffing for oversized paired lines', () => {
+    const before = `before ${'a'.repeat(5000)}`;
+    const after = `after ${'b'.repeat(5000)}`;
+    const { result } = renderHook(() => useDiff(before, after, undefined, 'full-file'));
+
+    expect(result.current.limited).toBe(false);
+    expect(result.current.lines).toHaveLength(2);
+    expect(result.current.lines.every((line) => line.wordSegments === undefined)).toBe(true);
   });
 });

--- a/apps/agor-ui/src/components/ToolUseRenderer/renderers/DiffBlock/useDiff.ts
+++ b/apps/agor-ui/src/components/ToolUseRenderer/renderers/DiffBlock/useDiff.ts
@@ -116,32 +116,85 @@ function fromStructuredPatch(hunks: StructuredPatchHunk[]): DiffData {
 
 function fromOldNew(oldContent: string, newContent: string): DiffData {
   const changes = diffLines(oldContent, newContent);
-  const lines: DiffLine[] = [];
+  let lines: DiffLine[] = [];
   let additions = 0;
   let deletions = 0;
+  let oldLine = 1;
+  let newLine = 1;
 
   for (const change of changes) {
     const changeLines = change.value.replace(/\n$/, '').split('\n');
     for (const line of changeLines) {
       if (change.added) {
-        lines.push({ type: 'add', content: line });
+        lines.push({ type: 'add', content: line, newLineNumber: newLine });
+        newLine++;
         additions++;
       } else if (change.removed) {
-        lines.push({ type: 'remove', content: line });
+        lines.push({ type: 'remove', content: line, oldLineNumber: oldLine });
+        oldLine++;
         deletions++;
       } else {
-        lines.push({ type: 'context', content: line });
+        lines.push({
+          type: 'context',
+          content: line,
+          oldLineNumber: oldLine,
+          newLineNumber: newLine,
+        });
+        oldLine++;
+        newLine++;
       }
     }
   }
 
+  if (additions === 0 && deletions === 0) {
+    lines = [];
+  } else {
+    lines = compactUnchangedContext(lines);
+  }
   addWordSegments(lines);
   return {
     lines,
     stats: { additions, deletions },
-    hasLineNumbers: false,
+    hasLineNumbers: true,
     totalLines: lines.length,
   };
+}
+
+/** Keep GitHub/VSCode-style context around edits instead of rendering the whole file. */
+function compactUnchangedContext(lines: DiffLine[], contextLines = 3): DiffLine[] {
+  const compacted: DiffLine[] = [];
+  let index = 0;
+
+  while (index < lines.length) {
+    if (lines[index].type !== 'context') {
+      compacted.push(lines[index]);
+      index++;
+      continue;
+    }
+
+    const start = index;
+    while (index < lines.length && lines[index].type === 'context') index++;
+    const run = lines.slice(start, index);
+    const isLeading = start === 0;
+    const isTrailing = index === lines.length;
+    const visibleLimit = isLeading || isTrailing ? contextLines : contextLines * 2;
+
+    if (run.length <= visibleLimit) {
+      compacted.push(...run);
+    } else if (isLeading) {
+      compacted.push({ type: 'context', content: '...' }, ...run.slice(-contextLines));
+    } else if (isTrailing) {
+      compacted.push(...run.slice(0, contextLines), { type: 'context', content: '...' });
+    } else {
+      compacted.push(
+        ...run.slice(0, contextLines),
+        { type: 'context', content: '...' },
+        ...run.slice(-contextLines)
+      );
+    }
+  }
+
+  return compacted;
 }
 
 function fromNewOnly(content: string): DiffData {

--- a/apps/agor-ui/src/components/ToolUseRenderer/renderers/DiffBlock/useDiff.ts
+++ b/apps/agor-ui/src/components/ToolUseRenderer/renderers/DiffBlock/useDiff.ts
@@ -40,6 +40,46 @@ export interface DiffData {
   hasLineNumbers: boolean;
   /** Total number of diff lines (for collapse decisions) */
   totalLines: number;
+  /** The raw diff exceeded the synchronous computation budget. */
+  limited: boolean;
+}
+
+export type RawContentKind = 'fragment' | 'full-file';
+
+export const RAW_DIFF_LIMITS = {
+  maxEditLength: 1000,
+  timeout: 50,
+} as const;
+
+const WORD_DIFF_TIMEOUT_MS = 25;
+const MAX_WORD_DIFF_LINE_LENGTH = 5000;
+const MAX_RAW_DIFF_CHARACTERS = 2 * 1024 * 1024;
+const MAX_RAW_DIFF_LINES = 20000;
+
+function exceedsRawDiffInputLimits(contents: string[]): boolean {
+  let characters = 0;
+  let lines = contents.length;
+  for (const content of contents) {
+    characters += content.length;
+    if (characters > MAX_RAW_DIFF_CHARACTERS) return true;
+    for (let index = 0; index < content.length; index++) {
+      if (content.charCodeAt(index) === 10) {
+        lines++;
+        if (lines > MAX_RAW_DIFF_LINES) return true;
+      }
+    }
+  }
+  return false;
+}
+
+function limitedDiff(hasLineNumbers: boolean): DiffData {
+  return {
+    lines: [],
+    stats: { additions: 0, deletions: 0 },
+    hasLineNumbers,
+    totalLines: 0,
+    limited: true,
+  };
 }
 
 /**
@@ -48,7 +88,8 @@ export interface DiffData {
 export function useDiff(
   oldContent: string | undefined,
   newContent: string | undefined,
-  structuredPatch?: StructuredPatchHunk[]
+  structuredPatch?: StructuredPatchHunk[],
+  rawContentKind: RawContentKind = 'fragment'
 ): DiffData {
   return useMemo(() => {
     // Tier 1: Use executor-provided structured patch
@@ -58,7 +99,7 @@ export function useDiff(
 
     // Tier 2: Compute client-side from old/new strings
     if (oldContent !== undefined && newContent !== undefined) {
-      return fromOldNew(oldContent, newContent);
+      return fromOldNew(oldContent, newContent, rawContentKind);
     }
 
     // Tier 3: All-new content (create)
@@ -71,8 +112,9 @@ export function useDiff(
       stats: { additions: 0, deletions: 0 },
       hasLineNumbers: false,
       totalLines: 0,
+      limited: false,
     };
-  }, [oldContent, newContent, structuredPatch]);
+  }, [oldContent, newContent, rawContentKind, structuredPatch]);
 }
 
 function fromStructuredPatch(hunks: StructuredPatchHunk[]): DiffData {
@@ -111,11 +153,34 @@ function fromStructuredPatch(hunks: StructuredPatchHunk[]): DiffData {
   }
 
   addWordSegments(lines);
-  return { lines, stats: { additions, deletions }, hasLineNumbers: true, totalLines: lines.length };
+  return {
+    lines,
+    stats: { additions, deletions },
+    hasLineNumbers: true,
+    totalLines: lines.length,
+    limited: false,
+  };
 }
 
-function fromOldNew(oldContent: string, newContent: string): DiffData {
-  const changes = diffLines(oldContent, newContent);
+function fromOldNew(
+  oldContent: string,
+  newContent: string,
+  rawContentKind: RawContentKind
+): DiffData {
+  const hasLineNumbers = rawContentKind === 'full-file';
+  if (oldContent === newContent) {
+    return {
+      lines: [],
+      stats: { additions: 0, deletions: 0 },
+      hasLineNumbers,
+      totalLines: 0,
+      limited: false,
+    };
+  }
+  if (exceedsRawDiffInputLimits([oldContent, newContent])) return limitedDiff(hasLineNumbers);
+
+  const changes = diffLines(oldContent, newContent, RAW_DIFF_LIMITS);
+  if (!changes) return limitedDiff(hasLineNumbers);
   let lines: DiffLine[] = [];
   let additions = 0;
   let deletions = 0;
@@ -126,19 +191,26 @@ function fromOldNew(oldContent: string, newContent: string): DiffData {
     const changeLines = change.value.replace(/\n$/, '').split('\n');
     for (const line of changeLines) {
       if (change.added) {
-        lines.push({ type: 'add', content: line, newLineNumber: newLine });
+        lines.push({
+          type: 'add',
+          content: line,
+          ...(hasLineNumbers ? { newLineNumber: newLine } : {}),
+        });
         newLine++;
         additions++;
       } else if (change.removed) {
-        lines.push({ type: 'remove', content: line, oldLineNumber: oldLine });
+        lines.push({
+          type: 'remove',
+          content: line,
+          ...(hasLineNumbers ? { oldLineNumber: oldLine } : {}),
+        });
         oldLine++;
         deletions++;
       } else {
         lines.push({
           type: 'context',
           content: line,
-          oldLineNumber: oldLine,
-          newLineNumber: newLine,
+          ...(hasLineNumbers ? { oldLineNumber: oldLine, newLineNumber: newLine } : {}),
         });
         oldLine++;
         newLine++;
@@ -155,8 +227,9 @@ function fromOldNew(oldContent: string, newContent: string): DiffData {
   return {
     lines,
     stats: { additions, deletions },
-    hasLineNumbers: true,
+    hasLineNumbers,
     totalLines: lines.length,
+    limited: false,
   };
 }
 
@@ -198,6 +271,8 @@ function compactUnchangedContext(lines: DiffLine[], contextLines = 3): DiffLine[
 }
 
 function fromNewOnly(content: string): DiffData {
+  if (exceedsRawDiffInputLimits([content])) return limitedDiff(true);
+
   const contentLines = content.split('\n');
   const lines: DiffLine[] = contentLines.map((line, i) => ({
     type: 'add' as const,
@@ -210,6 +285,7 @@ function fromNewOnly(content: string): DiffData {
     stats: { additions: contentLines.length, deletions: 0 },
     hasLineNumbers: true,
     totalLines: lines.length,
+    limited: false,
   };
 }
 
@@ -219,6 +295,7 @@ function fromNewOnly(content: string): DiffData {
  * Mutates lines in place.
  */
 function addWordSegments(lines: DiffLine[]): void {
+  const abortAt = Date.now() + WORD_DIFF_TIMEOUT_MS;
   let i = 0;
   while (i < lines.length) {
     // Find a run of remove lines followed by a run of add lines
@@ -242,7 +319,15 @@ function addWordSegments(lines: DiffLine[]): void {
     for (let p = 0; p < pairs; p++) {
       const removeLine = lines[removeStart + p];
       const addLine = lines[addStart + p];
-      const changes = diffWords(removeLine.content, addLine.content);
+      if (removeLine.content.length + addLine.content.length > MAX_WORD_DIFF_LINE_LENGTH) continue;
+
+      const remainingTime = abortAt - Date.now();
+      if (remainingTime <= 0) return;
+      const changes = diffWords(removeLine.content, addLine.content, {
+        maxEditLength: RAW_DIFF_LIMITS.maxEditLength,
+        timeout: remainingTime,
+      });
+      if (!changes) return;
 
       const removeSegments: WordSegment[] = [];
       const addSegments: WordSegment[] = [];

--- a/apps/agor-ui/src/pages/KnowledgePage.tsx
+++ b/apps/agor-ui/src/pages/KnowledgePage.tsx
@@ -3870,6 +3870,7 @@ export function KnowledgePage({
                     operationType="edit"
                     oldContent={previousVersion.content_text ?? ''}
                     newContent={selectedVersion.content_text ?? ''}
+                    rawContentKind="full-file"
                     forceExpanded
                   />
                 ) : (

--- a/packages/core/src/types/file.ts
+++ b/packages/core/src/types/file.ts
@@ -11,6 +11,33 @@
 export type FilePath = string;
 
 /**
+ * Working-tree git status for a single file, relative to HEAD.
+ *
+ * Mirrors the VSCode / IDE source-control vocabulary so the UI can color-code
+ * and badge entries consistently:
+ * - `added`      — staged new file (index `A`)
+ * - `modified`   — content changed (index/worktree `M`/`T`)
+ * - `deleted`    — removed from the working tree (index/worktree `D`)
+ * - `renamed`    — moved/renamed (index/worktree `R`)
+ * - `copied`     — copied from another tracked file (index/worktree `C`)
+ * - `untracked`  — new, not yet tracked by git (`??`)
+ * - `conflicted` — unmerged / merge conflict (`U`, `AA`, `DD`, …)
+ * - `ignored`    — matched by a gitignore rule (`!!`)
+ *
+ * `undefined` means the file is unchanged relative to HEAD (or status could
+ * not be computed, e.g. the branch is not a git repository).
+ */
+export type GitFileStatus =
+  | 'added'
+  | 'modified'
+  | 'deleted'
+  | 'renamed'
+  | 'copied'
+  | 'untracked'
+  | 'conflicted'
+  | 'ignored';
+
+/**
  * File list response (lightweight, for browsing)
  * Returned by GET /file
  */
@@ -49,6 +76,12 @@ export interface FileListItem {
 
   /** Detected MIME type (optional) */
   mimeType?: string;
+
+  /**
+   * Working-tree git status relative to HEAD. Omitted when the file is
+   * unchanged or status could not be computed (non-git branch, git error).
+   */
+  gitStatus?: GitFileStatus;
 }
 
 /**
@@ -61,4 +94,20 @@ export interface FileDetail extends FileListItem {
 
   /** Content encoding: 'utf-8' for text files, 'base64' for binary files */
   encoding: 'utf-8' | 'base64';
+
+  /**
+   * Text content from HEAD used to compare the checked-out file with its
+   * committed version. Present only for previewable working-tree changes.
+   * Added/untracked files use an empty base; deleted files use empty current
+   * `content` and retain their committed text here.
+   */
+  gitDiff?: FileGitDiff;
+}
+
+export interface FileGitDiff {
+  /** UTF-8 content of the file at HEAD (or an empty string for a new file). */
+  baseContent: string;
+
+  /** Original HEAD path when git reports a rename or copy. */
+  basePath?: FilePath;
 }

--- a/packages/core/src/types/file.ts
+++ b/packages/core/src/types/file.ts
@@ -11,7 +11,9 @@
 export type FilePath = string;
 
 /**
- * Working-tree git status for a single file, relative to HEAD.
+ * Git status for a single file. `FileListItem.gitStatus` is the combined
+ * status used by the all-files view; the staged and working-tree fields retain
+ * the two porcelain dimensions separately.
  *
  * Mirrors the VSCode / IDE source-control vocabulary so the UI can color-code
  * and badge entries consistently:
@@ -36,6 +38,9 @@ export type GitFileStatus =
   | 'untracked'
   | 'conflicted'
   | 'ignored';
+
+/** Git snapshot used when opening a source-control file preview. */
+export type GitFileStatusSource = 'combined' | 'workingTree' | 'staged';
 
 /**
  * File list response (lightweight, for browsing)
@@ -78,10 +83,24 @@ export interface FileListItem {
   mimeType?: string;
 
   /**
-   * Working-tree git status relative to HEAD. Omitted when the file is
+   * Combined source-control status relative to HEAD. Omitted when the file is
    * unchanged or status could not be computed (non-git branch, git error).
    */
   gitStatus?: GitFileStatus;
+
+  /**
+   * Change in the working tree relative to the index. Omitted when the file
+   * has no unstaged change. Untracked files are working-tree changes; ignored
+   * files may also carry `ignored` so callers can exclude them explicitly.
+   */
+  gitWorkingTreeStatus?: GitFileStatus;
+
+  /**
+   * Change in the index relative to HEAD. Omitted when the file has no staged
+   * change. A file can have both staged and working-tree statuses (for example
+   * porcelain `MM`).
+   */
+  gitStagedStatus?: GitFileStatus;
 }
 
 /**

--- a/packages/executor/src/commands/files.test.ts
+++ b/packages/executor/src/commands/files.test.ts
@@ -1,7 +1,9 @@
-import { mkdir, mkdtemp, symlink, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, symlink, unlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import type { FileListItem } from '@agor/core/types';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createGit } from '../git/index.js';
 import { browseBranchFiles, readBranchFile } from './files.js';
 
 describe('branch file commands', () => {
@@ -47,5 +49,110 @@ describe('branch file commands', () => {
 
     await expect(readBranchFile(root, '../secret.txt')).rejects.toThrow(/path escapes branch/i);
     await expect(readBranchFile(root, 'escape.txt')).rejects.toThrow(/path escapes branch/i);
+  });
+});
+
+/**
+ * Integration coverage for the git-status enrichment in `browseBranchFiles`.
+ * Uses a real throwaway git repo so the porcelain parsing is exercised against
+ * actual git output rather than a fixture.
+ */
+describe('browseBranchFiles git status', () => {
+  let dir: string;
+
+  const statusByPath = (files: FileListItem[]) => new Map(files.map((f) => [f.path, f.gitStatus]));
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'agor-files-git-'));
+    const { git } = createGit(dir);
+    await git.init();
+    await git.addConfig('user.email', 'test@agor.test');
+    await git.addConfig('user.name', 'Agor Test');
+    await git.addConfig('commit.gpgsign', 'false');
+
+    await writeFile(join(dir, 'keep.txt'), 'unchanged\n');
+    await writeFile(join(dir, 'mod.txt'), 'original\n');
+    await writeFile(join(dir, 'del.txt'), 'to be deleted\n');
+    await writeFile(join(dir, 'old-name.txt'), 'rename me to a new path\n');
+    await writeFile(join(dir, '.gitignore'), '*.log\n');
+    await git.add('.');
+    await git.commit('initial');
+
+    // Working-tree mutations covering each VSCode-style status.
+    await writeFile(join(dir, 'mod.txt'), 'original\nchanged\n');
+    await unlink(join(dir, 'del.txt'));
+    await git.mv('old-name.txt', 'new-name.txt');
+    await writeFile(join(dir, 'fresh.txt'), 'brand new untracked\n');
+    await writeFile(join(dir, 'debug.log'), 'ignored by *.log\n');
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('tags each file with its working-tree status', async () => {
+    const files = await browseBranchFiles(dir);
+    const status = statusByPath(files);
+
+    expect(status.get('keep.txt')).toBeUndefined();
+    expect(status.get('mod.txt')).toBe('modified');
+    expect(status.get('new-name.txt')).toBe('renamed');
+    expect(status.get('fresh.txt')).toBe('untracked');
+    expect(status.get('debug.log')).toBe('ignored');
+  });
+
+  it('appends deleted files as synthetic entries', async () => {
+    const files = await browseBranchFiles(dir);
+    const deleted = files.find((f) => f.path === 'del.txt');
+
+    expect(deleted).toBeDefined();
+    expect(deleted?.gitStatus).toBe('deleted');
+    expect(deleted?.isText).toBe(true);
+    // The renamed-away original path must not resurface as a deletion.
+    expect(files.some((f) => f.path === 'old-name.txt')).toBe(false);
+  });
+
+  it('returns HEAD and working-tree text for content-level diffs', async () => {
+    await expect(readBranchFile(dir, 'mod.txt')).resolves.toMatchObject({
+      gitStatus: 'modified',
+      content: 'original\nchanged\n',
+      gitDiff: { baseContent: 'original\n' },
+    });
+
+    await expect(readBranchFile(dir, 'fresh.txt')).resolves.toMatchObject({
+      gitStatus: 'untracked',
+      content: 'brand new untracked\n',
+      gitDiff: { baseContent: '' },
+    });
+  });
+
+  it('reads deleted and renamed files from their original HEAD paths', async () => {
+    await expect(readBranchFile(dir, 'del.txt')).resolves.toMatchObject({
+      gitStatus: 'deleted',
+      content: '',
+      encoding: 'utf-8',
+      gitDiff: { baseContent: 'to be deleted\n' },
+    });
+
+    await expect(readBranchFile(dir, 'new-name.txt')).resolves.toMatchObject({
+      gitStatus: 'renamed',
+      content: 'rename me to a new path\n',
+      gitDiff: {
+        basePath: 'old-name.txt',
+        baseContent: 'rename me to a new path\n',
+      },
+    });
+  });
+
+  it('leaves the file list intact for a non-git directory', async () => {
+    const plainDir = await mkdtemp(join(tmpdir(), 'agor-files-plain-'));
+    try {
+      await writeFile(join(plainDir, 'note.txt'), 'no repo here\n');
+      const files = await browseBranchFiles(plainDir);
+      expect(files.map((f) => f.path)).toContain('note.txt');
+      expect(files.every((f) => f.gitStatus === undefined)).toBe(true);
+    } finally {
+      await rm(plainDir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/executor/src/commands/files.test.ts
+++ b/packages/executor/src/commands/files.test.ts
@@ -74,6 +74,9 @@ describe('browseBranchFiles git status', () => {
     await writeFile(join(dir, 'mod.txt'), 'original\n');
     await writeFile(join(dir, 'del.txt'), 'to be deleted\n');
     await writeFile(join(dir, 'old-name.txt'), 'rename me to a new path\n');
+    await writeFile(join(dir, 'recreated.txt'), 'original recreated content\n');
+    await writeFile(join(dir, 'staged-modified.txt'), 'original staged content\n');
+    await writeFile(join(dir, 'rename-then-delete.txt'), 'original renamed content\n');
     await writeFile(join(dir, '.gitignore'), '*.log\n');
     await git.add('.');
     await git.commit('initial');
@@ -99,6 +102,58 @@ describe('browseBranchFiles git status', () => {
     expect(status.get('new-name.txt')).toBe('renamed');
     expect(status.get('fresh.txt')).toBe('untracked');
     expect(status.get('debug.log')).toBe('ignored');
+
+    expect(files.find((file) => file.path === 'mod.txt')).toMatchObject({
+      gitWorkingTreeStatus: 'modified',
+    });
+    expect(files.find((file) => file.path === 'new-name.txt')).toMatchObject({
+      gitStagedStatus: 'renamed',
+    });
+    expect(files.find((file) => file.path === 'fresh.txt')).toMatchObject({
+      gitWorkingTreeStatus: 'untracked',
+    });
+  });
+
+  it('reports staged and working-tree changes independently', async () => {
+    const { git } = createGit(dir);
+    await writeFile(join(dir, 'staged-modified.txt'), 'staged content\n');
+    await git.add('staged-modified.txt');
+    await writeFile(join(dir, 'staged-modified.txt'), 'staged and unstaged content\n');
+
+    const files = await browseBranchFiles(dir);
+    expect(files.find((file) => file.path === 'staged-modified.txt')).toMatchObject({
+      gitStatus: 'modified',
+      gitStagedStatus: 'modified',
+      gitWorkingTreeStatus: 'modified',
+    });
+  });
+
+  it('reports a staged addition deleted from the working tree in both dimensions', async () => {
+    const { git } = createGit(dir);
+    await writeFile(join(dir, 'added-then-deleted.txt'), 'staged new content\n');
+    await git.add('added-then-deleted.txt');
+    await unlink(join(dir, 'added-then-deleted.txt'));
+
+    const files = await browseBranchFiles(dir);
+    expect(files.find((file) => file.path === 'added-then-deleted.txt')).toMatchObject({
+      gitStatus: 'deleted',
+      gitStagedStatus: 'added',
+      gitWorkingTreeStatus: 'deleted',
+      size: 0,
+    });
+
+    await expect(readBranchFile(dir, 'added-then-deleted.txt', 'staged')).resolves.toMatchObject({
+      gitStatus: 'added',
+      content: 'staged new content\n',
+      gitDiff: { baseContent: '' },
+    });
+    await expect(
+      readBranchFile(dir, 'added-then-deleted.txt', 'workingTree')
+    ).resolves.toMatchObject({
+      gitStatus: 'deleted',
+      content: '',
+      gitDiff: { baseContent: 'staged new content\n' },
+    });
   });
 
   it('appends deleted files as synthetic entries', async () => {
@@ -140,6 +195,71 @@ describe('browseBranchFiles git status', () => {
       gitDiff: {
         basePath: 'old-name.txt',
         baseContent: 'rename me to a new path\n',
+      },
+    });
+  });
+
+  it('uses the on-disk untracked record after a staged deletion is recreated', async () => {
+    const { git } = createGit(dir);
+    await unlink(join(dir, 'recreated.txt'));
+    await git.add('recreated.txt');
+    await writeFile(join(dir, 'recreated.txt'), 'new untracked content\n');
+
+    const files = await browseBranchFiles(dir);
+    const recreated = files.filter((file) => file.path === 'recreated.txt');
+
+    expect(recreated).toHaveLength(1);
+    expect(recreated[0]).toMatchObject({
+      gitStatus: 'untracked',
+      gitStagedStatus: 'deleted',
+      gitWorkingTreeStatus: 'untracked',
+    });
+    await expect(readBranchFile(dir, 'recreated.txt')).resolves.toMatchObject({
+      gitStatus: 'untracked',
+      content: 'new untracked content\n',
+      gitDiff: { baseContent: '' },
+    });
+  });
+
+  it('surfaces an MD path as a working-tree deletion', async () => {
+    const { git } = createGit(dir);
+    await writeFile(join(dir, 'staged-modified.txt'), 'staged content\n');
+    await git.add('staged-modified.txt');
+    await unlink(join(dir, 'staged-modified.txt'));
+
+    const files = await browseBranchFiles(dir);
+    expect(files.find((file) => file.path === 'staged-modified.txt')).toMatchObject({
+      gitStatus: 'deleted',
+      gitStagedStatus: 'modified',
+      gitWorkingTreeStatus: 'deleted',
+      size: 0,
+    });
+    await expect(readBranchFile(dir, 'staged-modified.txt')).resolves.toMatchObject({
+      gitStatus: 'deleted',
+      content: '',
+      gitDiff: { baseContent: 'original staged content\n' },
+    });
+  });
+
+  it('surfaces an RD destination as a deletion with its original HEAD path', async () => {
+    const { git } = createGit(dir);
+    await git.mv('rename-then-delete.txt', 'renamed-then-deleted.txt');
+    await unlink(join(dir, 'renamed-then-deleted.txt'));
+
+    const files = await browseBranchFiles(dir);
+    expect(files.find((file) => file.path === 'renamed-then-deleted.txt')).toMatchObject({
+      gitStatus: 'deleted',
+      gitStagedStatus: 'renamed',
+      gitWorkingTreeStatus: 'deleted',
+      size: 0,
+    });
+    expect(files.some((file) => file.path === 'rename-then-delete.txt')).toBe(false);
+    await expect(readBranchFile(dir, 'renamed-then-deleted.txt')).resolves.toMatchObject({
+      gitStatus: 'deleted',
+      content: '',
+      gitDiff: {
+        basePath: 'rename-then-delete.txt',
+        baseContent: 'original renamed content\n',
       },
     });
   });

--- a/packages/executor/src/commands/files.ts
+++ b/packages/executor/src/commands/files.ts
@@ -1,6 +1,7 @@
 import { lstat, open, readdir, readFile, realpath } from 'node:fs/promises';
-import { extname, join, relative, sep } from 'node:path';
-import type { FileDetail, FileListItem } from '@agor/core/types';
+import { basename, extname, join, relative, sep } from 'node:path';
+import type { FileDetail, FileListItem, GitFileStatus } from '@agor/core/types';
+import { createGit } from '../git/index.js';
 import type {
   BranchFilesBrowsePayload,
   BranchFilesReadPayload,
@@ -164,10 +165,150 @@ async function scanDirectory(
   }
 }
 
+/**
+ * Classify a git porcelain XY status pair into a single VSCode-style status.
+ * `x` is the index (staged) column, `y` is the working-tree column.
+ * Returns null for an unrecognized/clean pair.
+ */
+function classifyPorcelain(x: string, y: string): GitFileStatus | null {
+  if (x === '?' && y === '?') return 'untracked';
+  if (x === '!' && y === '!') return 'ignored';
+  // Unmerged / conflict states: any 'U', plus the AA/DD both-sides pairs.
+  if (x === 'U' || y === 'U' || (x === 'A' && y === 'A') || (x === 'D' && y === 'D')) {
+    return 'conflicted';
+  }
+  if (x === 'R' || y === 'R') return 'renamed';
+  if (x === 'C' || y === 'C') return 'copied';
+  if (x === 'A' || y === 'A') return 'added';
+  if (x === 'M' || y === 'M' || x === 'T' || y === 'T') return 'modified';
+  if (x === 'D' || y === 'D') return 'deleted';
+  return null;
+}
+
+interface PorcelainEntry {
+  x: string;
+  y: string;
+  path: string;
+  originalPath?: string;
+}
+
+/**
+ * Parse `git status --porcelain=v1 -z` output.
+ *
+ * Records are NUL-terminated. A normal record is `XY <path>`. Rename/copy
+ * records (`R`/`C` in either column) are followed by an extra NUL-separated
+ * record holding the original path, which is retained for HEAD lookups.
+ */
+function parsePorcelainZ(raw: string): PorcelainEntry[] {
+  const parts = raw.split('\0');
+  const entries: PorcelainEntry[] = [];
+  for (let i = 0; i < parts.length; i++) {
+    const record = parts[i];
+    if (record.length < 3) continue;
+    const x = record[0];
+    const y = record[1];
+    // Skip the "XY " prefix (status pair + single space) to get the path.
+    const path = record.slice(3);
+    const hasOriginalPath = x === 'R' || y === 'R' || x === 'C' || y === 'C';
+    // With `-z`, rename/copy records contain the current path first and the
+    // original path in the following NUL-delimited field.
+    const originalPath = hasOriginalPath ? parts[++i] : undefined;
+    entries.push({ x, y, path, originalPath });
+  }
+  return entries;
+}
+
+async function readGitStatus(root: string): Promise<PorcelainEntry[] | null> {
+  try {
+    const { git } = createGit(root);
+    const raw = await git.raw([
+      '-c',
+      `safe.directory=${root}`,
+      'status',
+      '--porcelain=v1',
+      '-z',
+      '--untracked-files=all',
+      '--ignored=matching',
+    ]);
+    return parsePorcelainZ(raw);
+  } catch (error) {
+    console.warn(
+      `[branch.files.browse] Skipping git status for ${root}:`,
+      error instanceof Error ? error.message : String(error)
+    );
+    return null;
+  }
+}
+
+/**
+ * Compute per-file working-tree git status for the branch and merge it into
+ * the browsed file list. Best-effort: any failure (non-git dir, dubious
+ * ownership, git error) leaves the file list untouched.
+ *
+ * On-disk files gain a `gitStatus`; files git reports as deleted (and not
+ * present in the walk) are appended as synthetic entries so the UI can show
+ * them struck-through, matching an IDE source-control view.
+ */
+async function applyGitStatus(root: string, files: FileListItem[]): Promise<void> {
+  const entries = await readGitStatus(root);
+  if (!entries) return;
+
+  const byPath = new Map<string, FileListItem>();
+  for (const file of files) byPath.set(file.path, file);
+
+  const ignoredDirs: string[] = [];
+  const deletedPaths: string[] = [];
+
+  for (const { x, y, path } of entries) {
+    const status = classifyPorcelain(x, y);
+    if (!status) continue;
+
+    // Git collapses a fully-ignored directory into a single `dir/` record;
+    // remember it so we can tag any browsed files that live underneath it.
+    if (status === 'ignored' && path.endsWith('/')) {
+      ignoredDirs.push(path);
+      continue;
+    }
+
+    const existing = byPath.get(path);
+    if (existing) {
+      existing.gitStatus = status;
+    } else if (status === 'deleted') {
+      deletedPaths.push(path);
+    }
+  }
+
+  if (ignoredDirs.length > 0) {
+    for (const file of files) {
+      if (file.gitStatus) continue;
+      if (ignoredDirs.some((dir) => file.path.startsWith(dir))) {
+        file.gitStatus = 'ignored';
+      }
+    }
+  }
+
+  // Surface deletions as synthetic entries (they are absent from the walk).
+  // Skip anything under an excluded directory to match the browse filter.
+  for (const path of deletedPaths) {
+    if (files.length >= MAX_FILES) break;
+    if (path.split('/').some((part) => EXCLUDED_DIRECTORIES.has(part))) continue;
+    files.push({
+      path,
+      title: basename(path),
+      size: 0,
+      lastModified: '',
+      isText: isTextFile(path, 0),
+      mimeType: getMimeType(path),
+      gitStatus: 'deleted',
+    });
+  }
+}
+
 export async function browseBranchFiles(branchRoot: string): Promise<FileListItem[]> {
   const root = await realpath(branchRoot);
   const files: FileListItem[] = [];
   await scanDirectory(root, root, files);
+  await applyGitStatus(root, files);
   return files;
 }
 
@@ -178,21 +319,76 @@ function normalizedRelativePath(input: string): string {
   return normalized;
 }
 
+async function readHeadText(
+  root: string,
+  filePath: string
+): Promise<{ content: string; size: number } | null> {
+  const object = `HEAD:${filePath}`;
+  try {
+    const { git } = createGit(root);
+    const safeDirectoryArgs = ['-c', `safe.directory=${root}`];
+    const sizeOutput = await git.raw([...safeDirectoryArgs, 'cat-file', '-s', object]);
+    const size = Number.parseInt(sizeOutput.trim(), 10);
+    if (!Number.isFinite(size) || !isTextFile(filePath, size)) return null;
+    const content = await git.raw([...safeDirectoryArgs, 'show', object]);
+    return { content, size };
+  } catch {
+    // Unborn HEAD, an index-only path, or an object that no longer exists all
+    // legitimately mean that there is no committed text to compare against.
+    return null;
+  }
+}
+
 export async function readBranchFile(
   branchRoot: string,
   relativeFilePath: string
 ): Promise<FileDetail> {
   const filePath = normalizedRelativePath(relativeFilePath);
   const { absolute: requestedPath } = await resolvePathInsideBranch(branchRoot, filePath, {
-    mustExist: true,
+    mustExist: false,
   });
-  const stats = await lstat(requestedPath);
-  if (stats.isSymbolicLink()) throw new Error('Access denied: symlinks not allowed');
-  if (!stats.isFile()) throw new Error('Requested path is not a file');
+
+  const statusEntries = await readGitStatus(branchRoot);
+  const statusEntry = statusEntries?.find((entry) => entry.path === filePath);
+  const gitStatus = statusEntry ? classifyPorcelain(statusEntry.x, statusEntry.y) : null;
+
+  let stats: Awaited<ReturnType<typeof lstat>> | null = null;
+  try {
+    stats = await lstat(requestedPath);
+  } catch (error) {
+    if ((error as { code?: string }).code !== 'ENOENT') throw error;
+  }
+
+  if (stats?.isSymbolicLink()) throw new Error('Access denied: symlinks not allowed');
+  if (stats && !stats.isFile()) throw new Error('Requested path is not a file');
+
+  // A deleted file has no working-tree bytes, but its HEAD content is still
+  // useful (and necessary) for a source-control diff preview.
+  if (!stats) {
+    if (gitStatus !== 'deleted') throw new Error('Requested file does not exist');
+    const base = await readHeadText(branchRoot, statusEntry?.originalPath ?? filePath);
+    if (!base) throw new Error('Deleted file is not previewable as text');
+    return {
+      path: filePath,
+      title: basename(filePath),
+      size: 0,
+      lastModified: '',
+      isText: true,
+      mimeType: getMimeType(filePath),
+      gitStatus,
+      content: '',
+      encoding: 'utf-8',
+      gitDiff: {
+        baseContent: base.content,
+        ...(statusEntry?.originalPath ? { basePath: statusEntry.originalPath } : {}),
+      },
+    };
+  }
+
   const isText = isTextFile(filePath, stats.size);
   const buffer = await readFile(requestedPath);
   const content = buffer.toString(isText ? 'utf-8' : 'base64');
-  return {
+  const detail: FileDetail = {
     path: filePath,
     title:
       filePath.endsWith('.md') && isText
@@ -202,9 +398,27 @@ export async function readBranchFile(
     lastModified: stats.mtime.toISOString(),
     isText,
     mimeType: getMimeType(filePath),
+    ...(gitStatus ? { gitStatus } : {}),
     content,
     encoding: isText ? 'utf-8' : 'base64',
   };
+
+  if (isText && gitStatus && gitStatus !== 'ignored') {
+    if (gitStatus === 'added' || gitStatus === 'untracked') {
+      detail.gitDiff = { baseContent: '' };
+    } else {
+      const basePath = statusEntry?.originalPath ?? filePath;
+      const base = await readHeadText(branchRoot, basePath);
+      if (base) {
+        detail.gitDiff = {
+          baseContent: base.content,
+          ...(statusEntry?.originalPath ? { basePath: statusEntry.originalPath } : {}),
+        };
+      }
+    }
+  }
+
+  return detail;
 }
 
 async function withBranch<T>(

--- a/packages/executor/src/commands/files.ts
+++ b/packages/executor/src/commands/files.ts
@@ -1,6 +1,11 @@
 import { lstat, open, readdir, readFile, realpath } from 'node:fs/promises';
 import { basename, extname, join, relative, sep } from 'node:path';
-import type { FileDetail, FileListItem, GitFileStatus } from '@agor/core/types';
+import type {
+  FileDetail,
+  FileListItem,
+  GitFileStatus,
+  GitFileStatusSource,
+} from '@agor/core/types';
 import { createGit } from '../git/index.js';
 import type {
   BranchFilesBrowsePayload,
@@ -192,6 +197,57 @@ interface PorcelainEntry {
   originalPath?: string;
 }
 
+interface ResolvedPorcelainEntry {
+  gitStatus: GitFileStatus;
+  gitWorkingTreeStatus?: GitFileStatus;
+  gitStagedStatus?: GitFileStatus;
+  originalPath?: string;
+}
+
+function isConflictEntry(entry: PorcelainEntry): boolean {
+  const { x, y } = entry;
+  return x === 'U' || y === 'U' || (x === 'A' && y === 'A') || (x === 'D' && y === 'D');
+}
+
+function classifyStatusColumn(status: string): GitFileStatus | undefined {
+  if (status === 'A') return 'added';
+  if (status === 'M' || status === 'T') return 'modified';
+  if (status === 'D') return 'deleted';
+  if (status === 'R') return 'renamed';
+  if (status === 'C') return 'copied';
+  return undefined;
+}
+
+function resolveStatusDimensions(entries: PorcelainEntry[]): {
+  gitWorkingTreeStatus?: GitFileStatus;
+  gitStagedStatus?: GitFileStatus;
+} {
+  if (entries.some(isConflictEntry)) {
+    // An unresolved index is presented as a working change rather than as a
+    // safely staged change.
+    return { gitWorkingTreeStatus: 'conflicted' };
+  }
+
+  let gitWorkingTreeStatus: GitFileStatus | undefined;
+  let gitStagedStatus: GitFileStatus | undefined;
+  for (const entry of entries) {
+    if (entry.x === '?' && entry.y === '?') {
+      gitWorkingTreeStatus = 'untracked';
+      continue;
+    }
+    if (entry.x === '!' && entry.y === '!') {
+      gitWorkingTreeStatus = 'ignored';
+      continue;
+    }
+    gitStagedStatus = classifyStatusColumn(entry.x) ?? gitStagedStatus;
+    gitWorkingTreeStatus = classifyStatusColumn(entry.y) ?? gitWorkingTreeStatus;
+  }
+  return {
+    ...(gitWorkingTreeStatus ? { gitWorkingTreeStatus } : {}),
+    ...(gitStagedStatus ? { gitStagedStatus } : {}),
+  };
+}
+
 /**
  * Parse `git status --porcelain=v1 -z` output.
  *
@@ -216,6 +272,81 @@ function parsePorcelainZ(raw: string): PorcelainEntry[] {
     entries.push({ x, y, path, originalPath });
   }
   return entries;
+}
+
+/**
+ * Collapse every porcelain record for a path into the status presented by the
+ * file browser. Git can emit more than one record for a path (for example a
+ * staged deletion followed by an untracked recreation), so callers must also
+ * supply whether current working-tree bytes exist.
+ */
+function resolvePorcelainEntries(
+  entries: PorcelainEntry[],
+  exists: boolean
+): ResolvedPorcelainEntry | null {
+  const dimensions = resolveStatusDimensions(entries);
+  const classified = entries.flatMap((entry) => {
+    const gitStatus = classifyPorcelain(entry.x, entry.y);
+    return gitStatus ? [{ entry, gitStatus }] : [];
+  });
+
+  // Conflicts remain conflicts even when the unresolved path is absent.
+  const conflict = classified.find(({ gitStatus }) => gitStatus === 'conflicted');
+  if (conflict) {
+    return {
+      gitStatus: 'conflicted',
+      ...dimensions,
+      ...(conflict.entry.originalPath ? { originalPath: conflict.entry.originalPath } : {}),
+    };
+  }
+
+  if (exists) {
+    // A record describing present bytes wins over an index-only deletion. In
+    // particular, Git reports a staged-delete/recreate pair as `D ` + `??`.
+    let present: (typeof classified)[number] | undefined;
+    for (let i = classified.length - 1; i >= 0; i--) {
+      if (classified[i].gitStatus !== 'deleted') {
+        present = classified[i];
+        break;
+      }
+    }
+    if (present) {
+      return {
+        gitStatus: present.gitStatus,
+        ...dimensions,
+        ...(present.entry.originalPath ? { originalPath: present.entry.originalPath } : {}),
+      };
+    }
+
+    // Status and lstat are separate operations, so a path may be recreated
+    // after Git reports it deleted. Never apply missing-file UI behavior to
+    // bytes that are present; compare them with HEAD as a modification.
+    if (classified.some(({ gitStatus }) => gitStatus === 'deleted')) {
+      return { gitStatus: 'modified', ...dimensions };
+    }
+    return null;
+  }
+
+  // Working-tree deletion is the visible state even when the index also says
+  // modified or renamed (`MD` / `RD`). Retain rename provenance for HEAD.
+  const workingTreeDeletion = classified.find(({ entry }) => entry.y === 'D');
+  if (workingTreeDeletion) {
+    return {
+      gitStatus: 'deleted',
+      ...dimensions,
+      ...(workingTreeDeletion.entry.originalPath
+        ? { originalPath: workingTreeDeletion.entry.originalPath }
+        : {}),
+    };
+  }
+
+  const resolved = classified.at(-1);
+  if (!resolved) return null;
+  return {
+    gitStatus: resolved.gitStatus,
+    ...dimensions,
+    ...(resolved.entry.originalPath ? { originalPath: resolved.entry.originalPath } : {}),
+  };
 }
 
 async function readGitStatus(root: string): Promise<PorcelainEntry[] | null> {
@@ -246,8 +377,8 @@ async function readGitStatus(root: string): Promise<PorcelainEntry[] | null> {
  * ownership, git error) leaves the file list untouched.
  *
  * On-disk files gain a `gitStatus`; files git reports as deleted (and not
- * present in the walk) are appended as synthetic entries so the UI can show
- * them struck-through, matching an IDE source-control view.
+ * present in the walk) are appended as synthetic entries so source-control
+ * views can show them even though the regular file browser omits them.
  */
 async function applyGitStatus(root: string, files: FileListItem[]): Promise<void> {
   const entries = await readGitStatus(root);
@@ -256,25 +387,34 @@ async function applyGitStatus(root: string, files: FileListItem[]): Promise<void
   const byPath = new Map<string, FileListItem>();
   for (const file of files) byPath.set(file.path, file);
 
-  const ignoredDirs: string[] = [];
-  const deletedPaths: string[] = [];
+  const entriesByPath = new Map<string, PorcelainEntry[]>();
+  for (const entry of entries) {
+    const pathEntries = entriesByPath.get(entry.path) ?? [];
+    pathEntries.push(entry);
+    entriesByPath.set(entry.path, pathEntries);
+  }
 
-  for (const { x, y, path } of entries) {
-    const status = classifyPorcelain(x, y);
-    if (!status) continue;
+  const ignoredDirs: string[] = [];
+  const deletedPaths = new Set<string>();
+
+  for (const [path, pathEntries] of entriesByPath) {
+    const existing = byPath.get(path);
+    const resolved = resolvePorcelainEntries(pathEntries, existing !== undefined);
+    if (!resolved) continue;
 
     // Git collapses a fully-ignored directory into a single `dir/` record;
     // remember it so we can tag any browsed files that live underneath it.
-    if (status === 'ignored' && path.endsWith('/')) {
+    if (resolved.gitStatus === 'ignored' && path.endsWith('/')) {
       ignoredDirs.push(path);
       continue;
     }
 
-    const existing = byPath.get(path);
     if (existing) {
-      existing.gitStatus = status;
-    } else if (status === 'deleted') {
-      deletedPaths.push(path);
+      existing.gitStatus = resolved.gitStatus;
+      existing.gitWorkingTreeStatus = resolved.gitWorkingTreeStatus;
+      existing.gitStagedStatus = resolved.gitStagedStatus;
+    } else if (resolved.gitStatus === 'deleted') {
+      deletedPaths.add(path);
     }
   }
 
@@ -283,6 +423,7 @@ async function applyGitStatus(root: string, files: FileListItem[]): Promise<void
       if (file.gitStatus) continue;
       if (ignoredDirs.some((dir) => file.path.startsWith(dir))) {
         file.gitStatus = 'ignored';
+        file.gitWorkingTreeStatus = 'ignored';
       }
     }
   }
@@ -292,6 +433,7 @@ async function applyGitStatus(root: string, files: FileListItem[]): Promise<void
   for (const path of deletedPaths) {
     if (files.length >= MAX_FILES) break;
     if (path.split('/').some((part) => EXCLUDED_DIRECTORIES.has(part))) continue;
+    const resolved = resolvePorcelainEntries(entriesByPath.get(path) ?? [], false);
     files.push({
       path,
       title: basename(path),
@@ -300,6 +442,10 @@ async function applyGitStatus(root: string, files: FileListItem[]): Promise<void
       isText: isTextFile(path, 0),
       mimeType: getMimeType(path),
       gitStatus: 'deleted',
+      ...(resolved?.gitWorkingTreeStatus
+        ? { gitWorkingTreeStatus: resolved.gitWorkingTreeStatus }
+        : {}),
+      ...(resolved?.gitStagedStatus ? { gitStagedStatus: resolved.gitStagedStatus } : {}),
     });
   }
 }
@@ -319,38 +465,49 @@ function normalizedRelativePath(input: string): string {
   return normalized;
 }
 
-async function readHeadText(
+async function readGitText(
   root: string,
-  filePath: string
+  object: string,
+  displayPath: string
 ): Promise<{ content: string; size: number } | null> {
-  const object = `HEAD:${filePath}`;
   try {
     const { git } = createGit(root);
     const safeDirectoryArgs = ['-c', `safe.directory=${root}`];
     const sizeOutput = await git.raw([...safeDirectoryArgs, 'cat-file', '-s', object]);
     const size = Number.parseInt(sizeOutput.trim(), 10);
-    if (!Number.isFinite(size) || !isTextFile(filePath, size)) return null;
+    if (!Number.isFinite(size) || !isTextFile(displayPath, size)) return null;
     const content = await git.raw([...safeDirectoryArgs, 'show', object]);
     return { content, size };
   } catch {
-    // Unborn HEAD, an index-only path, or an object that no longer exists all
-    // legitimately mean that there is no committed text to compare against.
+    // Missing HEAD/index entries and non-previewable objects are normal for
+    // added and deleted source-control states.
     return null;
   }
 }
 
+async function readHeadText(
+  root: string,
+  filePath: string
+): Promise<{ content: string; size: number } | null> {
+  return readGitText(root, `HEAD:${filePath}`, filePath);
+}
+
+async function readIndexText(
+  root: string,
+  filePath: string
+): Promise<{ content: string; size: number } | null> {
+  return readGitText(root, `:${filePath}`, filePath);
+}
+
 export async function readBranchFile(
   branchRoot: string,
-  relativeFilePath: string
+  relativeFilePath: string,
+  gitStatusSource: GitFileStatusSource = 'combined'
 ): Promise<FileDetail> {
   const filePath = normalizedRelativePath(relativeFilePath);
   const { absolute: requestedPath } = await resolvePathInsideBranch(branchRoot, filePath, {
     mustExist: false,
   });
-
-  const statusEntries = await readGitStatus(branchRoot);
-  const statusEntry = statusEntries?.find((entry) => entry.path === filePath);
-  const gitStatus = statusEntry ? classifyPorcelain(statusEntry.x, statusEntry.y) : null;
 
   let stats: Awaited<ReturnType<typeof lstat>> | null = null;
   try {
@@ -362,11 +519,93 @@ export async function readBranchFile(
   if (stats?.isSymbolicLink()) throw new Error('Access denied: symlinks not allowed');
   if (stats && !stats.isFile()) throw new Error('Requested path is not a file');
 
+  const statusEntries = await readGitStatus(branchRoot);
+  const resolvedStatus = resolvePorcelainEntries(
+    statusEntries?.filter((entry) => entry.path === filePath) ?? [],
+    stats !== null
+  );
+  const gitStatus = resolvedStatus?.gitStatus ?? null;
+  const statusDimensions = {
+    ...(resolvedStatus?.gitWorkingTreeStatus
+      ? { gitWorkingTreeStatus: resolvedStatus.gitWorkingTreeStatus }
+      : {}),
+    ...(resolvedStatus?.gitStagedStatus ? { gitStagedStatus: resolvedStatus.gitStagedStatus } : {}),
+  };
+
+  if (gitStatusSource === 'staged') {
+    const stagedStatus = resolvedStatus?.gitStagedStatus;
+    if (!stagedStatus) throw new Error('Requested file has no staged change');
+
+    const index = stagedStatus === 'deleted' ? null : await readIndexText(branchRoot, filePath);
+    if (stagedStatus !== 'deleted' && !index) {
+      throw new Error('Staged file is not previewable as text');
+    }
+
+    const basePath = resolvedStatus?.originalPath ?? filePath;
+    const base =
+      stagedStatus === 'added'
+        ? { content: '', size: 0 }
+        : await readHeadText(branchRoot, basePath);
+    return {
+      path: filePath,
+      title: basename(filePath),
+      size: index?.size ?? 0,
+      lastModified: stats?.mtime.toISOString() ?? '',
+      isText: true,
+      mimeType: getMimeType(filePath),
+      gitStatus: stagedStatus,
+      ...statusDimensions,
+      content: index?.content ?? '',
+      encoding: 'utf-8',
+      ...(base
+        ? {
+            gitDiff: {
+              baseContent: base.content,
+              ...(resolvedStatus?.originalPath ? { basePath: resolvedStatus.originalPath } : {}),
+            },
+          }
+        : {}),
+    };
+  }
+
+  if (gitStatusSource === 'workingTree') {
+    const workingTreeStatus = resolvedStatus?.gitWorkingTreeStatus;
+    if (!workingTreeStatus || workingTreeStatus === 'ignored') {
+      throw new Error('Requested file has no working-tree change');
+    }
+
+    let current: { content: string; size: number } | null = null;
+    if (stats) {
+      if (!isTextFile(filePath, stats.size)) {
+        throw new Error('Working-tree file is not previewable as text');
+      }
+      current = { content: (await readFile(requestedPath)).toString('utf-8'), size: stats.size };
+    }
+
+    const base =
+      workingTreeStatus === 'added' || workingTreeStatus === 'untracked'
+        ? { content: '', size: 0 }
+        : await readIndexText(branchRoot, filePath);
+    return {
+      path: filePath,
+      title: basename(filePath),
+      size: current?.size ?? 0,
+      lastModified: stats?.mtime.toISOString() ?? '',
+      isText: true,
+      mimeType: getMimeType(filePath),
+      gitStatus: workingTreeStatus,
+      ...statusDimensions,
+      content: current?.content ?? '',
+      encoding: 'utf-8',
+      ...(base ? { gitDiff: { baseContent: base.content } } : {}),
+    };
+  }
+
   // A deleted file has no working-tree bytes, but its HEAD content is still
   // useful (and necessary) for a source-control diff preview.
   if (!stats) {
     if (gitStatus !== 'deleted') throw new Error('Requested file does not exist');
-    const base = await readHeadText(branchRoot, statusEntry?.originalPath ?? filePath);
+    const base = await readHeadText(branchRoot, resolvedStatus?.originalPath ?? filePath);
     if (!base) throw new Error('Deleted file is not previewable as text');
     return {
       path: filePath,
@@ -376,11 +615,12 @@ export async function readBranchFile(
       isText: true,
       mimeType: getMimeType(filePath),
       gitStatus,
+      ...statusDimensions,
       content: '',
       encoding: 'utf-8',
       gitDiff: {
         baseContent: base.content,
-        ...(statusEntry?.originalPath ? { basePath: statusEntry.originalPath } : {}),
+        ...(resolvedStatus?.originalPath ? { basePath: resolvedStatus.originalPath } : {}),
       },
     };
   }
@@ -399,6 +639,7 @@ export async function readBranchFile(
     isText,
     mimeType: getMimeType(filePath),
     ...(gitStatus ? { gitStatus } : {}),
+    ...statusDimensions,
     content,
     encoding: isText ? 'utf-8' : 'base64',
   };
@@ -407,12 +648,12 @@ export async function readBranchFile(
     if (gitStatus === 'added' || gitStatus === 'untracked') {
       detail.gitDiff = { baseContent: '' };
     } else {
-      const basePath = statusEntry?.originalPath ?? filePath;
+      const basePath = resolvedStatus?.originalPath ?? filePath;
       const base = await readHeadText(branchRoot, basePath);
       if (base) {
         detail.gitDiff = {
           baseContent: base.content,
-          ...(statusEntry?.originalPath ? { basePath: statusEntry.originalPath } : {}),
+          ...(resolvedStatus?.originalPath ? { basePath: resolvedStatus.originalPath } : {}),
         };
       }
     }
@@ -502,7 +743,9 @@ export async function handleBranchFilesRead(
 ): Promise<ExecutorResult> {
   if (options.dryRun) return { success: true, data: { dryRun: true, command: payload.command } };
   try {
-    const file = await withBranch(payload, (root) => readBranchFile(root, payload.params.filePath));
+    const file = await withBranch(payload, (root) =>
+      readBranchFile(root, payload.params.filePath, payload.params.gitStatusSource)
+    );
     return { success: true, data: { file } };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/packages/executor/src/payload-types.test.ts
+++ b/packages/executor/src/payload-types.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   AgenticToolInvokePayloadSchema,
+  BranchFilesReadPayloadSchema,
   EnvironmentLifecyclePayloadSchema,
   EnvironmentLogsPayloadSchema,
   ExecutorPayloadSchema,
@@ -24,6 +25,36 @@ import {
   parseExecutorPayload,
   ZellijAttachPayloadSchema,
 } from './payload-types.js';
+
+describe('BranchFilesReadPayloadSchema', () => {
+  const payload = {
+    command: 'branch.files.read',
+    sessionToken: 'jwt-token-here',
+    params: {
+      branchId: '550e8400-e29b-41d4-a716-446655440000',
+      filePath: 'src/example.ts',
+    },
+  };
+
+  it('accepts a staged source-control preview', () => {
+    expect(
+      BranchFilesReadPayloadSchema.parse({
+        ...payload,
+        params: { ...payload.params, gitStatusSource: 'staged' },
+      }).params.gitStatusSource
+    ).toBe('staged');
+  });
+
+  it('defaults to the combined preview and rejects unknown snapshots', () => {
+    expect(BranchFilesReadPayloadSchema.parse(payload).params.gitStatusSource).toBe('combined');
+    expect(() =>
+      BranchFilesReadPayloadSchema.parse({
+        ...payload,
+        params: { ...payload.params, gitStatusSource: 'unknown' },
+      })
+    ).toThrow();
+  });
+});
 
 describe('PromptPayloadSchema', () => {
   it('should parse valid prompt payload', () => {

--- a/packages/executor/src/payload-types.ts
+++ b/packages/executor/src/payload-types.ts
@@ -422,6 +422,7 @@ export const BranchFilesReadPayloadSchema = BasePayloadSchema.extend({
   params: z.object({
     branchId: z.string().uuid(),
     filePath: z.string().min(1),
+    gitStatusSource: z.enum(['combined', 'workingTree', 'staged']).optional().default('combined'),
   }),
 });
 


### PR DESCRIPTION
## Summary

Show per-file git change status on a branch's **Files** tab, colored and badged like a VSCode / IDE source-control view. Status is computed from the branch worktree's git state in the executor and surfaced through the file list and preview modal.

![status vocabulary: green = added/untracked/copied, orange = modified, blue = renamed, red = deleted/conflicted, grey = ignored]

## What changed

### Executor / core (`packages/executor`, `packages/core`)
- New `GitFileStatus` and `FileGitDiff` types. `FileListItem` gains an optional `gitStatus`; `FileDetail` gains an optional `gitDiff`.
- `browseBranchFiles` runs `git status --porcelain=v1 -z` (`--untracked-files=all --ignored=matching`) and classifies each porcelain `XY` pair into a VSCode-style status (`added`, `modified`, `deleted`, `renamed`, `copied`, `untracked`, `conflicted`, `ignored`).
  - Ignored directories (collapsed by git into a single `dir/` record) tag their browsed descendants.
  - Deletions are absent from the filesystem walk, so they're appended as **synthetic entries** so the UI can render them struck-through.
  - **Best-effort:** any git failure (non-git dir, dubious ownership, error) is logged and leaves the file list untouched.
- `readBranchFile` no longer requires the path to exist on disk: a deleted file returns its **HEAD** text, and previewable changes carry `gitDiff.baseContent` (empty base for added/untracked, original HEAD text otherwise, with `basePath` on rename/copy) for a source-control diff.
- **Staged vs. working-tree split:** `FileListItem.gitStatus` (combined) is now joined by `gitWorkingTreeStatus` / `gitStagedStatus`, resolved per-path from every porcelain record — covering conflicts, staged-delete/recreate (`D ` + `??`), working-tree deletions with staged rename provenance (`RD`), and races between `git status` and the filesystem walk.
- `readBranchFile` accepts a `gitStatusSource` (`combined` | `workingTree` | `staged`) so a caller can preview the index version of a file independent of the working tree; the `file` daemon service validates and forwards `git_status_source`.

### UI (`apps/agor-ui`)
- **FileCollection** colors files and folders by status with a single-letter badge (A/M/D/R/C/U/!/I) and a status-aware tooltip. Colors come from `theme.useToken()` so they adapt to light/dark. Folders tint to their most-significant descendant change; deleted files render struck-through.
- **CodePreviewModal** gains a **File / Changes** segmented toggle backed by `DiffBlock`, renders markdown inline, and defaults deleted files to the diff view.
- **useDiff** now assigns old/new line numbers and compacts distant unchanged context (GitHub/VSCode style) when diffing raw old/new content, and takes a `rawContentKind` (`full-file` vs. unknown-position fragment) so full-file comparisons (e.g. `KnowledgePage` version diffs) get accurate line numbers.
- **DiffBlock** caps client-side diffing with `RAW_DIFF_LIMITS` and renders a "Diff preview limited" notice instead of hanging the browser on huge raw old/new content; copy-diff surfaces the same limit as a warning instead of copying a truncated patch silently.
- **FilesTab** routes all previews through `CodePreviewModal` (replacing the separate MarkdownModal branch) and blocks downloading a file that was deleted in the working tree.

## Tests
- `packages/executor/src/commands/files.test.ts` — porcelain parsing/classification, ignored-dir tagging, synthetic deletions, HEAD-text diff, staged/working-tree resolution.
- `apps/agor-daemon/src/services/file.test.ts` — `git_status_source` validation/forwarding.
- `apps/agor-ui/.../FilesTab.test.tsx`, `CodePreviewModal.test.tsx`, `DiffBlock/DiffBlock.test.tsx`, `DiffBlock/useDiff.test.ts` — badge/color rendering, File/Changes toggle, deleted-file behavior, line numbering + context folding, large-diff safety limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
