### PR TITLE
fix(sessions): persist MCP selection at session create time (#2629)

### DIFF
--- a/apps/agor-daemon/src/services/sessions.mcp-attach.postgres.test.ts
+++ b/apps/agor-daemon/src/services/sessions.mcp-attach.postgres.test.ts
@@ -1,0 +1,188 @@
+import type { AgorConfig } from '@agor/core/config';
+import {
+  BranchRepository,
+  createDatabase,
+  createTenantScopedDatabaseProxy,
+  type Database,
+  executeRaw,
+  generateId,
+  initializeDatabase,
+  isPostgresDatabase,
+  MCPServerRepository,
+  RepoRepository,
+  runWithTenantDatabaseScope,
+  SessionMCPServerRepository,
+  SessionRepository,
+  sql,
+  UsersRepository,
+} from '@agor/core/db';
+import type { Application } from '@agor/core/feathers';
+import { NotFound } from '@agor/core/feathers';
+import type { TenantID } from '@agor/core/types';
+import { SessionStatus } from '@agor/core/types';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { SessionsService } from './sessions.js';
+
+const postgresUrl = process.env.AGOR_TEST_POSTGRES_URL;
+const usesPostgresSchema = process.env.AGOR_DB_DIALECT === 'postgresql';
+
+function rowsOf(result: unknown): Array<Record<string, unknown>> {
+  if (Array.isArray(result)) return result as Array<Record<string, unknown>>;
+  const rows = (result as { rows?: unknown[] } | undefined)?.rows;
+  return Array.isArray(rows) ? (rows as Array<Record<string, unknown>>) : [];
+}
+
+interface EmittedEvent {
+  path: string;
+  event: string;
+  data: unknown;
+  tenantId?: string;
+}
+
+function appStub(events: EmittedEvent[]): Application {
+  const config = { execution: { unix_user_mode: 'simple' } } as AgorConfig;
+  return {
+    get: (key: string) => (key === 'config' ? config : undefined),
+    service: (path: string) => ({
+      emit: (
+        event: string,
+        data: unknown,
+        hook?: { params?: { tenant?: { tenant_id?: string } } }
+      ) => events.push({ path, event, data, tenantId: hook?.params?.tenant?.tenant_id }),
+    }),
+  } as unknown as Application;
+}
+
+describe.skipIf(!postgresUrl || !usesPostgresSchema)(
+  'SessionsService create-time MCP attachment (PostgreSQL/RLS)',
+  () => {
+    let rawDb: Database;
+
+    beforeAll(async () => {
+      rawDb = createDatabase({ dialect: 'postgresql', url: postgresUrl! });
+      await initializeDatabase(rawDb);
+      if (!isPostgresDatabase(rawDb)) throw new Error('PostgreSQL test requires PostgreSQL');
+      const [role] = rowsOf(
+        await executeRaw(
+          rawDb,
+          sql`SELECT rolsuper, rolbypassrls FROM pg_roles WHERE rolname = current_user`
+        )
+      );
+      expect(role).toMatchObject({ rolsuper: false, rolbypassrls: false });
+    }, 60_000);
+
+    afterAll(async () => {
+      await (rawDb as Database & { $client: { end: () => Promise<void> } }).$client.end();
+    });
+
+    it('publishes one tenant-scoped event after commit and rejects a cross-tenant server atomically', async () => {
+      const tenantA = `session-mcp-a-${generateId()}` as TenantID;
+      const tenantB = `session-mcp-b-${generateId()}` as TenantID;
+      const db = createTenantScopedDatabaseProxy(rawDb, {
+        requireScope: true,
+        label: 'sessions-mcp-attach-postgres-test',
+      });
+      const owner = await runWithTenantDatabaseScope(db, tenantA, async (scoped) => {
+        const user = await new UsersRepository(scoped).create({
+          email: `${tenantA}@example.test`,
+          name: 'Tenant A session owner',
+        });
+        const repo = await new RepoRepository(scoped).create({
+          slug: `session-mcp-${generateId()}`,
+          name: 'Tenant A session repo',
+          repo_type: 'remote',
+          remote_url: 'https://example.invalid/session-mcp.git',
+          local_path: `/tmp/${generateId()}`,
+          default_branch: 'main',
+        });
+        const branch = await new BranchRepository(scoped).create({
+          repo_id: repo.repo_id,
+          name: `session-mcp-${generateId()}`,
+          ref: 'main',
+          branch_unique_id: Date.now() % 1_000_000_000,
+          path: `/tmp/${generateId()}`,
+          created_by: user.user_id,
+        });
+        const server = await new MCPServerRepository(scoped).create({
+          name: `tenant-a-${generateId()}`,
+          transport: 'stdio',
+          command: 'node',
+          args: ['tenant-a.js'],
+          scope: 'global',
+          source: 'user',
+          enabled: true,
+        });
+        return { user, branch, server };
+      });
+      const foreignServer = await runWithTenantDatabaseScope(db, tenantB, (scoped) =>
+        new MCPServerRepository(scoped).create({
+          name: `tenant-b-${generateId()}`,
+          transport: 'stdio',
+          command: 'node',
+          args: ['tenant-b.js'],
+          scope: 'global',
+          source: 'user',
+          enabled: true,
+        })
+      );
+      const events: EmittedEvent[] = [];
+      const service = new SessionsService(db, appStub(events));
+      const params = {
+        _agenticConfigResolved: true,
+        tenant: { tenant_id: tenantA, source: 'explicit' },
+      } as never;
+
+      const session = await runWithTenantDatabaseScope(db, tenantA, async () => {
+        const created = await service.create(
+          {
+            branch_id: owner.branch.branch_id,
+            created_by: owner.user.user_id,
+            agentic_tool: 'claude-code',
+            status: SessionStatus.IDLE,
+            mcpServerIds: [owner.server.mcp_server_id, owner.server.mcp_server_id],
+          },
+          params
+        );
+        expect(events).toEqual([]);
+        return created;
+      });
+
+      expect(events).toEqual([
+        {
+          path: 'session-mcp-servers',
+          event: 'created',
+          data: expect.objectContaining({
+            session_id: session.session_id,
+            mcp_server_id: owner.server.mcp_server_id,
+          }),
+          tenantId: tenantA,
+        },
+      ]);
+
+      await expect(
+        runWithTenantDatabaseScope(db, tenantA, () =>
+          service.create(
+            {
+              branch_id: owner.branch.branch_id,
+              created_by: owner.user.user_id,
+              agentic_tool: 'claude-code',
+              status: SessionStatus.IDLE,
+              mcpServerIds: [foreignServer.mcp_server_id],
+            },
+            params
+          )
+        )
+      ).rejects.toMatchObject({ name: NotFound.name, code: 404 });
+
+      const state = await runWithTenantDatabaseScope(db, tenantA, async (scoped) => ({
+        sessions: await new SessionRepository(scoped).findAll(),
+        attached: await new SessionMCPServerRepository(scoped).listServers(session.session_id),
+      }));
+      expect(state.sessions.map((item) => item.session_id)).toEqual([session.session_id]);
+      expect(state.attached.map((server) => server.mcp_server_id)).toEqual([
+        owner.server.mcp_server_id,
+      ]);
+      expect(events).toHaveLength(1);
+    }, 30_000);
+  }
+);

--- a/apps/agor-daemon/src/services/sessions.mcp-attach.test.ts
+++ b/apps/agor-daemon/src/services/sessions.mcp-attach.test.ts
@@ -9,7 +9,7 @@ import {
   UsersRepository,
 } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
-import { MCPServerNotUsableError } from '@agor/core/mcp';
+import { BadRequest, Forbidden, NotFound } from '@agor/core/feathers';
 import { SessionStatus } from '@agor/core/types';
 import { describe, expect } from 'vitest';
 import { dbTest } from '../../../../packages/core/src/db/test-helpers';
@@ -20,11 +20,19 @@ import { SessionsService } from './sessions';
 // a best-effort follow-up loop that could silently drop servers. It now attaches
 // inside the same create call.
 
-function appStub(): Application {
+interface EmittedEvent {
+  path: string;
+  event: string;
+  data: unknown;
+}
+
+function appStub(events: EmittedEvent[] = []): Application {
   const config = { execution: { unix_user_mode: 'simple' } } as AgorConfig;
   return {
     get: (key: string) => (key === 'config' ? config : undefined),
-    service: () => ({ emit: () => {} }),
+    service: (path: string) => ({
+      emit: (event: string, data: unknown) => events.push({ path, event, data }),
+    }),
   } as unknown as Application;
 }
 
@@ -65,9 +73,10 @@ async function fixture(db: TenantScopeAwareDatabase) {
 }
 
 describe('SessionsService create-time MCP attachment', () => {
-  dbTest('attaches explicit mcpServerIds in the same create call', async ({ db }) => {
+  dbTest('deduplicates explicit mcpServerIds for persistence and events', async ({ db }) => {
     const { user, branch, sharedServer } = await fixture(db);
-    const service = new SessionsService(db, appStub());
+    const events: EmittedEvent[] = [];
+    const service = new SessionsService(db, appStub(events));
 
     const session = await service.create(
       {
@@ -75,16 +84,51 @@ describe('SessionsService create-time MCP attachment', () => {
         created_by: user.user_id,
         agentic_tool: 'claude-code',
         status: SessionStatus.IDLE,
-        mcpServerIds: [sharedServer.mcp_server_id],
+        mcpServerIds: [sharedServer.mcp_server_id, sharedServer.mcp_server_id],
       },
       { _agenticConfigResolved: true } as never
     );
 
     const attached = await new SessionMCPServerRepository(db).listServers(session.session_id);
     expect(attached.map((server) => server.mcp_server_id)).toEqual([sharedServer.mcp_server_id]);
+    expect(events).toEqual([
+      {
+        path: 'session-mcp-servers',
+        event: 'created',
+        data: expect.objectContaining({
+          session_id: session.session_id,
+          mcp_server_id: sharedServer.mcp_server_id,
+          enabled: true,
+        }),
+      },
+    ]);
   });
 
-  dbTest('rejects a server private to another user and creates no session', async ({ db }) => {
+  dbTest('rejects malformed mcpServerIds as typed bad requests', async ({ db }) => {
+    const service = new SessionsService(db, appStub());
+    const base = {
+      branch_id: generateId(),
+      created_by: generateId(),
+      agentic_tool: 'claude-code',
+      status: SessionStatus.IDLE,
+    } as const;
+
+    for (const mcpServerIds of [null, 'not-an-array', [generateId(), 42], [' ']]) {
+      await expect(
+        service.create(
+          { ...base, mcpServerIds } as never,
+          { _agenticConfigResolved: true } as never
+        )
+      ).rejects.toMatchObject({
+        name: BadRequest.name,
+        code: 400,
+      });
+    }
+
+    await expect(new SessionRepository(db).findAll()).resolves.toHaveLength(0);
+  });
+
+  dbTest('maps an inaccessible server to Forbidden and rolls the session back', async ({ db }) => {
     const { user, branch, servers } = await fixture(db);
     const otherUser = await new UsersRepository(db).create({
       email: `${generateId()}-other-owner@example.com`,
@@ -100,7 +144,8 @@ describe('SessionsService create-time MCP attachment', () => {
       enabled: true,
       owner_user_id: otherUser.user_id,
     });
-    const service = new SessionsService(db, appStub());
+    const events: EmittedEvent[] = [];
+    const service = new SessionsService(db, appStub(events));
 
     await expect(
       service.create(
@@ -113,8 +158,39 @@ describe('SessionsService create-time MCP attachment', () => {
         },
         { _agenticConfigResolved: true } as never
       )
-    ).rejects.toBeInstanceOf(MCPServerNotUsableError);
+    ).rejects.toMatchObject({
+      name: Forbidden.name,
+      code: 403,
+      message: 'That MCP server is private to another user',
+    });
 
     await expect(new SessionRepository(db).findAll()).resolves.toHaveLength(0);
+    expect(events).toEqual([]);
+  });
+
+  dbTest('maps a missing server to NotFound and rolls the session back', async ({ db }) => {
+    const { user, branch } = await fixture(db);
+    const events: EmittedEvent[] = [];
+    const service = new SessionsService(db, appStub(events));
+
+    await expect(
+      service.create(
+        {
+          branch_id: branch.branch_id,
+          created_by: user.user_id,
+          agentic_tool: 'claude-code',
+          status: SessionStatus.IDLE,
+          mcpServerIds: [generateId()],
+        },
+        { _agenticConfigResolved: true } as never
+      )
+    ).rejects.toMatchObject({
+      name: NotFound.name,
+      code: 404,
+      message: 'That MCP server was not found',
+    });
+
+    await expect(new SessionRepository(db).findAll()).resolves.toHaveLength(0);
+    expect(events).toEqual([]);
   });
 });

--- a/apps/agor-daemon/src/services/sessions.mcp-attach.test.ts
+++ b/apps/agor-daemon/src/services/sessions.mcp-attach.test.ts
@@ -1,0 +1,120 @@
+import type { AgorConfig } from '@agor/core/config';
+import {
+  BranchRepository,
+  MCPServerRepository,
+  RepoRepository,
+  SessionMCPServerRepository,
+  SessionRepository,
+  type TenantScopeAwareDatabase,
+  UsersRepository,
+} from '@agor/core/db';
+import type { Application } from '@agor/core/feathers';
+import { MCPServerNotUsableError } from '@agor/core/mcp';
+import { SessionStatus } from '@agor/core/types';
+import { describe, expect } from 'vitest';
+import { dbTest } from '../../../../packages/core/src/db/test-helpers';
+import { generateId } from '../../../../packages/core/src/lib/ids';
+import { SessionsService } from './sessions';
+
+// Regression coverage for #2629: the create-time MCP selection was persisted by
+// a best-effort follow-up loop that could silently drop servers. It now attaches
+// inside the same create call.
+
+function appStub(): Application {
+  const config = { execution: { unix_user_mode: 'simple' } } as AgorConfig;
+  return {
+    get: (key: string) => (key === 'config' ? config : undefined),
+    service: () => ({ emit: () => {} }),
+  } as unknown as Application;
+}
+
+async function fixture(db: TenantScopeAwareDatabase) {
+  const user = await new UsersRepository(db).create({
+    email: `${generateId()}-mcp-attach@example.com`,
+    name: 'MCP attach owner',
+  });
+  const repo = await new RepoRepository(db).create({
+    slug: `mcp-attach-${generateId()}`,
+    name: 'MCP attach repo',
+    repo_type: 'remote',
+    remote_url: 'https://example.com/mcp-attach.git',
+    local_path: `/tmp/${generateId()}`,
+    default_branch: 'main',
+  });
+  const branch = await new BranchRepository(db).create({
+    repo_id: repo.repo_id,
+    name: `mcp-attach-${generateId()}`,
+    ref: 'main',
+    branch_unique_id: Math.floor(Math.random() * 1_000_000),
+    path: `/tmp/${generateId()}`,
+    base_ref: 'main',
+    new_branch: false,
+    created_by: user.user_id,
+  });
+  const servers = new MCPServerRepository(db);
+  const sharedServer = await servers.create({
+    name: `shared-${generateId()}`,
+    transport: 'stdio',
+    command: 'node',
+    args: ['shared.js'],
+    scope: 'global',
+    source: 'user',
+    enabled: true,
+  });
+  return { user, branch, servers, sharedServer };
+}
+
+describe('SessionsService create-time MCP attachment', () => {
+  dbTest('attaches explicit mcpServerIds in the same create call', async ({ db }) => {
+    const { user, branch, sharedServer } = await fixture(db);
+    const service = new SessionsService(db, appStub());
+
+    const session = await service.create(
+      {
+        branch_id: branch.branch_id,
+        created_by: user.user_id,
+        agentic_tool: 'claude-code',
+        status: SessionStatus.IDLE,
+        mcpServerIds: [sharedServer.mcp_server_id],
+      },
+      { _agenticConfigResolved: true } as never
+    );
+
+    const attached = await new SessionMCPServerRepository(db).listServers(session.session_id);
+    expect(attached.map((server) => server.mcp_server_id)).toEqual([sharedServer.mcp_server_id]);
+  });
+
+  dbTest('rejects a server private to another user and creates no session', async ({ db }) => {
+    const { user, branch, servers } = await fixture(db);
+    const otherUser = await new UsersRepository(db).create({
+      email: `${generateId()}-other-owner@example.com`,
+      name: 'Other owner',
+    });
+    const privateServer = await servers.create({
+      name: `private-${generateId()}`,
+      transport: 'stdio',
+      command: 'node',
+      args: ['private.js'],
+      scope: 'global',
+      source: 'user',
+      enabled: true,
+      owner_user_id: otherUser.user_id,
+    });
+    const service = new SessionsService(db, appStub());
+
+    await expect(
+      service.create(
+        {
+          branch_id: branch.branch_id,
+          created_by: user.user_id,
+          agentic_tool: 'claude-code',
+          status: SessionStatus.IDLE,
+          mcpServerIds: [privateServer.mcp_server_id],
+        },
+        { _agenticConfigResolved: true } as never
+      )
+    ).rejects.toBeInstanceOf(MCPServerNotUsableError);
+
+    await expect(new SessionRepository(db).findAll()).resolves.toHaveLength(0);
+  });
+});

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -18,6 +18,7 @@ import {
 import {
   BranchRepository,
   bindRepositoryToTenantUnitOfWork,
+  EntityNotFoundError,
   getCurrentTenantId,
   runWithTenantDatabaseScope,
   runWithTenantDatabaseTransaction,
@@ -38,6 +39,7 @@ import {
   NotAuthenticated,
   NotFound,
 } from '@agor/core/feathers';
+import { MCPServerNotUsableError } from '@agor/core/mcp';
 import {
   formatModelToolMismatchWarning,
   getCodexModelSelectionError,
@@ -134,6 +136,17 @@ function resolvedSessionModelConfig(
     throw new BadRequest('model_config must be resolved before session creation');
   }
   return modelConfig;
+}
+
+function normalizeCreateMcpServerIds(value: unknown): MCPServerID[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) {
+    throw new BadRequest('mcpServerIds must be an array');
+  }
+  if (!value.every((serverId) => typeof serverId === 'string' && serverId.trim().length > 0)) {
+    throw new BadRequest('mcpServerIds must contain non-empty strings');
+  }
+  return [...new Set(value)] as MCPServerID[];
 }
 
 /**
@@ -399,9 +412,15 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
     if (Array.isArray(data)) {
       return Promise.all(data.map((session) => this.create(session, params) as Promise<Session>));
     }
+    if (!data || typeof data !== 'object') {
+      throw new BadRequest('Session data must be an object');
+    }
     if (Object.hasOwn(data, 'sdk_home_scope')) {
       throw new BadRequest('sdk_home_scope is server-managed and cannot be set by clients');
     }
+    const explicitMcpServerIds = normalizeCreateMcpServerIds(
+      (data as { mcpServerIds?: unknown }).mcpServerIds
+    );
     const agenticTool = requireActiveAgenticTool(data.agentic_tool ?? 'claude-code');
     this.assertDeploymentToolConfigured(agenticTool);
     if (!(await isTenantAgenticToolEnabled(agenticTool, this.db))) {
@@ -410,7 +429,7 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
     const {
       agentic_tool_preset_id: configurationReference,
       model_config: originalModelConfig,
-      mcpServerIds: explicitMcpServerIds,
+      mcpServerIds: _requestedMcpServerIds,
       ...sessionData
     } = data as CreateSessionInput;
     let createData: Partial<Session> = { ...sessionData };
@@ -530,8 +549,18 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
       // Attach in-transaction: a bad server rolls the create back, not a silent drop (#2629).
       if (explicitMcpServerIds && explicitMcpServerIds.length > 0) {
         const mcpRepo = new SessionMCPServerRepository(scoped);
-        for (const serverId of explicitMcpServerIds) {
-          await mcpRepo.addServer(createdSession.session_id, serverId as MCPServerID);
+        try {
+          for (const serverId of explicitMcpServerIds) {
+            await mcpRepo.addServer(createdSession.session_id, serverId);
+          }
+        } catch (error) {
+          if (error instanceof MCPServerNotUsableError) {
+            throw new Forbidden('That MCP server is private to another user');
+          }
+          if (error instanceof EntityNotFoundError) {
+            throw new NotFound('That MCP server was not found');
+          }
+          throw error;
         }
       }
 
@@ -551,6 +580,8 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
             enabled: true,
             added_at: new Date(),
           },
+          params,
+          id: created.session_id,
         });
       }
     }

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -410,8 +410,9 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
     const {
       agentic_tool_preset_id: configurationReference,
       model_config: originalModelConfig,
+      mcpServerIds: explicitMcpServerIds,
       ...sessionData
-    } = data;
+    } = data as CreateSessionInput;
     let createData: Partial<Session> = { ...sessionData };
     if (params?._agenticConfigResolved) {
       createData = {
@@ -521,13 +522,40 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
       }
       if (admission.adoptBranch) await branchRepo.adoptSdkHome(branch.branch_id);
 
-      return new SessionRepository(scoped).create({
+      const createdSession = await new SessionRepository(scoped).create({
         ...createData,
         sdk_home_scope: admission.scope,
       });
+
+      // An explicit create-time MCP selection must persist atomically with the
+      // session. addServer validates usability against the session owner and
+      // throws when it fails, so a bad server rolls the whole create back
+      // rather than silently dropping the selection (issue #2629).
+      if (explicitMcpServerIds && explicitMcpServerIds.length > 0) {
+        const mcpRepo = new SessionMCPServerRepository(scoped);
+        for (const serverId of explicitMcpServerIds) {
+          await mcpRepo.addServer(createdSession.session_id, serverId as MCPServerID);
+        }
+      }
+
+      return createdSession;
     });
     if (Array.isArray(created)) {
       throw new Error('Single-session creation returned multiple sessions');
+    }
+    if (explicitMcpServerIds && explicitMcpServerIds.length > 0) {
+      for (const serverId of explicitMcpServerIds) {
+        emitServiceEvent(this.app, {
+          path: 'session-mcp-servers',
+          event: 'created',
+          data: {
+            session_id: created.session_id,
+            mcp_server_id: serverId,
+            enabled: true,
+            added_at: new Date(),
+          },
+        });
+      }
     }
     return created;
   }

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -527,10 +527,7 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
         sdk_home_scope: admission.scope,
       });
 
-      // An explicit create-time MCP selection must persist atomically with the
-      // session. addServer validates usability against the session owner and
-      // throws when it fails, so a bad server rolls the whole create back
-      // rather than silently dropping the selection (issue #2629).
+      // Attach in-transaction: a bad server rolls the create back, not a silent drop (#2629).
       if (explicitMcpServerIds && explicitMcpServerIds.length > 0) {
         const mcpRepo = new SessionMCPServerRepository(scoped);
         for (const serverId of explicitMcpServerIds) {

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -577,9 +577,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
         try {
           let targetSessionId = sessionId;
 
-          // If creating new session, create it first. MCP servers attach in the
-          // same create call so the selection can't be silently dropped (#2629);
-          // a failure rejects here and surfaces via the catch below.
+          // Attach MCP in the create call so failures reject here, not silently dropped (#2629).
           if (sessionId === 'new') {
             const newSession = await client.service('sessions').create({
               branch_id: triggerModal.branchId,

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -1,5 +1,4 @@
 import type {
-  AgenticToolName,
   AgorClient,
   Board,
   BoardComment,
@@ -107,6 +106,7 @@ import {
 import { getValidZoneParentId, sanitizeOrphanedNodeParents } from './canvas/utils/nodeParentUtils';
 import { ZoneTriggerModal } from './canvas/ZoneTriggerModal';
 import { DEFAULT_BOARD_OBJECT_Z_INDEX, selectedZIndex } from './canvas/zOrder';
+import { createZoneTriggerSession } from './canvas/zoneTriggerSessionCreation';
 
 interface SessionCanvasProps {
   board: Board | null;
@@ -579,24 +579,14 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
 
           // Attach MCP in the create call so failures reject here, not silently dropped (#2629).
           if (sessionId === 'new') {
-            const newSession = await client.service('sessions').create({
-              branch_id: triggerModal.branchId,
-              agentic_tool: (agent || 'claude-code') as AgenticToolName,
-              agentic_tool_preset_id: agenticToolPresetId,
-              description: `Session from zone "${triggerModal.zoneName}"`,
-              status: 'idle',
-              mcpServerIds: mcpServerIds?.length ? mcpServerIds : undefined,
-              model_config: modelConfig
-                ? {
-                    ...modelConfig,
-                    updated_at: new Date().toISOString(),
-                  }
-                : undefined,
-              permission_config: permissionMode
-                ? {
-                    mode: permissionMode,
-                  }
-                : undefined,
+            const newSession = await createZoneTriggerSession(client, {
+              branchId: triggerModal.branchId,
+              zoneName: triggerModal.zoneName,
+              agent,
+              agenticToolPresetId,
+              modelConfig,
+              permissionMode,
+              mcpServerIds,
             });
             targetSessionId = newSession.session_id;
           }

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -577,7 +577,9 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
         try {
           let targetSessionId = sessionId;
 
-          // If creating new session, create it first
+          // If creating new session, create it first. MCP servers attach in the
+          // same create call so the selection can't be silently dropped (#2629);
+          // a failure rejects here and surfaces via the catch below.
           if (sessionId === 'new') {
             const newSession = await client.service('sessions').create({
               branch_id: triggerModal.branchId,
@@ -585,6 +587,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
               agentic_tool_preset_id: agenticToolPresetId,
               description: `Session from zone "${triggerModal.zoneName}"`,
               status: 'idle',
+              mcpServerIds: mcpServerIds?.length ? mcpServerIds : undefined,
               model_config: modelConfig
                 ? {
                     ...modelConfig,
@@ -598,15 +601,6 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                 : undefined,
             });
             targetSessionId = newSession.session_id;
-
-            // Attach MCP servers if provided
-            if (mcpServerIds && mcpServerIds.length > 0) {
-              for (const serverId of mcpServerIds) {
-                await client
-                  .service(`sessions/${targetSessionId}/mcp-servers`)
-                  .create({ mcpServerId: serverId });
-              }
-            }
           }
 
           // Execute action and capture the session the user should land on so

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/zoneTriggerSessionCreation.test.ts
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/zoneTriggerSessionCreation.test.ts
@@ -1,0 +1,31 @@
+import type { AgorClient, Session } from '@agor-live/client';
+import { describe, expect, it, vi } from 'vitest';
+import { createZoneTriggerSession } from './zoneTriggerSessionCreation';
+
+describe('createZoneTriggerSession', () => {
+  it('hands the selected MCP servers to the single session create request', async () => {
+    const session = { session_id: 'session-1' } as Session;
+    const create = vi.fn(async () => session);
+    const service = vi.fn(() => ({ create }));
+    const client = { service } as unknown as AgorClient;
+
+    await expect(
+      createZoneTriggerSession(client, {
+        branchId: 'branch-1',
+        zoneName: 'Review',
+        agent: 'codex',
+        mcpServerIds: ['mcp-1', 'mcp-2'],
+      })
+    ).resolves.toBe(session);
+
+    expect(service).toHaveBeenCalledTimes(1);
+    expect(service).toHaveBeenCalledWith('sessions');
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        branch_id: 'branch-1',
+        mcpServerIds: ['mcp-1', 'mcp-2'],
+      })
+    );
+  });
+});

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/zoneTriggerSessionCreation.ts
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/zoneTriggerSessionCreation.ts
@@ -1,0 +1,43 @@
+import type {
+  AgenticToolName,
+  AgorClient,
+  DefaultModelConfig,
+  PermissionMode,
+  Session,
+} from '@agor-live/client';
+
+interface ZoneTriggerSessionCreationInput {
+  branchId: string;
+  zoneName: string;
+  agent?: string;
+  agenticToolPresetId?: string;
+  modelConfig?: DefaultModelConfig;
+  permissionMode?: PermissionMode;
+  mcpServerIds?: string[];
+}
+
+/** Keep zone-trigger configuration in the session's atomic create request. */
+export function createZoneTriggerSession(
+  client: AgorClient,
+  input: ZoneTriggerSessionCreationInput
+): Promise<Session> {
+  return client.service('sessions').create({
+    branch_id: input.branchId,
+    agentic_tool: (input.agent || 'claude-code') as AgenticToolName,
+    agentic_tool_preset_id: input.agenticToolPresetId,
+    description: `Session from zone "${input.zoneName}"`,
+    status: 'idle',
+    mcpServerIds: input.mcpServerIds?.length ? input.mcpServerIds : undefined,
+    model_config: input.modelConfig
+      ? {
+          ...input.modelConfig,
+          updated_at: new Date().toISOString(),
+        }
+      : undefined,
+    permission_config: input.permissionMode
+      ? {
+          mode: input.permissionMode,
+        }
+      : undefined,
+  });
+}

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -626,6 +626,8 @@ export type CreateSessionInput = Omit<
   agentic_tool?: AgenticToolName;
   agentic_tool_preset_id?: AgenticToolConfigurationReference | null;
   model_config?: Partial<NonNullable<Session['model_config']>> | null;
+  /** MCP server IDs to attach in the same create call (issue #2629). */
+  mcpServerIds?: string[];
 };
 
 /** Session patch semantics: omit/undefined preserves, string sets, null clears. */


### PR DESCRIPTION
## Problem

Starting a conversation from the UI and attaching an MCP server (e.g. Slack) in the popover produced a session with **0 MCP servers attached** — the selection was silently lost. Closes #2629.

The primary-assistant / New Session path was already fixed by #2497 (it attaches server-side via `POST /sessions/:id/initialize`). The remaining broken path was the **zone-trigger**, which created the session and then ran a best-effort per-server attach loop, and there was **no create-time server-side attach** for the raw `sessions.create` path.

## Fix — two layers

**1. Create-time persistence (server-side).** `CreateSessionInput` gains `mcpServerIds`, and `SessionsService.create()` attaches them **inside the create transaction** via `SessionMCPServerRepository.addServer`. That repo validates usability against `session.created_by` and throws `MCPServerNotUsableError`, so a bad server rolls the whole create back rather than silently dropping the selection. Realtime `session-mcp-servers` `created` events are emitted after commit (idempotent, keyed by `session_id`).

**2. No swallowed failures (client-side).** The `SessionCanvas` zone-trigger `'new'` path now passes `mcpServerIds` into the single `sessions.create` call and **drops the swallow-prone follow-up loop**. Any failure now rejects `create()` and surfaces through the existing `catch → showError` toast (per `context/guidelines/toasts.md`) — no false "success".

## Tests

New `sessions.mcp-attach.test.ts`:
- `create({…, mcpServerIds})` → those servers are attached.
- A server private to another user → `create` rejects **and no session row is created** (atomic rollback).

All related suites pass (session create/spawn/init, MCP tools, ZoneTriggerModal, client API). Biome + focused typecheck clean on touched files.

## Out of scope
The zone-trigger `reuse_existing` fork/spawn branch does not forward `mcpServerIds` — a pre-existing, separate gap (fork route doesn't accept it) unrelated to this create-time bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)