### PR TITLE
fix(executor): await terminal Codex stream events

### DIFF
--- a/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
@@ -1445,7 +1445,7 @@ describe('CodexPromptService - tool payload mapping', () => {
     });
   });
 
-  it('clears resume state on a fatal stream error even when the session started fresh', async () => {
+  it('clears resume state when an observed stream error is followed by EOF on a fresh thread', async () => {
     const service = new CodexPromptService(
       mockMessagesRepo,
       mockSessionsRepo,
@@ -1491,7 +1491,7 @@ describe('CodexPromptService - tool payload mapping', () => {
           // no-op
         }
       })()
-    ).rejects.toThrow('The MCP operation failed');
+    ).rejects.toThrow('Codex ended the turn without a completion event');
 
     expect(mockSessionsRepo.update).toHaveBeenCalledWith('session-1', {
       sdk_session_id: null,
@@ -1915,7 +1915,7 @@ describe('CodexPromptService - event_msg terminal handling (issue #1749)', () =>
     });
   });
 
-  it('treats the SDK-defined fatal error event as authoritative without parsing reconnect prose', async () => {
+  it('allows Codex to recover after a stream error without parsing reconnect prose', async () => {
     const { service } = await makeInitializedStreamingService('existing-thread-id');
 
     const reconnectMessage =
@@ -1923,19 +1923,67 @@ describe('CodexPromptService - event_msg terminal handling (issue #1749)', () =>
     mockStreamEvents = [
       { type: 'error', message: reconnectMessage },
       {
+        type: 'item.completed',
+        item: { id: 'answer-1', type: 'agent_message', text: 'Recovered answer.' },
+      },
+      {
         type: 'turn.completed',
         usage: { input_tokens: 5, cached_input_tokens: 0, output_tokens: 2 },
       },
     ];
-    await expect(drain(service)).rejects.toThrow('The MCP operation failed');
-    expect(mockSessionsRepo.update).not.toHaveBeenCalled();
+    const log = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      const emitted = await drain(service);
+      expect(JSON.stringify(emitted)).toContain('Recovered answer.');
+      expect(log).toHaveBeenCalledWith(
+        expect.stringContaining('[codex.provider] event=stream_error_observed')
+      );
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('outcome=awaiting_terminal_event'));
+      expect(JSON.stringify(log.mock.calls)).not.toContain(reconnectMessage);
+      expect(mockSessionsRepo.update).not.toHaveBeenCalled();
+    } finally {
+      log.mockRestore();
+    }
+  });
+
+  it('fails only after Codex completes without an assistant response following a stream error', async () => {
+    const { service } = await makeInitializedStreamingService('existing-thread-id');
+    const providerMessage = 'SENTINEL_PROVIDER_STREAM_BODY';
+    mockStreamEvents = [
+      { type: 'error', message: providerMessage },
+      {
+        type: 'item.completed',
+        item: { id: 'empty-answer', type: 'agent_message', text: '' },
+      },
+      {
+        type: 'turn.completed',
+        usage: { input_tokens: 5, cached_input_tokens: 0, output_tokens: 0 },
+      },
+    ];
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    try {
+      await expect(drain(service)).rejects.toThrow(
+        'Codex completed after a provider stream error but returned no assistant response'
+      );
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('event=stream_error_observed'));
+      expect(error).toHaveBeenCalledWith(
+        expect.stringContaining('event=turn_completed_without_response')
+      );
+      expect(JSON.stringify([...warn.mock.calls, ...error.mock.calls])).not.toContain(
+        providerMessage
+      );
+    } finally {
+      warn.mockRestore();
+      error.mockRestore();
+    }
   });
 
   it.each([
     ['fresh', null],
     ['established', 'existing-thread-id'],
   ])(
-    'classifies a real SDK-shaped turn.failed as unknown for a %s thread',
+    'reports a real SDK-shaped turn.failed as a Codex provider failure for a %s thread',
     async (_threadKind, sdkSessionId) => {
       const { service } = await makeInitializedStreamingService(sdkSessionId);
 
@@ -1943,7 +1991,7 @@ describe('CodexPromptService - event_msg terminal handling (issue #1749)', () =>
         { type: 'turn.failed', error: { message: 'provider rejected the turn' } },
       ];
 
-      await expect(drain(service)).rejects.toThrow('The MCP operation failed');
+      await expect(drain(service)).rejects.toThrow('The Codex provider failed the turn');
 
       expect(mockSessionsRepo.update).not.toHaveBeenCalled();
     }
@@ -1968,6 +2016,7 @@ describe('CodexPromptService - event_msg terminal handling (issue #1749)', () =>
       const failure = await drain(service).catch((error: unknown) => error);
       expect(String(failure)).not.toContain(sentinel);
       expect(JSON.stringify(spies.flatMap((spy) => spy.mock.calls))).not.toContain(sentinel);
+      expect(JSON.stringify(spies.flatMap((spy) => spy.mock.calls))).toContain('event=turn_failed');
       expect(JSON.stringify(mockSessionsRepo.update.mock.calls)).not.toContain(sentinel);
     } finally {
       for (const spy of spies) spy.mockRestore();
@@ -1984,7 +2033,7 @@ describe('CodexPromptService - event_msg terminal handling (issue #1749)', () =>
     ];
 
     const failure = await drain(service).catch((error: unknown) => error);
-    expect(String(failure)).toContain('The MCP operation failed');
+    expect(String(failure)).toContain('The Codex provider failed the turn');
     expect(String(failure)).not.toContain('SENTINEL_REJECTED_BODY');
     expect(String(failure)).not.toContain('sign in again');
   });
@@ -1998,7 +2047,7 @@ describe('CodexPromptService - event_msg terminal handling (issue #1749)', () =>
     ];
 
     await expect(drain(service)).rejects.toThrow(
-      'This MCP authentication configuration is incomplete. Review the saved server settings and retry.'
+      'Codex authentication is not configured. Review Codex authentication settings and retry the prompt.'
     );
   });
 
@@ -2007,12 +2056,12 @@ describe('CodexPromptService - event_msg terminal handling (issue #1749)', () =>
     ['Reconnecting...', 'missing N/M'],
     [' Reconnecting... 2/5', 'leading whitespace'],
     ['Error: Reconnecting... 2/5', 'prefixed text'],
-  ])('treats %s as a fatal stream error (%s)', async (message) => {
+  ])('awaits a terminal event after %s without trusting prose shape (%s)', async (message) => {
     const { service } = await makeInitializedStreamingService('existing-thread-id');
 
     mockStreamEvents = [{ type: 'error', message }];
 
-    await expect(drain(service)).rejects.toThrow('The MCP operation failed');
+    await expect(drain(service)).rejects.toThrow('Codex ended the turn without a completion event');
 
     expect(mockSessionsRepo.update).not.toHaveBeenCalled();
   });

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
@@ -1915,75 +1915,90 @@ describe('CodexPromptService - event_msg terminal handling (issue #1749)', () =>
     });
   });
 
-  it('allows Codex to recover after a stream error without parsing reconnect prose', async () => {
-    const { service } = await makeInitializedStreamingService('existing-thread-id');
+  it.each([
+    ['fresh', null],
+    ['established', 'existing-thread-id'],
+  ])(
+    'allows Codex to recover after a stream error for a %s thread without parsing reconnect prose',
+    async (_threadKind, sdkSessionId) => {
+      const { service } = await makeInitializedStreamingService(sdkSessionId);
 
-    const reconnectMessage =
-      'Reconnecting... 2/5 (stream disconnected before completion: websocket closed by server before response.completed)';
-    mockStreamEvents = [
-      { type: 'error', message: reconnectMessage },
-      {
-        type: 'item.completed',
-        item: { id: 'answer-1', type: 'agent_message', text: 'Recovered answer.' },
-      },
-      {
-        type: 'turn.completed',
-        usage: { input_tokens: 5, cached_input_tokens: 0, output_tokens: 2 },
-      },
-    ];
-    const log = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-    try {
-      const emitted = await drain(service);
-      expect(JSON.stringify(emitted)).toContain('Recovered answer.');
-      expect(log).toHaveBeenCalledWith(
-        expect.stringContaining('[codex.provider] event=stream_error_observed')
-      );
-      expect(log).toHaveBeenCalledWith(expect.stringContaining('outcome=awaiting_terminal_event'));
-      expect(JSON.stringify(log.mock.calls)).not.toContain(reconnectMessage);
-      expect(mockSessionsRepo.update).not.toHaveBeenCalled();
-    } finally {
-      log.mockRestore();
+      const reconnectMessage =
+        'Reconnecting... 2/5 (stream disconnected before completion: websocket closed by server before response.completed)';
+      mockStreamEvents = [
+        { type: 'error', message: reconnectMessage },
+        {
+          type: 'item.completed',
+          item: { id: 'answer-1', type: 'agent_message', text: 'Recovered answer.' },
+        },
+        {
+          type: 'turn.completed',
+          usage: { input_tokens: 5, cached_input_tokens: 0, output_tokens: 2 },
+        },
+      ];
+      const log = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      try {
+        const emitted = await drain(service);
+        expect(JSON.stringify(emitted)).toContain('Recovered answer.');
+        expect(log).toHaveBeenCalledWith(
+          expect.stringContaining('[codex.runtime] event=stream_error_observed')
+        );
+        expect(log).toHaveBeenCalledWith(
+          expect.stringContaining('outcome=awaiting_terminal_event')
+        );
+        expect(JSON.stringify(log.mock.calls)).not.toContain(reconnectMessage);
+        expect(mockSessionsRepo.update).not.toHaveBeenCalled();
+      } finally {
+        log.mockRestore();
+      }
     }
-  });
-
-  it('fails only after Codex completes without an assistant response following a stream error', async () => {
-    const { service } = await makeInitializedStreamingService('existing-thread-id');
-    const providerMessage = 'SENTINEL_PROVIDER_STREAM_BODY';
-    mockStreamEvents = [
-      { type: 'error', message: providerMessage },
-      {
-        type: 'item.completed',
-        item: { id: 'empty-answer', type: 'agent_message', text: '' },
-      },
-      {
-        type: 'turn.completed',
-        usage: { input_tokens: 5, cached_input_tokens: 0, output_tokens: 0 },
-      },
-    ];
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
-    try {
-      await expect(drain(service)).rejects.toThrow(
-        'Codex completed after a provider stream error but returned no assistant response'
-      );
-      expect(warn).toHaveBeenCalledWith(expect.stringContaining('event=stream_error_observed'));
-      expect(error).toHaveBeenCalledWith(
-        expect.stringContaining('event=turn_completed_without_response')
-      );
-      expect(JSON.stringify([...warn.mock.calls, ...error.mock.calls])).not.toContain(
-        providerMessage
-      );
-    } finally {
-      warn.mockRestore();
-      error.mockRestore();
-    }
-  });
+  );
 
   it.each([
     ['fresh', null],
     ['established', 'existing-thread-id'],
   ])(
-    'reports a real SDK-shaped turn.failed as a Codex provider failure for a %s thread',
+    'fails only after Codex completes without an assistant response following a stream error for a %s thread',
+    async (_threadKind, sdkSessionId) => {
+      const { service } = await makeInitializedStreamingService(sdkSessionId);
+      const runtimeMessage = 'SENTINEL_RUNTIME_STREAM_BODY';
+      mockStreamEvents = [
+        { type: 'error', message: runtimeMessage },
+        {
+          type: 'item.completed',
+          item: { id: 'empty-answer', type: 'agent_message', text: '' },
+        },
+        {
+          type: 'turn.completed',
+          usage: { input_tokens: 5, cached_input_tokens: 0, output_tokens: 0 },
+        },
+      ];
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+      try {
+        await expect(drain(service)).rejects.toThrow(
+          'Codex completed after a stream error but returned no assistant response'
+        );
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('event=stream_error_observed'));
+        expect(error).toHaveBeenCalledWith(
+          expect.stringContaining('event=turn_completed_without_response')
+        );
+        expect(JSON.stringify([...warn.mock.calls, ...error.mock.calls])).not.toContain(
+          runtimeMessage
+        );
+        expect(mockSessionsRepo.update).not.toHaveBeenCalled();
+      } finally {
+        warn.mockRestore();
+        error.mockRestore();
+      }
+    }
+  );
+
+  it.each([
+    ['fresh', null],
+    ['established', 'existing-thread-id'],
+  ])(
+    'reports a real SDK-shaped turn.failed as a Codex runtime failure for a %s thread',
     async (_threadKind, sdkSessionId) => {
       const { service } = await makeInitializedStreamingService(sdkSessionId);
 
@@ -1991,7 +2006,7 @@ describe('CodexPromptService - event_msg terminal handling (issue #1749)', () =>
         { type: 'turn.failed', error: { message: 'provider rejected the turn' } },
       ];
 
-      await expect(drain(service)).rejects.toThrow('The Codex provider failed the turn');
+      await expect(drain(service)).rejects.toThrow('Codex failed the turn');
 
       expect(mockSessionsRepo.update).not.toHaveBeenCalled();
     }
@@ -2033,7 +2048,7 @@ describe('CodexPromptService - event_msg terminal handling (issue #1749)', () =>
     ];
 
     const failure = await drain(service).catch((error: unknown) => error);
-    expect(String(failure)).toContain('The Codex provider failed the turn');
+    expect(String(failure)).toContain('Codex failed the turn');
     expect(String(failure)).not.toContain('SENTINEL_REJECTED_BODY');
     expect(String(failure)).not.toContain('sign in again');
   });

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -122,7 +122,7 @@ const GATEWAY_MCP_STARTUP_TIMEOUT_MS = 30_000;
 type CodexLifecycleFailureCode =
   | 'authentication_required'
   | 'completed_without_response'
-  | 'provider_turn_failed'
+  | 'turn_failed'
   | 'stream_start_failed'
   | 'stream_interrupted'
   | 'stream_ended_without_completion';
@@ -131,9 +131,9 @@ const CODEX_LIFECYCLE_MESSAGES: Record<CodexLifecycleFailureCode, string> = {
   authentication_required:
     'Codex authentication is not configured. Review Codex authentication settings and retry the prompt.',
   completed_without_response:
-    'Codex completed after a provider stream error but returned no assistant response. Retry the prompt.',
-  provider_turn_failed:
-    'The Codex provider failed the turn. Retry the prompt; review Codex authentication or provider status if it continues.',
+    'Codex completed after a stream error but returned no assistant response. Retry the prompt.',
+  turn_failed:
+    'Codex failed the turn. Retry the prompt; review Codex authentication or runtime status if it continues.',
   stream_start_failed: 'Codex could not start the turn. Retry the prompt.',
   stream_interrupted: 'The Codex turn was interrupted before completion. Retry the prompt.',
   stream_ended_without_completion:
@@ -193,7 +193,7 @@ function isKnownCodexBoundaryError(
   }
 }
 
-function logCodexProviderFailure(
+function logCodexRuntimeFailure(
   event: 'stream_error_observed' | 'turn_completed_without_response' | 'turn_failed',
   error: unknown,
   sessionId: SessionID,
@@ -204,7 +204,7 @@ function logCodexProviderFailure(
     ...(category ? { category } : {}),
   });
   const code = safe.diagnostic.code;
-  const message = `[codex.provider] event=${event} session_id=${sessionId} category=${safe.category} type=${safe.diagnostic.type}${code ? ` code=${code}` : ''}`;
+  const message = `[codex.runtime] event=${event} session_id=${sessionId} category=${safe.category} type=${safe.diagnostic.type}${code ? ` code=${code}` : ''}`;
   if (event === 'stream_error_observed') {
     console.warn(`${message} outcome=awaiting_terminal_event`);
   } else {
@@ -1504,7 +1504,7 @@ export class CodexPromptService {
             }
 
             if (observedStreamError && !receivedAssistantMessage) {
-              logCodexProviderFailure(
+              logCodexRuntimeFailure(
                 'turn_completed_without_response',
                 observedStreamError,
                 sessionId
@@ -1673,7 +1673,7 @@ export class CodexPromptService {
             // Turn complete, emit final message
             receivedTerminalEvent = true;
             if (observedStreamError && !receivedAssistantMessage) {
-              logCodexProviderFailure(
+              logCodexRuntimeFailure(
                 'turn_completed_without_response',
                 observedStreamError,
                 sessionId
@@ -1705,14 +1705,14 @@ export class CodexPromptService {
           case 'turn.failed': {
             receivedTerminalEvent = true;
             const missingAuthentication = !this.apiKey && !this.useNativeAuth;
-            logCodexProviderFailure(
+            logCodexRuntimeFailure(
               'turn_failed',
               event.error,
               sessionId,
               missingAuthentication ? 'configuration_required' : undefined
             );
             throw new CodexLifecycleError(
-              missingAuthentication ? 'authentication_required' : 'provider_turn_failed'
+              missingAuthentication ? 'authentication_required' : 'turn_failed'
             );
           }
 
@@ -1724,7 +1724,7 @@ export class CodexPromptService {
             // not parse provider prose or terminate early: remember the error
             // and wait for the authoritative turn.completed / turn.failed / EOF.
             observedStreamError = event;
-            logCodexProviderFailure('stream_error_observed', event, sessionId);
+            logCodexRuntimeFailure('stream_error_observed', event, sessionId);
             break;
           }
 

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -1760,7 +1760,7 @@ export class CodexPromptService {
       if (isKnownCodexBoundaryError(error)) throw error;
 
       // Convert opaque SDK lifecycle failures to local, fixed control-flow
-      // errors. Provider failures emitted as typed events above have already
+      // errors. Codex runtime failures emitted as typed events above have already
       // been converted to Codex-specific fixed lifecycle errors.
       throw new CodexLifecycleError(
         runtimePhase === 'starting' ? 'stream_start_failed' : 'stream_interrupted'

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -29,7 +29,6 @@ import * as path from 'node:path';
 import { loadManagedAgenticToolSdk } from '@agor/core/agentic-integrations';
 import { shortId } from '@agor/core/db';
 import {
-  asMCPExternalError,
   getMcpServersForSession,
   isMCPAbortError,
   listMcpToolsWithPermission,
@@ -121,11 +120,20 @@ function applyMcpToolPermissions(config: CodexConfigObject, server: MCPServer): 
 const GATEWAY_MCP_STARTUP_TIMEOUT_MS = 30_000;
 
 type CodexLifecycleFailureCode =
+  | 'authentication_required'
+  | 'completed_without_response'
+  | 'provider_turn_failed'
   | 'stream_start_failed'
   | 'stream_interrupted'
   | 'stream_ended_without_completion';
 
 const CODEX_LIFECYCLE_MESSAGES: Record<CodexLifecycleFailureCode, string> = {
+  authentication_required:
+    'Codex authentication is not configured. Review Codex authentication settings and retry the prompt.',
+  completed_without_response:
+    'Codex completed after a provider stream error but returned no assistant response. Retry the prompt.',
+  provider_turn_failed:
+    'The Codex provider failed the turn. Retry the prompt; review Codex authentication or provider status if it continues.',
   stream_start_failed: 'Codex could not start the turn. Retry the prompt.',
   stream_interrupted: 'The Codex turn was interrupted before completion. Retry the prompt.',
   stream_ended_without_completion:
@@ -182,6 +190,25 @@ function isKnownCodexBoundaryError(
     return error instanceof CodexLifecycleError || error instanceof MCPExternalError;
   } catch {
     return false;
+  }
+}
+
+function logCodexProviderFailure(
+  event: 'stream_error_observed' | 'turn_completed_without_response' | 'turn_failed',
+  error: unknown,
+  sessionId: SessionID,
+  category?: 'configuration_required'
+): void {
+  const safe = sanitizeMCPExternalError(error, {
+    stage: 'runtime',
+    ...(category ? { category } : {}),
+  });
+  const code = safe.diagnostic.code;
+  const message = `[codex.provider] event=${event} session_id=${sessionId} category=${safe.category} type=${safe.diagnostic.type}${code ? ` code=${code}` : ''}`;
+  if (event === 'stream_error_observed') {
+    console.warn(`${message} outcome=awaiting_terminal_event`);
+  } else {
+    console.error(message);
   }
 }
 
@@ -1386,6 +1413,8 @@ export class CodexPromptService {
       let allToolUses: Array<{ id: string; name: string; input: Record<string, unknown> }> = [];
       let todoIdsEmittedViaUpdate = new Set<string>();
       let latestContextUsage: ContextUsageSnapshot | undefined;
+      let observedStreamError: unknown;
+      let receivedAssistantMessage = false;
 
       let eventCount = 0;
       let didStop = false;
@@ -1442,6 +1471,7 @@ export class CodexPromptService {
                     ? eventPayload.message
                     : '';
             if (text) {
+              receivedAssistantMessage = true;
               currentMessage.push({ type: 'text', text });
             }
             continue;
@@ -1469,7 +1499,17 @@ export class CodexPromptService {
               (block) => block.type === 'text' && block.text === lastAgentMessage
             );
             if (lastAgentMessage && !hasSameTextContent) {
+              receivedAssistantMessage = true;
               currentMessage.push({ type: 'text', text: lastAgentMessage });
+            }
+
+            if (observedStreamError && !receivedAssistantMessage) {
+              logCodexProviderFailure(
+                'turn_completed_without_response',
+                observedStreamError,
+                sessionId
+              );
+              throw new CodexLifecycleError('completed_without_response');
             }
 
             codexDebug(
@@ -1589,7 +1629,9 @@ export class CodexPromptService {
               // Codex can emit multiple agent_message items per turn, interleaved with tool calls.
               // Yielding them immediately gives a "chatty" UX where users see text as it arrives.
               if ('text' in event.item && event.item.type === 'agent_message') {
-                const textContent = [{ type: 'text', text: event.item.text as string }];
+                const agentMessageText = event.item.text as string;
+                if (agentMessageText) receivedAssistantMessage = true;
+                const textContent = [{ type: 'text', text: agentMessageText }];
 
                 yield {
                   type: 'complete',
@@ -1630,6 +1672,14 @@ export class CodexPromptService {
           case 'turn.completed': {
             // Turn complete, emit final message
             receivedTerminalEvent = true;
+            if (observedStreamError && !receivedAssistantMessage) {
+              logCodexProviderFailure(
+                'turn_completed_without_response',
+                observedStreamError,
+                sessionId
+              );
+              throw new CodexLifecycleError('completed_without_response');
+            }
             threadId = thread.id || '';
             const mappedUsage = extractCodexTokenUsage((event as { usage?: unknown }).usage);
             const contextUsage =
@@ -1654,25 +1704,28 @@ export class CodexPromptService {
 
           case 'turn.failed': {
             receivedTerminalEvent = true;
-            const classification = {
-              stage: 'runtime' as const,
-              ...(!this.apiKey && !this.useNativeAuth
-                ? { category: 'configuration_required' as const }
-                : {}),
-            };
-            const safe = sanitizeMCPExternalError(event.error, classification);
-            console.error(
-              `❌ [Codex] Turn failed for session ${shortId(sessionId)} category=${safe.category} type=${safe.diagnostic.type}`
+            const missingAuthentication = !this.apiKey && !this.useNativeAuth;
+            logCodexProviderFailure(
+              'turn_failed',
+              event.error,
+              sessionId,
+              missingAuthentication ? 'configuration_required' : undefined
             );
-            throw asMCPExternalError(event.error, classification);
+            throw new CodexLifecycleError(
+              missingAuthentication ? 'authentication_required' : 'provider_turn_failed'
+            );
           }
 
           case 'error': {
-            // The public SDK defines every `error` event as unrecoverable and
-            // exposes only an arbitrary provider/CLI message. It has no typed
-            // reconnect/auth discriminator, so do not parse prose to invent
-            // control flow or recovery state.
-            throw asMCPExternalError(event, { stage: 'runtime' });
+            // Despite the public type's "unrecoverable" wording, Codex exec
+            // keeps its event processor running after this notification. In
+            // particular, retry progress is projected through this same lossy
+            // event shape without the source `will_retry` discriminator. Do
+            // not parse provider prose or terminate early: remember the error
+            // and wait for the authoritative turn.completed / turn.failed / EOF.
+            observedStreamError = event;
+            logCodexProviderFailure('stream_error_observed', event, sessionId);
+            break;
           }
 
           default:
@@ -1707,8 +1760,8 @@ export class CodexPromptService {
       if (isKnownCodexBoundaryError(error)) throw error;
 
       // Convert opaque SDK lifecycle failures to local, fixed control-flow
-      // errors. Provider failures emitted as typed events above retain their
-      // closed MCP category/action contract instead of being flattened here.
+      // errors. Provider failures emitted as typed events above have already
+      // been converted to Codex-specific fixed lifecycle errors.
       throw new CodexLifecycleError(
         runtimePhase === 'starting' ? 'stream_start_failed' : 'stream_interrupted'
       );


### PR DESCRIPTION
## Summary

- stop classifying Codex provider/stream failures as MCP failures
- keep consuming non-terminal Codex `error` events so retry recovery can finish
- fail clearly when Codex completes after a stream error without returning an assistant response
- emit sanitized structured provider diagnostics without logging raw provider bodies

## Root cause

Codex projects both retryable and terminal provider notifications through the same lossy top-level `error` event. The projection omits the source `will_retry` discriminator, while Codex itself keeps processing until `turn.completed`, `turn.failed`, or EOF.

Agor treated every top-level `error` event as terminal and immediately raised an `MCPExternalError`. That could abort an otherwise recoverable Codex stream and produced the misleading user-facing message that an MCP operation had failed.

## Changes

- remember top-level stream errors and await an authoritative terminal event
- accept a recovered turn when a non-empty assistant response follows
- reject empty/absent assistant output after a stream error with a Codex-specific lifecycle error
- map `turn.failed` and missing Codex authentication to Codex-specific lifecycle errors
- add safe structured logs for observed stream errors and terminal provider failures
- cover reconnect recovery, empty completion, EOF, authentication, and secret-redaction behavior

## Validation

- `pnpm i`
- `pnpm check`
- `env -u AGOR_MANAGED_AGENTIC_TOOLS -u AGOR_VERSION pnpm --filter @agor/executor exec vitest run src/sdk-handlers/codex/prompt-service.test.ts` — 78 tests passed

## Multi-tenancy

No tenant-owned resource or authorization boundary changes. This change is limited to Codex event classification, lifecycle control flow, and sanitized operational logging.
