### PR TITLE
refactor(core): retire MCPServerFilters.scopeId and findByScope

### DIFF
--- a/apps/agor-daemon/src/services/mcp-catalog-connect.test.ts
+++ b/apps/agor-daemon/src/services/mcp-catalog-connect.test.ts
@@ -189,12 +189,6 @@ function buildApp(
         const query = findParams?.query ?? {};
         let rows = serverStore.filter((server) => {
           if (query.scope && server.scope !== query.scope) return false;
-          // MCPServerRepository only has a materialized scope foreign key for
-          // global rows. Session scope is represented by the attachment table,
-          // so scopeId deliberately adds no condition for every other scope.
-          if (query.scopeId && query.scope === 'global' && server.owner_user_id !== query.scopeId) {
-            return false;
-          }
           if (query.transport && server.transport !== query.transport) return false;
           if (query.enabled !== undefined && server.enabled !== query.enabled) return false;
           if (query.source && server.source !== query.source) return false;
@@ -484,28 +478,6 @@ const attachOf = (app: { service: (p: string) => unknown }) =>
 const services = serversOf;
 
 describe('stateful mcp-servers.find harness', () => {
-  it('maps global scopeId to owner_user_id and ignores scopeId for other scopes', async () => {
-    const aliceGlobal = installOf({ mcp_server_id: 'alice-global', scope: 'global' });
-    const ownerlessGlobal = installOf({
-      mcp_server_id: 'ownerless-global',
-      scope: 'global',
-      owner_user_id: undefined,
-    });
-    const session = installOf({
-      mcp_server_id: 'session-row',
-      scope: 'session',
-      owner_user_id: undefined,
-    });
-    const { app } = buildApp(CURATED, [aliceGlobal, ownerlessGlobal, session]);
-
-    await expect(
-      serversOf(app).find({ query: { scope: 'global', scopeId: ALICE } })
-    ).resolves.toMatchObject({ data: [{ mcp_server_id: 'alice-global' }] });
-    await expect(
-      serversOf(app).find({ query: { scope: 'session', scopeId: 'session-attachment-id' } })
-    ).resolves.toMatchObject({ data: [{ mcp_server_id: 'session-row' }] });
-  });
-
   it('does not apply an owner filter for ownerless:false', async () => {
     const owned = installOf({ mcp_server_id: 'owned' });
     const ownerless = installOf({ mcp_server_id: 'ownerless', owner_user_id: undefined });

--- a/apps/agor-daemon/src/services/mcp-servers.ts
+++ b/apps/agor-daemon/src/services/mcp-servers.ts
@@ -33,7 +33,6 @@ import { DrizzleService, type Repository } from '../adapters/drizzle';
  */
 export type MCPServerParams = QueryParams<{
   scope?: string;
-  scopeId?: string;
   transport?: string;
   enabled?: boolean;
   source?: string;
@@ -105,7 +104,6 @@ export class MCPServersService extends DrizzleService<
 
     if (params?.query) {
       if (params.query.scope) filters.scope = params.query.scope as MCPScope;
-      if (params.query.scopeId) filters.scopeId = params.query.scopeId;
       if (params.query.transport) filters.transport = params.query.transport as MCPTransport;
       if (params.query.enabled !== undefined) filters.enabled = params.query.enabled;
       if (params.query.source) filters.source = params.query.source as MCPSource;
@@ -133,17 +131,6 @@ export class MCPServersService extends DrizzleService<
     }
 
     return data as MCPServer[] | Paginated<MCPServer>;
-  }
-
-  /**
-   * Custom method: Find by scope
-   */
-  async findByScope(
-    scope: string,
-    scopeId?: string,
-    _params?: MCPServerParams
-  ): Promise<MCPServer[]> {
-    return this.mcpServerRepo.findByScope(scope, scopeId);
   }
 
   override async update(

--- a/packages/core/src/db/repositories/mcp-servers.test.ts
+++ b/packages/core/src/db/repositories/mcp-servers.test.ts
@@ -184,25 +184,6 @@ describe('MCPServerRepository.findAll', () => {
     expect(globalServers[0].name).toBe('global-1');
   });
 
-  dbTest('should filter by scope and owner (global with scopeId)', async ({ db }) => {
-    const repo = new MCPServerRepository(db);
-    const user1 = generateId() as UserID;
-    const user2 = generateId() as UserID;
-
-    await repo.create(
-      createMCPServerData({ name: 'user1-server', scope: 'global', owner_user_id: user1 })
-    );
-    await repo.create(
-      createMCPServerData({ name: 'user2-server', scope: 'global', owner_user_id: user2 })
-    );
-
-    const user1Servers = await repo.findAll({ scope: 'global', scopeId: user1 });
-
-    expect(user1Servers).toHaveLength(1);
-    expect(user1Servers[0].name).toBe('user1-server');
-    expect(user1Servers[0].owner_user_id).toBe(user1);
-  });
-
   dbTest('should keep shared and caller-owned servers for usableByUserId', async ({ db }) => {
     const repo = new MCPServerRepository(db);
     const user1 = generateId() as UserID;
@@ -586,33 +567,6 @@ describe('MCPServerRepository scope model', () => {
       createMCPServerData({ name: 'session-server', scope: 'session' })
     );
     expect(sessionServer.scope).toBe('session');
-  });
-
-  dbTest('should filter global servers by owner', async ({ db }) => {
-    const repo = new MCPServerRepository(db);
-    const user1 = generateId() as UserID;
-    const user2 = generateId() as UserID;
-
-    // Create servers for different users
-    await repo.create(
-      createMCPServerData({ name: 'user1-fs', scope: 'global', owner_user_id: user1 })
-    );
-    await repo.create(
-      createMCPServerData({ name: 'user1-git', scope: 'global', owner_user_id: user1 })
-    );
-    await repo.create(
-      createMCPServerData({ name: 'user2-fs', scope: 'global', owner_user_id: user2 })
-    );
-
-    // Each user should only see their own servers
-    const user1Servers = await repo.findAll({ scope: 'global', scopeId: user1 });
-    const user2Servers = await repo.findAll({ scope: 'global', scopeId: user2 });
-
-    expect(user1Servers).toHaveLength(2);
-    expect(user2Servers).toHaveLength(1);
-    expect(user1Servers.map((s) => s.name)).toContain('user1-fs');
-    expect(user1Servers.map((s) => s.name)).toContain('user1-git');
-    expect(user2Servers[0].name).toBe('user2-fs');
   });
 });
 

--- a/packages/core/src/db/repositories/mcp-servers.ts
+++ b/packages/core/src/db/repositories/mcp-servers.ts
@@ -7,7 +7,6 @@
 import type {
   CreateMCPServerInput,
   MCPAuth,
-  MCPScope,
   MCPServer,
   MCPServerFilters,
   MCPServerID,
@@ -97,9 +96,6 @@ const MCP_SERVER_SORT_COLUMNS: Record<MCPServerSortField, AnyColumn> = {
 function buildMCPServerConditions(filters?: MCPServerFilters): SQL[] {
   const conditions: SQL[] = [];
   if (filters?.scope) conditions.push(eq(mcpServers.scope, filters.scope));
-  if (filters?.scopeId && filters.scope === 'global') {
-    conditions.push(eq(mcpServers.owner_user_id, filters.scopeId));
-  }
   if (filters?.transport) conditions.push(eq(mcpServers.transport, filters.transport));
   if (filters?.enabled !== undefined) conditions.push(eq(mcpServers.enabled, filters.enabled));
   if (filters?.source) conditions.push(eq(mcpServers.source, filters.source));
@@ -601,13 +597,6 @@ export class MCPServerRepository
         error
       );
     }
-  }
-
-  /**
-   * Find MCP servers by scope
-   */
-  async findByScope(scope: string, scopeId?: string): Promise<MCPServer[]> {
-    return this.findAll({ scope: scope as MCPScope, scopeId });
   }
 
   /**

--- a/packages/core/src/lib/feathers-validation.ts
+++ b/packages/core/src/lib/feathers-validation.ts
@@ -387,7 +387,6 @@ export const mcpServerQuerySchema = createQuerySchema(
     mcp_server_id: Type.Optional(CommonSchemas.uuid),
     server_id: Type.Optional(CommonSchemas.uuid), // Legacy alias
     scope: Type.Optional(Type.Union([Type.Literal('global'), Type.Literal('session')])),
-    scopeId: Type.Optional(Type.String()), // scope_id for session-scoped servers
     transport: Type.Optional(
       Type.Union([Type.Literal('stdio'), Type.Literal('http'), Type.Literal('sse')])
     ),

--- a/packages/core/src/types/mcp.ts
+++ b/packages/core/src/types/mcp.ts
@@ -544,7 +544,6 @@ export interface SessionMCPServer {
  */
 export interface MCPServerFilters {
   scope?: MCPScope;
-  scopeId?: string; // user_id, team_id, repo_id, or session_id
   transport?: MCPTransport;
   enabled?: boolean;
   source?: MCPSource;

--- a/packages/executor/src/db/feathers-repositories.ts
+++ b/packages/executor/src/db/feathers-repositories.ts
@@ -153,9 +153,6 @@ export class FeathersMCPServersRepository {
     if (filters?.scope) {
       query.scope = filters.scope;
     }
-    if (filters?.scopeId) {
-      query.scopeId = filters.scopeId;
-    }
     if (filters?.transport) {
       query.transport = filters.transport;
     }


### PR DESCRIPTION
## What

Removes `MCPServerFilters.scopeId` and `MCPServerRepository.findByScope`, along with the query
validator entry, the daemon param type, and the executor's passthrough. Pure deletion — 103 lines
out, nothing added.

## Why

`scopeId` had three different meanings depending on where you looked:

| Layer | What it says |
|---|---|
| Name | "the id of the scope" |
| Type doc | `user_id, team_id, repo_id, or session_id` |
| Implementation | only ever `owner_user_id`, and only when `scope === 'global'` |

Two concrete consequences:

1. **Silent no-op for session scope.** The condition is gated on `scope === 'global'`, so filtering
   session-scoped servers by `scopeId` returned *every* session-scoped server — no error, no warning.
   The comment documented the gap instead of closing it.
2. **It overloads `owner_user_id`.** That column now means "the user this server is private to", so
   passing a user id returned that user's *private* servers while excluding the shared ones they can
   also use — neither the old meaning nor `usableByUserId`'s.

`findByScope` was a thin wrapper over `findAll({ scope, scopeId })` with no callers.

`usableByUserId` ("shared servers plus private servers owned by this user") already expresses
"servers this identity may reach" and is the correct filter, as the issue notes.

## How

Deletions in seven files:

| File | Removed |
|---|---|
| `core/src/types/mcp.ts` | `scopeId?: string` from `MCPServerFilters` |
| `core/src/lib/feathers-validation.ts` | `scopeId` from the query schema |
| `core/src/db/repositories/mcp-servers.ts` | the `scopeId` condition, `findByScope`, and the now-unused `MCPScope` import |
| `executor/src/db/feathers-repositories.ts` | the `scopeId` passthrough in `findAll` |
| `daemon/src/services/mcp-servers.ts` | `scopeId` param type, its `find` handling, and the `findByScope` custom method |
| `core/…/mcp-servers.test.ts` | two tests (below) |
| `daemon/…/mcp-catalog-connect.test.ts` | one test and its stub branch (below) |

`buildMCPServerConditions` feeds both `findAll` and `count`, so removing the condition there covers
both paths.

### Verification of the issue's claims

The issue was written at `b1f14837`; re-checked everything against `main` @ `d7d1b35`:

- `findByScope` has no callers and is not routed. **One detail in the issue is now stale:** it says
  the registration "passes no `methods` array", but as of `d7d1b35` it *does* pass an options object
  — `{ events: [MCP_MEMBER_POLICY_CHANGED_EVENT] }`. That object has no `methods` key, so the
  conclusion still holds.
- `scopeId` could not widen access: `scopeMcpServerFindToUsable` still ANDs `usableByUserId` into the
  same query. Agreed this is cleanup, not a vulnerability.

### Two files the issue did not list

Found by grep rather than assumption: `executor/src/db/feathers-repositories.ts` forwards `scopeId`
in its outbound query, and `mcp-catalog-connect.test.ts` encodes the mapping in both a test and its
`find` stub.

### Why three tests were deleted

Deleting tests always deserves an explanation, so naming each one:

- **`'should filter by scope and owner (global with scopeId)'`** — named for the parameter; existed
  to pin the `scopeId` → `owner_user_id` mapping.
- **`'should filter global servers by owner'`** — its intent ("each user should only see their own
  servers") is already covered in the same file by
  `'should keep shared and caller-owned servers for usableByUserId'`, which asserts shared *and*
  caller-owned are visible while another user's are not. No coverage is lost.
- **`'maps global scopeId to owner_user_id and ignores scopeId for other scopes'`** — pins the
  retired mapping by name; its stub branch went with it.

I deliberately did **not** add a test asserting `scopeId` is now ignored — pinning the absence of a
removed field just re-freezes what this PR is retiring.

### Scope note

This removes a field from an exported interface in `packages/core/src/types/`, which normally wants
maintainer sign-off first. Taking the issue as that sign-off: it was filed by @kgabryje and says
*"agreed as a follow-up rather than a blocker"*. Happy to fold this into the
[#2298](https://github.com/preset-io/agor/issues/2298) consolidation instead if you'd prefer that
order.

## Testing

- `pnpm typecheck` — 21/21. This is the real safety net: removing a field from an exported interface
  turns every remaining reader into a compile error, so a clean typecheck proves the inventory was
  complete.
- `pnpm lint` — clean.
- `@agor/core` 4056 passed · `@agor/daemon` 3946 passed · `agor-ui` 2110 passed ·
  `@agor/executor` vitest 701 passed.
- Post-removal grep for `scopeId|findByScope` across `packages/` and `apps/` returns nothing
  (excluding the unrelated `scopeIdx` schema index names).

**No migration and no persisted change:** `scopeId` was only ever a query parameter. The
`mcp_servers` table has `scope` and `owner_user_id`; there is no `scope_id` column.

**Blast radius is internal:** `MCPServerFilters` is not re-exported by `@agor-live/client`,
`@agor/core` is `private: true`, and no MCP tool or UI code references `scopeId` — so this cannot
break a published consumer. The only behaviour change is that a caller passing `?scopeId=` now has
it ignored rather than silently mis-filtered.

Closes #2299
