### PR TITLE
fix(ui): bind MCP gateway service calls

### DIFF
--- a/apps/agor-ui/src/components/SettingsModal/MCPEgressGatewayStatus.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPEgressGatewayStatus.test.tsx
@@ -1,5 +1,5 @@
 import type { AgorClient } from '@agor-live/client';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { App as AntdApp } from 'antd';
 import { describe, expect, it, vi } from 'vitest';
 import { MCPEgressGatewayStatus } from './MCPEgressGatewayStatus';
@@ -12,6 +12,49 @@ function clientFor(status: object) {
 }
 
 describe('MCPEgressGatewayStatus', () => {
+  it('keeps the Feathers service receiver when it reads and changes status', async () => {
+    const gatewayService = {
+      status: {
+        mode: 'off',
+        supported_transports: [],
+        unsupported_transports: ['stdio'],
+        in_flight_requests: 0,
+        provider_in_flight_requests: 0,
+        reserved_requests: 0,
+        oldest_request_ms: 0,
+        excluded_servers: [],
+        excluded_servers_truncated: false,
+        admission_available: null,
+        operator: true,
+        guarantee: 'Direct mode has no gateway admission guarantee.',
+      },
+      find(this: { status: object }) {
+        return Promise.resolve(this.status);
+      },
+      patch(this: { status: Record<string, unknown> }, _id: null, data: { mode: string }) {
+        this.status = { ...this.status, mode: data.mode };
+        return Promise.resolve({ mode: data.mode });
+      },
+    };
+    const client = {
+      service: (path: string) => (path === 'mcp-egress/status' ? gatewayService : {}),
+    } as unknown as AgorClient;
+
+    render(
+      <AntdApp>
+        <MCPEgressGatewayStatus client={client} connectionReady />
+      </AntdApp>
+    );
+
+    expect(await screen.findByText('MCP gateway is off')).toBeInTheDocument();
+    expect(screen.queryByText('MCP gateway status unavailable')).not.toBeInTheDocument();
+
+    fireEvent.mouseDown(screen.getByRole('combobox', { name: 'MCP gateway rollout mode' }));
+    fireEvent.click(await screen.findByTitle('observe'));
+
+    expect(await screen.findByText('MCP gateway is observing')).toBeInTheDocument();
+  });
+
   it('renders the exact enforced guarantee and truthful transport lists', async () => {
     const client = clientFor({
       mode: 'enforced',

--- a/apps/agor-ui/src/components/SettingsModal/MCPEgressGatewayStatus.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPEgressGatewayStatus.tsx
@@ -71,11 +71,11 @@ export function MCPEgressGatewayStatus({ client, connectionReady }: Props) {
   const [busy, setBusy] = useState(false);
 
   const refresh = useCallback(async () => {
-    const find = service(client, 'mcp-egress/status')?.find;
-    if (!client || !connectionReady || typeof find !== 'function') return;
+    const gatewayService = service(client, 'mcp-egress/status');
+    if (!client || !connectionReady || typeof gatewayService?.find !== 'function') return;
     setBusy(true);
     try {
-      setStatus((await find()) as GatewayStatus);
+      setStatus((await gatewayService.find()) as GatewayStatus);
       setError(null);
     } catch {
       setError(
@@ -132,11 +132,11 @@ export function MCPEgressGatewayStatus({ client, connectionReady }: Props) {
     acknowledgeRawSecretDowngrade = false,
     verifiedLegacyExecutorsFenced = false
   ) => {
-    const patch = service(client, 'mcp-egress/status')?.patch;
-    if (typeof patch !== 'function') return;
+    const gatewayService = service(client, 'mcp-egress/status');
+    if (typeof gatewayService?.patch !== 'function') return;
     setBusy(true);
     try {
-      await patch(null, {
+      await gatewayService.patch(null, {
         mode,
         ...(acknowledgeRawSecretDowngrade ? { acknowledge_raw_secret_downgrade: true } : {}),
         ...(verifiedLegacyExecutorsFenced ? { verified_legacy_executors_fenced: true } : {}),


### PR DESCRIPTION
## Summary

- Retain the Feathers service receiver when reading and patching MCP egress gateway status.
- Add receiver-dependent regression coverage for both the status read and rollout-mode change.

## Why / context

This is **not related to MCP Marketplace**. The Settings component detached the Feathers `find` and `patch` methods from their service object, so invocation lost the required receiver and produced the false “MCP gateway status unavailable” warning.

## Implementation notes

The component now calls `gatewayService.find()` and `gatewayService.patch(...)` directly. It does not hide or downgrade warnings: genuine status failures still surface the fail-closed unavailable warning, while the default-off security notice, rollout guards, and acknowledgement requirements remain unchanged.

## Validation / test plan

- [x] Focused Vitest: 4 passed
- [x] UI TypeScript check
- [x] Biome on touched files
- [x] Managed SQLite environment healthy; Settings MCP flow verified in browser with no gateway-related console or network errors
- [x] Independent correctness and architecture reviews completed with no findings

## Risks / rollout / rollback

Low-risk UI receiver-binding fix with focused regression coverage; no API, configuration, Marketplace, or persistence changes.
