### PR TITLE
chore(release): bump Agor to 0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,10 @@ Every release-version bump PR must include its finalized changelog section; a ve
 
 ### Breaking
 
-- **Board and branch permissions use a normalized capability model** — the upgrade is a coordinated offline, big-bang migration; old daemons cannot run against the migrated authority model. Legacy rules are mapped conservatively, so some access may become more restrictive; review important board and branch permissions after upgrading. Rollback requires restoring the complete pre-migration database backup. ([#2555](https://github.com/preset-io/agor/pull/2555))
+- **Board and branch permissions use a normalized capability model** — the upgrade is a coordinated offline, big-bang migration; old daemons cannot run against the migrated authority model. Legacy rules are mapped conservatively, so some access may become more restrictive. ([#2555](https://github.com/preset-io/agor/pull/2555))
+  - Before upgrading, inspect `agor db status --json`, drain work, stop every daemon connected to the database, and take and test a complete database backup. Install 0.26.0 without starting its daemon.
+  - From 0.26.0, run `agor db migrate --offline-cutover --yes` once. If primary-owner attribution fails, resolve the listed board or branch IDs and retry; do not assign an arbitrary owner merely to pass migration.
+  - Start only 0.26.0 daemons, then review important board and branch permission screens, especially materialized overrides and legacy cross-user prompt access. To roll back, stop the new cohort and restore the complete pre-migration database backup; do not run an old daemon against the migrated policy schema.
 - **Socket clients authenticate only at the namespace handshake** — `createClient` requires `socketAuthentication` for protected services and no longer exposes Feathers' post-connect `authenticate`, `reAuthenticate`, or `logout` methods. Use `createRestClient` for credential exchange/refresh and let reconnect present the latest access token. ([#2520](https://github.com/preset-io/agor/pull/2520))
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ Every release-version bump PR must include its finalized changelog section; a ve
 
 ## Unreleased
 
+## 0.26.0 (2026-08-30)
+
 ### Breaking
 
 - **Board and branch permissions use a normalized capability model** — the upgrade is a coordinated offline, big-bang migration; old daemons cannot run against the migrated authority model. Legacy rules are mapped conservatively, so some access may become more restrictive; review important board and branch permissions after upgrading. Rollback requires restoring the complete pre-migration database backup. ([#2555](https://github.com/preset-io/agor/pull/2555))
@@ -50,6 +52,10 @@ Every release-version bump PR must include its finalized changelog section; a ve
   - GitHub, MongoDB, Box, HubSpot, Slack, Prisma, PagerDuty, and Kagi are no longer advertised because the read-only OAuth audit could not reach a safely bound client-registration boundary. Existing saved rows are not deleted.
   - Existing strict grants retain their binding. Moving an install into or out of marketplace compatibility invalidates the old grant and requires authorization again.
   - Standalone SQLite callbacks now bind the saved server through provider exchange, and Settings shows catalog-managed Marketplace policy instead of labeling it Strict.
+
+### Chores
+
+- **Align the 0.26.0 release train** — `agor-live`, the CLI, client, and version-aligned agentic-tool packages now share the release version. Agent SDK versions remain unchanged after a conservative compatibility review. ([#2623](https://github.com/preset-io/agor/pull/2623))
 
 ## 0.25.2 (2026-08-18)
 

--- a/apps/agor-cli/package.json
+++ b/apps/agor-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor/cli",
-  "version": "0.25.2",
+  "version": "0.26.0",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/agor-claude/package.json
+++ b/packages/agor-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/claude",
-  "version": "0.25.2",
+  "version": "0.26.0",
   "description": "Version-aligned claude agentic tool integration for Agor",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agor-claude/src/index.ts
+++ b/packages/agor-claude/src/index.ts
@@ -1,4 +1,4 @@
 /** Agor-managed, release-aligned claude integration. */
-export const AGOR_INTEGRATION_VERSION = '0.25.2';
+export const AGOR_INTEGRATION_VERSION = '0.26.0';
 export const VENDOR_PACKAGE = '@anthropic-ai/claude-agent-sdk';
 export * as sdk from '@anthropic-ai/claude-agent-sdk';

--- a/packages/agor-codex/package.json
+++ b/packages/agor-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/codex",
-  "version": "0.25.2",
+  "version": "0.26.0",
   "description": "Version-aligned codex agentic tool integration for Agor",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agor-codex/src/index.ts
+++ b/packages/agor-codex/src/index.ts
@@ -1,4 +1,4 @@
 /** Agor-managed, release-aligned codex integration. */
-export const AGOR_INTEGRATION_VERSION = '0.25.2';
+export const AGOR_INTEGRATION_VERSION = '0.26.0';
 export const VENDOR_PACKAGE = '@openai/codex-sdk';
 export * as sdk from '@openai/codex-sdk';

--- a/packages/agor-copilot/package.json
+++ b/packages/agor-copilot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/copilot",
-  "version": "0.25.2",
+  "version": "0.26.0",
   "description": "Version-aligned copilot agentic tool integration for Agor",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agor-copilot/src/index.ts
+++ b/packages/agor-copilot/src/index.ts
@@ -1,4 +1,4 @@
 /** Agor-managed, release-aligned copilot integration. */
-export const AGOR_INTEGRATION_VERSION = '0.25.2';
+export const AGOR_INTEGRATION_VERSION = '0.26.0';
 export const VENDOR_PACKAGE = '@github/copilot-sdk';
 export * as sdk from '@github/copilot-sdk';

--- a/packages/agor-cursor/package.json
+++ b/packages/agor-cursor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/cursor",
-  "version": "0.25.2",
+  "version": "0.26.0",
   "description": "Version-aligned cursor agentic tool integration for Agor",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agor-cursor/src/index.ts
+++ b/packages/agor-cursor/src/index.ts
@@ -1,4 +1,4 @@
 /** Agor-managed, release-aligned cursor integration. */
-export const AGOR_INTEGRATION_VERSION = '0.25.2';
+export const AGOR_INTEGRATION_VERSION = '0.26.0';
 export const VENDOR_PACKAGE = '@cursor/sdk';
 export * as sdk from '@cursor/sdk';

--- a/packages/agor-gemini/package.json
+++ b/packages/agor-gemini/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/gemini",
-  "version": "0.25.2",
+  "version": "0.26.0",
   "description": "Version-aligned gemini agentic tool integration for Agor",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agor-gemini/src/index.ts
+++ b/packages/agor-gemini/src/index.ts
@@ -1,4 +1,4 @@
 /** Agor-managed, release-aligned gemini integration. */
-export const AGOR_INTEGRATION_VERSION = '0.25.2';
+export const AGOR_INTEGRATION_VERSION = '0.26.0';
 export const VENDOR_PACKAGE = '@google/gemini-cli-core';
 export * as sdk from '@google/gemini-cli-core';

--- a/packages/agor-live/package.json
+++ b/packages/agor-live/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agor-live",
-  "version": "0.25.2",
+  "version": "0.26.0",
   "description": "Team command center for all things agentic — shared canvas for coding agents and assistants on isolated git branches, with real-time multiplayer and an MCP surface agents drive themselves.",
   "type": "module",
   "bin": {

--- a/packages/agor-opencode/package.json
+++ b/packages/agor-opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/opencode",
-  "version": "0.25.2",
+  "version": "0.26.0",
   "description": "Version-aligned opencode agentic tool integration for Agor",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agor-opencode/src/index.ts
+++ b/packages/agor-opencode/src/index.ts
@@ -1,5 +1,5 @@
 /** Agor-managed, release-aligned opencode integration. */
-export const AGOR_INTEGRATION_VERSION = '0.25.2';
+export const AGOR_INTEGRATION_VERSION = '0.26.0';
 export const VENDOR_PACKAGE = '@opencode-ai/sdk';
 export * as sdk from '@opencode-ai/sdk';
 export * as sdkV2 from '@opencode-ai/sdk/v2';

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/client",
-  "version": "0.25.2",
+  "version": "0.26.0",
   "description": "TypeScript client for connecting to the Agor daemon",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Runs the repository release pipeline with `packages/agor-live/build.sh --bump minor`, moving the aligned Agor release train from 0.25.2 to 0.26.0. The script updated the nine release manifests and six runtime integration constants, then built and packed the release artifacts. Generated `dist/`, `release/`, and tarball outputs remain ignored and are not committed.

The agent SDK review was intentionally conservative. None of the three SDKs changed, and `pnpm-lock.yaml` is unchanged.

## Version decisions

| Component | Before | After | Decision |
|---|---:|---:|---|
| Agor release train | 0.25.2 | **0.26.0** | Required minor bump; aligned package metadata and runtime constants through the prescribed script. |
| Codex SDK (`@openai/codex-sdk`) | 0.144.0 | 0.144.0 | **Held.** Latest stable reviewed: 0.151.0. The intervening pre-1.0 releases change sandbox/permission profiles, MCP bearer-token and startup behavior, provider authentication, remote-executor paths/homes, structured MCP errors, and model fallback/tool behavior. This is not a dependency-only update. [Release notes](https://github.com/openai/codex/releases) / [0.151.0](https://github.com/openai/codex/releases/tag/rust-v0.151.0) |
| Claude Agent SDK (`@anthropic-ai/claude-agent-sdk`) | 0.3.197 | 0.3.197 | **Held.** Latest reviewed: 0.3.251. The range includes a nested-subagent default-depth change, new concurrency limits, removals from the default tool surface, a TypeScript union removal, PDF result-shape changes, and session/MCP/permission/auth behavior changes. [Changelog](https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md) |
| OpenCode (`opencode-ai`, `@opencode-ai/sdk`) | 1.14.33 | 1.14.33 | **Held.** Latest reviewed: 1.18.25. The intervening minor releases include event/SDK architecture, auth/provider/OAuth, and HTTP API changes. This needs a dedicated compatibility review rather than a release-train bump. [Release notes](https://github.com/anomalyco/opencode/releases) |

Existing pinning conventions are preserved: exact SDK versions in published wrappers, existing workspace development ranges where applicable, and exact locked resolutions.

## Files and generated outputs

The bump script changed only:

- `packages/agor-live/package.json`
- `apps/agor-cli/package.json`
- `packages/client/package.json`
- six `packages/agor-*/package.json` integration manifests
- six matching `AGOR_INTEGRATION_VERSION` constants

The complete tracked diff is 15 one-line version replacements. The lockfile and dependency graph did not change. Packed metadata reports 0.26.0 for all eight tarballs, and the packaged daemon runtime reports 0.26.0.

## Validation

- `packages/agor-live/build.sh --bump minor` — passed (15 build tasks, dependency/package alignment checks, client pack check, eight tarballs, package content/size budget)
- `pnpm install --frozen-lockfile` — passed
- `pnpm i` — passed; workspace already up to date and lockfile unchanged
- `pnpm check` — passed end to end: typecheck, lint, short-ID policy, multitenancy/filesystem/realtime boundary checks, and all non-doc builds
- `pnpm --filter agor-live test` — 4/4 passed
- CLI release-version and offline-migration suites — 25/25 passed
- Core migration suites, including normalized board/branch capability-policy coverage — 39/39 passed
- Claude + Codex executor handler suites — 278/278 passed
- OpenCode integration suite — 144/144 passed
- Focused daemon Claude/Codex/OpenCode/auth suites — 89/89 passed
- `pnpm typecheck` — passed (21 tasks)
- `pnpm lint` — passed (2,666 files; frontend design-system checks included)
- `pnpm audit --audit-level=critical --prod` — passed; 0 critical advisories. The existing 5 high, 4 moderate, and 1 low transitive advisories match the unchanged lockfile/default branch inventory.
- `git diff --check` — passed

Provider tests were run with the outer Agor session's managed-agent injection variables unset so their test fixtures, rather than the host session's installed tools/version, were exercised.

## Changelog, license, and security

- Finalizes the existing `Unreleased` notes as the 0.26.0 section.
- Documents the board/branch permission cutover: inspect status, drain and stop all daemons, take a tested database backup, install 0.26.0 without starting it, run `agor db migrate --offline-cutover --yes`, resolve any listed primary-owner attribution failures, then start only 0.26.0 and review migrated policies. Rollback requires restoring the pre-migration database backup.
- No dependency or lockfile change means no new third-party license or advisory delta.
- Release packages retain existing license metadata/files; no license text changed.
- No credentials, authentication configuration, database schema, or provider protocol changed.

## Rollback

Revert the release-version and changelog commits. There is no lockfile, dependency, migration, or persisted-data change to unwind. Locally generated ignored build/tarball outputs can simply be removed. No package was published and no release or deployment was created by this PR.

