### PR TITLE
fix(user-settings): restore profile emoji picker

### DIFF
--- a/apps/agor-daemon/src/services/users.authority.test.ts
+++ b/apps/agor-daemon/src/services/users.authority.test.ts
@@ -27,6 +27,23 @@ function externalParams(actor: User, provider = 'rest'): AuthenticatedParams {
 }
 
 describe('UsersService role authority', () => {
+  dbTest('allows self-service emoji updates without allowing peer edits', async ({ db }) => {
+    const service = new UsersService(db);
+    const member = await createUser(service, 'member', 'member');
+    const peer = await createUser(service, 'member', 'peer');
+
+    await expect(
+      service.patch(member.user_id as UserID, { emoji: '🧭' }, externalParams(member))
+    ).resolves.toMatchObject({ emoji: '🧭' });
+    await expect(
+      service.patch(member.user_id as UserID, { emoji: '🛠️' }, externalParams(peer))
+    ).rejects.toMatchObject({ code: 403 });
+
+    await expect(
+      service.get(member.user_id as UserID, externalParams(member))
+    ).resolves.toMatchObject({ emoji: '🧭' });
+  });
+
   for (const provider of ['rest', 'socketio', 'mcp']) {
     dbTest(`denies ${provider} admins every mutation against a superadmin`, async ({ db }) => {
       const service = new UsersService(db);

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.test.tsx
@@ -11,6 +11,18 @@ import { UserSettingsModal } from './UserSettingsModal';
 const { syncGroupsForUser } = vi.hoisted(() => ({ syncGroupsForUser: vi.fn() }));
 vi.mock('./groupMembershipSync', () => ({ syncGroupsForUser }));
 
+vi.mock('../EmojiPickerInput/AgorEmojiPickerInner', () => ({
+  default: ({ onEmojiClick }: { onEmojiClick: (data: { emoji: string }) => void }) => (
+    <button
+      type="button"
+      aria-label="Choose tools emoji"
+      onClick={() => onEmojiClick({ emoji: '🛠️' })}
+    >
+      tools
+    </button>
+  ),
+}));
+
 vi.mock('../ApiKeyFields', () => ({
   ApiKeyFields: () => null,
   TOOL_FIELD_CONFIGS: {
@@ -175,6 +187,41 @@ function makeUser(overrides: Partial<User> = {}): User {
 const ASYNC = { timeout: 10_000 };
 
 describe('UserSettingsModal', { timeout: 60_000 }, () => {
+  it('renders the emoji picker beside the name and saves both for a local user', async () => {
+    const user = makeUser({ emoji: '🧭' });
+    const onUpdate = vi.fn(async () => {});
+
+    renderWithApp(
+      <UserSettingsModal
+        open
+        onClose={vi.fn()}
+        user={user}
+        currentUser={user}
+        client={null}
+        onUpdate={onUpdate}
+      />
+    );
+
+    // Let the auth-capability hook settle before retaining a reference to the
+    // Popover trigger; its hydration re-render replaces the initial button.
+    await act(async () => {});
+
+    const picker = screen.getByRole('button', { name: 'Choose emoji' });
+    const name = screen.getByRole('textbox', { name: 'Name' });
+    expect(picker).toHaveTextContent('🧭');
+    expect(picker.parentElement).toBe(name.parentElement);
+
+    fireEvent.change(name, { target: { value: 'Updated Admin' } });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+
+    await waitFor(() => expect(onUpdate).toHaveBeenCalled(), ASYNC);
+    expect(onUpdate.mock.calls[0]?.[1]).toMatchObject({
+      emoji: '🧭',
+      name: 'Updated Admin',
+      email: user.email,
+    });
+  });
+
   it('keeps deferred resume distinct from destructive restart', async () => {
     const onReopenOnboarding = vi.fn(async () => undefined);
     const user = makeUser({
@@ -508,7 +555,7 @@ describe('UserSettingsModal', { timeout: 60_000 }, () => {
         }),
       })
     );
-    const user = makeUser({ role: 'admin' });
+    const user = makeUser({ role: 'admin', emoji: '🧭' });
     const onUpdate = vi.fn(async () => {});
 
     renderWithApp(
@@ -526,6 +573,11 @@ describe('UserSettingsModal', { timeout: 60_000 }, () => {
     expect(screen.getByPlaceholderText('John Doe')).toBeDisabled();
     expect(screen.getByPlaceholderText('user@example.com')).toBeDisabled();
     expect(screen.queryByRole('menuitem', { name: /security/i })).not.toBeInTheDocument();
+    const emojiPicker = screen.getByRole('button', { name: 'Choose emoji' });
+    expect(emojiPicker).toBeEnabled();
+    expect(emojiPicker).toHaveTextContent('🧭');
+    fireEvent.click(emojiPicker);
+    fireEvent.click(await screen.findByRole('button', { name: 'Choose tools emoji' }));
     const useSlackAvatar = screen.getByRole('switch');
     expect(useSlackAvatar).toBeEnabled();
     fireEvent.click(useSlackAvatar);
@@ -543,6 +595,7 @@ describe('UserSettingsModal', { timeout: 60_000 }, () => {
     const patch = onUpdate.mock.calls[0][1];
     expect(patch.preferences?.audio?.enabled).toBe(true);
     expect(patch.preferences?.use_slack_avatar).toBe(false);
+    expect(patch.emoji).toBe('🛠️');
     expect(patch).not.toHaveProperty('email');
     expect(patch).not.toHaveProperty('name');
     expect(patch).not.toHaveProperty('role');

--- a/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/UserSettingsModal.tsx
@@ -89,6 +89,7 @@ import {
 } from '../AgenticToolConfigForm';
 import { ApiKeyFields, type FieldStatus, TOOL_FIELD_CONFIGS } from '../ApiKeyFields';
 import { CodexAuthSettings } from '../CodexAuth';
+import { FormEmojiPickerInput } from '../EmojiPickerInput';
 import { EnvVarEditor } from '../EnvVarEditor';
 import { HighlightMatch } from '../HighlightMatch';
 import { SessionMcpServersField } from '../MCPServerSelect';
@@ -502,6 +503,7 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
       form.setFieldsValue({
         email: userData.email,
         name: userData.name,
+        emoji: userData.emoji,
         role: userData.role,
         unix_username: userData.unix_username,
         groupIds: [],
@@ -800,7 +802,11 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
       let preferencesTouched = false;
 
       if (panels.has('profile')) {
-        const values = form.getFieldsValue(['email', 'name', 'role', 'useSlackAvatar']);
+        const values = form.getFieldsValue(['email', 'name', 'emoji', 'role', 'useSlackAvatar']);
+        // Emoji is Agor-owned profile data even when name/email come from an
+        // external identity provider, so it is intentionally independent of
+        // `canWriteIdentity`.
+        updates.emoji = values.emoji;
         if (canWriteIdentity) {
           updates.email = values.email;
           updates.name = values.name;
@@ -1672,8 +1678,18 @@ const UserSettingsModalForIdentity: React.FC<UserSettingsModalProps> = ({
         />
       )}
       <Form form={form} layout="vertical" onValuesChange={() => markMainPanelDirty('profile')}>
-        <FieldRow label="Name" name="name" help={identityWriteHelp}>
-          <Input placeholder="John Doe" disabled={!canWriteIdentity} />
+        <FieldRow label="Name" help={identityWriteHelp}>
+          <Space.Compact style={{ display: 'flex', width: '100%' }}>
+            <FormEmojiPickerInput fieldName="emoji" defaultEmoji="👤" disabled={!canEditTarget} />
+            <Form.Item name="name" noStyle>
+              <Input
+                aria-label="Name"
+                placeholder="John Doe"
+                disabled={!canWriteIdentity}
+                style={{ flex: 1, minWidth: 0 }}
+              />
+            </Form.Item>
+          </Space.Compact>
         </FieldRow>
 
         <FieldRow


### PR DESCRIPTION
## Summary

- restore the shared emoji picker beside the user name in Profile settings
- persist `user.emoji` independently from externally managed name/email/role fields
- keep the name input accessible and responsive inside the compact row
- add UI coverage for local and externally managed profiles
- add daemon authorization coverage for self-service emoji updates versus peer edits

## Root cause

Commit `01797d0` (“de-clutter decorative/fallback emoji”) intentionally retired human emoji presentation and removed the profile picker along with it. The persisted `users.emoji` field, API patch path, external-identity allowlist, tenant scoping, and settings search entry remained in place. That made the UI removal broader than the desired identity-display change.

This PR restores editing only. Human avatar rendering remains photo-or-initials; the locally owned emoji field is still available to Agor and its API consumers.

## Identity and security behavior

- Local profiles can save name and emoji together.
- Externally managed profiles keep name, email, role, password, and execution-home controls protected while emoji remains editable.
- The picker is disabled when the caller cannot edit the target user.
- The existing users service remains the server authority, including tenant predicates, role hierarchy, atomic patching, and realtime `patched` events.
- Added a service test proving a member can update their own emoji but cannot update a peer's.
- Existing PostgreSQL authority coverage continues to prove cross-tenant user IDs are indistinguishable from absent targets.

## Validation

- `pnpm install --reporter=append-only` — dependencies already up to date
- `pnpm --filter @agor-live/client build` — generated declarations required by the fresh worktree
- `pnpm check` — passed
- `UserSettingsModal.test.tsx` — 43/43 passed
- `EmojiPickerInput.test.tsx` — 5/5 passed
- focused daemon external-identity and self/peer authorization tests — 2/2 passed

## Rollback

Revert commit `f9ca7dc5`. No schema, migration, or persisted-data transformation is involved.
