### PR TITLE
feat: recover Slack MCP auth in thread

### DIFF
--- a/apps/agor-daemon/src/register-hooks.mcp-recovery-redaction.test.ts
+++ b/apps/agor-daemon/src/register-hooks.mcp-recovery-redaction.test.ts
@@ -47,4 +47,44 @@ describe('production Task MCP recovery response hook', () => {
     expect(returned.dispatch).not.toBe(task);
     expect(JSON.stringify(returned.dispatch)).not.toContain('Private CRM');
   });
+
+  it('strips Slack action authority from an admin transport response without mutating the row', async () => {
+    const task = {
+      task_id: 'task-1',
+      session_id: 'session-1',
+      created_by: 'owner',
+      metadata: {
+        mcp_slack_recovery_notice: {
+          notice_id: 'notice-secret',
+          token_jti: 'jti-secret',
+          slack_thread_id: 'C1-1.1',
+        },
+        gateway_task_source: {
+          gateway_channel_id: 'gateway-secret',
+          channel_type: 'slack',
+          thread_id: 'C1-1.1',
+        },
+      },
+    } as unknown as Task;
+    const hook = createRedactTaskMcpRecoveryAfter({
+      findById: async () => ({ created_by: 'owner' }),
+    } as Pick<SessionRepository, 'findById'>);
+    const context = {
+      event: 'patched',
+      method: 'patch',
+      params: {
+        provider: 'socketio',
+        user: { user_id: 'admin', role: ROLES.ADMIN } as User,
+      },
+      result: task,
+    } as HookContext;
+
+    const returned = await hook(context);
+
+    expect(returned.result).toBe(task);
+    expect(JSON.stringify(returned.result)).toContain('notice-secret');
+    expect(JSON.stringify(returned.dispatch)).not.toMatch(
+      /notice-secret|jti-secret|gateway-secret/
+    );
+  });
 });

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -183,7 +183,10 @@ import {
   redactMCPServerSecrets,
   shouldExposeMCPServerSecrets,
 } from './utils/mcp-header-secrets.js';
-import { redactMcpRecoveryTopology } from './utils/mcp-recovery-redaction.js';
+import {
+  redactMcpRecoveryTopology,
+  stripMcpSlackRecoveryNotice,
+} from './utils/mcp-recovery-redaction.js';
 import {
   didMcpPrincipalRoleChange,
   isMcpRuntimeRecoveryEnabled,
@@ -945,13 +948,13 @@ export function createRedactTaskMcpRecoveryAfter(
   sessionsRepository: Pick<SessionRepository, 'findById'>
 ): (context: HookContext) => Promise<HookContext> {
   return async (context: HookContext): Promise<HookContext> => {
-    if (!context.params.provider || hasMinimumRole(context.params.user?.role, ROLES.ADMIN)) {
-      return context;
-    }
+    if (!context.params.provider) return context;
+    const isAdmin = hasMinimumRole(context.params.user?.role, ROLES.ADMIN);
     const viewerId = context.params.user?.user_id;
     const sessions = new Map<string, Session | null>();
     const redact = async (task: Task): Promise<Task> => {
-      if (!task.metadata?.mcp_recovery) return task;
+      const stripped = stripMcpSlackRecoveryNotice(task);
+      if (isAdmin || !stripped.metadata?.mcp_recovery) return stripped;
       if (!sessions.has(task.session_id)) {
         sessions.set(
           task.session_id,
@@ -959,8 +962,8 @@ export function createRedactTaskMcpRecoveryAfter(
         );
       }
       return sessions.get(task.session_id)?.created_by === viewerId
-        ? task
-        : redactMcpRecoveryTopology(task);
+        ? stripped
+        : redactMcpRecoveryTopology(stripped);
     };
     let dispatch = context.result;
     if (Array.isArray(context.result)) {

--- a/apps/agor-daemon/src/register-services.oauth-callback.test.ts
+++ b/apps/agor-daemon/src/register-services.oauth-callback.test.ts
@@ -243,7 +243,7 @@ describe('register-services OAuth callback URL regression', () => {
     const hintIndex = successBody.indexOf("code: 'runtime_authority_hint'");
     const notifyIndex = successBody.indexOf('emitOAuthCompletion(pendingFlow, true)');
     const resolveIndex = successBody.indexOf('pendingFlow.tokenResolve?.(tokenResponse)');
-    const renderIndex = successBody.indexOf('sendOAuthResultPage(res, true');
+    const renderIndex = successBody.indexOf('sendOAuthResultPage(');
 
     expect(persistIndex).toBeGreaterThanOrEqual(0);
     expect(hintIndex).toBeGreaterThan(persistIndex);

--- a/apps/agor-daemon/src/register-services.oauth-sqlite.integration.test.ts
+++ b/apps/agor-daemon/src/register-services.oauth-sqlite.integration.test.ts
@@ -1,12 +1,21 @@
 import http, { type Server as HttpServer } from 'node:http';
 import {
+  BranchRepository,
   createDatabaseAsync,
   eq,
+  GatewayChannelRepository,
+  generateId,
   MCPServerRepository,
   mcpServers,
+  RepoRepository,
   runMigrations,
+  SessionMCPServerRepository,
+  SessionRepository,
+  setMCPEgressGatewayMode,
   shortId,
+  TaskRepository,
   type TenantScopeAwareDatabase,
+  ThreadSessionMapRepository,
   UserMCPOAuthTokenRepository,
   UsersRepository,
   update,
@@ -30,6 +39,7 @@ import type {
   User,
   UserID,
 } from '@agor/core/types';
+import { TaskStatus } from '@agor/core/types';
 import type { OutboundDnsLookup } from '@agor/core/utils/safe-outbound-fetch';
 import { type Socket as ClientSocket, io as createSocketClient } from 'socket.io-client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -42,6 +52,7 @@ import {
 import { createRegisteredMCPCatalogConnectService } from './register-routes.js';
 import { type RegisterServicesContext, registerMCPServices } from './register-services.js';
 import { createSocketIOConfig } from './setup/socketio.js';
+import { issueMCPSlackRecoveryToken } from './utils/mcp-slack-recovery-token.js';
 import {
   AGOR_SOCKET_AUTHORITY_ID_PROPERTY,
   installSocketAuthorityId,
@@ -380,6 +391,12 @@ type SQLiteHarness = {
   user: User;
   server: MCPServer;
   emittedBrowserEvents: Array<Record<string, unknown>>;
+  gatewayOAuthResults: Array<{
+    taskId: string;
+    noticeId: string;
+    attemptId: string;
+    success: boolean;
+  }>;
   nextAuthorizationUrl: () => Promise<string>;
   callback: (state: string) => Promise<{ status: number; body: string }>;
   deny: (state: string) => Promise<{ status: number; body: string }>;
@@ -459,6 +476,17 @@ async function createHarness(
   };
   const app = feathers() as Application & { io: typeof io };
   app.io = io;
+  const gatewayOAuthResults: SQLiteHarness['gatewayOAuthResults'] = [];
+  app.use(
+    '/gateway',
+    {
+      async syncMcpSlackRecoveryNoticeAfterCommit() {},
+      async markMcpSlackOAuthResult(input: SQLiteHarness['gatewayOAuthResults'][number]) {
+        gatewayOAuthResults.push(input);
+      },
+    },
+    { methods: ['syncMcpSlackRecoveryNoticeAfterCommit', 'markMcpSlackOAuthResult'] }
+  );
   const { oauthCallbackHandler } = await registerMCPServices({
     db,
     app,
@@ -528,6 +556,7 @@ async function createHarness(
     user,
     server,
     emittedBrowserEvents,
+    gatewayOAuthResults,
     nextAuthorizationUrl: async () => {
       const value = await nextUrl.promise;
       nextUrl = deferred<string>();
@@ -647,6 +676,156 @@ async function authorizeSavedServer(harness: SQLiteHarness): Promise<void> {
   const state = new URL(started.authorizationUrl).searchParams.get('state');
   expect(state).toBeTruthy();
   expect((await harness.callback(state!)).status).toBe(200);
+}
+
+async function seedSlackRecoveryAction(harness: SQLiteHarness): Promise<{
+  token: string;
+  taskId: string;
+  sessionId: string;
+}> {
+  const repo = await new RepoRepository(harness.rawDb).create({
+    repo_id: generateId(),
+    slug: `slack-recovery-${generateId()}`,
+    name: 'Slack recovery integration',
+    repo_type: 'remote',
+    remote_url: 'https://example.invalid/slack-recovery.git',
+    local_path: `/tmp/slack-recovery-${generateId()}`,
+    default_branch: 'main',
+  });
+  const branch = await new BranchRepository(harness.rawDb).create({
+    branch_id: generateId(),
+    repo_id: repo.repo_id,
+    name: `slack-recovery-${generateId()}`,
+    ref: 'main',
+    branch_unique_id: 100_000 + Math.floor(Math.random() * 1_000_000_000),
+    path: `/tmp/slack-recovery-${generateId()}/branch`,
+    created_by: harness.user.user_id,
+  });
+  const session = await new SessionRepository(harness.rawDb).create({
+    session_id: generateId(),
+    branch_id: branch.branch_id,
+    agentic_tool: 'claude-code',
+    created_by: harness.user.user_id,
+    sdk_session_id: 'sdk-session-preserved',
+  });
+  await new SessionMCPServerRepository(harness.rawDb).addServer(
+    session.session_id,
+    harness.server.mcp_server_id
+  );
+  const channel = await new GatewayChannelRepository(harness.rawDb).create({
+    name: 'Slack recovery',
+    channel_type: 'slack',
+    enabled: true,
+    created_by: harness.user.user_id,
+    agor_user_id: harness.user.user_id,
+    target_branch_id: branch.branch_id,
+    config: { bot_token: 'xoxb-test-only', app_token: 'xapp-test-only' },
+  });
+  const threadId = 'C2515-1756200000.000001';
+  await new ThreadSessionMapRepository(harness.rawDb).create({
+    channel_id: channel.id,
+    thread_id: threadId,
+    session_id: session.session_id,
+    branch_id: branch.branch_id,
+  });
+  await setMCPEgressGatewayMode(harness.rawDb, 'compatibility', harness.user.user_id);
+
+  const issued = new Date(Math.floor(Date.now() / 1_000) * 1_000);
+  const expires = new Date(issued.getTime() + 10 * 60_000);
+  const taskId = generateId();
+  const noticeId = generateId();
+  const jti = generateId();
+  const requestId = generateId();
+  const generation = 7;
+  const task = await new TaskRepository(harness.rawDb).create({
+    task_id: taskId,
+    session_id: session.session_id,
+    created_by: harness.user.user_id,
+    full_prompt: 'recover MCP in this same Slack Task',
+    status: TaskStatus.RUNNING,
+    message_range: {
+      start_index: 0,
+      end_index: 0,
+      start_timestamp: issued.toISOString(),
+    },
+    git_state: { ref_at_start: 'main', sha_at_start: 'slack-recovery' },
+    tool_use_count: 0,
+    metadata: {
+      gateway_task_source: {
+        gateway_channel_id: channel.id,
+        channel_type: 'slack',
+        thread_id: threadId,
+        provider_user_id: 'U2515',
+        slack_team_id: 'T2515',
+        slack_channel_id: 'C2515',
+      },
+      mcp_recovery_generation: generation,
+      mcp_recovery: {
+        generation,
+        code: 'oauth_reauth_required',
+        status: 'action_required',
+        task_id: taskId,
+        session_id: session.session_id,
+        mcp_server_id: harness.server.mcp_server_id,
+        provider: { mode: 'in_place', transport_reload: true, retries_unstarted_call: false },
+        action: 'reauthenticate',
+        message: 'MCP sign-in required',
+        observed_at: issued.toISOString(),
+        request_id: requestId,
+        provider_dispatch: 'not_started',
+      },
+      mcp_slack_recovery_notice: {
+        notice_id: noticeId,
+        token_jti: jti,
+        issued_at: issued.toISOString(),
+        expires_at: expires.toISOString(),
+        principal_user_id: harness.user.user_id,
+        credential_user_id: harness.user.user_id,
+        slack_user_id: 'U2515',
+        slack_team_id: 'T2515',
+        gateway_channel_id: channel.id,
+        gateway_config_generation: channel.provider_config_generation,
+        slack_channel_id: 'C2515',
+        slack_thread_id: threadId,
+        session_id: session.session_id,
+        task_id: taskId,
+        mcp_server_id: harness.server.mcp_server_id,
+        mcp_server_config_version: harness.server.config_version ?? 1,
+        recovery_generation: generation,
+        recovery_request_id: requestId,
+        provider_dispatch: 'not_started',
+        delivery_id: generateId(),
+        next_repair_at: issued.toISOString(),
+      },
+    },
+  });
+  expect(task.task_id).toBe(taskId);
+  const token = issueMCPSlackRecoveryToken(
+    {
+      type: 'mcp-slack-recovery',
+      tid: 'default',
+      sub: harness.user.user_id,
+      credential_user_id: harness.user.user_id,
+      slack_user_id: 'U2515',
+      slack_team_id: 'T2515',
+      gateway_channel_id: channel.id,
+      gateway_config_generation: channel.provider_config_generation,
+      slack_channel_id: 'C2515',
+      slack_thread_id: threadId,
+      task_id: taskId,
+      session_id: session.session_id,
+      mcp_server_id: harness.server.mcp_server_id,
+      mcp_server_config_version: harness.server.config_version ?? 1,
+      recovery_generation: generation,
+      recovery_request_id: requestId,
+      notice_id: noticeId,
+      jti,
+      expiresAt: expires,
+    },
+    process.env.AGOR_MASTER_SECRET!,
+    issued
+  );
+  return { token, taskId, sessionId: session.session_id };
 }
 
 async function replaceWithNewAuthorization(harness: SQLiteHarness): Promise<number> {
@@ -919,6 +1098,111 @@ afterEach(async () => {
   else process.env.AGOR_BASE_URL = previousBaseUrl;
   if (previousMasterSecret === undefined) delete process.env.AGOR_MASTER_SECRET;
   else process.env.AGOR_MASTER_SECRET = previousMasterSecret;
+});
+
+describe('Slack MCP recovery authenticated route', () => {
+  it('preflights, consumes once, and propagates the exact reserved OAuth attempt', async () => {
+    const provider = await createTestProvider();
+    providers.push(provider);
+    const harness = await createHarness(provider);
+    databases.push(harness.rawDb);
+    const seeded = await seedSlackRecoveryAction(harness);
+    const params = paramsFor(harness);
+
+    const preflight = (await harness.app
+      .service('mcp-slack-recovery')
+      .create({ token: seeded.token }, params)) as { state: string; return_to_slack_url: string };
+    expect(preflight).toMatchObject({ state: 'reconnect_required' });
+    expect(preflight.return_to_slack_url).toContain('team=T2515');
+
+    const started = (await harness.app
+      .service('mcp-servers/oauth-start')
+      .create({ slack_recovery_token: seeded.token }, params)) as {
+      success: boolean;
+      attempt_id: string;
+      authorizationUrl: string;
+    };
+    expect(started.success).toBe(true);
+    expect(new URL(started.authorizationUrl).searchParams.get('state')).toBeTruthy();
+
+    const task = await new TaskRepository(harness.rawDb).findById(seeded.taskId);
+    expect(task?.metadata?.mcp_slack_recovery_notice).toMatchObject({
+      token_consumed_at: expect.any(String),
+      oauth_attempt_id: started.attempt_id,
+      oauth_started_at: expect.any(String),
+    });
+    expect(task?.metadata?.mcp_slack_recovery_notice?.oauth_start_claim_expires_at).toBeUndefined();
+    expect(
+      (await new SessionRepository(harness.rawDb).findById(seeded.sessionId))?.sdk_session_id
+    ).toBe('sdk-session-preserved');
+
+    const duplicate = (await harness.app
+      .service('mcp-servers/oauth-start')
+      .create({ slack_recovery_token: seeded.token }, params)) as { success: boolean };
+    expect(duplicate.success).toBe(false);
+
+    const state = new URL(started.authorizationUrl).searchParams.get('state');
+    expect(state).toBeTruthy();
+    expect((await harness.callback(state!)).status).toBe(200);
+    expect(harness.gatewayOAuthResults).toContainEqual({
+      taskId: seeded.taskId,
+      noticeId: task?.metadata?.mcp_slack_recovery_notice?.notice_id,
+      attemptId: started.attempt_id,
+      success: true,
+    });
+    expect(
+      (await new SessionRepository(harness.rawDb).findById(seeded.sessionId))?.sdk_session_id
+    ).toBe('sdk-session-preserved');
+  });
+
+  it('fails closed after preflight when the Agor principal is revoked', async () => {
+    const provider = await createTestProvider();
+    providers.push(provider);
+    const harness = await createHarness(provider);
+    databases.push(harness.rawDb);
+    const seeded = await seedSlackRecoveryAction(harness);
+    const params = paramsFor(harness);
+
+    await harness.app.service('mcp-slack-recovery').create({ token: seeded.token }, params);
+    await new UsersRepository(harness.rawDb).update(harness.user.user_id, { role: 'viewer' });
+    const revoked = (await harness.app
+      .service('mcp-servers/oauth-start')
+      .create({ slack_recovery_token: seeded.token }, params)) as { success: boolean };
+    expect(revoked.success).toBe(false);
+    expect(provider.requests).toHaveLength(0);
+  });
+
+  it('projects provider success as superseded when authority changes during exchange', async () => {
+    const provider = await createTestProvider({ holdToken: true });
+    providers.push(provider);
+    const harness = await createHarness(provider);
+    databases.push(harness.rawDb);
+    const seeded = await seedSlackRecoveryAction(harness);
+    const params = paramsFor(harness);
+    const started = (await harness.app
+      .service('mcp-servers/oauth-start')
+      .create({ slack_recovery_token: seeded.token }, params)) as {
+      success: boolean;
+      attempt_id: string;
+      authorizationUrl: string;
+    };
+    expect(started.success).toBe(true);
+    const state = new URL(started.authorizationUrl).searchParams.get('state');
+    expect(state).toBeTruthy();
+
+    const callback = harness.callback(state!);
+    await provider.tokenRequested.promise;
+    await new UsersRepository(harness.rawDb).update(harness.user.user_id, { role: 'viewer' });
+    provider.releaseToken();
+
+    expect((await callback).status).toBe(409);
+    expect(harness.gatewayOAuthResults).toContainEqual({
+      taskId: seeded.taskId,
+      noticeId: expect.any(String),
+      attemptId: started.attempt_id,
+      success: true,
+    });
+  });
 });
 
 describe('real Feathers Socket.IO request authority', () => {

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -46,6 +46,7 @@ import {
   mcpServers,
   RepoRepository,
   runWithoutTenantDatabaseScope,
+  runWithTenantContext,
   runWithTenantDatabaseScope,
   runWithTenantDatabaseTransaction,
   type SaveTokenInput,
@@ -55,8 +56,10 @@ import {
   sessionMcpServers,
   sessions,
   shortId,
+  TaskRepository,
   type TenantScopeAwareDatabase,
   type TenantScopedDatabase,
+  ThreadSessionMapRepository,
   type UserMCPOAuthToken,
   UserMCPOAuthTokenRepository,
   UsersRepository,
@@ -64,6 +67,7 @@ import {
 } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import { BadRequest, Conflict, Forbidden, NotAuthenticated } from '@agor/core/feathers';
+import { isSlackWriteTargetAllowed, parseSlackThreadId } from '@agor/core/gateway';
 import {
   hasTemplateMarker,
   isMCPServerUsableBy,
@@ -92,6 +96,9 @@ import type {
   MCPOAuthStartFailure,
   MCPServer,
   MCPServerID,
+  MCPSlackOAuthRecoveryContext,
+  MCPSlackRecoveryNotice,
+  MCPSlackRecoveryTokenClaims,
   MessageSource,
   Params,
   SessionID,
@@ -177,7 +184,7 @@ import { createExecutorGitEnvironmentService } from './services/executor-git-env
 import { prepareSessionForExecutorStart } from './services/executor-startup.js';
 import { createFileService } from './services/file.js';
 import { createFilesService } from './services/files.js';
-import { createGatewayService } from './services/gateway.js';
+import { createGatewayService, taskMayNeedMcpSlackRecoverySync } from './services/gateway.js';
 import {
   createGatewayChannelsService,
   GATEWAY_CHANNELS_SERVICE_TRANSPORT_METHODS,
@@ -289,13 +296,18 @@ import {
   shouldExposeMCPServerSecrets,
   shouldExposeMCPServerSecretsForSessionToken,
 } from './utils/mcp-header-secrets.js';
-import { scheduleMcpRuntimeHint } from './utils/mcp-runtime-hints.js';
+import { isMcpRuntimeRecoveryEnabled, scheduleMcpRuntimeHint } from './utils/mcp-runtime-hints.js';
 import {
   isMcpGrantOwnerEntitled,
   isSessionMcpServerLinkVisibleToCaller,
   loadMcpServerForCaller,
   registerMcpCapabilityRoleFloor,
 } from './utils/mcp-server-authorization.js';
+import {
+  mcpSlackRecoveryClaimsMatchCaller,
+  mcpSlackRecoveryClaimsMatchNotice,
+  verifyMCPSlackRecoveryToken,
+} from './utils/mcp-slack-recovery-token.js';
 import { resolveOwnerHomeStore, resolveSandboxStoragePaths } from './utils/sandbox-context.js';
 import {
   AGOR_SOCKET_AUTHORITY_DISCONNECTED_EVENT,
@@ -354,7 +366,9 @@ type OAuthPostCommitTailCode =
   | 'completion_waiter'
   | 'disconnect_hint'
   | 'disconnect_notification'
-  | 'failure_notification';
+  | 'failure_notification'
+  | 'slack_recovery_projection'
+  | 'slack_recovery_failure_projection';
 
 export async function preserveCommittedOAuthResult<T>(
   result: T,
@@ -768,13 +782,27 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
     app.service('gateway-channels/app-info').publish(() => []);
 
     app.use('/thread-session-map', createThreadSessionMapService(db));
-    app.use('/gateway', createGatewayService(db, app, { appRbacEnabled: branchRbacEnabled }), {
+    const gatewayService = createGatewayService(db, app, {
+      appRbacEnabled: branchRbacEnabled,
+    });
+    app.use('/gateway', gatewayService, {
       // Only expose the inbound gateway entrypoint and existing route hook
       // externally. Proactive outbound emits are intentionally invoked through
       // the authenticated Agor MCP tool surface; exposing emitMessage here would
       // bypass the gateway service's normal channel_key auth model.
       methods: ['create', 'routeMessage'],
     });
+    // Structured Task recovery is authoritative. This listener is only a
+    // post-commit Slack availability projection; lost events are repaired by
+    // the bounded gateway startup/task reads and every later Task mutation.
+    const syncSlackRecovery = (task: unknown, hook?: { params?: unknown }) => {
+      if (!taskMayNeedMcpSlackRecoverySync(task)) return;
+      const taskId = (task as { task_id?: unknown } | null)?.task_id;
+      if (typeof taskId !== 'string') return;
+      gatewayService.syncMcpSlackRecoveryNoticeAfterCommit(taskId, hook?.params);
+    };
+    app.service('tasks').on('patched', syncSlackRecovery);
+    app.service('tasks').on('updated', syncSlackRecovery);
 
     const uiUrl = ctx.bundledUiAvailable ? `${daemonUrl}/ui` : `http://localhost:${ctx.UI_PORT}`;
     registerGitHubAppSetupRoutes(app, {
@@ -1849,6 +1877,8 @@ export async function registerMCPServices(
     localGrantBinding?: NonNullable<SaveTokenInput['grantBinding']>;
     /** Subject key whose temporary generation reservation this flow owns. */
     localGrantSubjectKey?: string;
+    /** Exact Slack notice that launched this canonical OAuth attempt. */
+    slackRecovery?: import('@agor/core/types').MCPSlackOAuthRecoveryContext;
   };
 
   // Store pending OAuth flow contexts
@@ -2060,6 +2090,10 @@ export async function registerMCPServices(
      * not use a browser-event reservation (notably oauth-start).
      */
     requestAuthority?: () => void;
+    slackRecovery?: import('@agor/core/types').MCPSlackOAuthRecoveryContext;
+    attemptId?: MCPOAuthAttemptID;
+    /** Renews and fences the exact one-use Slack start lease before persistence. */
+    assertStartAuthority?: () => Promise<void>;
   };
 
   type StartTwoPhaseOAuthResult = {
@@ -2212,7 +2246,9 @@ export async function registerMCPServices(
     // Local reservations are attempt-aware, so establish identity before
     // allocating a generation. PostgreSQL obtains its durable attempt ID from
     // the pending-flow authority below instead.
-    const localAttemptId = durableOAuthFlows ? undefined : (generateId() as MCPOAuthAttemptID);
+    const localAttemptId = durableOAuthFlows
+      ? undefined
+      : (opts.attemptId ?? (generateId() as MCPOAuthAttemptID));
 
     // Metadata discovery and DCR are the first provider-owned side effects in
     // this helper. Re-check the live socket authority immediately before they
@@ -2244,6 +2280,7 @@ export async function registerMCPServices(
       })
     );
     assertFlowAuthority?.();
+    await opts.assertStartAuthority?.();
 
     const resolvedGrantBinding = {
       resourceUri: context.resourceUri,
@@ -2355,6 +2392,8 @@ export async function registerMCPServices(
               durableOAuthFlows!.create({
                 context,
                 ...durableBinding,
+                ...(opts.attemptId ? { attemptId: opts.attemptId } : {}),
+                ...(opts.slackRecovery ? { slackRecovery: opts.slackRecovery } : {}),
                 configFingerprint: fingerprintMCPOAuthGrantConfiguration(
                   process.env.AGOR_MASTER_SECRET!,
                   currentServer,
@@ -2440,6 +2479,7 @@ export async function registerMCPServices(
         savedServerAuthority,
         localGrantBinding,
         localGrantSubjectKey,
+        ...(opts.slackRecovery ? { slackRecovery: opts.slackRecovery } : {}),
       });
       localOAuthAttemptStatuses.set(attemptId, {
         status: 'pending',
@@ -2853,6 +2893,91 @@ export async function registerMCPServices(
     }
   };
 
+  const slackRecoveryThreadAllowed = (
+    notice: MCPSlackRecoveryNotice,
+    config: Record<string, unknown>
+  ): boolean => {
+    try {
+      const parsed = parseSlackThreadId(notice.slack_thread_id);
+      return (
+        parsed.channel === notice.slack_channel_id &&
+        isSlackWriteTargetAllowed(config, parsed.channel)
+      );
+    } catch {
+      return false;
+    }
+  };
+
+  const assertSlackRecoveryFlowStillAuthorized = async (
+    pendingFlow: PendingOAuthFlow
+  ): Promise<void> => {
+    const recovery = pendingFlow.slackRecovery;
+    const tenantId = pendingFlow.durableRecord?.tenantId ?? pendingFlow.tenantId;
+    const userId = pendingFlow.durableRecord?.userId ?? pendingFlow.userId;
+    if (!recovery) return;
+    if (!tenantId || !userId) throw new Error('Slack MCP recovery authority is unavailable');
+    await runInOAuthTenantScope(db, tenantId, async () => {
+      const tasks = new TaskRepository(db);
+      const authority = await tasks.mutateMCPSlackRecoveryNotice(
+        recovery.task_id,
+        (notice, task) => {
+          const runtimeRecovery = task.metadata?.mcp_recovery;
+          return notice?.notice_id === recovery.notice_id &&
+            notice.oauth_attempt_id === pendingFlow.attemptId &&
+            notice.principal_user_id === userId &&
+            notice.credential_user_id === userId &&
+            task.created_by === userId &&
+            task.session_id === recovery.session_id &&
+            [
+              TaskStatus.RUNNING,
+              TaskStatus.AWAITING_PERMISSION,
+              TaskStatus.AWAITING_INPUT,
+            ].includes(task.status as never) &&
+            runtimeRecovery?.code === 'oauth_reauth_required' &&
+            runtimeRecovery.status === 'action_required' &&
+            runtimeRecovery.mcp_server_id === recovery.mcp_server_id &&
+            runtimeRecovery.generation === recovery.recovery_generation &&
+            runtimeRecovery.request_id === recovery.recovery_request_id
+            ? notice
+            : null;
+        }
+      );
+      const task = authority.task;
+      const notice = task.metadata?.mcp_slack_recovery_notice;
+      if (!authority.changed || !notice) {
+        throw new Error('Slack MCP recovery request is no longer current');
+      }
+      const [session, channel, mapping, server, mode] = await Promise.all([
+        sessionsRepository.findById(recovery.session_id),
+        new GatewayChannelRepository(db).findById(notice.gateway_channel_id),
+        new ThreadSessionMapRepository(db).findBySession(recovery.session_id),
+        new MCPServerRepository(db).findById(recovery.mcp_server_id),
+        getMCPEgressGatewayMode(db),
+      ]);
+      const recoveryEnabled = await isMcpRuntimeRecoveryEnabled(db);
+      const attached = (
+        await new SessionMCPServerRepository(db).listServers(recovery.session_id, true)
+      ).some((candidate) => candidate.mcp_server_id === recovery.mcp_server_id);
+      if (
+        session?.created_by !== userId ||
+        !channel?.enabled ||
+        channel.channel_type !== 'slack' ||
+        channel.provider_config_generation !== notice.gateway_config_generation ||
+        !slackRecoveryThreadAllowed(notice, channel.config) ||
+        mapping?.channel_id !== channel.id ||
+        mapping.thread_id !== notice.slack_thread_id ||
+        !server?.enabled ||
+        server.auth?.type !== 'oauth' ||
+        (server.config_version ?? 1) !== notice.mcp_server_config_version ||
+        !attached ||
+        !recoveryEnabled ||
+        (mode !== 'compatibility' && mode !== 'enforced')
+      ) {
+        throw new Error('Slack MCP recovery authority changed');
+      }
+    });
+  };
+
   const assertPendingFlowStillAuthorized = async (
     pendingFlow: PendingOAuthFlow,
     afterProviderExchange = false
@@ -2864,6 +2989,7 @@ export async function registerMCPServices(
         record?.tenantId ?? pendingFlow.tenantId,
         record?.oauthMode ?? pendingFlow.oauthMode ?? 'per_user'
       );
+      await assertSlackRecoveryFlowStillAuthorized(pendingFlow);
       if (!record) {
         if (!pendingFlow.mcpServerId) return;
         const savedAuthority = pendingFlow.savedServerAuthority;
@@ -3102,6 +3228,30 @@ export async function registerMCPServices(
     }
   };
 
+  const projectSlackRecoveryOAuthResult = async (
+    pendingFlow: PendingOAuthFlow,
+    success: boolean
+  ): Promise<void> => {
+    const recovery = pendingFlow.slackRecovery;
+    if (!recovery || !pendingFlow.tenantId) return;
+    await runWithTenantContext(pendingFlow.tenantId, async () => {
+      const gateway = app.service('gateway') as unknown as {
+        markMcpSlackOAuthResult(input: {
+          taskId: string;
+          noticeId: string;
+          attemptId: string;
+          success: boolean;
+        }): Promise<void>;
+      };
+      await gateway.markMcpSlackOAuthResult({
+        taskId: recovery.task_id,
+        noticeId: recovery.notice_id,
+        attemptId: pendingFlow.attemptId,
+        success,
+      });
+    });
+  };
+
   const pendingFromDurableClaim = (
     claimed: ReturnType<MCPOAuthPendingFlowAuthority['openClaim']>
   ): PendingOAuthFlow => ({
@@ -3113,6 +3263,7 @@ export async function registerMCPServices(
     tenantId: claimed.record.tenantId,
     createdAt: claimed.record.createdAt.getTime(),
     durableRecord: claimed.record,
+    ...(claimed.slackRecovery ? { slackRecovery: claimed.slackRecovery } : {}),
   });
 
   const terminalMessageForStatus = (status: MCPOAuthPendingFlowStatus): string => {
@@ -3154,11 +3305,43 @@ export async function registerMCPServices(
         // caller (discover / test-oauth) can surface the failure.
         if (state) {
           if (durableOAuthFlows) {
-            await durableOAuthFlows.failPendingCallback(state, 'authorization_denied');
+            const claimed = await durableOAuthFlows.claimForCallback(state);
+            if (claimed.outcome === 'claimed') {
+              try {
+                const denied = pendingFromDurableClaim(
+                  durableOAuthFlows.openClaim(claimed.flow, state)
+                );
+                await durableOAuthFlows.finish(claimed.flow, 'failed', 'authorization_denied');
+                await preserveCommittedOAuthResult(undefined, [
+                  {
+                    code: 'slack_recovery_failure_projection',
+                    run: () => projectSlackRecoveryOAuthResult(denied, false),
+                  },
+                  {
+                    code: 'failure_notification',
+                    run: () => emitOAuthCompletion(denied, false),
+                  },
+                ]);
+              } catch {
+                await durableOAuthFlows.finish(claimed.flow, 'failed', 'authorization_denied');
+              }
+            }
           } else {
             const pending = pendingOAuthFlows.get(state);
             pending?.tokenReject?.(new Error('Authorization was not completed'));
-            if (pending) markLocalOAuthAttempt(pending, 'failed', 'authorization_denied');
+            if (pending) {
+              markLocalOAuthAttempt(pending, 'failed', 'authorization_denied');
+              await preserveCommittedOAuthResult(undefined, [
+                {
+                  code: 'slack_recovery_failure_projection',
+                  run: () => projectSlackRecoveryOAuthResult(pending, false),
+                },
+                {
+                  code: 'failure_notification',
+                  run: () => emitOAuthCompletion(pending, false),
+                },
+              ]);
+            }
             pendingOAuthFlows.delete(state);
           }
         }
@@ -3242,6 +3425,10 @@ export async function registerMCPServices(
         if (!pendingFlow.durableRecord) markLocalOAuthAttempt(pendingFlow, 'succeeded');
         await preserveCommittedOAuthResult(undefined, [
           {
+            code: 'slack_recovery_projection',
+            run: () => projectSlackRecoveryOAuthResult(pendingFlow, true),
+          },
+          {
             code: 'runtime_authority_hint',
             run: () => {
               if (!pendingFlow.tenantId || !pendingFlow.mcpServerId) return;
@@ -3288,10 +3475,21 @@ export async function registerMCPServices(
         ]);
 
         console.log('[OAuth Callback] Flow completed successfully');
-        sendOAuthResultPage(res, true, 'OAuth authentication was successful.');
+        sendOAuthResultPage(
+          res,
+          true,
+          pendingFlow.slackRecovery
+            ? 'OAuth authentication was successful. You can close this tab and return to Slack; Agor will update the original thread.'
+            : 'OAuth authentication was successful.'
+        );
       } catch (innerErr) {
         const classification = classifyMCPOAuthCompletionFailure(innerErr);
         const { ambiguous } = classification;
+        // The provider exchange did succeed in this typed case, but current
+        // Agor authority prevented the grant from being committed. Project it
+        // as superseded rather than falsely describing provider auth failure.
+        const slackProviderSucceeded =
+          innerErr instanceof OAuthFlowAuthorizationChangedError && innerErr.afterProviderExchange;
         if (pendingFlow.durableRecord) {
           try {
             await durableOAuthFlows!.finish(
@@ -3307,6 +3505,10 @@ export async function registerMCPServices(
           markLocalOAuthAttempt(pendingFlow, classification.status, classification.failureCode);
         }
         await preserveCommittedOAuthResult(undefined, [
+          {
+            code: 'slack_recovery_failure_projection',
+            run: () => projectSlackRecoveryOAuthResult(pendingFlow, slackProviderSucceeded),
+          },
           {
             code: 'failure_notification',
             run: () => emitOAuthCompletion(pendingFlow, false),
@@ -4204,13 +4406,262 @@ export async function registerMCPServices(
 
   app.service('mcp-servers/test-oauth').hooks({ before: { create: [ctx.requireAuth] } });
 
+  type SlackRecoveryBinding = {
+    claims: MCPSlackRecoveryTokenClaims;
+    notice: MCPSlackRecoveryNotice;
+    oauthContext: MCPSlackOAuthRecoveryContext;
+  };
+
+  const loadSlackRecoveryBinding = async (
+    rawToken: unknown,
+    params: AuthenticatedParams | undefined,
+    consume: boolean,
+    attemptId?: MCPOAuthAttemptID
+  ): Promise<SlackRecoveryBinding> => {
+    const genericFailure = 'This MCP recovery action is invalid, expired, or superseded.';
+    try {
+      if (typeof rawToken !== 'string') throw new Error(genericFailure);
+      const claims = verifyMCPSlackRecoveryToken(rawToken, process.env.AGOR_MASTER_SECRET ?? '');
+      const tenantId = tenantIdFromParams(params);
+      const callerId = params?.user?.user_id;
+      if (
+        !tenantId ||
+        !callerId ||
+        !mcpSlackRecoveryClaimsMatchCaller(claims, tenantId, callerId)
+      ) {
+        throw new Error(genericFailure);
+      }
+      const taskRepo = new TaskRepository(db);
+      const task = await taskRepo.findById(claims.task_id);
+      const notice = task?.metadata?.mcp_slack_recovery_notice;
+      const recovery = task?.metadata?.mcp_recovery;
+      const source = task?.metadata?.gateway_task_source;
+      if (
+        !task ||
+        !notice ||
+        !mcpSlackRecoveryClaimsMatchNotice(claims, notice, tenantId) ||
+        task.session_id !== claims.session_id ||
+        task.created_by !== callerId ||
+        ![TaskStatus.RUNNING, TaskStatus.AWAITING_PERMISSION, TaskStatus.AWAITING_INPUT].includes(
+          task.status as never
+        ) ||
+        !recovery ||
+        recovery.code !== 'oauth_reauth_required' ||
+        recovery.status !== 'action_required' ||
+        recovery.action !== 'reauthenticate' ||
+        recovery.generation !== claims.recovery_generation ||
+        recovery.request_id !== claims.recovery_request_id ||
+        recovery.mcp_server_id !== claims.mcp_server_id ||
+        source?.gateway_channel_id !== claims.gateway_channel_id ||
+        source.channel_type !== 'slack' ||
+        source.thread_id !== claims.slack_thread_id ||
+        source.provider_user_id !== claims.slack_user_id ||
+        source.slack_team_id !== claims.slack_team_id ||
+        source.slack_channel_id !== claims.slack_channel_id
+      ) {
+        throw new Error(genericFailure);
+      }
+      const [session, principal, credentialUser, channel, server, mapping, mode] =
+        await Promise.all([
+          sessionsRepository.findById(claims.session_id),
+          new UsersRepository(db).findById(claims.sub),
+          new UsersRepository(db).findById(claims.credential_user_id),
+          new GatewayChannelRepository(db).findById(claims.gateway_channel_id),
+          new MCPServerRepository(db).findById(claims.mcp_server_id),
+          new ThreadSessionMapRepository(db).findBySession(claims.session_id),
+          getMCPEgressGatewayMode(db),
+        ]);
+      const recoveryEnabled = await isMcpRuntimeRecoveryEnabled(db);
+      const attached = await new SessionMCPServerRepository(db)
+        .listServers(claims.session_id, true)
+        .then((servers) =>
+          servers.some((candidate) => candidate.mcp_server_id === claims.mcp_server_id)
+        );
+      if (
+        !session ||
+        session.created_by !== claims.credential_user_id ||
+        !principal ||
+        !credentialUser ||
+        !hasMinimumRole(principal.role, ROLES.MEMBER) ||
+        !hasMinimumRole(
+          credentialUser.role,
+          server?.auth?.type === 'oauth' && (server.auth.oauth_mode ?? 'per_user') === 'shared'
+            ? ROLES.ADMIN
+            : ROLES.MEMBER
+        ) ||
+        !channel?.enabled ||
+        channel.channel_type !== 'slack' ||
+        channel.provider_config_generation !== claims.gateway_config_generation ||
+        !slackRecoveryThreadAllowed(notice, channel.config) ||
+        mapping?.channel_id !== channel.id ||
+        mapping.thread_id !== claims.slack_thread_id ||
+        !server?.enabled ||
+        server.auth?.type !== 'oauth' ||
+        (server.config_version ?? 1) !== claims.mcp_server_config_version ||
+        !attached ||
+        !recoveryEnabled ||
+        (mode !== 'compatibility' && mode !== 'enforced')
+      ) {
+        throw new Error(genericFailure);
+      }
+      if (consume) {
+        const consumedAt = new Date();
+        const consumed = await taskRepo.mutateMCPSlackRecoveryNotice(
+          task.task_id,
+          (current, lockedTask) => {
+            const lockedRecovery = lockedTask.metadata?.mcp_recovery;
+            if (
+              !current ||
+              !mcpSlackRecoveryClaimsMatchNotice(claims, current, tenantId) ||
+              current.token_consumed_at ||
+              new Date(current.expires_at).getTime() <= consumedAt.getTime() ||
+              !lockedRecovery ||
+              lockedRecovery.code !== 'oauth_reauth_required' ||
+              lockedRecovery.status !== 'action_required' ||
+              lockedRecovery.generation !== claims.recovery_generation ||
+              lockedRecovery.request_id !== claims.recovery_request_id ||
+              lockedRecovery.mcp_server_id !== claims.mcp_server_id
+            ) {
+              return null;
+            }
+            return {
+              ...current,
+              token_consumed_at: consumedAt.toISOString(),
+              ...(attemptId
+                ? {
+                    oauth_attempt_id: attemptId,
+                    oauth_start_claimed_at: consumedAt.toISOString(),
+                    oauth_start_claim_expires_at: new Date(
+                      consumedAt.getTime() + 30_000
+                    ).toISOString(),
+                    next_repair_at: new Date(consumedAt.getTime() + 30_000).toISOString(),
+                  }
+                : { next_repair_at: consumedAt.toISOString() }),
+            };
+          }
+        );
+        if (!consumed.changed) throw new Error(genericFailure);
+      }
+      return {
+        claims,
+        notice,
+        oauthContext: {
+          notice_id: notice.notice_id,
+          task_id: notice.task_id,
+          session_id: notice.session_id,
+          mcp_server_id: notice.mcp_server_id,
+          recovery_generation: notice.recovery_generation,
+          recovery_request_id: notice.recovery_request_id,
+        },
+      };
+    } catch {
+      throw new Forbidden(genericFailure);
+    }
+  };
+
+  // Authenticated, secret-free browser preflight. The fragment token never
+  // enters an HTTP URL or referrer; the SPA posts it in the request body.
+  app.use('/mcp-slack-recovery', {
+    async create(data: { token?: unknown }, params?: AuthenticatedParams) {
+      const binding = await loadSlackRecoveryBinding(data?.token, params, false);
+      const separator = binding.claims.slack_thread_id.lastIndexOf('-');
+      const rootTs =
+        separator >= 0 ? binding.claims.slack_thread_id.slice(separator + 1) : undefined;
+      return {
+        state: binding.notice.oauth_failed_at
+          ? 'failed'
+          : binding.notice.oauth_started_at || binding.notice.token_consumed_at
+            ? 'sign_in_pending'
+            : 'reconnect_required',
+        provider_dispatch: binding.notice.provider_dispatch,
+        expires_at: binding.notice.expires_at,
+        return_to_slack_url: `slack://channel?team=${encodeURIComponent(binding.claims.slack_team_id)}&id=${encodeURIComponent(binding.claims.slack_channel_id)}${rootTs ? `&message=${encodeURIComponent(rootTs)}` : ''}`,
+      };
+    },
+  });
+  app.service('mcp-slack-recovery').hooks({ before: { create: [ctx.requireAuth] } });
+  app.service('mcp-slack-recovery').publish?.(() => []);
+
   // OAuth start endpoint
   app.use('/mcp-servers/oauth-start', {
     async create(
-      data: { mcp_url?: string; mcp_server_id?: string; client_id?: string },
+      data: {
+        mcp_url?: string;
+        mcp_server_id?: string;
+        client_id?: string;
+        slack_recovery_token?: string;
+      },
       params?: AuthenticatedParams
     ) {
       const assertRequestAuthority = requestAuthorityAssertion(params);
+      let slackRecoveryBinding: SlackRecoveryBinding | undefined;
+      let slackStartLeaseTimer: NodeJS.Timeout | undefined;
+      let slackStartLeaseLost = false;
+      const reservedSlackAttemptId = data.slack_recovery_token
+        ? (generateId() as MCPOAuthAttemptID)
+        : undefined;
+      const stopSlackStartLeaseRenewal = (): void => {
+        if (slackStartLeaseTimer) clearInterval(slackStartLeaseTimer);
+        slackStartLeaseTimer = undefined;
+      };
+      const renewSlackStartLease = async (): Promise<void> => {
+        const binding = slackRecoveryBinding;
+        if (!binding || !reservedSlackAttemptId || slackStartLeaseLost) {
+          throw new Conflict('This MCP recovery action was superseded before sign-in opened.');
+        }
+        const now = new Date();
+        const renewed = await new TaskRepository(db).mutateMCPSlackRecoveryNotice(
+          binding.notice.task_id,
+          (current) => {
+            if (
+              !current ||
+              current.notice_id !== binding.notice.notice_id ||
+              current.oauth_attempt_id !== reservedSlackAttemptId ||
+              !current.token_consumed_at ||
+              current.oauth_started_at ||
+              current.oauth_failed_at ||
+              !current.oauth_start_claim_expires_at ||
+              new Date(current.oauth_start_claim_expires_at).getTime() <= now.getTime()
+            ) {
+              return null;
+            }
+            return {
+              ...current,
+              oauth_start_claim_expires_at: new Date(now.getTime() + 30_000).toISOString(),
+              next_repair_at: new Date(now.getTime() + 30_000).toISOString(),
+            };
+          }
+        );
+        if (!renewed.changed) {
+          slackStartLeaseLost = true;
+          stopSlackStartLeaseRenewal();
+          throw new Conflict('This MCP recovery action was superseded before sign-in opened.');
+        }
+      };
+      const markSlackRecoveryStartFailed = async (): Promise<void> => {
+        stopSlackStartLeaseRenewal();
+        const binding = slackRecoveryBinding;
+        if (!binding) return;
+        const failed = await new TaskRepository(db)
+          .mutateMCPSlackRecoveryNotice(binding.notice.task_id, (current) =>
+            current?.notice_id === binding.notice.notice_id &&
+            current.oauth_attempt_id === reservedSlackAttemptId
+              ? {
+                  ...current,
+                  oauth_failed_at: new Date().toISOString(),
+                  oauth_start_claim_expires_at: undefined,
+                  next_repair_at: new Date().toISOString(),
+                }
+              : null
+          )
+          .catch(() => null);
+        if (failed?.changed) {
+          const gateway = app.service('gateway') as unknown as {
+            syncMcpSlackRecoveryNoticeAfterCommit(taskId: string, params?: unknown): void;
+          };
+          gateway.syncMcpSlackRecoveryNoticeAfterCommit(binding.notice.task_id, params);
+        }
+      };
       try {
         assertRequestAuthority?.();
         console.log('[OAuth Start] Starting two-phase OAuth flow');
@@ -4225,7 +4676,33 @@ export async function registerMCPServices(
         let scopeOverride: string | undefined;
         let compatibilityMode: MCPOAuthRuntimeCompatibilityMode = 'strict';
         let dcrMode: MCPOAuthDCRMode | undefined;
-        const savedServerId = data.mcp_server_id;
+        if (data.slack_recovery_token) {
+          slackRecoveryBinding = await loadSlackRecoveryBinding(
+            data.slack_recovery_token,
+            params,
+            true,
+            reservedSlackAttemptId
+          );
+          // The Task consume CAS is intentionally short. Re-read every related
+          // authority immediately afterward and before metadata discovery/DCR,
+          // so a concurrent revocation cannot begin provider work on the
+          // strength of the pre-CAS snapshot.
+          await loadSlackRecoveryBinding(data.slack_recovery_token, params, false);
+          await renewSlackStartLease();
+          slackStartLeaseTimer = setInterval(() => {
+            const tenantId = slackRecoveryBinding?.claims.tid;
+            if (!tenantId) return;
+            void runWithTenantContext(tenantId, renewSlackStartLease).catch(() => undefined);
+          }, 10_000);
+          slackStartLeaseTimer.unref();
+          if (
+            data.mcp_server_id &&
+            data.mcp_server_id !== slackRecoveryBinding.claims.mcp_server_id
+          ) {
+            throw new Forbidden('This MCP recovery action does not match the requested server.');
+          }
+        }
+        const savedServerId = slackRecoveryBinding?.claims.mcp_server_id ?? data.mcp_server_id;
         // Its stored OAuth client configuration belongs to whoever owns the
         // row; a caller who may not use the server may not borrow it either.
         const savedServer = savedServerId
@@ -4247,6 +4724,7 @@ export async function registerMCPServices(
               'OAuth requires an enabled, saved MCP server in the current tenant. Save changes, then restart OAuth.',
             ...(savedServerId ? { mcp_server_id: savedServerId as MCPServerID } : {}),
           };
+          await markSlackRecoveryStartFailed();
           return {
             success: false,
             error: recovery.message,
@@ -4263,6 +4741,7 @@ export async function registerMCPServices(
             new OAuthConfigurationError('metadata_unavailable'),
             { mcpServerId: savedServerId }
           );
+          await markSlackRecoveryStartFailed();
           return {
             success: false,
             error: recovery.message,
@@ -4287,6 +4766,7 @@ export async function registerMCPServices(
               'The saved MCP server changed before OAuth could start. Reload it, save the intended configuration, then retry.',
             ...(savedServerId ? { mcp_server_id: savedServerId as MCPServerID } : {}),
           };
+          await markSlackRecoveryStartFailed();
           return {
             success: false,
             error: recovery.message,
@@ -4358,6 +4838,7 @@ export async function registerMCPServices(
               'This MCP server did not request OAuth authentication. Verify the saved MCP URL and authentication type, then retry.',
             ...(savedServerId ? { mcp_server_id: savedServerId as MCPServerID } : {}),
           };
+          await markSlackRecoveryStartFailed();
           return {
             success: false,
             error: recovery.message,
@@ -4384,6 +4865,7 @@ export async function registerMCPServices(
               mcpServerId: savedServerId,
             }
           );
+          await markSlackRecoveryStartFailed();
           return {
             success: false,
             error: recovery.message,
@@ -4415,6 +4897,9 @@ export async function registerMCPServices(
             compatibilityMode,
             dcrMode,
             requestAuthority: assertRequestAuthority,
+            slackRecovery: slackRecoveryBinding?.oauthContext,
+            attemptId: reservedSlackAttemptId,
+            assertStartAuthority: slackRecoveryBinding ? renewSlackStartLease : undefined,
           });
         } catch (err) {
           const recovery = classifyMCPAuthRecovery(err, {
@@ -4422,6 +4907,7 @@ export async function registerMCPServices(
           });
           if (recovery.category === 'redirect_configuration_required') {
             console.error('[OAuth Start] Failed category=PublicBaseUrlNotConfiguredError');
+            await markSlackRecoveryStartFailed();
             return {
               success: false,
               error: recovery.message,
@@ -4432,15 +4918,75 @@ export async function registerMCPServices(
         }
 
         assertRequestAuthority?.();
+        if (slackRecoveryBinding) {
+          if (result.attemptId !== reservedSlackAttemptId) {
+            throw new Conflict('This MCP recovery action was superseded before sign-in opened.');
+          }
+          const opened = await new TaskRepository(db).mutateMCPSlackRecoveryNotice(
+            slackRecoveryBinding.notice.task_id,
+            (current) => {
+              const openedAt = new Date();
+              if (
+                !current ||
+                current.notice_id !== slackRecoveryBinding?.notice.notice_id ||
+                current.oauth_attempt_id !== reservedSlackAttemptId ||
+                !current.token_consumed_at ||
+                current.oauth_failed_at ||
+                !current.oauth_start_claim_expires_at ||
+                new Date(current.oauth_start_claim_expires_at).getTime() <= openedAt.getTime()
+              ) {
+                return null;
+              }
+              return {
+                ...current,
+                oauth_started_at: openedAt.toISOString(),
+                oauth_start_claim_expires_at: undefined,
+                next_repair_at: new Date(openedAt.getTime() + 60_000).toISOString(),
+              };
+            }
+          );
+          if (!opened.changed) {
+            if (durableOAuthFlows) {
+              const cancelled = await durableOAuthFlows.failPendingCallback(
+                result.state,
+                'superseded_by_newer_attempt'
+              );
+              if (!cancelled) {
+                console.warn('[OAuth Start] Slack recovery orphan attempt was already terminal');
+              }
+            } else {
+              const orphan = pendingOAuthFlows.get(result.state);
+              if (orphan?.attemptId === result.attemptId) {
+                pendingOAuthFlows.delete(result.state);
+                releaseLocalGrantGeneration(orphan);
+                markLocalOAuthAttempt(orphan, 'failed', 'superseded_by_newer_attempt');
+                orphan.tokenReject?.(
+                  new Error('The Slack MCP recovery start lease expired before sign-in opened')
+                );
+              }
+            }
+            throw new Conflict('This MCP recovery action was superseded before sign-in opened.');
+          }
+          const gateway = app.service('gateway') as unknown as {
+            syncMcpSlackRecoveryNoticeAfterCommit(taskId: string, params?: unknown): void;
+          };
+          gateway.syncMcpSlackRecoveryNoticeAfterCommit(
+            slackRecoveryBinding.notice.task_id,
+            params
+          );
+          stopSlackStartLeaseRenewal();
+        }
         return {
           success: true,
           authorizationUrl: result.authorizationUrl,
           attempt_id: result.attemptId,
           state: result.state,
-          message:
-            'Browser opened for authentication. After signing in, copy the callback URL and paste it below.',
+          message: slackRecoveryBinding
+            ? 'Browser opened for authentication. Return to Slack after signing in.'
+            : 'Browser opened for authentication. After signing in, copy the callback URL and paste it below.',
         };
       } catch (error) {
+        await markSlackRecoveryStartFailed();
         // A live-authority failure must never be normalized into an ordinary
         // provider diagnostic; callers may otherwise continue an obsolete
         // flow under the replacement identity on the same socket.
@@ -4587,6 +5133,10 @@ export async function registerMCPServices(
           { success: true, message: 'OAuth authentication successful!', tokenObtained: true },
           [
             {
+              code: 'slack_recovery_projection',
+              run: () => projectSlackRecoveryOAuthResult(completedFlow, true),
+            },
+            {
               code: 'completion_hint',
               run: () => {
                 if (!completedServerId || !completedTenantId) return;
@@ -4635,6 +5185,8 @@ export async function registerMCPServices(
         if (pendingFlow) {
           const classification = classifyMCPOAuthCompletionFailure(error);
           const { ambiguous, failureCode } = classification;
+          const slackProviderSucceeded =
+            error instanceof OAuthFlowAuthorizationChangedError && error.afterProviderExchange;
           completionFailureCode = failureCode;
           completionStatus = classification.status;
           if (pendingFlow.durableRecord) {
@@ -4649,6 +5201,10 @@ export async function registerMCPServices(
             markLocalOAuthAttempt(pendingFlow, completionStatus, failureCode);
           }
           await preserveCommittedOAuthResult(undefined, [
+            {
+              code: 'slack_recovery_failure_projection',
+              run: () => projectSlackRecoveryOAuthResult(pendingFlow!, slackProviderSucceeded),
+            },
             {
               code: 'failure_notification',
               run: () => emitOAuthCompletion(pendingFlow!, false),

--- a/apps/agor-daemon/src/services/gateway-mcp-slack-recovery.test.ts
+++ b/apps/agor-daemon/src/services/gateway-mcp-slack-recovery.test.ts
@@ -1,0 +1,315 @@
+import { runWithTenantContext } from '@agor/core/db';
+import type { MCPSlackRecoveryNotice, Task } from '@agor/core/types';
+import { TaskStatus } from '@agor/core/types';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  GatewayService,
+  mcpSlackRecoveryExpiryDelay,
+  mcpSlackRecoveryMessageCopy,
+  mcpSlackRecoveryRenderedState,
+  taskMayNeedMcpSlackRecoverySync,
+} from './gateway.js';
+
+const expiresAt = '2026-08-26T12:10:00.000Z';
+const now = Date.parse('2026-08-26T12:00:00.000Z');
+
+function notice(overrides: Partial<MCPSlackRecoveryNotice> = {}): MCPSlackRecoveryNotice {
+  return {
+    notice_id: 'notice-1',
+    token_jti: 'jti-1',
+    issued_at: '2026-08-26T12:00:00.000Z',
+    expires_at: expiresAt,
+    principal_user_id: 'user-1',
+    credential_user_id: 'user-1',
+    slack_user_id: 'U1',
+    slack_team_id: 'T1',
+    gateway_channel_id: 'gateway-1',
+    gateway_config_generation: 1,
+    slack_channel_id: 'C1',
+    slack_thread_id: 'C1-1.1',
+    session_id: 'session-1',
+    task_id: 'task-1',
+    mcp_server_id: 'server-1' as never,
+    mcp_server_config_version: 1,
+    recovery_generation: 4,
+    recovery_request_id: 'request-1',
+    provider_dispatch: 'not_started',
+    delivery_id: 'delivery-1',
+    ...overrides,
+  };
+}
+
+function task(overrides: Record<string, unknown> = {}): Task {
+  return {
+    task_id: 'task-1',
+    session_id: 'session-1',
+    status: TaskStatus.RUNNING,
+    metadata: {
+      mcp_recovery_generation: 4,
+      mcp_recovery: {
+        generation: 4,
+        code: 'oauth_reauth_required',
+        status: 'action_required',
+        task_id: 'task-1',
+        session_id: 'session-1',
+        mcp_server_id: 'server-1',
+        provider: { mode: 'in_place', transport_reload: true, retries_unstarted_call: false },
+        action: 'reauthenticate',
+        message: 'redacted',
+        observed_at: '2026-08-26T12:00:00.000Z',
+        request_id: 'request-1',
+        provider_dispatch: 'not_started',
+      },
+    },
+    ...overrides,
+  } as Task;
+}
+
+describe('Slack MCP recovery presentation', () => {
+  it('projects every durable lifecycle state without provider errors', () => {
+    expect(mcpSlackRecoveryRenderedState(task(), notice(), now)).toBe('reconnect_required');
+    expect(
+      mcpSlackRecoveryRenderedState(
+        task(),
+        notice({ oauth_started_at: new Date(now).toISOString() }),
+        now
+      )
+    ).toBe('sign_in_pending');
+    expect(
+      mcpSlackRecoveryRenderedState(
+        task(),
+        notice({ oauth_failed_at: new Date(now).toISOString() }),
+        now
+      )
+    ).toBe('failed');
+    expect(mcpSlackRecoveryRenderedState(task(), notice(), Date.parse(expiresAt) + 1)).toBe(
+      'expired_or_superseded'
+    );
+    expect(
+      mcpSlackRecoveryRenderedState(
+        task({
+          metadata: {
+            mcp_recovery_generation: 4,
+            mcp_recovery_settled_request_id: 'request-1',
+            mcp_recovery_settled_at: new Date(now).toISOString(),
+          },
+        }),
+        notice({ oauth_succeeded_at: new Date(now).toISOString() }),
+        now
+      )
+    ).toBe('recovered');
+    expect(
+      mcpSlackRecoveryRenderedState(
+        task({
+          metadata: {
+            mcp_recovery: {
+              ...task().metadata?.mcp_recovery,
+              code: 'rollout_changed',
+              action: 'retry_next_turn',
+            },
+          },
+        }),
+        notice(),
+        now
+      )
+    ).toBe('manual_next_turn');
+  });
+
+  it('requires durable settlement evidence when a request id is absent', () => {
+    const requestless = notice({ recovery_request_id: undefined });
+    const succeeded = { ...requestless, oauth_succeeded_at: new Date(now).toISOString() };
+    expect(
+      mcpSlackRecoveryRenderedState(
+        task({ metadata: { mcp_recovery_generation: 4 } }),
+        succeeded,
+        now
+      )
+    ).toBe('sign_in_pending');
+    expect(
+      mcpSlackRecoveryRenderedState(
+        task({
+          metadata: {
+            mcp_recovery_generation: 4,
+            mcp_recovery_settled_at: new Date(now).toISOString(),
+          },
+        }),
+        succeeded,
+        now
+      )
+    ).toBe('recovered');
+  });
+
+  it('renders provider success after authority drift as superseded, never failed', () => {
+    expect(
+      mcpSlackRecoveryRenderedState(
+        task(),
+        notice({ oauth_superseded_at: new Date(now).toISOString() }),
+        now
+      )
+    ).toBe('expired_or_superseded');
+  });
+
+  it('never schedules terminal or already-expired expiry notices', () => {
+    expect(mcpSlackRecoveryExpiryDelay('expired_or_superseded', notice(), now)).toBeUndefined();
+    expect(mcpSlackRecoveryExpiryDelay('failed', notice(), now)).toBeUndefined();
+    expect(
+      mcpSlackRecoveryExpiryDelay('reconnect_required', notice(), Date.parse(expiresAt))
+    ).toBeUndefined();
+    expect(mcpSlackRecoveryExpiryDelay('reconnect_required', notice(), now)).toBe(601_000);
+  });
+
+  it('creates no process timer for terminal or expired notices', () => {
+    vi.useFakeTimers();
+    try {
+      const service = new GatewayService({ run: vi.fn() } as never, {} as never);
+      const schedule = (
+        service as unknown as {
+          scheduleMcpSlackRecoveryExpiry(
+            taskId: string,
+            value: MCPSlackRecoveryNotice,
+            state: 'expired_or_superseded' | 'reconnect_required'
+          ): void;
+        }
+      ).scheduleMcpSlackRecoveryExpiry.bind(service);
+      schedule('task-1', notice(), 'expired_or_superseded');
+      schedule(
+        'task-1',
+        notice({ expires_at: new Date(now - 1).toISOString() }),
+        'reconnect_required'
+      );
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('guards global task events before recovery synchronization', () => {
+    expect(taskMayNeedMcpSlackRecoverySync({ task_id: 'ordinary' })).toBe(false);
+    expect(taskMayNeedMcpSlackRecoverySync(task())).toBe(false);
+    expect(
+      taskMayNeedMcpSlackRecoverySync({
+        ...task(),
+        metadata: {
+          ...task().metadata,
+          gateway_task_source: { channel_type: 'slack' },
+        },
+      })
+    ).toBe(true);
+    expect(
+      taskMayNeedMcpSlackRecoverySync({
+        metadata: { mcp_slack_recovery_notice: notice() },
+      })
+    ).toBe(true);
+  });
+
+  it('distinguishes known-not-started from ambiguous calls and never offers automatic replay', () => {
+    const known = mcpSlackRecoveryMessageCopy('recovered', 'not_started').text;
+    const ambiguous = mcpSlackRecoveryMessageCopy('recovered', 'ambiguous').text;
+    expect(known).toMatch(/explicitly ask.*retry/i);
+    expect(ambiguous).toMatch(/may have started.*not replayed/i);
+    for (const state of [
+      'reconnect_required',
+      'sign_in_pending',
+      'recovered',
+      'expired_or_superseded',
+      'failed',
+      'manual_next_turn',
+    ] as const) {
+      const copy = mcpSlackRecoveryMessageCopy(state, 'ambiguous').text;
+      expect(copy).not.toMatch(/automatically retr(y|ied)|provider error|access[_ -]?token/i);
+    }
+  });
+});
+
+describe('Slack MCP recovery durable delivery', () => {
+  function deliveryHarness(sendMessage: ReturnType<typeof vi.fn>) {
+    let currentTask = task({
+      metadata: {
+        ...task().metadata,
+        mcp_slack_recovery_notice: notice({
+          expires_at: new Date(now - 1).toISOString(),
+          next_repair_at: new Date(now).toISOString(),
+        }),
+      },
+    });
+    const service = new GatewayService({ run: vi.fn() } as never, {} as never);
+    const findMessageByMetadata = vi.fn(async () => '1700000000.000002');
+    const connector = { channelType: 'slack' as const, findMessageByMetadata, sendMessage };
+    const mutateMCPSlackRecoveryNotice = vi.fn(
+      async (
+        _taskId: string,
+        build: (
+          current: MCPSlackRecoveryNotice | undefined,
+          locked: Task
+        ) => MCPSlackRecoveryNotice | null | Promise<MCPSlackRecoveryNotice | null>
+      ) => {
+        const next = await build(currentTask.metadata?.mcp_slack_recovery_notice, currentTask);
+        if (!next) return { task: currentTask, changed: false };
+        currentTask = {
+          ...currentTask,
+          metadata: { ...currentTask.metadata, mcp_slack_recovery_notice: next },
+        };
+        return { task: currentTask, changed: true };
+      }
+    );
+    Object.assign(service as unknown as Record<string, unknown>, {
+      taskRepo: { mutateMCPSlackRecoveryNotice },
+      channelRepo: {
+        findById: vi.fn(async () => ({
+          id: 'gateway-1',
+          enabled: true,
+          channel_type: 'slack',
+          provider_config_generation: 1,
+          config: { bot_token: 'redacted', allowed_channel_ids: ['C1'] },
+        })),
+      },
+      activeListeners: new Map([['tenant-a\0gateway-1', connector]]),
+    });
+    const deliver = () =>
+      runWithTenantContext('tenant-a', () =>
+        (
+          service as unknown as { deliverMcpSlackRecoveryNotice(value: Task): Promise<void> }
+        ).deliverMcpSlackRecoveryNotice(currentTask)
+      );
+    return {
+      service,
+      deliver,
+      findMessageByMetadata,
+      current: () => currentTask.metadata?.mcp_slack_recovery_notice,
+    };
+  }
+
+  it('reconciles a crash-after-send claim before posting again', async () => {
+    const sendMessage = vi.fn(async (request: { metadata?: Record<string, unknown> }) => {
+      expect(request.metadata).toMatchObject({ slack_update_ts: '1700000000.000002' });
+      expect(request.metadata).not.toHaveProperty('slack_message_metadata');
+      return '1700000000.000002';
+    });
+    const harness = deliveryHarness(sendMessage);
+
+    await harness.deliver();
+
+    expect(harness.findMessageByMetadata).toHaveBeenCalledOnce();
+    expect(sendMessage).toHaveBeenCalledOnce();
+    expect(harness.current()).toMatchObject({
+      slack_message_ts: '1700000000.000002',
+      rendered_state: 'expired_or_superseded',
+    });
+    expect(harness.current()?.next_repair_at).toBeUndefined();
+  });
+
+  it('retries a terminal projection within a durable window after browser expiry', async () => {
+    const harness = deliveryHarness(vi.fn(async () => Promise.reject(new Error('provider'))));
+
+    await harness.deliver();
+
+    expect(harness.current()).toMatchObject({
+      delivery_attempt_count: 1,
+      delivery_last_failed_at: expect.any(String),
+      delivery_next_retry_at: expect.any(String),
+      delivery_retry_until: expect.any(String),
+      next_repair_at: expect.any(String),
+    });
+    await harness.service.stopListeners();
+  });
+});

--- a/apps/agor-daemon/src/services/gateway.test.ts
+++ b/apps/agor-daemon/src/services/gateway.test.ts
@@ -952,6 +952,12 @@ describe('GatewayService multi-tenant process state', () => {
     );
     const channelRepo = { findAll: vi.fn(async () => [channel]) };
     (service as unknown as { channelRepo: typeof channelRepo }).channelRepo = channelRepo;
+    const findMcpSlackRecoveryNoticePage = vi.fn(async () => ({ tasks: [] }));
+    (
+      service as unknown as {
+        taskRepo: { findMcpSlackRecoveryNoticePage: typeof findMcpSlackRecoveryNoticePage };
+      }
+    ).taskRepo = { findMcpSlackRecoveryNoticePage };
     const startListening = vi.fn(async () => undefined);
     vi.mocked(getConnector).mockReturnValue({
       startListening,
@@ -959,6 +965,7 @@ describe('GatewayService multi-tenant process state', () => {
     });
 
     await runWithTenantContext('static-tenant', () => service.startListeners());
+    await vi.waitFor(() => expect(findMcpSlackRecoveryNoticePage).toHaveBeenCalledOnce());
 
     expect(channelRepo.findAll).toHaveBeenCalledOnce();
     expect(startListening).toHaveBeenCalledOnce();
@@ -968,6 +975,10 @@ describe('GatewayService multi-tenant process state', () => {
     expect([
       ...(service as unknown as { activeListeners: Map<string, unknown> }).activeListeners.keys(),
     ]).toEqual(['static-tenant\0static-channel']);
+    expect(findMcpSlackRecoveryNoticePage).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 50, now: expect.any(Date), horizon: expect.any(Date) })
+    );
+    await service.stopListeners();
   });
 
   it('fails closed on a discovered tenant mismatch while continuing other tenants', async () => {

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -6,6 +6,7 @@
  * since it orchestrates across multiple repositories and services.
  */
 
+import { randomUUID } from 'node:crypto';
 import { materializeAgenticToolConfiguration } from '@agor/agentic-tools/config';
 import { getBaseUrl, resolveExecutionSecurityMode } from '@agor/core/config';
 import {
@@ -27,6 +28,7 @@ import {
   generateId,
   getCurrentTenantId,
   getHiddenTenantId,
+  getMCPEgressGatewayMode,
   isDatabaseUniqueConstraintError,
   isPostgresDatabase,
   MCPServerRepository,
@@ -36,6 +38,7 @@ import {
   runWithSystemDatabaseScope,
   runWithTenantContext,
   runWithTenantDatabaseScope,
+  SessionMCPServerRepository,
   SessionRepository,
   shortId,
   TaskRepository,
@@ -66,10 +69,12 @@ import {
   gatewayListenerFailure,
   getConnector,
   hasConnector,
+  isSlackWriteTargetAllowed,
   normalizeOutbound,
   normalizeSendReceipt,
   parseDiscordAuthorityMetadata,
   parseGitHubThreadId,
+  parseSlackThreadId,
 } from '@agor/core/gateway';
 import { resolveSessionMcpServerIds } from '@agor/core/sessions';
 import type {
@@ -81,7 +86,10 @@ import type {
   GatewayOutboundMessage,
   GatewayOutboundMessageID,
   GatewayOutboundReplyAdmission,
+  MCPOAuthAttemptID,
   MCPServerID,
+  MCPSlackRecoveryNotice,
+  MCPSlackRecoveryRenderedState,
   Message,
   MessageSource,
   Session,
@@ -99,11 +107,12 @@ import {
   isDiscordSnowflake,
   ROLES,
   SessionStatus,
+  TaskStatus,
   USER_DEFAULT_AGENTIC_CONFIGURATION,
   validateDiscordConfig,
 } from '@agor/core/types';
 import { assertExecutionHomeKeySatisfiesMode } from '@agor/core/unix';
-import { getSessionUrl } from '@agor/core/utils/url';
+import { getMcpSlackRecoveryUrl, getSessionUrl } from '@agor/core/utils/url';
 import { gatewayAgenticConfigToInlineConfiguration } from '../utils/agentic-configuration-sources.js';
 import { requireActiveAgenticTool } from '../utils/agentic-tool-runtime.js';
 import { hasBranchPermission, sessionPromptDeniedMessage } from '../utils/branch-authorization.js';
@@ -113,6 +122,8 @@ import {
   ingestInboundAttachments,
 } from '../utils/gateway-attachments.js';
 import { fetchGatewayCatchUp, GatewayCatchUpError } from '../utils/gateway-catch-up.js';
+import { isMcpRuntimeRecoveryEnabled } from '../utils/mcp-runtime-hints.js';
+import { issueMCPSlackRecoveryToken } from '../utils/mcp-slack-recovery-token.js';
 import { deferWithTenantContext } from '../utils/tenant-db-scope.js';
 import { isMCPOAuthGrantAuthorizedForServer } from './mcp-oauth-grant-authority.js';
 import type { SessionParams } from './sessions.js';
@@ -183,6 +194,14 @@ const GATEWAY_EVENT_PROCESSING_LEASE_MS = 2 * 60_000;
 const GATEWAY_LISTENER_STOP_TIMEOUT_MS = 5_000;
 const GATEWAY_LISTENER_RETRY_BASE_MS = 5_000;
 const GATEWAY_LISTENER_RETRY_MAX_MS = 5 * 60_000;
+const MCP_SLACK_REPAIR_BATCH = 50;
+const MCP_SLACK_REPAIR_HORIZON_MS = 24 * 60 * 60_000;
+const MCP_SLACK_SWEEP_INTERVAL_MS = 30_000;
+const MCP_SLACK_SWEEP_TENANT_BUDGET = 10;
+const MCP_SLACK_ACTIVE_BACKSTOP_MS = 60_000;
+const MCP_SLACK_DELIVERY_RETRY_WINDOW_MS = 15 * 60_000;
+const MCP_SLACK_DELIVERY_MAX_ATTEMPTS = 6;
+const MCP_SLACK_DELIVERY_BACKOFF_MS = [5_000, 15_000, 30_000, 60_000, 120_000, 300_000] as const;
 
 async function withGatewayTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
   let timer: NodeJS.Timeout | undefined;
@@ -838,6 +857,115 @@ function buildGatewayContext(channel: GatewayChannel, data: PostMessageData): Ga
 /**
  * Gateway routing service
  */
+export function mcpSlackRecoveryRenderedState(
+  task: Task,
+  notice: MCPSlackRecoveryNotice,
+  now = Date.now()
+): MCPSlackRecoveryRenderedState {
+  const recovery = task.metadata?.mcp_recovery;
+  const settledAt = task.metadata?.mcp_recovery_settled_at;
+  const settledGeneration = task.metadata?.mcp_recovery_generation ?? 0;
+  const exactRequestSettled = notice.recovery_request_id
+    ? task.metadata?.mcp_recovery_settled_request_id === notice.recovery_request_id
+    : !!settledAt && settledGeneration >= notice.recovery_generation;
+  const settled =
+    !!settledAt && settledGeneration >= notice.recovery_generation && exactRequestSettled;
+  if (
+    [TaskStatus.COMPLETED, TaskStatus.FAILED, TaskStatus.STOPPED, TaskStatus.TIMED_OUT].includes(
+      task.status as never
+    )
+  ) {
+    return notice.oauth_succeeded_at && settled ? 'recovered' : 'expired_or_superseded';
+  }
+  if (notice.oauth_succeeded_at && !recovery) {
+    return settled ? 'recovered' : 'sign_in_pending';
+  }
+  if (!notice.oauth_succeeded_at && new Date(notice.expires_at).getTime() <= now) {
+    return 'expired_or_superseded';
+  }
+  if (notice.binding_invalidated_at) return 'expired_or_superseded';
+  if (notice.oauth_superseded_at) return 'expired_or_superseded';
+  if (notice.recovery_disabled_at) return 'manual_next_turn';
+  if (recovery?.action === 'retry_next_turn' || recovery?.code === 'rollout_changed') {
+    return 'manual_next_turn';
+  }
+  if (recovery && recovery.generation > notice.recovery_generation && !notice.oauth_succeeded_at) {
+    return 'expired_or_superseded';
+  }
+  if (
+    !notice.oauth_succeeded_at &&
+    (!recovery ||
+      recovery.mcp_server_id !== notice.mcp_server_id ||
+      recovery.generation !== notice.recovery_generation ||
+      recovery.request_id !== notice.recovery_request_id)
+  ) {
+    return 'expired_or_superseded';
+  }
+  if (notice.oauth_failed_at || recovery?.status === 'failed') return 'failed';
+  if (notice.oauth_started_at || notice.oauth_succeeded_at) return 'sign_in_pending';
+  return 'reconnect_required';
+}
+
+export function mcpSlackRecoveryExpiryDelay(
+  state: MCPSlackRecoveryRenderedState,
+  notice: MCPSlackRecoveryNotice,
+  now = Date.now()
+): number | undefined {
+  if (state !== 'reconnect_required' && state !== 'sign_in_pending') return undefined;
+  const expiresAt = new Date(notice.expires_at).getTime();
+  if (!Number.isFinite(expiresAt) || expiresAt <= now) return undefined;
+  return expiresAt - now + 1_000;
+}
+
+export function taskMayNeedMcpSlackRecoverySync(task: unknown): boolean {
+  if (!task || typeof task !== 'object') return false;
+  const metadata = (task as { metadata?: Task['metadata'] }).metadata;
+  return !!(
+    metadata?.mcp_slack_recovery_notice ||
+    (metadata?.gateway_task_source?.channel_type === 'slack' &&
+      metadata.mcp_recovery?.code === 'oauth_reauth_required')
+  );
+}
+
+export function mcpSlackRecoveryMessageCopy(
+  state: MCPSlackRecoveryRenderedState,
+  dispatch: MCPSlackRecoveryNotice['provider_dispatch']
+): { text: string; button?: string } {
+  switch (state) {
+    case 'reconnect_required':
+      return {
+        text:
+          dispatch === 'ambiguous'
+            ? 'MCP sign-in is required. The interrupted provider call may have started, so Agor will not replay it automatically.'
+            : 'MCP sign-in is required. Agor will not replay the interrupted call automatically.',
+        button: 'Reconnect MCP',
+      };
+    case 'sign_in_pending':
+      return {
+        text: 'MCP sign-in was opened and recovery is pending. You can return to Slack while Agor verifies the connection.',
+      };
+    case 'recovered':
+      return {
+        text:
+          dispatch === 'ambiguous'
+            ? 'MCP is reconnected for later calls. The interrupted call may have started and was not replayed. Tell the assistant what to do next.'
+            : 'MCP is reconnected. The interrupted call was not replayed; explicitly ask the assistant to retry if you still want it.',
+      };
+    case 'manual_next_turn':
+      return {
+        text: 'MCP authority is current, but this provider can apply it only on the next turn. Conversation history is preserved; send a new Slack message to continue.',
+      };
+    case 'expired_or_superseded':
+      return {
+        text: 'This MCP reconnect action expired or was superseded. Send a new Slack message if recovery is still needed.',
+      };
+    case 'failed':
+      return {
+        text: 'MCP recovery could not be completed. No provider call was replayed. Try again from a new Slack turn or contact an administrator.',
+      };
+  }
+}
+
 export class GatewayService {
   private channelRepo: GatewayChannelRepository;
   private threadMapRepo: ThreadSessionMapRepository;
@@ -852,6 +980,7 @@ export class GatewayService {
 
   private mcpServerRepo: MCPServerRepository;
   private userTokenRepo: UserMCPOAuthTokenRepository;
+  private sessionMcpRepo: SessionMCPServerRepository;
   private db: TenantScopeAwareDatabase;
   private app: Application;
   private appRbacEnabled: boolean;
@@ -905,6 +1034,13 @@ export class GatewayService {
   private slackStreamedMessageIds = new Set<string>();
   private slackStreamedTaskIds = new Set<string>();
   private slackStreamTaskByMessage = new Map<string, string>();
+  private mcpSlackRecoveryExpiryTimers = new Map<string, NodeJS.Timeout>();
+  private mcpSlackDeliveryRetryTimers = new Map<string, NodeJS.Timeout>();
+  private mcpSlackOAuthStartClaimTimers = new Map<string, NodeJS.Timeout>();
+  private mcpSlackRepairTenants = new Set<string>();
+  private mcpSlackRecoveryTenants = new Set<string>();
+  private mcpSlackSweepTimer: NodeJS.Timeout | null = null;
+  private mcpSlackSweepCursor = 0;
   private static SLACK_PROGRESS_MIN_UPDATE_MS = 2500;
   private static SLACK_STREAM_STATUS_REFRESH_MS = 300;
   private static SLACK_STREAMED_MESSAGE_CACHE_MAX = 500;
@@ -940,6 +1076,7 @@ export class GatewayService {
 
     this.mcpServerRepo = bindRepositoryToTenantUnitOfWork(db, new MCPServerRepository(db));
     this.userTokenRepo = bindRepositoryToTenantUnitOfWork(db, new UserMCPOAuthTokenRepository(db));
+    this.sessionMcpRepo = bindRepositoryToTenantUnitOfWork(db, new SessionMCPServerRepository(db));
     this.db = db;
     this.app = app;
     this.appRbacEnabled = options.appRbacEnabled ?? resolveExecutionSecurityMode().appRbacEnabled;
@@ -1018,6 +1155,58 @@ export class GatewayService {
     console.log(
       `[gateway] refreshChannelState: tenant=${tenantId} found ${channels.length} channels, ${channels.filter((ch) => ch.enabled).length} enabled`
     );
+    // Bounded restart/lost-event repair. Never scan a tenant wholesale and
+    // never hold a database transaction while Slack is called.
+    if (channels.some((channel) => channel.enabled && channel.channel_type === 'slack')) {
+      this.mcpSlackRecoveryTenants.add(tenantId);
+      this.scheduleMcpSlackRecoveryRepair(tenantId);
+      this.ensureMcpSlackPeriodicSweep();
+    } else {
+      this.mcpSlackRecoveryTenants.delete(tenantId);
+    }
+  }
+
+  private scheduleMcpSlackRecoveryRepair(tenantId: string): void {
+    if (this.mcpSlackRepairTenants.has(tenantId)) return;
+    this.mcpSlackRepairTenants.add(tenantId);
+    setTimeout(() => {
+      if (this.listenerStopped) {
+        this.mcpSlackRepairTenants.delete(tenantId);
+        return;
+      }
+      void runWithTenantContext(tenantId, async () => {
+        const now = new Date();
+        const page = await this.taskRepo.findMcpSlackRecoveryNoticePage({
+          limit: MCP_SLACK_REPAIR_BATCH,
+          now,
+          horizon: new Date(now.getTime() - MCP_SLACK_REPAIR_HORIZON_MS),
+        });
+        for (const task of page.tasks) {
+          await this.syncMcpSlackRecoveryNotice(task.task_id).catch(() => undefined);
+        }
+      })
+        .catch(() => console.warn('[gateway] MCP Slack recovery bounded repair failed'))
+        .finally(() => this.mcpSlackRepairTenants.delete(tenantId));
+    }, 0).unref?.();
+  }
+
+  private ensureMcpSlackPeriodicSweep(): void {
+    if (this.listenerStopped || this.mcpSlackSweepTimer) return;
+    this.mcpSlackSweepTimer = setTimeout(() => {
+      this.mcpSlackSweepTimer = null;
+      if (this.listenerStopped) return;
+      const tenants = [...this.mcpSlackRecoveryTenants].sort();
+      if (tenants.length > 0) {
+        const count = Math.min(MCP_SLACK_SWEEP_TENANT_BUDGET, tenants.length);
+        for (let index = 0; index < count; index += 1) {
+          const tenant = tenants[(this.mcpSlackSweepCursor + index) % tenants.length];
+          if (tenant) this.scheduleMcpSlackRecoveryRepair(tenant);
+        }
+        this.mcpSlackSweepCursor = (this.mcpSlackSweepCursor + count) % tenants.length;
+      }
+      this.ensureMcpSlackPeriodicSweep();
+    }, MCP_SLACK_SWEEP_INTERVAL_MS);
+    this.mcpSlackSweepTimer.unref?.();
   }
 
   /**
@@ -1088,6 +1277,726 @@ export class GatewayService {
     } catch (error) {
       console.warn('[gateway] Failed to post prompt authorization denial:', error);
     }
+  }
+
+  private recoveryEnvelopeSecret(): string | null {
+    const secret = process.env.AGOR_MASTER_SECRET;
+    return typeof secret === 'string' && secret.length > 0 ? secret : null;
+  }
+
+  private async mcpSlackRecoveryUrl(
+    tenantId: string,
+    notice: MCPSlackRecoveryNotice
+  ): Promise<string | undefined> {
+    const secret = this.recoveryEnvelopeSecret();
+    if (!secret || notice.token_consumed_at) return undefined;
+    const token = issueMCPSlackRecoveryToken(
+      {
+        type: 'mcp-slack-recovery',
+        tid: tenantId,
+        sub: notice.principal_user_id,
+        credential_user_id: notice.credential_user_id,
+        slack_user_id: notice.slack_user_id,
+        slack_team_id: notice.slack_team_id,
+        gateway_channel_id: notice.gateway_channel_id,
+        gateway_config_generation: notice.gateway_config_generation,
+        slack_channel_id: notice.slack_channel_id,
+        slack_thread_id: notice.slack_thread_id,
+        task_id: notice.task_id,
+        session_id: notice.session_id,
+        mcp_server_id: notice.mcp_server_id,
+        mcp_server_config_version: notice.mcp_server_config_version,
+        recovery_generation: notice.recovery_generation,
+        recovery_request_id: notice.recovery_request_id,
+        notice_id: notice.notice_id,
+        jti: notice.token_jti,
+        expiresAt: new Date(notice.expires_at),
+      },
+      secret,
+      new Date(notice.issued_at)
+    );
+    const page = getMcpSlackRecoveryUrl(await getBaseUrl());
+    return `${page}#token=${encodeURIComponent(token)}`;
+  }
+
+  private mcpSlackNextActiveRepairAt(
+    state: MCPSlackRecoveryRenderedState,
+    notice: MCPSlackRecoveryNotice,
+    now = Date.now()
+  ): string | undefined {
+    if (state !== 'reconnect_required' && state !== 'sign_in_pending') return undefined;
+    const expiryDelay = mcpSlackRecoveryExpiryDelay(state, notice, now);
+    return new Date(
+      now + Math.min(expiryDelay ?? MCP_SLACK_ACTIVE_BACKSTOP_MS, MCP_SLACK_ACTIVE_BACKSTOP_MS)
+    ).toISOString();
+  }
+
+  private mcpSlackFailedDeliveryNotice(
+    notice: MCPSlackRecoveryNotice,
+    now = new Date()
+  ): MCPSlackRecoveryNotice {
+    const attempt = (notice.delivery_attempt_count ?? 0) + 1;
+    const retryUntil = notice.delivery_retry_until
+      ? new Date(notice.delivery_retry_until)
+      : new Date(now.getTime() + MCP_SLACK_DELIVERY_RETRY_WINDOW_MS);
+    const backoff =
+      MCP_SLACK_DELIVERY_BACKOFF_MS[
+        Math.min(attempt - 1, MCP_SLACK_DELIVERY_BACKOFF_MS.length - 1)
+      ]!;
+    const next = new Date(now.getTime() + backoff);
+    const canRetry =
+      attempt < MCP_SLACK_DELIVERY_MAX_ATTEMPTS &&
+      Number.isFinite(retryUntil.getTime()) &&
+      next.getTime() <= retryUntil.getTime();
+    return {
+      ...notice,
+      delivery_claim: undefined,
+      delivery_attempt_count: attempt,
+      delivery_last_failed_at: now.toISOString(),
+      delivery_retry_until: retryUntil.toISOString(),
+      delivery_next_retry_at: canRetry ? next.toISOString() : undefined,
+      next_repair_at: canRetry ? next.toISOString() : undefined,
+    };
+  }
+
+  private async recordMcpSlackDeliveryFailure(
+    taskId: string,
+    noticeId: string,
+    claimId: string
+  ): Promise<void> {
+    const failed = await this.taskRepo
+      .mutateMCPSlackRecoveryNotice(taskId, (current) =>
+        current?.notice_id === noticeId && current.delivery_claim?.claim_id === claimId
+          ? this.mcpSlackFailedDeliveryNotice(current)
+          : null
+      )
+      .catch(() => undefined);
+    console.warn('[gateway] MCP recovery Slack delivery failed');
+    const failedNotice = failed?.task.metadata?.mcp_slack_recovery_notice;
+    if (failed?.changed && failedNotice?.delivery_next_retry_at) {
+      this.scheduleMcpSlackDeliveryRetry(
+        taskId,
+        noticeId,
+        Math.max(100, new Date(failedNotice.delivery_next_retry_at).getTime() - Date.now())
+      );
+    }
+  }
+
+  private async deliverMcpSlackRecoveryNotice(task: Task): Promise<void> {
+    const initial = task.metadata?.mcp_slack_recovery_notice;
+    if (!initial) return;
+    const state = mcpSlackRecoveryRenderedState(task, initial);
+    this.scheduleMcpSlackRecoveryExpiry(task.task_id, initial, state);
+    if (initial.slack_message_ts && initial.rendered_state === state) {
+      const nextRepairAt = this.mcpSlackNextActiveRepairAt(state, initial);
+      if (initial.next_repair_at !== nextRepairAt) {
+        await this.taskRepo.mutateMCPSlackRecoveryNotice(task.task_id, (current) =>
+          current?.notice_id === initial.notice_id && current.rendered_state === state
+            ? { ...current, next_repair_at: nextRepairAt }
+            : null
+        );
+      }
+      return;
+    }
+    const claimId = randomUUID();
+    const now = new Date();
+    const claimExpiresAt = new Date(now.getTime() + 30_000).toISOString();
+    const claimed = await this.taskRepo.mutateMCPSlackRecoveryNotice(task.task_id, (current) => {
+      if (!current || current.notice_id !== initial.notice_id) return null;
+      if (current.slack_message_ts && current.rendered_state === state) return null;
+      if (
+        current.delivery_claim &&
+        new Date(current.delivery_claim.expires_at).getTime() > now.getTime()
+      ) {
+        return null;
+      }
+      return {
+        ...current,
+        delivery_claim: {
+          claim_id: claimId,
+          claimed_at: now.toISOString(),
+          expires_at: claimExpiresAt,
+        },
+        next_repair_at: claimExpiresAt,
+      };
+    });
+    const notice = claimed.task.metadata?.mcp_slack_recovery_notice;
+    if (!claimed.changed || notice?.delivery_claim?.claim_id !== claimId) {
+      if (
+        notice?.notice_id === initial.notice_id &&
+        notice.delivery_claim &&
+        new Date(notice.delivery_claim.expires_at).getTime() > Date.now()
+      ) {
+        this.scheduleMcpSlackDeliveryRetry(
+          task.task_id,
+          notice.notice_id,
+          Math.max(100, new Date(notice.delivery_claim.expires_at).getTime() - Date.now() + 100)
+        );
+      }
+      return;
+    }
+
+    let parsedThread: ReturnType<typeof parseSlackThreadId>;
+    try {
+      parsedThread = parseSlackThreadId(notice.slack_thread_id);
+    } catch {
+      parsedThread = { channel: '', thread_ts: '' };
+    }
+    const channel = await this.channelRepo.findById(notice.gateway_channel_id);
+    if (!channel?.enabled || channel.channel_type !== 'slack') {
+      await this.taskRepo.mutateMCPSlackRecoveryNotice(task.task_id, (current) =>
+        current?.notice_id === notice.notice_id && current.delivery_claim?.claim_id === claimId
+          ? { ...current, delivery_claim: undefined, next_repair_at: undefined }
+          : null
+      );
+      return;
+    }
+    if (
+      parsedThread.channel !== notice.slack_channel_id ||
+      !isSlackWriteTargetAllowed(channel.config, parsedThread.channel)
+    ) {
+      await this.taskRepo.mutateMCPSlackRecoveryNotice(task.task_id, (current) =>
+        current?.notice_id === notice.notice_id && current.delivery_claim?.claim_id === claimId
+          ? {
+              ...current,
+              delivery_claim: undefined,
+              binding_invalidated_at: current.binding_invalidated_at ?? new Date().toISOString(),
+              next_repair_at: undefined,
+            }
+          : null
+      );
+      return;
+    }
+    // A generation mismatch must never reuse the process-local listener: its
+    // connector can still carry the pre-mutation token while listener restart
+    // is draining. Verify and deliver only with freshly loaded credentials.
+    let connector: GatewayConnector;
+    try {
+      connector =
+        channel.provider_config_generation !== notice.gateway_config_generation
+          ? getConnector('slack', channel.config)
+          : (this.getActiveListener(channel.id) ?? getConnector('slack', channel.config));
+    } catch {
+      await this.recordMcpSlackDeliveryFailure(task.task_id, notice.notice_id, claimId);
+      return;
+    }
+    if (channel.provider_config_generation !== notice.gateway_config_generation) {
+      let currentApp: Awaited<ReturnType<NonNullable<GatewayConnector['getAppInfo']>>> | undefined;
+      try {
+        currentApp = connector.getAppInfo ? await connector.getAppInfo() : undefined;
+      } catch {
+        await this.recordMcpSlackDeliveryFailure(task.task_id, notice.notice_id, claimId);
+        return;
+      }
+      if (
+        currentApp?.teamId !== notice.slack_team_id ||
+        !isSlackWriteTargetAllowed(channel.config, parsedThread.channel)
+      ) {
+        await this.taskRepo.mutateMCPSlackRecoveryNotice(task.task_id, (current) =>
+          current?.notice_id === notice.notice_id && current.delivery_claim?.claim_id === claimId
+            ? { ...current, delivery_claim: undefined, next_repair_at: undefined }
+            : null
+        );
+        return;
+      }
+      if (!notice.binding_invalidated_at) {
+        const invalidated = await this.taskRepo.mutateMCPSlackRecoveryNotice(
+          task.task_id,
+          (current) =>
+            current?.notice_id === notice.notice_id &&
+            current.delivery_claim?.claim_id === claimId &&
+            !current.binding_invalidated_at
+              ? {
+                  ...current,
+                  delivery_claim: undefined,
+                  binding_invalidated_at: new Date().toISOString(),
+                  next_repair_at: new Date().toISOString(),
+                }
+              : null
+        );
+        if (invalidated.changed) await this.deliverMcpSlackRecoveryNotice(invalidated.task);
+        return;
+      }
+    }
+    const copy = mcpSlackRecoveryMessageCopy(state, notice.provider_dispatch);
+    const url =
+      state === 'reconnect_required'
+        ? await this.mcpSlackRecoveryUrl(requireCurrentTenantId(), notice)
+        : undefined;
+    const blocks: unknown[] = [
+      {
+        type: 'section',
+        text: { type: 'mrkdwn', text: `*MCP recovery*\n${copy.text}` },
+      },
+      ...(url && copy.button
+        ? [
+            {
+              type: 'actions',
+              elements: [
+                {
+                  type: 'button',
+                  text: { type: 'plain_text', text: copy.button },
+                  url,
+                  // Slack requires action_id even for URL buttons. Agor does
+                  // not treat this as an interactive callback or auth input.
+                  action_id: 'agor_mcp_reconnect_link',
+                  accessibility_label: 'Reconnect MCP in Agor',
+                },
+              ],
+            },
+          ]
+        : []),
+      { type: 'context', elements: [{ type: 'mrkdwn', text: 'Return here after using Agor.' }] },
+    ];
+    try {
+      let reconciledMessageTs = notice.slack_message_ts;
+      if (!reconciledMessageTs && connector.findMessageByMetadata) {
+        reconciledMessageTs = await connector
+          .findMessageByMetadata({
+            threadId: notice.slack_thread_id,
+            eventType: 'agor_mcp_recovery',
+            payloadKey: 'delivery_id',
+            payloadValue: notice.delivery_id,
+            limit: 100,
+          })
+          .catch(() => undefined);
+      }
+      const sent = await connector.sendMessage({
+        threadId: notice.slack_thread_id,
+        text: copy.text,
+        blocks,
+        metadata: {
+          ...(reconciledMessageTs ? { slack_update_ts: reconciledMessageTs } : {}),
+          ...(!reconciledMessageTs
+            ? {
+                slack_message_metadata: {
+                  event_type: 'agor_mcp_recovery',
+                  event_payload: { delivery_id: notice.delivery_id },
+                },
+              }
+            : {}),
+        },
+      });
+      const receipt = normalizeSendReceipt(sent);
+      const renderedAt = new Date();
+      await this.taskRepo.mutateMCPSlackRecoveryNotice(task.task_id, (current) =>
+        current?.notice_id === notice.notice_id && current.delivery_claim?.claim_id === claimId
+          ? {
+              ...current,
+              slack_message_ts:
+                current.slack_message_ts ?? reconciledMessageTs ?? receipt.messageId,
+              delivery_claim: undefined,
+              rendered_state: state,
+              rendered_at: renderedAt.toISOString(),
+              delivery_next_retry_at: undefined,
+              next_repair_at: this.mcpSlackNextActiveRepairAt(state, current, renderedAt.getTime()),
+            }
+          : null
+      );
+      const retry = this.mcpSlackDeliveryRetryTimers.get(notice.notice_id);
+      if (retry) clearTimeout(retry);
+      this.mcpSlackDeliveryRetryTimers.delete(notice.notice_id);
+    } catch {
+      await this.recordMcpSlackDeliveryFailure(task.task_id, notice.notice_id, claimId);
+    }
+  }
+
+  private scheduleMcpSlackDeliveryRetry(taskId: string, noticeId: string, delay = 5_000): void {
+    if (this.mcpSlackDeliveryRetryTimers.has(noticeId)) return;
+    const tenantId = requireCurrentTenantId();
+    const timer = setTimeout(() => {
+      this.mcpSlackDeliveryRetryTimers.delete(noticeId);
+      void runWithTenantContext(tenantId, async () => {
+        const task = await this.taskRepo.findById(taskId);
+        if (task?.metadata?.mcp_slack_recovery_notice?.notice_id === noticeId) {
+          await this.deliverMcpSlackRecoveryNotice(task);
+        }
+      }).catch(() => console.warn('[gateway] MCP recovery Slack retry failed'));
+    }, delay);
+    timer.unref?.();
+    this.mcpSlackDeliveryRetryTimers.set(noticeId, timer);
+  }
+
+  private scheduleMcpSlackRecoveryExpiry(
+    taskId: string,
+    notice: MCPSlackRecoveryNotice,
+    state: MCPSlackRecoveryRenderedState
+  ): void {
+    const delay = mcpSlackRecoveryExpiryDelay(state, notice);
+    if (delay === undefined) {
+      const existing = this.mcpSlackRecoveryExpiryTimers.get(notice.notice_id);
+      if (existing) clearTimeout(existing);
+      this.mcpSlackRecoveryExpiryTimers.delete(notice.notice_id);
+      return;
+    }
+    if (this.mcpSlackRecoveryExpiryTimers.has(notice.notice_id)) return;
+    const tenantId = requireCurrentTenantId();
+    const timer = setTimeout(() => {
+      this.mcpSlackRecoveryExpiryTimers.delete(notice.notice_id);
+      void runWithTenantContext(tenantId, () => this.syncMcpSlackRecoveryNotice(taskId)).catch(() =>
+        console.warn('[gateway] MCP recovery expiry projection failed')
+      );
+    }, delay);
+    timer.unref?.();
+    this.mcpSlackRecoveryExpiryTimers.set(notice.notice_id, timer);
+  }
+
+  private scheduleMcpSlackOAuthStartClaimRepair(
+    taskId: string,
+    notice: MCPSlackRecoveryNotice,
+    retryDelay?: number
+  ): void {
+    if (
+      !notice.oauth_start_claim_expires_at ||
+      notice.oauth_started_at ||
+      notice.oauth_failed_at ||
+      this.mcpSlackOAuthStartClaimTimers.has(notice.notice_id)
+    ) {
+      return;
+    }
+    const tenantId = requireCurrentTenantId();
+    const delay =
+      retryDelay ??
+      Math.max(0, new Date(notice.oauth_start_claim_expires_at).getTime() - Date.now() + 100);
+    const timer = setTimeout(() => {
+      this.mcpSlackOAuthStartClaimTimers.delete(notice.notice_id);
+      void runWithTenantContext(tenantId, () => this.syncMcpSlackRecoveryNotice(taskId)).catch(
+        () => {
+          console.warn('[gateway] MCP recovery OAuth start claim repair failed');
+          runWithTenantContext(tenantId, () =>
+            this.scheduleMcpSlackOAuthStartClaimRepair(taskId, notice, 5_000)
+          );
+        }
+      );
+    }, delay);
+    timer.unref?.();
+    this.mcpSlackOAuthStartClaimTimers.set(notice.notice_id, timer);
+  }
+
+  /** Project authoritative Task recovery into one idempotently editable Slack row. */
+  async syncMcpSlackRecoveryNotice(taskId: string): Promise<void> {
+    const recoveryEnabled = await isMcpRuntimeRecoveryEnabled(this.db);
+    const mode = await getMCPEgressGatewayMode(this.db);
+    const task = await this.taskRepo.findById(taskId);
+    if (!task) return;
+    const recovery = task.metadata?.mcp_recovery;
+    const existing = task.metadata?.mcp_slack_recovery_notice;
+
+    if (
+      existing?.oauth_start_claim_expires_at &&
+      !existing.oauth_started_at &&
+      !existing.oauth_failed_at
+    ) {
+      if (new Date(existing.oauth_start_claim_expires_at).getTime() <= Date.now()) {
+        const orphaned = await this.taskRepo.mutateMCPSlackRecoveryNotice(
+          task.task_id,
+          (current) =>
+            current?.notice_id === existing.notice_id &&
+            current.oauth_attempt_id === existing.oauth_attempt_id &&
+            current.oauth_start_claim_expires_at === existing.oauth_start_claim_expires_at &&
+            !current.oauth_started_at &&
+            !current.oauth_failed_at
+              ? {
+                  ...current,
+                  oauth_failed_at: new Date().toISOString(),
+                  next_repair_at: new Date().toISOString(),
+                }
+              : null
+        );
+        await this.deliverMcpSlackRecoveryNotice(orphaned.changed ? orphaned.task : task);
+        return;
+      }
+      this.scheduleMcpSlackOAuthStartClaimRepair(task.task_id, existing);
+    }
+
+    if (!recoveryEnabled) {
+      if (!existing) return;
+      const disabled = await this.taskRepo.mutateMCPSlackRecoveryNotice(task.task_id, (current) =>
+        current?.notice_id === existing.notice_id && !current.recovery_disabled_at
+          ? {
+              ...current,
+              recovery_disabled_at: new Date().toISOString(),
+              next_repair_at: new Date().toISOString(),
+            }
+          : null
+      );
+      await this.deliverMcpSlackRecoveryNotice(disabled.changed ? disabled.task : task);
+      return;
+    }
+
+    if (
+      recovery?.code === 'oauth_reauth_required' &&
+      recovery.action === 'reauthenticate' &&
+      recovery.status === 'action_required' &&
+      recovery.mcp_server_id &&
+      (mode === 'compatibility' || mode === 'enforced')
+    ) {
+      const source = task.metadata?.gateway_task_source;
+      let sourceThread: ReturnType<typeof parseSlackThreadId> | undefined;
+      try {
+        sourceThread = source?.thread_id ? parseSlackThreadId(source.thread_id) : undefined;
+      } catch {
+        sourceThread = undefined;
+      }
+      const session = await this.sessionRepo.findById(task.session_id);
+      const channel = source ? await this.channelRepo.findById(source.gateway_channel_id) : null;
+      const mapping = session ? await this.threadMapRepo.findBySession(session.session_id) : null;
+      const server = await this.mcpServerRepo.findById(recovery.mcp_server_id);
+      const [principal, credentialUser] = session
+        ? await Promise.all([
+            this.usersRepo.findById(task.created_by),
+            this.usersRepo.findById(session.created_by),
+          ])
+        : [null, null];
+      const attached = session
+        ? (await this.sessionMcpRepo.listServers(session.session_id, true)).some(
+            (candidate) => candidate.mcp_server_id === recovery.mcp_server_id
+          )
+        : false;
+      const existingBindingCurrent =
+        !existing ||
+        (existing.gateway_channel_id === channel?.id &&
+          existing.gateway_config_generation === channel.provider_config_generation &&
+          existing.mcp_server_id === server?.mcp_server_id &&
+          existing.mcp_server_config_version === (server.config_version ?? 1) &&
+          existing.slack_team_id === source?.slack_team_id &&
+          existing.slack_channel_id === source.slack_channel_id &&
+          existing.slack_thread_id === source.thread_id &&
+          existing.slack_user_id === source.provider_user_id);
+      const eligible =
+        source?.channel_type === 'slack' &&
+        !!source.slack_team_id &&
+        !!source.slack_channel_id &&
+        sourceThread?.channel === source.slack_channel_id &&
+        source.provider_user_id !== 'unknown' &&
+        !!session &&
+        session.created_by === task.created_by &&
+        !!principal &&
+        !!credentialUser &&
+        hasMinimumRole(principal.role, ROLES.MEMBER) &&
+        hasMinimumRole(
+          credentialUser.role,
+          server?.auth?.type === 'oauth' && (server.auth.oauth_mode ?? 'per_user') === 'shared'
+            ? ROLES.ADMIN
+            : ROLES.MEMBER
+        ) &&
+        !!channel?.enabled &&
+        channel.channel_type === 'slack' &&
+        isSlackWriteTargetAllowed(channel.config, sourceThread.channel) &&
+        mapping?.channel_id === channel.id &&
+        mapping.thread_id === source.thread_id &&
+        !!server?.enabled &&
+        server.auth?.type === 'oauth' &&
+        attached &&
+        existingBindingCurrent;
+      if (eligible) {
+        const same =
+          existing?.mcp_server_id === recovery.mcp_server_id &&
+          existing.mcp_server_config_version === (server.config_version ?? 1) &&
+          existing.gateway_config_generation === channel.provider_config_generation &&
+          existing.recovery_generation === recovery.generation &&
+          existing.recovery_request_id === recovery.request_id;
+        if (!same) {
+          const issued = new Date(Math.floor(Date.now() / 1_000) * 1_000);
+          const expires = new Date(issued.getTime() + 10 * 60_000);
+          const noticeId = randomUUID();
+          const created = await this.taskRepo.mutateMCPSlackRecoveryNotice(
+            task.task_id,
+            (current, lockedTask) => {
+              const locked = lockedTask.metadata?.mcp_recovery;
+              if (
+                locked?.code !== 'oauth_reauth_required' ||
+                locked.status !== 'action_required' ||
+                locked.mcp_server_id !== recovery.mcp_server_id ||
+                locked.generation !== recovery.generation ||
+                locked.request_id !== recovery.request_id
+              ) {
+                return null;
+              }
+              return {
+                notice_id: noticeId,
+                token_jti: randomUUID(),
+                issued_at: issued.toISOString(),
+                expires_at: expires.toISOString(),
+                principal_user_id: task.created_by as UserID,
+                credential_user_id: session.created_by as UserID,
+                slack_user_id: source.provider_user_id,
+                slack_team_id: source.slack_team_id!,
+                gateway_channel_id: channel.id,
+                gateway_config_generation: channel.provider_config_generation,
+                slack_channel_id: source.slack_channel_id!,
+                slack_thread_id: source.thread_id,
+                session_id: session.session_id,
+                task_id: task.task_id,
+                mcp_server_id: recovery.mcp_server_id!,
+                mcp_server_config_version: server.config_version ?? 1,
+                recovery_generation: recovery.generation,
+                recovery_request_id: recovery.request_id,
+                provider_dispatch: recovery.provider_dispatch,
+                delivery_id: current?.delivery_id ?? randomUUID(),
+                next_repair_at: issued.toISOString(),
+                ...(current?.slack_message_ts
+                  ? { slack_message_ts: current.slack_message_ts }
+                  : {}),
+              };
+            }
+          );
+          if (created.changed) await this.deliverMcpSlackRecoveryNotice(created.task);
+          return;
+        }
+      } else if (
+        existing?.mcp_server_id === recovery.mcp_server_id &&
+        existing.recovery_generation === recovery.generation &&
+        existing.recovery_request_id === recovery.request_id
+      ) {
+        const invalidated = await this.taskRepo.mutateMCPSlackRecoveryNotice(
+          task.task_id,
+          (current) =>
+            current?.notice_id === existing.notice_id && !current.binding_invalidated_at
+              ? {
+                  ...current,
+                  binding_invalidated_at: new Date().toISOString(),
+                  next_repair_at: new Date().toISOString(),
+                }
+              : null
+        );
+        await this.deliverMcpSlackRecoveryNotice(invalidated.changed ? invalidated.task : task);
+        return;
+      }
+    }
+
+    if (!existing) return;
+    // OAuth completion may create a newer structured recovery generation. The
+    // browser token is already consumed, so relink presentation to that exact
+    // request without minting a second action.
+    if (
+      existing.oauth_succeeded_at &&
+      recovery?.mcp_server_id === existing.mcp_server_id &&
+      recovery.generation > existing.recovery_generation
+    ) {
+      const relinked = await this.taskRepo.mutateMCPSlackRecoveryNotice(
+        task.task_id,
+        (current, lockedTask) => {
+          const locked = lockedTask.metadata?.mcp_recovery;
+          return current?.notice_id === existing.notice_id &&
+            current.oauth_succeeded_at &&
+            locked?.mcp_server_id === current.mcp_server_id &&
+            locked.generation > current.recovery_generation
+            ? {
+                ...current,
+                recovery_generation: locked.generation,
+                recovery_request_id: locked.request_id,
+                next_repair_at: new Date().toISOString(),
+              }
+            : null;
+        }
+      );
+      if (relinked.changed) {
+        await this.deliverMcpSlackRecoveryNotice(relinked.task);
+        return;
+      }
+    }
+    await this.deliverMcpSlackRecoveryNotice(task);
+  }
+
+  syncMcpSlackRecoveryNoticeAfterCommit(taskId: string, params?: unknown): void {
+    deferWithTenantContext(
+      params,
+      () => this.syncMcpSlackRecoveryNotice(taskId),
+      () => console.warn('[gateway] MCP recovery notice synchronization failed')
+    );
+  }
+
+  async markMcpSlackOAuthResult(input: {
+    taskId: string;
+    noticeId: string;
+    attemptId: MCPOAuthAttemptID;
+    success: boolean;
+  }): Promise<void> {
+    let authorityCurrent = !input.success;
+    if (input.success) {
+      const task = await this.taskRepo.findById(input.taskId);
+      const notice = task?.metadata?.mcp_slack_recovery_notice;
+      const recovery = task?.metadata?.mcp_recovery;
+      if (task && notice?.notice_id === input.noticeId && recovery) {
+        const [session, channel, mapping, server, principal, credentialUser, mode] =
+          await Promise.all([
+            this.sessionRepo.findById(task.session_id),
+            this.channelRepo.findById(notice.gateway_channel_id),
+            this.threadMapRepo.findBySession(task.session_id),
+            this.mcpServerRepo.findById(notice.mcp_server_id),
+            this.usersRepo.findById(notice.principal_user_id),
+            this.usersRepo.findById(notice.credential_user_id),
+            getMCPEgressGatewayMode(this.db),
+          ]);
+        const attached = (await this.sessionMcpRepo.listServers(task.session_id, true)).some(
+          (candidate) => candidate.mcp_server_id === notice.mcp_server_id
+        );
+        const grantUserId =
+          server?.auth?.type === 'oauth' && (server.auth.oauth_mode ?? 'per_user') === 'shared'
+            ? null
+            : notice.credential_user_id;
+        const grant = server
+          ? await this.userTokenRepo.getToken(grantUserId as UserID | null, notice.mcp_server_id)
+          : null;
+        let parsedThread: ReturnType<typeof parseSlackThreadId> | undefined;
+        try {
+          parsedThread = parseSlackThreadId(notice.slack_thread_id);
+        } catch {
+          parsedThread = undefined;
+        }
+        authorityCurrent = !!(
+          session &&
+          session.session_id === notice.session_id &&
+          session.created_by === notice.credential_user_id &&
+          task.created_by === notice.principal_user_id &&
+          [TaskStatus.RUNNING, TaskStatus.AWAITING_PERMISSION, TaskStatus.AWAITING_INPUT].includes(
+            task.status as never
+          ) &&
+          recovery.code === 'oauth_reauth_required' &&
+          recovery.status === 'action_required' &&
+          recovery.mcp_server_id === notice.mcp_server_id &&
+          recovery.generation === notice.recovery_generation &&
+          recovery.request_id === notice.recovery_request_id &&
+          channel?.enabled &&
+          channel.channel_type === 'slack' &&
+          channel.provider_config_generation === notice.gateway_config_generation &&
+          parsedThread?.channel === notice.slack_channel_id &&
+          isSlackWriteTargetAllowed(channel.config, parsedThread.channel) &&
+          mapping?.channel_id === channel.id &&
+          mapping.thread_id === notice.slack_thread_id &&
+          server?.enabled &&
+          server.auth?.type === 'oauth' &&
+          (server.config_version ?? 1) === notice.mcp_server_config_version &&
+          attached &&
+          principal &&
+          credentialUser &&
+          hasMinimumRole(principal.role, ROLES.MEMBER) &&
+          hasMinimumRole(
+            credentialUser.role,
+            (server.auth.oauth_mode ?? 'per_user') === 'shared' ? ROLES.ADMIN : ROLES.MEMBER
+          ) &&
+          grant &&
+          (await isMCPOAuthGrantAuthorizedForServer(this.db, server, grant)) &&
+          (mode === 'compatibility' || mode === 'enforced')
+        );
+      }
+    }
+    const resultAt = new Date().toISOString();
+    const changed = await this.taskRepo.mutateMCPSlackRecoveryNotice(input.taskId, (current) =>
+      current?.notice_id === input.noticeId && current.oauth_attempt_id === input.attemptId
+        ? {
+            ...current,
+            ...(input.success && authorityCurrent
+              ? { oauth_succeeded_at: resultAt }
+              : input.success
+                ? { oauth_superseded_at: resultAt }
+                : { oauth_failed_at: resultAt }),
+            next_repair_at: resultAt,
+          }
+        : null
+    );
+    if (changed.changed) await this.deliverMcpSlackRecoveryNotice(changed.task);
   }
 
   /**
@@ -3106,6 +4015,7 @@ export class GatewayService {
             metadata?: {
               gateway_inbound_event_id?: import('@agor/core/types').GatewayInboundEventID;
               gateway_reply_metadata?: Record<string, unknown>;
+              gateway_task_source?: import('@agor/core/types').TaskMetadata['gateway_task_source'];
             };
             idempotencyTaskId?: TaskID;
           },
@@ -3336,20 +4246,33 @@ export class GatewayService {
           prompt: promptText,
           permissionMode,
           messageSource: 'gateway',
-          ...(data.gateway_inbound_event_id
-            ? {
-                metadata: {
-                  gateway_inbound_event_id: data.gateway_inbound_event_id,
-                  ...(data.metadata?.processing_comment_id
-                    ? {
-                        gateway_reply_metadata: {
-                          processing_comment_id: data.metadata.processing_comment_id,
-                        },
-                      }
-                    : {}),
-                },
-              }
-            : {}),
+          metadata: {
+            ...(data.gateway_inbound_event_id
+              ? { gateway_inbound_event_id: data.gateway_inbound_event_id }
+              : {}),
+            ...(data.metadata?.processing_comment_id
+              ? {
+                  gateway_reply_metadata: {
+                    processing_comment_id: data.metadata.processing_comment_id,
+                  },
+                }
+              : {}),
+            gateway_task_source: {
+              gateway_channel_id: channel.id,
+              channel_type: channel.channel_type as ChannelType,
+              thread_id: data.thread_id,
+              provider_user_id: data.user_name ?? 'unknown',
+              ...(typeof data.metadata?.slack_message_ts === 'string'
+                ? { provider_message_id: data.metadata.slack_message_ts }
+                : {}),
+              ...(typeof data.metadata?.slack_team_id === 'string'
+                ? { slack_team_id: data.metadata.slack_team_id }
+                : {}),
+              ...(typeof data.metadata?.channel === 'string'
+                ? { slack_channel_id: data.metadata.channel }
+                : {}),
+            },
+          },
           ...(data.idempotency_task_id ? { idempotencyTaskId: data.idempotency_task_id } : {}),
         },
         {
@@ -3859,6 +4782,11 @@ export class GatewayService {
           );
         }
         this.activeChannelTenants.add(ref.tenant_id);
+        if (channel.channel_type === 'slack') {
+          this.mcpSlackRecoveryTenants.add(ref.tenant_id);
+          this.scheduleMcpSlackRecoveryRepair(ref.tenant_id);
+          this.ensureMcpSlackPeriodicSweep();
+        }
         if (!hasConnector(channel.channel_type as ChannelType) || !hasListeningConfig(channel)) {
           return;
         }
@@ -3893,12 +4821,18 @@ export class GatewayService {
       tenantId,
       async (scopedDb) => isPostgresDatabase(scopedDb)
     );
+    const channels = await this.channelRepo.findAll();
+    if (channels.some((channel) => channel.enabled)) this.activeChannelTenants.add(tenantId);
+    if (channels.some((channel) => channel.enabled && channel.channel_type === 'slack')) {
+      this.mcpSlackRecoveryTenants.add(tenantId);
+      this.scheduleMcpSlackRecoveryRepair(tenantId);
+      this.ensureMcpSlackPeriodicSweep();
+    }
     if (this.durableListenerOwnership) {
       this.listenerDiscoveryTenantId = tenantId;
       await this.startListenerWorker();
       return;
     }
-    const channels = await this.channelRepo.findAll();
     if (channels.some((channel) => channel.enabled)) {
       this.activeChannelTenants.add(tenantId);
     } else {
@@ -3973,6 +4907,11 @@ export class GatewayService {
           }
 
           this.activeChannelTenants.add(tenantId);
+          if (channel.channel_type === 'slack') {
+            this.mcpSlackRecoveryTenants.add(tenantId);
+            this.scheduleMcpSlackRecoveryRepair(tenantId);
+            this.ensureMcpSlackPeriodicSweep();
+          }
           if (hasConnector(channel.channel_type as ChannelType) && hasListeningConfig(channel)) {
             await this.startChannelListener(channel, tenantId);
           }
@@ -4005,6 +4944,11 @@ export class GatewayService {
     if (!channel) {
       console.warn(`[gateway] Cannot manage listener: channel ${channelId} not found`);
       return;
+    }
+    if (channel.enabled && channel.channel_type === 'slack') {
+      this.mcpSlackRecoveryTenants.add(tenantId);
+      this.scheduleMcpSlackRecoveryRepair(tenantId);
+      this.ensureMcpSlackPeriodicSweep();
     }
 
     // If channel is disabled, stop the listener
@@ -4563,6 +5507,16 @@ export class GatewayService {
     this.listenerDraining = true;
     if (this.listenerTimer) clearTimeout(this.listenerTimer);
     this.listenerTimer = null;
+    if (this.mcpSlackSweepTimer) clearTimeout(this.mcpSlackSweepTimer);
+    this.mcpSlackSweepTimer = null;
+    this.mcpSlackRecoveryTenants.clear();
+    this.mcpSlackRepairTenants.clear();
+    for (const timer of this.mcpSlackRecoveryExpiryTimers.values()) clearTimeout(timer);
+    this.mcpSlackRecoveryExpiryTimers.clear();
+    for (const timer of this.mcpSlackDeliveryRetryTimers.values()) clearTimeout(timer);
+    this.mcpSlackDeliveryRetryTimers.clear();
+    for (const timer of this.mcpSlackOAuthStartClaimTimers.values()) clearTimeout(timer);
+    this.mcpSlackOAuthStartClaimTimers.clear();
     const leases = new Map(this.activeListenerLeases);
     const retryKeys = new Set(this.listenerRetries.keys());
     for (const retry of this.listenerRetries.values()) {

--- a/apps/agor-daemon/src/services/mcp-oauth-pending-flow-authority.postgres.test.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-pending-flow-authority.postgres.test.ts
@@ -148,6 +148,14 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
         mcpServerId: bound.serverId,
         oauthMode: 'per_user',
         configFingerprint: 'a'.repeat(64),
+        slackRecovery: {
+          notice_id: 'notice-peer-callback',
+          task_id: 'task-peer-callback',
+          session_id: 'session-peer-callback',
+          mcp_server_id: bound.serverId,
+          recovery_generation: 7,
+          recovery_request_id: 'request-peer-callback',
+        },
       } satisfies DurableMCPOAuthFlowCreate);
 
       const stored = await runWithTenantDatabaseScope(dbB, bound.tenantId, async (scoped) => {
@@ -171,6 +179,14 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
         throw new Error('Expected a supported grant binding version');
       }
       const opened = authorityB.openClaim(claimed.flow, context.state);
+      expect(opened.slackRecovery).toEqual({
+        notice_id: 'notice-peer-callback',
+        task_id: 'task-peer-callback',
+        session_id: 'session-peer-callback',
+        mcp_server_id: bound.serverId,
+        recovery_generation: 7,
+        recovery_request_id: 'request-peer-callback',
+      });
       await runWithTenantDatabaseScope(dbB, bound.tenantId, async (scoped) => {
         await new UserMCPOAuthTokenRepository(scoped, masterSecret).saveToken(
           bound.userId,

--- a/apps/agor-daemon/src/services/mcp-oauth-pending-flow-authority.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-pending-flow-authority.ts
@@ -26,6 +26,7 @@ import type {
   MCPOAuthMode,
   MCPOAuthPendingFlowSealedMaterial,
   MCPServerID,
+  MCPSlackOAuthRecoveryContext,
   UserID,
 } from '@agor/core/types';
 import { isMCPOAuthGrantBindingVersion } from '@agor/core/types';
@@ -36,17 +37,20 @@ const FLOW_TTL_MS = 10 * 60 * 1000;
 export type DurableMCPOAuthFlowContext = OAuthFlowContext;
 
 export interface DurableMCPOAuthFlowCreate {
+  attemptId?: MCPOAuthAttemptID;
   context: DurableMCPOAuthFlowContext;
   tenantId: string;
   userId: UserID;
   mcpServerId: MCPServerID;
   oauthMode: MCPOAuthMode;
   configFingerprint: string;
+  slackRecovery?: MCPSlackOAuthRecoveryContext;
 }
 
 export interface ClaimedDurableMCPOAuthFlow {
   record: MCPOAuthPendingFlowRecord;
   context: DurableMCPOAuthFlowContext;
+  slackRecovery?: MCPSlackOAuthRecoveryContext;
 }
 
 export function fingerprintMCPOAuthState(state: string): string {
@@ -80,7 +84,16 @@ function hasOnlyExpectedMaterialShape(value: unknown): value is MCPOAuthPendingF
       material.compatibilityMode === 'marketplace') &&
     (material.authorizationResponseIssuerParameterSupported === undefined ||
       typeof material.authorizationResponseIssuerParameterSupported === 'boolean') &&
-    typeof material.allowLocalhostHttp === 'boolean'
+    typeof material.allowLocalhostHttp === 'boolean' &&
+    (material.slackRecovery === undefined ||
+      (!!material.slackRecovery &&
+        typeof material.slackRecovery.notice_id === 'string' &&
+        typeof material.slackRecovery.task_id === 'string' &&
+        typeof material.slackRecovery.session_id === 'string' &&
+        typeof material.slackRecovery.mcp_server_id === 'string' &&
+        Number.isSafeInteger(material.slackRecovery.recovery_generation) &&
+        (material.slackRecovery.recovery_request_id === undefined ||
+          typeof material.slackRecovery.recovery_request_id === 'string')))
   );
 }
 
@@ -115,7 +128,7 @@ export class MCPOAuthPendingFlowAuthority {
   }
 
   async create(input: DurableMCPOAuthFlowCreate): Promise<MCPOAuthAttemptID> {
-    const attemptId = generateId() as MCPOAuthAttemptID;
+    const attemptId = input.attemptId ?? (generateId() as MCPOAuthAttemptID);
     await runWithTenantDatabaseScope(this.db, input.tenantId, async (scoped) => {
       const repository = new MCPOAuthPendingFlowRepository(scoped);
       const subjectUserId = input.oauthMode === 'per_user' ? input.userId : null;
@@ -153,6 +166,7 @@ export class MCPOAuthPendingFlowAuthority {
         authorizationResponseIssuerParameterSupported:
           input.context.authorizationResponseIssuerParameterSupported,
         allowLocalhostHttp: input.context.allowLocalhostHttp,
+        ...(input.slackRecovery ? { slackRecovery: input.slackRecovery } : {}),
       };
       const sealedMaterial = sealBoundSecret(
         JSON.stringify(material),
@@ -274,6 +288,7 @@ export class MCPOAuthPendingFlowAuthority {
 
     return {
       record,
+      ...(material.slackRecovery ? { slackRecovery: material.slackRecovery } : {}),
       context: {
         metadataUrl: material.metadataUrl,
         resourceUri: material.resourceUri,

--- a/apps/agor-daemon/src/utils/mcp-recovery-redaction.test.ts
+++ b/apps/agor-daemon/src/utils/mcp-recovery-redaction.test.ts
@@ -1,6 +1,9 @@
 import type { Task } from '@agor/core/types';
 import { describe, expect, it } from 'vitest';
-import { redactMcpRecoveryTopology } from './mcp-recovery-redaction.js';
+import {
+  redactMcpRecoveryTopology,
+  stripMcpSlackRecoveryNotice,
+} from './mcp-recovery-redaction.js';
 
 describe('redactMcpRecoveryTopology', () => {
   it('retains the action while removing server ids and names', () => {
@@ -42,5 +45,36 @@ describe('redactMcpRecoveryTopology', () => {
     expect(redacted.metadata?.mcp_recovery?.server_states).toBeUndefined();
     expect(JSON.stringify(redacted)).not.toContain('Private CRM');
     expect(JSON.stringify(redacted)).not.toContain('server-secret-topology');
+  });
+});
+
+describe('stripMcpSlackRecoveryNotice', () => {
+  it('never exposes the signed action identity or Slack routing topology', () => {
+    const task = {
+      task_id: 'task-1',
+      metadata: {
+        mcp_slack_recovery_notice: {
+          notice_id: 'notice-secret',
+          token_jti: 'jti-secret',
+          slack_thread_id: 'C1-1.1',
+          slack_user_id: 'U1',
+        },
+        gateway_task_source: {
+          gateway_channel_id: 'gateway-secret',
+          channel_type: 'slack',
+          thread_id: 'C1-1.1',
+          provider_user_id: 'U1',
+        },
+        caller_metadata: { safe: true },
+      },
+    } as unknown as Task;
+
+    const stripped = stripMcpSlackRecoveryNotice(task);
+    expect(stripped.metadata?.mcp_slack_recovery_notice).toBeUndefined();
+    expect(stripped.metadata?.caller_metadata).toEqual({ safe: true });
+    expect(stripped.metadata?.gateway_task_source).toBeUndefined();
+    expect(JSON.stringify(stripped)).not.toMatch(
+      /notice-secret|jti-secret|gateway-secret|C1-1\.1|U1/
+    );
   });
 });

--- a/apps/agor-daemon/src/utils/mcp-recovery-redaction.ts
+++ b/apps/agor-daemon/src/utils/mcp-recovery-redaction.ts
@@ -1,14 +1,24 @@
 import type { Task } from '@agor/core/types';
 
+/** Internal Slack recovery authority and routing never cross API or realtime boundaries. */
+export function stripMcpSlackRecoveryNotice(task: Task): Task {
+  if (!task.metadata?.mcp_slack_recovery_notice && !task.metadata?.gateway_task_source) return task;
+  const metadata = { ...task.metadata };
+  delete metadata.mcp_slack_recovery_notice;
+  delete metadata.gateway_task_source;
+  return { ...task, metadata };
+}
+
 /** Keep the action while hiding attached-server topology from broader Task viewers. */
 export function redactMcpRecoveryTopology(task: Task): Task {
-  const recovery = task.metadata?.mcp_recovery;
-  if (!recovery) return task;
+  const stripped = stripMcpSlackRecoveryNotice(task);
+  const recovery = stripped.metadata?.mcp_recovery;
+  if (!recovery) return stripped;
   const affectedCount = recovery.server_states?.length ?? (recovery.mcp_server_id ? 1 : 0);
   return {
-    ...task,
+    ...stripped,
     metadata: {
-      ...task.metadata,
+      ...stripped.metadata,
       mcp_recovery: {
         ...recovery,
         mcp_server_id: undefined,

--- a/apps/agor-daemon/src/utils/mcp-slack-recovery-token.test.ts
+++ b/apps/agor-daemon/src/utils/mcp-slack-recovery-token.test.ts
@@ -1,0 +1,152 @@
+import type {
+  MCPServerID,
+  MCPSlackRecoveryNotice,
+  MCPSlackRecoveryTokenClaims,
+  SessionID,
+  TenantID,
+  UserID,
+} from '@agor/core/types';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  issueMCPSlackRecoveryToken,
+  mcpSlackRecoveryClaimsMatchCaller,
+  mcpSlackRecoveryClaimsMatchNotice,
+  verifyMCPSlackRecoveryToken,
+} from './mcp-slack-recovery-token.js';
+
+const SECRET = 'test-secret-with-enough-entropy';
+const NOW = new Date('2026-08-26T12:00:00.000Z');
+const EXPIRES = new Date('2026-08-26T12:10:00.000Z');
+
+function notice(): MCPSlackRecoveryNotice {
+  return {
+    notice_id: 'notice-1',
+    token_jti: 'jti-1',
+    issued_at: NOW.toISOString(),
+    expires_at: EXPIRES.toISOString(),
+    principal_user_id: 'user-1' as UserID,
+    credential_user_id: 'user-1' as UserID,
+    slack_user_id: 'U123',
+    slack_team_id: 'T123',
+    gateway_channel_id: 'gateway-1',
+    gateway_config_generation: 7,
+    slack_channel_id: 'C123',
+    slack_thread_id: 'C123-1724688000.000100',
+    session_id: 'session-1' as SessionID,
+    task_id: 'task-1',
+    mcp_server_id: 'server-1' as MCPServerID,
+    mcp_server_config_version: 3,
+    recovery_generation: 11,
+    recovery_request_id: 'request-1',
+    provider_dispatch: 'ambiguous',
+    delivery_id: 'delivery-1',
+  };
+}
+
+function issue(value = notice()): string {
+  return issueMCPSlackRecoveryToken(
+    {
+      type: 'mcp-slack-recovery',
+      tid: 'tenant-1',
+      sub: value.principal_user_id,
+      credential_user_id: value.credential_user_id,
+      slack_user_id: value.slack_user_id,
+      slack_team_id: value.slack_team_id,
+      gateway_channel_id: value.gateway_channel_id,
+      gateway_config_generation: value.gateway_config_generation,
+      slack_channel_id: value.slack_channel_id,
+      slack_thread_id: value.slack_thread_id,
+      task_id: value.task_id,
+      session_id: value.session_id,
+      mcp_server_id: value.mcp_server_id,
+      mcp_server_config_version: value.mcp_server_config_version,
+      recovery_generation: value.recovery_generation,
+      recovery_request_id: value.recovery_request_id,
+      notice_id: value.notice_id,
+      jti: value.token_jti,
+      expiresAt: EXPIRES,
+    },
+    SECRET,
+    NOW
+  );
+}
+
+describe('MCP Slack recovery tokens', () => {
+  beforeAll(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+  afterAll(() => vi.useRealTimers());
+
+  it('seals an opaque, expiring token and verifies every durable binding', () => {
+    const token = issue();
+    const claims = verifyMCPSlackRecoveryToken(token, SECRET);
+    expect(token).not.toMatch(/tenant-1|user-1|task-1|session-1|server-1|C123|U123|T123/);
+    expect(claims.iat).toBe(NOW.getTime() / 1_000);
+    expect(claims.exp).toBe(EXPIRES.getTime() / 1_000);
+    expect(mcpSlackRecoveryClaimsMatchNotice(claims, notice(), 'tenant-1' as TenantID)).toBe(true);
+  });
+
+  it('rejects expiry, forgery, and an unsupported envelope', () => {
+    expect(() => verifyMCPSlackRecoveryToken(issue(), SECRET, EXPIRES)).toThrow(/expired/i);
+    expect(() => verifyMCPSlackRecoveryToken(issue(), 'different-secret')).toThrow();
+    const token = issue();
+    const forged = `${token.slice(0, -1)}${token.endsWith('a') ? 'b' : 'a'}`;
+    expect(() => verifyMCPSlackRecoveryToken(forged, SECRET)).toThrow();
+    expect(() => verifyMCPSlackRecoveryToken('not-an-envelope', SECRET)).toThrow();
+  });
+
+  it('rejects cross-tenant, cross-user, and credential-owner caller authority', () => {
+    const claims = verifyMCPSlackRecoveryToken(issue(), SECRET);
+    expect(mcpSlackRecoveryClaimsMatchCaller(claims, 'tenant-1', 'user-1')).toBe(true);
+    expect(mcpSlackRecoveryClaimsMatchCaller(claims, 'tenant-2', 'user-1')).toBe(false);
+    expect(mcpSlackRecoveryClaimsMatchCaller(claims, 'tenant-1', 'user-2')).toBe(false);
+    expect(
+      mcpSlackRecoveryClaimsMatchCaller(
+        { ...claims, credential_user_id: 'user-2' as UserID },
+        'tenant-1',
+        'user-1'
+      )
+    ).toBe(false);
+  });
+
+  it.each([
+    ['tenant', (claims: MCPSlackRecoveryTokenClaims) => ({ ...claims, tid: 'tenant-2' })],
+    ['user', (claims: MCPSlackRecoveryTokenClaims) => ({ ...claims, sub: 'user-2' as UserID })],
+    ['task', (claims: MCPSlackRecoveryTokenClaims) => ({ ...claims, task_id: 'task-2' })],
+    [
+      'session',
+      (claims: MCPSlackRecoveryTokenClaims) => ({
+        ...claims,
+        session_id: 'session-2' as SessionID,
+      }),
+    ],
+    ['channel', (claims: MCPSlackRecoveryTokenClaims) => ({ ...claims, slack_channel_id: 'C999' })],
+    [
+      'thread',
+      (claims: MCPSlackRecoveryTokenClaims) => ({ ...claims, slack_thread_id: 'C123-999.1' }),
+    ],
+    [
+      'gateway generation',
+      (claims: MCPSlackRecoveryTokenClaims) => ({ ...claims, gateway_config_generation: 8 }),
+    ],
+    [
+      'server configuration',
+      (claims: MCPSlackRecoveryTokenClaims) => ({ ...claims, mcp_server_config_version: 4 }),
+    ],
+    [
+      'recovery generation',
+      (claims: MCPSlackRecoveryTokenClaims) => ({ ...claims, recovery_generation: 12 }),
+    ],
+    [
+      'request identity',
+      (claims: MCPSlackRecoveryTokenClaims) => ({ ...claims, recovery_request_id: 'request-2' }),
+    ],
+    ['single-use identity', (claims: MCPSlackRecoveryTokenClaims) => ({ ...claims, jti: 'jti-2' })],
+  ])('rejects a mismatched %s binding', (_name, mutate) => {
+    const claims = verifyMCPSlackRecoveryToken(issue(), SECRET);
+    expect(
+      mcpSlackRecoveryClaimsMatchNotice(mutate(claims), notice(), 'tenant-1' as TenantID)
+    ).toBe(false);
+  });
+});

--- a/apps/agor-daemon/src/utils/mcp-slack-recovery-token.ts
+++ b/apps/agor-daemon/src/utils/mcp-slack-recovery-token.ts
@@ -1,0 +1,130 @@
+import { openBoundSecret, sealBoundSecret } from '@agor/core/db';
+import type {
+  MCPSlackRecoveryNotice,
+  MCPSlackRecoveryTokenClaims,
+  TenantID,
+} from '@agor/core/types';
+
+export const MCP_SLACK_RECOVERY_AUDIENCE = 'agor:mcp-slack-recovery' as const;
+export const MCP_SLACK_RECOVERY_ISSUER = 'agor' as const;
+const MCP_SLACK_RECOVERY_ENVELOPE_BINDING = 'agor:mcp-slack-recovery:v1';
+
+function isBoundString(value: unknown, max = 512): value is string {
+  return typeof value === 'string' && value.length > 0 && value.length <= max;
+}
+
+function isClaims(value: unknown): value is MCPSlackRecoveryTokenClaims {
+  if (!value || typeof value !== 'object') return false;
+  const claims = value as Partial<MCPSlackRecoveryTokenClaims>;
+  return (
+    claims.type === 'mcp-slack-recovery' &&
+    claims.aud === MCP_SLACK_RECOVERY_AUDIENCE &&
+    claims.iss === MCP_SLACK_RECOVERY_ISSUER &&
+    isBoundString(claims.tid) &&
+    isBoundString(claims.sub) &&
+    isBoundString(claims.credential_user_id) &&
+    isBoundString(claims.slack_user_id) &&
+    isBoundString(claims.slack_team_id) &&
+    isBoundString(claims.gateway_channel_id) &&
+    Number.isSafeInteger(claims.gateway_config_generation) &&
+    claims.gateway_config_generation! >= 0 &&
+    isBoundString(claims.slack_channel_id) &&
+    isBoundString(claims.slack_thread_id, 2_048) &&
+    isBoundString(claims.task_id) &&
+    isBoundString(claims.session_id) &&
+    isBoundString(claims.mcp_server_id) &&
+    Number.isSafeInteger(claims.mcp_server_config_version) &&
+    claims.mcp_server_config_version! >= 1 &&
+    isBoundString(claims.notice_id) &&
+    isBoundString(claims.jti) &&
+    Number.isSafeInteger(claims.recovery_generation) &&
+    claims.recovery_generation! >= 0 &&
+    (claims.recovery_request_id === undefined || isBoundString(claims.recovery_request_id, 128)) &&
+    Number.isSafeInteger(claims.iat) &&
+    Number.isSafeInteger(claims.exp)
+  );
+}
+
+export function issueMCPSlackRecoveryToken(
+  input: Omit<MCPSlackRecoveryTokenClaims, 'aud' | 'iss' | 'iat' | 'exp'> & {
+    expiresAt: Date;
+  },
+  secret: string,
+  now = new Date()
+): string {
+  const { expiresAt, ...claims } = input;
+  const iat = Math.floor(now.getTime() / 1_000);
+  const exp = Math.floor(expiresAt.getTime() / 1_000);
+  if (!secret || exp <= iat) throw new Error('MCP Slack recovery token lifetime is invalid');
+  return sealBoundSecret(
+    JSON.stringify({
+      ...claims,
+      iat,
+      exp,
+      aud: MCP_SLACK_RECOVERY_AUDIENCE,
+      iss: MCP_SLACK_RECOVERY_ISSUER,
+    }),
+    secret,
+    'slack-mcp-recovery',
+    MCP_SLACK_RECOVERY_ENVELOPE_BINDING
+  );
+}
+
+export function verifyMCPSlackRecoveryToken(
+  token: string,
+  secret: string,
+  now = new Date()
+): MCPSlackRecoveryTokenClaims {
+  if (!isBoundString(token, 16_384)) throw new Error('MCP Slack recovery token is invalid');
+  const decoded = JSON.parse(
+    openBoundSecret(token, secret, 'slack-mcp-recovery', MCP_SLACK_RECOVERY_ENVELOPE_BINDING)
+  ) as unknown;
+  if (!isClaims(decoded)) throw new Error('MCP Slack recovery token binding is invalid');
+  const nowSeconds = Math.floor(now.getTime() / 1_000);
+  if (decoded.exp <= nowSeconds || decoded.iat > nowSeconds + 30) {
+    throw new Error('MCP Slack recovery token expired or is not yet valid');
+  }
+  return decoded;
+}
+
+export function mcpSlackRecoveryClaimsMatchNotice(
+  claims: MCPSlackRecoveryTokenClaims,
+  notice: MCPSlackRecoveryNotice,
+  tenantId: TenantID | string
+): boolean {
+  return (
+    claims.tid === tenantId &&
+    claims.sub === notice.principal_user_id &&
+    claims.credential_user_id === notice.credential_user_id &&
+    claims.slack_user_id === notice.slack_user_id &&
+    claims.slack_team_id === notice.slack_team_id &&
+    claims.gateway_channel_id === notice.gateway_channel_id &&
+    claims.gateway_config_generation === notice.gateway_config_generation &&
+    claims.slack_channel_id === notice.slack_channel_id &&
+    claims.slack_thread_id === notice.slack_thread_id &&
+    claims.task_id === notice.task_id &&
+    claims.session_id === notice.session_id &&
+    claims.mcp_server_id === notice.mcp_server_id &&
+    claims.mcp_server_config_version === notice.mcp_server_config_version &&
+    claims.recovery_generation === notice.recovery_generation &&
+    claims.recovery_request_id === notice.recovery_request_id &&
+    claims.notice_id === notice.notice_id &&
+    claims.jti === notice.token_jti &&
+    claims.iat * 1_000 === new Date(notice.issued_at).getTime() &&
+    claims.exp * 1_000 === new Date(notice.expires_at).getTime()
+  );
+}
+
+export function mcpSlackRecoveryClaimsMatchCaller(
+  claims: MCPSlackRecoveryTokenClaims,
+  tenantId: string | undefined,
+  userId: string | undefined
+): boolean {
+  return (
+    !!tenantId &&
+    !!userId &&
+    claims.tid === tenantId &&
+    claims.sub === userId &&
+    claims.credential_user_id === userId
+  );
+}

--- a/apps/agor-daemon/src/utils/realtime-publish.ts
+++ b/apps/agor-daemon/src/utils/realtime-publish.ts
@@ -46,7 +46,10 @@ import {
   isKnowledgeRealtimeSuppressedEvent,
   resolveKnowledgeRealtimeUserIds,
 } from './knowledge-realtime-publish.js';
-import { redactMcpRecoveryTopology } from './mcp-recovery-redaction.js';
+import {
+  redactMcpRecoveryTopology,
+  stripMcpSlackRecoveryNotice,
+} from './mcp-recovery-redaction.js';
 import {
   type RealtimeAccessBranchRepository,
   RealtimeAccessCache,
@@ -1122,6 +1125,14 @@ export function configureRealtimePublish(options: RealtimePublishOptions): void 
     const taskData = data as Task | undefined;
     if (
       context.path === 'tasks' &&
+      (taskData?.metadata?.mcp_slack_recovery_notice || taskData?.metadata?.gateway_task_source) &&
+      !taskData.metadata.mcp_recovery
+    ) {
+      const channels = Array.isArray(delivery) ? delivery : [delivery];
+      delivery = channels.map((channel) => channel.send(stripMcpSlackRecoveryNotice(taskData)));
+    }
+    if (
+      context.path === 'tasks' &&
       taskData?.metadata?.mcp_recovery &&
       typeof taskData.session_id === 'string'
     ) {
@@ -1136,7 +1147,7 @@ export function configureRealtimePublish(options: RealtimePublishOptions): void 
           }
           return ownerId !== null && userFromConnection(connection)?.user_id === ownerId;
         })
-        .send(taskData);
+        .send(stripMcpSlackRecoveryNotice(taskData));
       const redacted = tenantScoped
         .filter((connection: unknown) => {
           if (!authorizedConnections.has(connection)) return false;

--- a/apps/agor-docs/content/guide/message-gateway.mdx
+++ b/apps/agor-docs/content/guide/message-gateway.mdx
@@ -594,6 +594,41 @@ Implement this interface, register it in the connector registry, and the gateway
 
 The `blocks` field is opaque platform-specific data. Currently only the Slack connector uses it (to emit Block Kit `table` blocks for markdown tables). Other connectors can ignore it and rely on `text`.
 
+### Recovering MCP sign-in from Slack
+
+When a Slack-originated Task reaches an actionable MCP OAuth recovery, Agor posts a
+**Reconnect MCP** action in the originating thread and updates that message as recovery
+progresses. The link opens an authenticated Agor page, starts the normal MCP OAuth flow, and
+reconnects MCP capabilities to the same Task without replacing its conversation history. The
+Slack post is visible to everyone who can read the thread, but the action works only for the
+bound Agor user. Slack requires an `action_id` on URL buttons; Agor does not accept that value as
+an interactive authentication callback.
+
+The action is short-lived, single-use, and bound to the Agor user, Slack identity, tenant,
+Task, Session, MCP server configuration, and original channel/thread. A changed role, detached
+server, replaced configuration, completed Task, newer recovery request, or different signed-in
+user invalidates it. The page never asks for a Slack bot, app, or broad user token: Slack gateway
+credentials and MCP OAuth grants are separate.
+
+Agor does not automatically replay the interrupted MCP invocation. After recovery, the thread
+states whether you may explicitly request a retry or whether the provider might already have
+observed the call and you should instead tell the assistant what to do next. If the active agent
+cannot accept live MCP reprojection, the thread truthfully asks for a new turn while retaining the
+existing conversation.
+
+Slack delivery is deliberately at least once. Agor attaches secret-free Slack message metadata
+and performs one bounded thread-history reconciliation after an ambiguous/crashed send when the
+workspace permits that read. Slack does not deduplicate posts by `client_msg_id`, so Agor makes no
+such claim. A provider outage or a crash at the send/commit boundary can briefly leave a duplicate;
+every copy carries the same expiring, single-use, user-bound action, and later recovery generations
+supersede it safely. Terminal thread updates have their own bounded retry window and do not depend
+on whether the browser action is still valid.
+
+Process-local timers are only a best-effort latency optimization. An indexed, tenant-scoped repair
+query runs at listener startup and in a periodic sweep. Each pass has a hard task and tenant budget
+and a 24-hour due-work horizon; it never scans a tenant's historical Tasks or calls Slack inside an
+authoritative mutation transaction.
+
 ## Best Practices
 
 - **Use trust or auto mode for unattended agents.** If you want the agent to operate without human approval on each tool call, set the permission mode accordingly.

--- a/apps/agor-ui/src/App.tsx
+++ b/apps/agor-ui/src/App.tsx
@@ -87,6 +87,7 @@ import {
   ARTIFACT_FULLSCREEN_ROUTE_PATHS,
   KNOWLEDGE_ROUTE_PATHS,
   MARKETPLACE_ROUTE_PATHS,
+  MCP_RECOVERY_ROUTE_PATHS,
   RBAC_POLICY_PROTOTYPE_ROUTE_PATH,
   routeUsesDeviceRouter,
 } from './surfaces/surfaceRegistry';
@@ -214,6 +215,11 @@ const loadArtifactFullscreenPage = cacheRouteLoader(
   () => import('./pages/ArtifactFullscreenPage'),
   (module) => ({ default: module.ArtifactFullscreenPage })
 );
+const loadMcpRecoveryPage = cacheRouteLoader(
+  'mcp-recovery',
+  () => import('./pages/MCPSlackRecoveryPage'),
+  (module) => ({ default: module.MCPSlackRecoveryPage })
+);
 const loadMobileApp = cacheRouteLoader(
   'mobile',
   () => import('./components/mobile/MobileApp'),
@@ -246,6 +252,7 @@ const AgorApp = lazy(loadAgorApp);
 const KnowledgePage = lazy(loadKnowledgePage);
 const MarketplacePage = lazy(loadMarketplacePage);
 const ArtifactFullscreenPage = lazy(loadArtifactFullscreenPage);
+const MCPSlackRecoveryPage = lazy(loadMcpRecoveryPage);
 const MobileApp = lazy(loadMobileApp);
 const StreamdownDemoPage = lazy(loadStreamdownDemoPage);
 
@@ -254,6 +261,7 @@ const routeModuleLoaders = {
   knowledge: loadKnowledgePage,
   marketplace: loadMarketplacePage,
   'artifact-fullscreen': loadArtifactFullscreenPage,
+  'mcp-recovery': loadMcpRecoveryPage,
   demo: loadStreamdownDemoPage,
   mobile: loadMobileApp,
 } satisfies Record<RouteModuleKey, () => Promise<unknown>>;
@@ -2144,6 +2152,8 @@ function AppContent() {
     />
   );
 
+  const mcpRecoveryElement = <MCPSlackRecoveryPage client={client} />;
+
   // All desktop entity URLs (/b/, /s/, /w/, /a/) render the same
   // AgorApp — the multiple routes exist so react-router's useParams
   // (read inside useUrlState) populates the right named params for
@@ -2380,6 +2390,10 @@ function AppContent() {
                 the tenant's board/session store. */}
           {MARKETPLACE_ROUTE_PATHS.map((path) => (
             <Route key={path} path={path} element={marketplacePageElement} />
+          ))}
+
+          {MCP_RECOVERY_ROUTE_PATHS.map((path) => (
+            <Route key={path} path={path} element={mcpRecoveryElement} />
           ))}
 
           {/* Lightweight artifact fullscreen surface. Uses the shared auth shell,

--- a/apps/agor-ui/src/pages/MCPSlackRecoveryLogin.browser.test.tsx
+++ b/apps/agor-ui/src/pages/MCPSlackRecoveryLogin.browser.test.tsx
@@ -1,0 +1,42 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { LoginPage } from '@/components/LoginPage/LoginPage';
+
+afterEach(() => {
+  window.history.replaceState({}, '', '/ui/');
+});
+
+describe('Slack MCP recovery login return', () => {
+  it('preserves the fragment token through external launch sign-in', () => {
+    window.history.replaceState({}, '', '/ui/recover/mcp#token=signed-browser-token');
+    render(
+      <LoginPage
+        onLogin={vi.fn()}
+        externalLaunchLoginRedirectUrl="https://workspace.example.test/launch"
+      />
+    );
+
+    const href = new URL(
+      screen.getByRole('link', { name: 'Return to workspace' }).getAttribute('href') ?? ''
+    );
+    expect(href.searchParams.get('return_to')).toBe('/ui/recover/mcp#token=signed-browser-token');
+    expect(window.location.hash).toBe('#token=signed-browser-token');
+  });
+
+  it('leaves the fragment in place while local login authenticates', async () => {
+    window.history.replaceState({}, '', '/ui/recover/mcp#token=signed-browser-token');
+    const onLogin = vi.fn(async () => true);
+    render(<LoginPage onLogin={onLogin} />);
+
+    fireEvent.change(screen.getByPlaceholderText('Email address'), {
+      target: { value: 'member@example.test' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Password'), {
+      target: { value: 'correct horse battery staple' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Sign In' }));
+
+    await waitFor(() => expect(onLogin).toHaveBeenCalledOnce());
+    expect(window.location.hash).toBe('#token=signed-browser-token');
+  });
+});

--- a/apps/agor-ui/src/pages/MCPSlackRecoveryPage.layout.browser.test.tsx
+++ b/apps/agor-ui/src/pages/MCPSlackRecoveryPage.layout.browser.test.tsx
@@ -1,0 +1,35 @@
+import type { AgorClient } from '@agor-live/client';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { MCPSlackRecoveryPage } from './MCPSlackRecoveryPage';
+
+afterEach(cleanup);
+
+describe('Slack MCP recovery responsive layout', () => {
+  it('keeps the authenticated recovery action visible and within the mobile viewport', async () => {
+    window.location.hash = '#token=browser-signed-token';
+    const client = {
+      service: () => ({
+        create: async () => ({
+          state: 'reconnect_required',
+          provider_dispatch: 'ambiguous',
+          expires_at: new Date(Date.now() + 60_000).toISOString(),
+          return_to_slack_url: 'slack://channel?team=T1&id=C1&message=1.1',
+        }),
+      }),
+    } as unknown as AgorClient;
+
+    const { container } = render(<MCPSlackRecoveryPage client={client} />);
+    const action = await screen.findByRole('button', { name: 'Continue to sign-in' });
+    await waitFor(() => expect(action.getBoundingClientRect().height).toBeGreaterThan(0));
+    const card = container.querySelector('.ant-card');
+    expect(card).not.toBeNull();
+    const bounds = card!.getBoundingClientRect();
+    expect(bounds.left).toBeGreaterThanOrEqual(0);
+    expect(bounds.right).toBeLessThanOrEqual(window.innerWidth);
+    expect(screen.getByRole('link', { name: 'Return to Slack' })).toBeVisible();
+    expect(screen.getByText(/may have started/i)).toBeVisible();
+    expect(document.activeElement).toBe(screen.getByRole('heading', { name: 'Reconnect MCP' }));
+    expect((container.querySelector('main') as HTMLElement).style.minHeight).toBe('100dvh');
+  });
+});

--- a/apps/agor-ui/src/pages/MCPSlackRecoveryPage.test.tsx
+++ b/apps/agor-ui/src/pages/MCPSlackRecoveryPage.test.tsx
@@ -1,0 +1,86 @@
+import type { AgorClient } from '@agor-live/client';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MCPSlackRecoveryPage } from './MCPSlackRecoveryPage';
+
+const popup = { close: vi.fn(), navigate: vi.fn(() => true), operationId: 'popup-1' };
+vi.mock('@/components/Marketplace/marketplaceOAuthPopup', () => ({
+  openMarketplaceOAuthPopup: () => popup,
+}));
+vi.mock('@/utils/mcpOAuthAttempt', () => ({
+  waitForMCPOAuthAttempt: vi.fn(async () => ({ status: 'succeeded' })),
+}));
+
+function client(preflight: object, start?: object): AgorClient {
+  return {
+    service: (path: string) => ({
+      create: vi.fn(async () =>
+        path === 'mcp-slack-recovery'
+          ? preflight
+          : (start ?? {
+              success: true,
+              authorizationUrl: 'https://provider.example/authorize',
+              attempt_id: 'attempt-1',
+            })
+      ),
+    }),
+  } as unknown as AgorClient;
+}
+
+describe('Slack MCP recovery browser surface', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.location.hash = '#token=signed-token';
+  });
+
+  it('shows ambiguous no-replay guidance without topology or secret prose', async () => {
+    render(
+      <MCPSlackRecoveryPage
+        client={client({
+          state: 'reconnect_required',
+          provider_dispatch: 'ambiguous',
+          expires_at: '2026-08-26T12:10:00.000Z',
+          return_to_slack_url: 'slack://channel?team=T1&id=C1&message=1.1',
+        })}
+      />
+    );
+
+    expect(await screen.findByRole('button', { name: 'Continue to sign-in' })).toBeVisible();
+    expect(window.location.hash).toBe('');
+    expect(screen.getByText(/may have started/i)).toBeVisible();
+    expect(screen.getByText(/never ask you to paste a broad Slack token/i)).toBeVisible();
+    expect(screen.queryByText(/signed-token|server-1|provider\.example/i)).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Return to Slack' })).toHaveAttribute(
+      'href',
+      'slack://channel?team=T1&id=C1&message=1.1'
+    );
+  });
+
+  it('uses the canonical OAuth start, preserves explicit no-replay truth, and returns to Slack', async () => {
+    const agor = client({
+      state: 'reconnect_required',
+      provider_dispatch: 'not_started',
+      expires_at: '2026-08-26T12:10:00.000Z',
+      return_to_slack_url: 'slack://channel?team=T1&id=C1',
+    });
+    render(<MCPSlackRecoveryPage client={agor} />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Continue to sign-in' }));
+
+    await waitFor(() =>
+      expect(popup.navigate).toHaveBeenCalledWith(
+        'https://provider.example/authorize',
+        expect.any(Function)
+      )
+    );
+    expect(await screen.findByText(/interrupted call was not replayed/i)).toBeVisible();
+  });
+
+  it('fails closed for an expired, used, or mismatched action', async () => {
+    const denied = {
+      service: () => ({ create: vi.fn(async () => Promise.reject(new Error('provider secret'))) }),
+    } as unknown as AgorClient;
+    render(<MCPSlackRecoveryPage client={denied} />);
+    expect(await screen.findByText('This recovery action is unavailable')).toBeVisible();
+    expect(screen.queryByText(/provider secret/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/agor-ui/src/pages/MCPSlackRecoveryPage.tsx
+++ b/apps/agor-ui/src/pages/MCPSlackRecoveryPage.tsx
@@ -1,0 +1,232 @@
+import type { AgorClient, MCPOAuthStartFailure } from '@agor-live/client';
+import { Alert, Button, Card, Flex, Spin, Typography, theme } from 'antd';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { openMarketplaceOAuthPopup } from '@/components/Marketplace/marketplaceOAuthPopup';
+import { waitForMCPOAuthAttempt } from '@/utils/mcpOAuthAttempt';
+
+type PageState =
+  | 'checking'
+  | 'ready'
+  | 'starting'
+  | 'pending'
+  | 'recovered'
+  | 'failed'
+  | 'unavailable';
+
+interface RecoveryPreflight {
+  state: 'reconnect_required' | 'sign_in_pending' | 'failed';
+  provider_dispatch: 'not_started' | 'ambiguous';
+  expires_at: string;
+  return_to_slack_url: string;
+}
+
+interface Props {
+  client: AgorClient | null;
+}
+
+function fragmentToken(): string | null {
+  const value = new URLSearchParams(window.location.hash.replace(/^#/, '')).get('token');
+  return value?.trim() || null;
+}
+
+export function MCPSlackRecoveryPage({ client }: Props) {
+  const token = useMemo(fragmentToken, []);
+  const [state, setState] = useState<PageState>('checking');
+  const [preflight, setPreflight] = useState<RecoveryPreflight | null>(null);
+  const mounted = useRef(true);
+  const pollAbort = useRef<AbortController | null>(null);
+  const titleRef = useRef<HTMLHeadingElement | null>(null);
+  const { token: designToken } = theme.useToken();
+
+  useEffect(() => {
+    titleRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    if (token && window.location.hash) {
+      window.history.replaceState(
+        window.history.state,
+        '',
+        `${window.location.pathname}${window.location.search}`
+      );
+    }
+  }, [token]);
+  useEffect(
+    () => () => {
+      mounted.current = false;
+      pollAbort.current?.abort();
+    },
+    []
+  );
+  useEffect(() => {
+    if (!client || !token) {
+      setState('unavailable');
+      return;
+    }
+    let cancelled = false;
+    client
+      .service('mcp-slack-recovery')
+      .create({ token })
+      .then((result) => {
+        if (cancelled) return;
+        setPreflight(result as RecoveryPreflight);
+        setState(
+          (result as RecoveryPreflight).state === 'sign_in_pending'
+            ? 'pending'
+            : (result as RecoveryPreflight).state === 'failed'
+              ? 'failed'
+              : 'ready'
+        );
+      })
+      .catch(() => !cancelled && setState('unavailable'));
+    return () => {
+      cancelled = true;
+    };
+  }, [client, token]);
+
+  const start = async () => {
+    if (!client || !token || state !== 'ready') return;
+    // Reserve a popup synchronously while the click still has user activation.
+    const popup = openMarketplaceOAuthPopup();
+    if (!popup) {
+      setState('failed');
+      return;
+    }
+    setState('starting');
+    try {
+      const result = (await client.service('mcp-servers/oauth-start').create({
+        slack_recovery_token: token,
+      })) as { success: true; authorizationUrl: string; attempt_id: string } | MCPOAuthStartFailure;
+      if (!mounted.current) return;
+      if (!result.success || !result.authorizationUrl || !result.attempt_id) {
+        popup.close();
+        setState('failed');
+        return;
+      }
+      if (!popup.navigate(result.authorizationUrl, () => mounted.current)) {
+        setState('failed');
+        return;
+      }
+      setState('pending');
+      pollAbort.current?.abort();
+      pollAbort.current = new AbortController();
+      const attempt = await waitForMCPOAuthAttempt(client, result.attempt_id, {
+        signal: pollAbort.current.signal,
+      });
+      if (!mounted.current) return;
+      setState(attempt.status === 'succeeded' ? 'recovered' : 'failed');
+    } catch {
+      popup.close();
+      if (mounted.current) setState('failed');
+    }
+  };
+
+  const ambiguous = preflight?.provider_dispatch === 'ambiguous';
+  const status = (() => {
+    if (state === 'checking' || state === 'starting') {
+      return (
+        <Spin
+          description={state === 'checking' ? 'Checking this recovery action…' : 'Opening sign-in…'}
+        />
+      );
+    }
+    if (state === 'unavailable') {
+      return (
+        <Alert
+          type="warning"
+          showIcon
+          title="This recovery action is unavailable"
+          description="It may have expired, been used already, or no longer match your Agor account. Return to Slack and send a new message if recovery is still needed."
+        />
+      );
+    }
+    if (state === 'failed') {
+      return (
+        <Alert
+          type="error"
+          showIcon
+          title="MCP recovery was not completed"
+          description="No provider call was replayed. Return to Slack and try from a new turn, or contact an administrator."
+        />
+      );
+    }
+    if (state === 'recovered') {
+      return (
+        <Alert
+          type="success"
+          showIcon
+          title="MCP sign-in completed"
+          description={
+            ambiguous
+              ? 'Agor is reconnecting later MCP calls. The interrupted call may have started and was not replayed.'
+              : 'Agor is reconnecting this task. The interrupted call was not replayed; ask explicitly in Slack if you want to retry it.'
+          }
+        />
+      );
+    }
+    return (
+      <Alert
+        type={state === 'pending' ? 'info' : 'warning'}
+        showIcon
+        title={state === 'pending' ? 'Sign-in is pending' : 'MCP sign-in is required'}
+        description={
+          ambiguous
+            ? 'The interrupted provider call may have started. Reconnecting updates MCP for later calls and never replays that call automatically.'
+            : 'Reconnect MCP for this same task and conversation. Agor will not replay the interrupted call automatically.'
+        }
+      />
+    );
+  })();
+
+  return (
+    <main
+      style={{
+        minHeight: '100dvh',
+        width: '100%',
+        padding: `max(${designToken.padding}px, env(safe-area-inset-top)) max(${designToken.padding}px, env(safe-area-inset-right)) max(${designToken.padding}px, env(safe-area-inset-bottom)) max(${designToken.padding}px, env(safe-area-inset-left))`,
+        boxSizing: 'border-box',
+        overflowX: 'hidden',
+        display: 'grid',
+        placeItems: 'center',
+        background: designToken.colorBgLayout,
+      }}
+      aria-labelledby="mcp-recovery-title"
+    >
+      <Card style={{ width: '100%', maxWidth: 560, overflowWrap: 'anywhere' }}>
+        <Flex vertical gap={20} aria-live="polite">
+          <div>
+            <Typography.Title
+              ref={titleRef}
+              id="mcp-recovery-title"
+              level={2}
+              tabIndex={-1}
+              style={{ marginBottom: designToken.marginXS, outline: 'none' }}
+            >
+              Reconnect MCP
+            </Typography.Title>
+            <Typography.Text type="secondary">
+              Sign in with your current Agor account, then return to the originating Slack thread.
+            </Typography.Text>
+          </div>
+          {status}
+          <Flex gap={12} wrap>
+            {state === 'ready' && (
+              <Button type="primary" size="large" onClick={start}>
+                Continue to sign-in
+              </Button>
+            )}
+            {preflight?.return_to_slack_url && (
+              <Button size="large" href={preflight.return_to_slack_url}>
+                Return to Slack
+              </Button>
+            )}
+          </Flex>
+          <Typography.Paragraph type="secondary" style={{ margin: 0 }}>
+            Slack app tokens and MCP authorization are separate. Agor will never ask you to paste a
+            broad Slack token here.
+          </Typography.Paragraph>
+        </Flex>
+      </Card>
+    </main>
+  );
+}

--- a/apps/agor-ui/src/surfaces/surfaceRegistry.ts
+++ b/apps/agor-ui/src/surfaces/surfaceRegistry.ts
@@ -5,6 +5,7 @@ export type RouteSurfaceId =
   | 'workspace'
   | 'knowledge'
   | 'marketplace'
+  | 'mcp-recovery'
   | 'artifact-fullscreen'
   | 'demo';
 
@@ -93,6 +94,18 @@ export const MARKETPLACE_SURFACE = defineSurface({
 
 export const ARTIFACT_FULLSCREEN_ROUTE_PATHS = ['/a/:artifactShortId/fullscreen'] as const;
 
+export const MCP_RECOVERY_ROUTE_PATHS = ['/recover/mcp'] as const;
+
+export const MCP_RECOVERY_SURFACE = defineSurface({
+  id: 'mcp-recovery',
+  label: 'MCP recovery',
+  routePaths: MCP_RECOVERY_ROUTE_PATHS,
+  startsWorkspaceRuntime: false,
+  usesDeviceRouter: false,
+  usesSharedUserSettings: true,
+  branding: surfaceTitle('MCP recovery'),
+});
+
 export const ARTIFACT_FULLSCREEN_SURFACE = defineSurface({
   id: 'artifact-fullscreen',
   label: 'Artifact fullscreen',
@@ -144,6 +157,7 @@ export const WORKSPACE_SURFACE = defineSurface({
 export const SURFACE_REGISTRY = [
   KNOWLEDGE_SURFACE,
   MARKETPLACE_SURFACE,
+  MCP_RECOVERY_SURFACE,
   ARTIFACT_FULLSCREEN_SURFACE,
   DEMO_SURFACE,
   WORKSPACE_SURFACE,

--- a/packages/core/drizzle/postgres/0100_mcp_slack_recovery_due.sql
+++ b/packages/core/drizzle/postgres/0100_mcp_slack_recovery_due.sql
@@ -1,0 +1,3 @@
+SET LOCAL lock_timeout = '3s';--> statement-breakpoint
+ALTER TABLE "tasks" ADD COLUMN "mcp_slack_recovery_due_at" timestamp with time zone;--> statement-breakpoint
+CREATE INDEX "tasks_mcp_slack_recovery_due_idx" ON "tasks" USING btree ("tenant_id","mcp_slack_recovery_due_at","task_id") WHERE "mcp_slack_recovery_due_at" IS NOT NULL;

--- a/packages/core/drizzle/postgres/meta/_journal.json
+++ b/packages/core/drizzle/postgres/meta/_journal.json
@@ -694,6 +694,13 @@
       "when": 1788206400000,
       "tag": "0099_shared_session_prompting",
       "breakpoints": true
+    },
+    {
+      "idx": 100,
+      "version": "7",
+      "when": 1788292800000,
+      "tag": "0100_mcp_slack_recovery_due",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/drizzle/sqlite/0103_mcp_slack_recovery_due.sql
+++ b/packages/core/drizzle/sqlite/0103_mcp_slack_recovery_due.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `tasks` ADD COLUMN `mcp_slack_recovery_due_at` integer;--> statement-breakpoint
+CREATE INDEX `tasks_mcp_slack_recovery_due_idx` ON `tasks` (`mcp_slack_recovery_due_at`,`task_id`) WHERE `mcp_slack_recovery_due_at` IS NOT NULL;

--- a/packages/core/drizzle/sqlite/meta/_journal.json
+++ b/packages/core/drizzle/sqlite/meta/_journal.json
@@ -708,6 +708,13 @@
       "when": 1788206400000,
       "tag": "0102_shared_session_prompting",
       "breakpoints": true
+    },
+    {
+      "idx": 103,
+      "version": "6",
+      "when": 1788292800000,
+      "tag": "0103_mcp_slack_recovery_due",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/db/oauth-secret-envelope.ts
+++ b/packages/core/src/db/oauth-secret-envelope.ts
@@ -10,6 +10,7 @@ const IV_LENGTH = 12;
 /** Purpose domains admitted by the durable bound-secret envelope. */
 export type BoundSecretPurpose =
   | 'pending-exchange'
+  | 'slack-mcp-recovery'
   | 'codex-device-attempt'
   | 'access-token'
   | 'refresh-token'

--- a/packages/core/src/db/repositories/tasks.postgres.test.ts
+++ b/packages/core/src/db/repositories/tasks.postgres.test.ts
@@ -245,4 +245,115 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)('TaskRepository PostgreSQL'
       queue_position: undefined,
     });
   });
+
+  it('serializes exact Slack recovery notice consumption under PostgreSQL row locks', async () => {
+    const label = crypto.randomUUID();
+    const owner = await new UsersRepository(db).create({
+      email: `postgres-slack-recovery-${label}@example.invalid`,
+      role: 'member',
+    });
+    const repo = await new RepoRepository(db).create({
+      repo_id: generateId(),
+      slug: `postgres-slack-recovery-${label}`,
+      name: 'Postgres Slack recovery',
+      repo_type: 'remote',
+      remote_url: 'https://example.invalid/postgres-slack-recovery.git',
+      local_path: `/tmp/postgres-slack-recovery-${label}`,
+      default_branch: 'main',
+    });
+    const branch = await new BranchRepository(db).create({
+      branch_id: generateId(),
+      repo_id: repo.repo_id,
+      name: `postgres-slack-recovery-${label}`,
+      ref: 'main',
+      branch_unique_id: 100_000 + Math.floor(Math.random() * 900_000),
+      path: `/tmp/postgres-slack-recovery-${label}/branch`,
+      created_by: owner.user_id,
+    });
+    const session = await new SessionRepository(db).create({
+      session_id: generateId(),
+      branch_id: branch.branch_id,
+      agentic_tool: 'claude-code',
+      created_by: owner.user_id,
+    });
+    const tasks = new TaskRepository(db);
+    const taskId = generateId();
+    await tasks.create({
+      task_id: taskId,
+      session_id: session.session_id,
+      created_by: owner.user_id,
+      full_prompt: 'postgres Slack recovery CAS',
+      status: TaskStatus.RUNNING,
+      message_range: {
+        start_index: 0,
+        end_index: 0,
+        start_timestamp: new Date().toISOString(),
+      },
+      git_state: { ref_at_start: 'main', sha_at_start: 'postgres-test' },
+      tool_use_count: 0,
+      metadata: {
+        mcp_slack_recovery_notice: {
+          notice_id: 'notice-postgres',
+          token_jti: 'jti-postgres',
+          issued_at: '2026-08-26T12:00:00.000Z',
+          expires_at: '2026-08-26T12:10:00.000Z',
+          principal_user_id: owner.user_id,
+          credential_user_id: owner.user_id,
+          slack_user_id: 'U1',
+          slack_team_id: 'T1',
+          gateway_channel_id: 'gateway-1',
+          gateway_config_generation: 1,
+          slack_channel_id: 'C1',
+          slack_thread_id: 'C1-1.1',
+          session_id: session.session_id,
+          task_id: taskId,
+          mcp_server_id: generateId() as never,
+          mcp_server_config_version: 1,
+          recovery_generation: 2,
+          recovery_request_id: 'request-postgres',
+          provider_dispatch: 'not_started',
+          delivery_id: 'delivery-postgres',
+          next_repair_at: '2026-08-26T12:00:00.000Z',
+        },
+      },
+    });
+
+    const consume = () =>
+      tasks.mutateMCPSlackRecoveryNotice(taskId, (current) =>
+        current?.notice_id === 'notice-postgres' &&
+        current.token_jti === 'jti-postgres' &&
+        current.recovery_request_id === 'request-postgres' &&
+        !current.token_consumed_at
+          ? { ...current, token_consumed_at: '2026-08-26T12:01:00.000Z' }
+          : null
+      );
+    const results = await Promise.all([consume(), consume()]);
+    expect(results.map((result) => result.changed).sort()).toEqual([false, true]);
+    const due = await tasks.findMcpSlackRecoveryNoticePage({
+      now: new Date('2026-08-26T12:02:00.000Z'),
+      horizon: new Date('2026-08-25T12:02:00.000Z'),
+      limit: 1,
+    });
+    expect(due.tasks.map((candidate) => candidate.task_id)).toContain(taskId);
+
+    if (!isPostgresDatabase(db)) throw new Error('PostgreSQL test requires PostgreSQL');
+    const columns = await db.execute(sql`
+      SELECT column_name, data_type
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'tasks'
+        AND column_name = 'mcp_slack_recovery_due_at'
+    `);
+    expect(columns).toEqual([
+      { column_name: 'mcp_slack_recovery_due_at', data_type: 'timestamp with time zone' },
+    ]);
+    const indexes = await db.execute(sql`
+      SELECT indexname
+      FROM pg_indexes
+      WHERE schemaname = 'public'
+        AND tablename = 'tasks'
+        AND indexname = 'tasks_mcp_slack_recovery_due_idx'
+    `);
+    expect(indexes).toEqual([{ indexname: 'tasks_mcp_slack_recovery_due_idx' }]);
+  });
 });

--- a/packages/core/src/db/repositories/tasks.test.ts
+++ b/packages/core/src/db/repositories/tasks.test.ts
@@ -4,7 +4,14 @@
  * Tests for type-safe CRUD operations on tasks with short ID support.
  */
 
-import type { MessageID, Task, TaskPendingDispatchStatus, UserID, UUID } from '@agor/core/types';
+import type {
+  MCPServerID,
+  MessageID,
+  Task,
+  TaskPendingDispatchStatus,
+  UserID,
+  UUID,
+} from '@agor/core/types';
 import { MessageRole, SessionStatus, TaskStatus } from '@agor/core/types';
 import { describe, expect, vi } from 'vitest';
 import { generateId, toShortId } from '../../lib/ids';
@@ -3846,5 +3853,131 @@ describe('TaskRepository sentinel invariants', () => {
         expect(task.git_state.sha_at_start).not.toBe('');
       }
     }
+  });
+});
+
+describe('TaskRepository MCP Slack recovery notice CAS', () => {
+  dbTest('allows only one exact single-use claim and rejects stale identities', async ({ db }) => {
+    const tasks = new TaskRepository(db);
+    const sessionId = await createSessionWithDeps(db);
+    const task = await tasks.create(
+      createTaskData({
+        session_id: sessionId,
+        metadata: {
+          mcp_slack_recovery_notice: {
+            notice_id: 'notice-1',
+            token_jti: 'jti-1',
+            issued_at: '2026-08-26T12:00:00.000Z',
+            expires_at: '2026-08-26T12:10:00.000Z',
+            principal_user_id: 'test-user' as UUID,
+            credential_user_id: 'test-user' as UUID,
+            slack_user_id: 'U1',
+            slack_team_id: 'T1',
+            gateway_channel_id: 'gateway-1',
+            gateway_config_generation: 1,
+            slack_channel_id: 'C1',
+            slack_thread_id: 'C1-1.1',
+            session_id: sessionId,
+            task_id: 'placeholder',
+            mcp_server_id: generateId() as MCPServerID,
+            mcp_server_config_version: 1,
+            recovery_generation: 3,
+            recovery_request_id: 'request-1',
+            provider_dispatch: 'not_started',
+            delivery_id: 'delivery-1',
+            next_repair_at: '2026-08-26T12:00:00.000Z',
+          },
+        },
+      })
+    );
+    // Align the durable task binding after creation, just as the gateway's
+    // row-locked notice projection does.
+    await tasks.mutateMCPSlackRecoveryNotice(task.task_id, (current) =>
+      current ? { ...current, task_id: task.task_id } : null
+    );
+
+    const consume = (jti: string, requestId: string) =>
+      tasks.mutateMCPSlackRecoveryNotice(task.task_id, (current) =>
+        current?.token_jti === jti &&
+        current.recovery_request_id === requestId &&
+        !current.token_consumed_at
+          ? { ...current, token_consumed_at: '2026-08-26T12:01:00.000Z' }
+          : null
+      );
+
+    const [first, duplicate] = await Promise.all([
+      consume('jti-1', 'request-1'),
+      consume('jti-1', 'request-1'),
+    ]);
+    expect([first.changed, duplicate.changed].sort()).toEqual([false, true]);
+    expect((await consume('jti-stale', 'request-1')).changed).toBe(false);
+    expect((await consume('jti-1', 'request-stale')).changed).toBe(false);
+    expect(
+      (await tasks.findById(task.task_id))?.metadata?.mcp_slack_recovery_notice?.token_consumed_at
+    ).toBe('2026-08-26T12:01:00.000Z');
+
+    await tasks.update(task.task_id, { status: TaskStatus.COMPLETED });
+    const repair = await tasks.findMcpSlackRecoveryNoticePage({
+      limit: 1,
+      now: new Date('2026-08-26T12:02:00.000Z'),
+      horizon: new Date('2026-08-25T12:02:00.000Z'),
+    });
+    expect(repair.tasks.map((candidate) => candidate.task_id)).toContain(task.task_id);
+
+    await tasks.mutateMCPSlackRecoveryNotice(task.task_id, (current) =>
+      current ? { ...current, next_repair_at: undefined } : null
+    );
+    expect(
+      (
+        await tasks.findMcpSlackRecoveryNoticePage({
+          limit: 1,
+          now: new Date('2026-08-26T12:02:00.000Z'),
+          horizon: new Date('2026-08-25T12:02:00.000Z'),
+        })
+      ).tasks
+    ).toEqual([]);
+
+    const firstDue = await tasks.mutateMCPSlackRecoveryNotice(task.task_id, (current) =>
+      current ? { ...current, next_repair_at: '2026-08-26T12:00:00.000Z' } : null
+    );
+    const template = firstDue.task.metadata?.mcp_slack_recovery_notice;
+    expect(template).toBeDefined();
+    const secondSessionId = await createSessionWithDeps(db);
+    const second = await tasks.create(
+      createTaskData({
+        session_id: secondSessionId,
+        metadata: {
+          mcp_slack_recovery_notice: {
+            ...template!,
+            notice_id: 'notice-2',
+            token_jti: 'jti-2',
+            task_id: 'placeholder-2',
+            session_id: secondSessionId,
+            next_repair_at: '2026-08-26T12:00:01.000Z',
+          },
+        },
+      })
+    );
+    expect(
+      (
+        await tasks.findMcpSlackRecoveryNoticePage({
+          limit: 1,
+          now: new Date('2026-08-26T12:02:00.000Z'),
+          horizon: new Date('2026-08-25T12:02:00.000Z'),
+        })
+      ).tasks
+    ).toHaveLength(1);
+    await tasks.mutateMCPSlackRecoveryNotice(task.task_id, (current) =>
+      current ? { ...current, next_repair_at: '2026-08-20T12:00:00.000Z' } : null
+    );
+    const recentOnly = await tasks.findMcpSlackRecoveryNoticePage({
+      limit: 10,
+      now: new Date('2026-08-26T12:02:00.000Z'),
+      horizon: new Date('2026-08-25T12:02:00.000Z'),
+    });
+    expect(recentOnly.tasks.map((candidate) => candidate.task_id)).toEqual([second.task_id]);
+    await expect(tasks.findMcpSlackRecoveryNoticePage({ limit: 101 })).rejects.toThrow(
+      /between 1 and 100/
+    );
   });
 });

--- a/packages/core/src/db/repositories/tasks.ts
+++ b/packages/core/src/db/repositories/tasks.ts
@@ -12,6 +12,7 @@ import type {
   ExecutorTerminationCompleteInput,
   MCPRuntimeRecovery,
   MCPServerID,
+  MCPSlackRecoveryNotice,
   SdkFailure,
   SessionID,
   Task,
@@ -37,6 +38,7 @@ import {
   desc,
   eq,
   gt,
+  gte,
   inArray,
   isNotNull,
   isNull,
@@ -541,6 +543,9 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
       status: task.status ?? TaskStatus.CREATED,
       queue_position: task.queue_position ?? null,
       created_by: task.created_by,
+      mcp_slack_recovery_due_at: task.metadata?.mcp_slack_recovery_notice?.next_repair_at
+        ? new Date(task.metadata.mcp_slack_recovery_notice.next_repair_at)
+        : undefined,
       data: {
         full_prompt: task.full_prompt ?? '',
         message_range: task.message_range ?? {
@@ -915,6 +920,41 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
       if (error instanceof RepositoryError) throw error;
       throw new RepositoryError(
         `Failed to page active MCP Tasks: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
+  /** One hard-bounded due-work batch backed by a tenant-aware partial index. */
+  async findMcpSlackRecoveryNoticePage(
+    options: { now?: Date; horizon?: Date; limit?: number } = {}
+  ): Promise<{ tasks: Task[] }> {
+    const limit = options.limit ?? 100;
+    if (!Number.isInteger(limit) || limit < 1 || limit > 100) {
+      throw new RepositoryError('MCP Slack recovery repair limit must be between 1 and 100');
+    }
+    try {
+      const now = options.now ?? new Date();
+      const horizon = options.horizon ?? new Date(now.getTime() - 24 * 60 * 60_000);
+      const rows = await select(this.db)
+        .from(tasks)
+        .where(
+          and(
+            isNotNull(tasks.mcp_slack_recovery_due_at),
+            lte(tasks.mcp_slack_recovery_due_at, now),
+            gte(tasks.mcp_slack_recovery_due_at, horizon)
+          )
+        )
+        .orderBy(asc(tasks.mcp_slack_recovery_due_at), asc(tasks.task_id))
+        .limit(limit)
+        .all();
+      return {
+        tasks: rows.map((row: TaskRow) => this.rowToTask(row)),
+      };
+    } catch (error) {
+      if (error instanceof RepositoryError) throw error;
+      throw new RepositoryError(
+        `Failed to page MCP Slack recovery notices: ${error instanceof Error ? error.message : String(error)}`,
         error
       );
     }
@@ -1921,6 +1961,48 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
             .returning()
             .one();
           return this.rowToTask(updated);
+        },
+        { sqliteImmediate: true }
+      )
+    );
+  }
+
+  /**
+   * Serialize internal Slack notice delivery against the same Task row that
+   * owns authoritative MCP recovery. Callers must perform provider I/O only
+   * after this short transaction returns.
+   */
+  async mutateMCPSlackRecoveryNotice(
+    id: string,
+    build: (
+      current: MCPSlackRecoveryNotice | undefined,
+      task: Task,
+      txDb: Database
+    ) => MCPSlackRecoveryNotice | null | Promise<MCPSlackRecoveryNotice | null>
+  ): Promise<{ task: Task; changed: boolean }> {
+    return this.runTaskMutation(() =>
+      runDatabaseTransaction(
+        this.db,
+        async (txDb) => {
+          const fullId = await this.resolveId(id);
+          await lockRowForUpdate(txDb, this.db, tasks, eq(tasks.task_id, fullId));
+          const row = await select(txDb).from(tasks).where(eq(tasks.task_id, fullId)).one();
+          if (!row) throw new EntityNotFoundError('Task', id);
+          const task = this.rowToTask(row);
+          const next = await build(task.metadata?.mcp_slack_recovery_notice, task, txDb);
+          if (!next) return { task, changed: false };
+          const updated = await update(txDb, tasks)
+            .set({
+              mcp_slack_recovery_due_at: next.next_repair_at ? new Date(next.next_repair_at) : null,
+              data: {
+                ...row.data,
+                metadata: { ...task.metadata, mcp_slack_recovery_notice: next },
+              },
+            })
+            .where(eq(tasks.task_id, fullId))
+            .returning()
+            .one();
+          return { task: this.rowToTask(updated), changed: true };
         },
         { sqliteImmediate: true }
       )

--- a/packages/core/src/db/schema.postgres.ts
+++ b/packages/core/src/db/schema.postgres.ts
@@ -359,6 +359,9 @@ export const tasks = pgTable(
     // User attribution
     created_by: varchar('created_by', { length: 36 }).notNull(),
 
+    // Indexed due-work projection for bounded Slack MCP recovery repair.
+    mcp_slack_recovery_due_at: t.timestamp('mcp_slack_recovery_due_at'),
+
     data: t
       .json<unknown>('data')
       .$type<{
@@ -413,6 +416,9 @@ export const tasks = pgTable(
     sessionTaskIdIdx: index('tasks_session_task_id_idx').on(table.session_id, table.task_id),
     statusIdx: index('tasks_status_idx').on(table.status),
     createdIdx: index('tasks_created_idx').on(table.created_at),
+    mcpSlackRecoveryDueIdx: index('tasks_mcp_slack_recovery_due_idx')
+      .on(table.tenant_id, table.mcp_slack_recovery_due_at, table.task_id)
+      .where(sql`${table.mcp_slack_recovery_due_at} IS NOT NULL`),
     // Composite for "latest task for session" queries (ORDER BY created_at DESC LIMIT 1).
     sessionCreatedIdx: index('tasks_session_created_idx').on(table.session_id, table.created_at),
     queueIdx: index('tasks_queue_idx').on(table.session_id, table.status, table.queue_position),

--- a/packages/core/src/db/schema.sqlite.ts
+++ b/packages/core/src/db/schema.sqlite.ts
@@ -337,6 +337,9 @@ export const tasks = sqliteTable(
     // User attribution
     created_by: text('created_by', { length: 36 }).notNull(),
 
+    // Indexed due-work projection for bounded Slack MCP recovery repair.
+    mcp_slack_recovery_due_at: t.timestamp('mcp_slack_recovery_due_at'),
+
     data: t
       .json<unknown>('data')
       .$type<{
@@ -390,6 +393,9 @@ export const tasks = sqliteTable(
     sessionTaskIdIdx: index('tasks_session_task_id_idx').on(table.session_id, table.task_id),
     statusIdx: index('tasks_status_idx').on(table.status),
     createdIdx: index('tasks_created_idx').on(table.created_at),
+    mcpSlackRecoveryDueIdx: index('tasks_mcp_slack_recovery_due_idx')
+      .on(table.mcp_slack_recovery_due_at, table.task_id)
+      .where(sql`${table.mcp_slack_recovery_due_at} IS NOT NULL`),
     queueIdx: index('tasks_queue_idx').on(table.session_id, table.status, table.queue_position),
     runtimeDispatchIdx: index('tasks_runtime_dispatch_idx')
       .on(table.started_at, table.task_id)

--- a/packages/core/src/db/task-runtime-ha.postgres.test.ts
+++ b/packages/core/src/db/task-runtime-ha.postgres.test.ts
@@ -576,4 +576,75 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)('Task runtime HA (PostgreSQ
       ).rejects.toThrow();
     });
   });
+
+  it('keeps Slack recovery single-use CAS tenant-scoped under forced RLS', async () => {
+    const a = await seedTenant(db, 'slack-recovery-a');
+    const b = await seedTenant(db, 'slack-recovery-b');
+    const task = await runWithTenantDatabaseScope(db, a.tenantId, (scoped) =>
+      new TaskRepository(scoped).create(taskInput(a, TaskStatus.RUNNING))
+    );
+    await runWithTenantDatabaseScope(db, a.tenantId, async (scoped) => {
+      await new TaskRepository(scoped).mutateMCPSlackRecoveryNotice(task.task_id, () => ({
+        notice_id: 'notice-rls',
+        token_jti: 'jti-rls',
+        issued_at: '2026-08-26T12:00:00.000Z',
+        expires_at: '2026-08-26T12:10:00.000Z',
+        principal_user_id: a.userId,
+        credential_user_id: a.userId,
+        slack_user_id: 'U1',
+        slack_team_id: 'T1',
+        gateway_channel_id: 'gateway-1',
+        gateway_config_generation: 1,
+        slack_channel_id: 'C1',
+        slack_thread_id: 'C1-1.1',
+        session_id: a.sessionId,
+        task_id: task.task_id,
+        mcp_server_id: generateId() as never,
+        mcp_server_config_version: 1,
+        recovery_generation: 1,
+        recovery_request_id: 'request-rls',
+        provider_dispatch: 'not_started',
+        delivery_id: 'delivery-rls',
+        next_repair_at: '2026-08-26T12:00:00.000Z',
+      }));
+    });
+    const consume = (database: Database) =>
+      runWithTenantDatabaseScope(database, a.tenantId, (scoped) =>
+        new TaskRepository(scoped).mutateMCPSlackRecoveryNotice(task.task_id, (current) =>
+          current?.token_jti === 'jti-rls' && !current.token_consumed_at
+            ? { ...current, token_consumed_at: '2026-08-26T12:01:00.000Z' }
+            : null
+        )
+      );
+    const results = await Promise.all([consume(db), consume(peerDb)]);
+    expect(results.map((result) => result.changed).sort()).toEqual([false, true]);
+    await runWithTenantDatabaseScope(db, a.tenantId, async (scoped) => {
+      const tasks = new TaskRepository(scoped);
+      expect(
+        (
+          await tasks.findMcpSlackRecoveryNoticePage({
+            now: new Date('2026-08-26T12:02:00.000Z'),
+            horizon: new Date('2026-08-25T12:02:00.000Z'),
+            limit: 10,
+          })
+        ).tasks.map((candidate) => candidate.task_id)
+      ).toContain(task.task_id);
+    });
+    await runWithTenantDatabaseScope(db, b.tenantId, async (scoped) => {
+      const tasks = new TaskRepository(scoped);
+      expect(await tasks.findById(task.task_id)).toBeNull();
+      expect(
+        (
+          await tasks.findMcpSlackRecoveryNoticePage({
+            now: new Date('2026-08-26T12:02:00.000Z'),
+            horizon: new Date('2026-08-25T12:02:00.000Z'),
+            limit: 10,
+          })
+        ).tasks
+      ).toEqual([]);
+      await expect(
+        tasks.mutateMCPSlackRecoveryNotice(task.task_id, (current) => current ?? null)
+      ).rejects.toThrow();
+    });
+  });
 });

--- a/packages/core/src/gateway/connector.ts
+++ b/packages/core/src/gateway/connector.ts
@@ -176,6 +176,19 @@ export interface GatewayConnector {
   }): Promise<GatewaySendResult>;
 
   /**
+   * Best-effort reconciliation for an ambiguous at-least-once post. Providers
+   * that expose durable message metadata may return the matching message id;
+   * absence is not proof that a previous post did not land.
+   */
+  findMessageByMetadata?(req: {
+    threadId: string;
+    eventType: string;
+    payloadKey: string;
+    payloadValue: string;
+    limit?: number;
+  }): Promise<string | undefined>;
+
+  /**
    * Optional bounded history read used by mention catch-up. The returned
    * interval is provider-neutral, ordered oldest-first, and remains in memory
    * until the daemon formats the single admitted Task prompt.

--- a/packages/core/src/gateway/connectors/slack.test.ts
+++ b/packages/core/src/gateway/connectors/slack.test.ts
@@ -1010,6 +1010,106 @@ describe('SlackConnector.fetchChannelHistory', () => {
 const SECTION_MAX_CHARS_TEST = 3000;
 
 describe('SlackConnector.sendMessage', () => {
+  it('attaches supported message metadata to the initial post, not a false client_msg_id', async () => {
+    const posts: unknown[] = [];
+    const updates: unknown[] = [];
+    const connector = new SlackConnector({ bot_token: 'xoxb-test' });
+    (connector as unknown as { web: unknown }).web = {
+      chat: {
+        postMessage: async (args: unknown) => {
+          posts.push(args);
+          return { ok: true, ts: '1700000000.000001' };
+        },
+        update: async (args: unknown) => {
+          updates.push(args);
+          return { ok: true, ts: '1700000000.000001' };
+        },
+      },
+    };
+
+    await connector.sendMessage({
+      threadId: 'C123-1700000000.000000',
+      text: 'Reconnect required',
+      metadata: {
+        slack_message_metadata: {
+          event_type: 'agor_mcp_recovery',
+          event_payload: { delivery_id: 'delivery-1' },
+        },
+      },
+    });
+    await connector.sendMessage({
+      threadId: 'C123-1700000000.000000',
+      text: 'Recovered',
+      metadata: {
+        slack_update_ts: '1700000000.000001',
+      },
+    });
+
+    expect(posts).toEqual([
+      expect.objectContaining({
+        channel: 'C123',
+        thread_ts: '1700000000.000000',
+        metadata: {
+          event_type: 'agor_mcp_recovery',
+          event_payload: { delivery_id: 'delivery-1' },
+        },
+      }),
+    ]);
+    expect(updates).toEqual([
+      expect.objectContaining({ channel: 'C123', ts: '1700000000.000001' }),
+    ]);
+    expect(posts[0]).not.toHaveProperty('client_msg_id');
+    expect(updates[0]).not.toHaveProperty('metadata');
+  });
+
+  it('reconciles one bounded ambiguous post by durable Slack metadata', async () => {
+    const calls: unknown[] = [];
+    const connector = new SlackConnector({
+      bot_token: 'xoxb-test',
+      allowed_channel_ids: ['C123'],
+    });
+    (connector as unknown as { web: unknown }).web = {
+      conversations: {
+        replies: async (args: unknown) => {
+          calls.push(args);
+          return {
+            ok: true,
+            messages: [
+              { ts: '1.1', metadata: { event_type: 'other', event_payload: {} } },
+              {
+                ts: '1.2',
+                metadata: {
+                  event_type: 'agor_mcp_recovery',
+                  event_payload: { delivery_id: 'delivery-1' },
+                },
+              },
+            ],
+          };
+        },
+      },
+    };
+
+    await expect(
+      connector.findMessageByMetadata({
+        threadId: 'C123-1.0',
+        eventType: 'agor_mcp_recovery',
+        payloadKey: 'delivery_id',
+        payloadValue: 'delivery-1',
+        limit: 500,
+      })
+    ).resolves.toBe('1.2');
+    expect(calls).toEqual([{ channel: 'C123', ts: '1.0', limit: 100, include_all_metadata: true }]);
+    await expect(
+      connector.findMessageByMetadata({
+        threadId: 'C_OTHER-1.0',
+        eventType: 'agor_mcp_recovery',
+        payloadKey: 'delivery_id',
+        payloadValue: 'delivery-1',
+      })
+    ).rejects.toThrow(/allowlist/);
+    expect(calls).toHaveLength(1);
+  });
+
   it('updates an existing Slack message when slack_update_ts metadata is present', async () => {
     const calls: unknown[] = [];
     const connector = new SlackConnector({ bot_token: 'xoxb-test' });

--- a/packages/core/src/gateway/connectors/slack.ts
+++ b/packages/core/src/gateway/connectors/slack.ts
@@ -223,7 +223,7 @@ export interface SlackChannelHistoryResult {
  * Format: "{channel_id}-{thread_ts}" where thread_ts contains a dot
  * e.g. "C07ABC123-1707340800.123456" → { channel: "C07ABC123", thread_ts: "1707340800.123456" }
  */
-function parseThreadId(threadId: string): { channel: string; thread_ts: string } {
+export function parseThreadId(threadId: string): { channel: string; thread_ts: string } {
   // thread_ts always contains a dot, so split on the last hyphen before the numeric part
   const lastHyphen = threadId.lastIndexOf('-');
   if (lastHyphen === -1) {
@@ -1399,6 +1399,20 @@ export class SlackConnector implements GatewayConnector {
     const blocks = req.blocks && req.blocks.length > 0 ? (req.blocks as KnownBlock[]) : undefined;
     const updateTs =
       typeof req.metadata?.slack_update_ts === 'string' ? req.metadata.slack_update_ts : undefined;
+    const requestedMessageMetadata = req.metadata?.slack_message_metadata as
+      | { event_type?: unknown; event_payload?: { delivery_id?: unknown } }
+      | undefined;
+    const messageMetadata =
+      requestedMessageMetadata?.event_type === 'agor_mcp_recovery' &&
+      typeof requestedMessageMetadata.event_payload?.delivery_id === 'string' &&
+      requestedMessageMetadata.event_payload.delivery_id.length <= 128
+        ? {
+            event_type: 'agor_mcp_recovery',
+            event_payload: {
+              delivery_id: requestedMessageMetadata.event_payload.delivery_id,
+            },
+          }
+        : undefined;
 
     const send = (withBlocks: boolean) => {
       const base = {
@@ -1419,6 +1433,7 @@ export class SlackConnector implements GatewayConnector {
       return this.web.chat.postMessage({
         ...base,
         thread_ts,
+        ...(messageMetadata ? { metadata: messageMetadata } : {}),
       });
     };
 
@@ -1452,6 +1467,43 @@ export class SlackConnector implements GatewayConnector {
     }
 
     return result.ts;
+  }
+
+  async findMessageByMetadata(req: {
+    threadId: string;
+    eventType: string;
+    payloadKey: string;
+    payloadValue: string;
+    limit?: number;
+  }): Promise<string | undefined> {
+    const { channel, thread_ts } = parseThreadId(req.threadId);
+    if (!isSlackWriteTargetAllowed(this.config as unknown as Record<string, unknown>, channel)) {
+      throw new Error(`Slack channel ${channel} is outside the configured allowlist`);
+    }
+    try {
+      const result = await this.web.conversations.replies({
+        channel,
+        ts: thread_ts,
+        limit: Math.min(Math.max(req.limit ?? 100, 1), 100),
+        include_all_metadata: true,
+      });
+      if (!result.ok) return undefined;
+      for (const message of result.messages ?? []) {
+        const metadata = message.metadata as
+          | { event_type?: unknown; event_payload?: Record<string, unknown> }
+          | undefined;
+        if (
+          metadata?.event_type === req.eventType &&
+          metadata.event_payload?.[req.payloadKey] === req.payloadValue &&
+          typeof message.ts === 'string'
+        ) {
+          return message.ts;
+        }
+      }
+      return undefined;
+    } catch (error) {
+      throw slackProviderFailure('Slack metadata reconciliation failed', error);
+    }
   }
 
   /**

--- a/packages/core/src/gateway/index.ts
+++ b/packages/core/src/gateway/index.ts
@@ -69,6 +69,7 @@ export {
   isSlackFileSourceAllowed,
   isSlackWriteTargetAllowed,
   markdownToMrkdwn,
+  parseThreadId as parseSlackThreadId,
   SlackConnector,
 } from './connectors/slack';
 export type {

--- a/packages/core/src/types/mcp.ts
+++ b/packages/core/src/types/mcp.ts
@@ -206,6 +206,8 @@ export interface MCPOAuthPendingFlowSealedMaterial {
   /** Whether RFC 9207 says this AS will return `iss` on the callback. */
   authorizationResponseIssuerParameterSupported?: boolean;
   allowLocalhostHttp: boolean;
+  /** Non-secret durable routing back to an exact Slack recovery notice. */
+  slackRecovery?: MCPSlackOAuthRecoveryContext;
 }
 
 /**
@@ -799,6 +801,112 @@ export interface MCPRuntimeRecovery {
   refresh_deadline_at?: string;
   /** Whether the rejected provider hop is proven unstarted or may have started. */
   provider_dispatch: 'not_started' | 'ambiguous';
+}
+
+/**
+ * Durable Slack presentation for one exact structured MCP runtime recovery.
+ *
+ * This is deliberately not a second recovery authority: `mcp_recovery` and
+ * its reprojection tombstones remain authoritative.  The notice only fences a
+ * one-use browser entry and an idempotent Slack message that projects that
+ * state. It is internal task metadata and is stripped from API/realtime DTOs.
+ */
+export interface MCPSlackRecoveryNotice {
+  notice_id: string;
+  token_jti: string;
+  token_consumed_at?: string;
+  issued_at: string;
+  expires_at: string;
+  principal_user_id: UserID;
+  credential_user_id: UserID;
+  slack_user_id: string;
+  slack_team_id: string;
+  gateway_channel_id: string;
+  gateway_config_generation: number;
+  slack_channel_id: string;
+  slack_thread_id: string;
+  session_id: SessionID;
+  task_id: string;
+  mcp_server_id: MCPServerID;
+  mcp_server_config_version: number;
+  recovery_generation: number;
+  recovery_request_id?: string;
+  provider_dispatch: 'not_started' | 'ambiguous';
+  oauth_attempt_id?: MCPOAuthAttemptID;
+  /** Short lease between one-use consumption and canonical flow creation. */
+  oauth_start_claimed_at?: string;
+  oauth_start_claim_expires_at?: string;
+  oauth_started_at?: string;
+  oauth_succeeded_at?: string;
+  /** OAuth completed, but the exact Task/config authority was no longer current. */
+  oauth_superseded_at?: string;
+  oauth_failed_at?: string;
+  /** Rollout disabled after issuance; keeps the stale action fail-closed. */
+  recovery_disabled_at?: string;
+  /** A bound channel/principal/server authority changed after issuance. */
+  binding_invalidated_at?: string;
+  /** Stable metadata identity used to reconcile an ambiguous Slack post when history permits. */
+  delivery_id: string;
+  slack_message_ts?: string;
+  delivery_claim?: {
+    claim_id: string;
+    claimed_at: string;
+    expires_at: string;
+  };
+  /** Last provider-neutral rendering successfully acknowledged by Slack. */
+  rendered_state?: MCPSlackRecoveryRenderedState;
+  rendered_at?: string;
+  /** Bounded at-least-once delivery retry state, independent of browser-token expiry. */
+  delivery_attempt_count?: number;
+  delivery_last_failed_at?: string;
+  delivery_next_retry_at?: string;
+  delivery_retry_until?: string;
+  /** Indexed durable backstop used by startup and periodic bounded repair. */
+  next_repair_at?: string;
+}
+
+export type MCPSlackRecoveryRenderedState =
+  | 'reconnect_required'
+  | 'sign_in_pending'
+  | 'recovered'
+  | 'expired_or_superseded'
+  | 'failed'
+  | 'manual_next_turn';
+
+/** Authenticated, encrypted browser-entry claims; every field is compared durably. */
+export interface MCPSlackRecoveryTokenClaims {
+  type: 'mcp-slack-recovery';
+  tid: string;
+  sub: UserID;
+  credential_user_id: UserID;
+  slack_user_id: string;
+  slack_team_id: string;
+  gateway_channel_id: string;
+  gateway_config_generation: number;
+  slack_channel_id: string;
+  slack_thread_id: string;
+  task_id: string;
+  session_id: SessionID;
+  mcp_server_id: MCPServerID;
+  mcp_server_config_version: number;
+  recovery_generation: number;
+  recovery_request_id?: string;
+  notice_id: string;
+  jti: string;
+  iat: number;
+  exp: number;
+  aud: 'agor:mcp-slack-recovery';
+  iss: 'agor';
+}
+
+/** Optional context sealed into the canonical OAuth pending flow. */
+export interface MCPSlackOAuthRecoveryContext {
+  notice_id: string;
+  task_id: string;
+  session_id: SessionID;
+  mcp_server_id: MCPServerID;
+  recovery_generation: number;
+  recovery_request_id?: string;
 }
 
 // ============================================================================

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -190,6 +190,16 @@ export interface TaskMetadata {
   gateway_inbound_event_id?: GatewayInboundEventID;
   /** Provider reply target captured for this gateway Task (for example an editable ack ID). */
   gateway_reply_metadata?: Record<string, unknown>;
+  /** Immutable gateway coordinates; stripped from API/realtime Task DTOs. */
+  gateway_task_source?: {
+    gateway_channel_id: string;
+    channel_type: import('./gateway').ChannelType;
+    thread_id: string;
+    provider_user_id: string;
+    provider_message_id?: string;
+    slack_team_id?: string;
+    slack_channel_id?: string;
+  };
   /**
    * Durable identity of the Task's first transcript row. Internal
    * idempotent producers persist this alongside the Task so any daemon that
@@ -227,6 +237,9 @@ export interface TaskMetadata {
     /** Bounded keyed hashes of the exact projection returned for this claim. */
     authority_fingerprints?: string[];
   };
+
+  /** Internal Slack delivery projection for the structured MCP recovery above. */
+  mcp_slack_recovery_notice?: import('./mcp').MCPSlackRecoveryNotice;
 
   /**
    * Immutable one-shot completion callback requested for this exact task.

--- a/packages/core/src/utils/url.test.ts
+++ b/packages/core/src/utils/url.test.ts
@@ -7,11 +7,23 @@ import {
   getBoardUrl,
   getBranchUrl,
   getKnowledgeUrl,
+  getMcpSlackRecoveryUrl,
   getSessionUrl,
   isAllowedHealthCheckUrl,
   normalizeHttpBaseUrl,
   normalizeOptionalHttpUrl,
 } from './url';
+
+describe('getMcpSlackRecoveryUrl', () => {
+  it('preserves a configured base path and avoids a duplicate UI mount', () => {
+    expect(getMcpSlackRecoveryUrl('https://example.test/agor')).toBe(
+      'https://example.test/agor/ui/recover/mcp'
+    );
+    expect(getMcpSlackRecoveryUrl('https://example.test/agor/ui/')).toBe(
+      'https://example.test/agor/ui/recover/mcp'
+    );
+  });
+});
 
 // Minimal UUIDv7-shaped IDs for URL builder tests.
 const SESSION_ID = '01927f9d-0000-7000-8000-000000000001' as SessionID;

--- a/packages/core/src/utils/url.ts
+++ b/packages/core/src/utils/url.ts
@@ -100,6 +100,11 @@ export function artifactFullscreenPath(artifactId: ArtifactID): string {
   return `/${ENTITY_PATH_SEGMENTS.artifact}/${shortId(artifactId)}/fullscreen`;
 }
 
+/** Lightweight authenticated browser surface for a Slack MCP recovery action. */
+export function mcpSlackRecoveryPath(): string {
+  return '/recover/mcp';
+}
+
 function encodePathSegments(path: string): string {
   return path
     .split('/')
@@ -176,6 +181,11 @@ export function getArtifactUrl(artifactId: ArtifactID, baseUrl: string): string 
  *  compact navbar. */
 export function getArtifactFullscreenUrl(artifactId: ArtifactID, baseUrl: string): string {
   return fullUrl(artifactFullscreenPath(artifactId), baseUrl);
+}
+
+/** Preserve any operator-configured base path while adding the UI mount. */
+export function getMcpSlackRecoveryUrl(baseUrl: string): string {
+  return fullUrl(mcpSlackRecoveryPath(), baseUrl);
 }
 
 /** Generate a Knowledge URL from namespace + optional document path. */


### PR DESCRIPTION
## Dependency

Stacked on **#2566** and intentionally targets `mcp-live-reconfiguration` at `de42e3e22870ea0de536be59d6b1ee504a3085ec`. Merge only after the parent is ready. **#2501 is excluded.**

Agor branch: https://agor.sandbox.preset.zone/ui/w/01a03ef735cc732782661e50/

Related: #2515

## Summary

- delivers Slack in-thread MCP OAuth recovery with an encrypted, expiring, single-use action bound to the exact tenant, user, task, session, server, Slack team/user/thread, and live reprojection generations
- preserves canonical OAuth URLs and login fragments, the real thread allowlist, accessible recovery UI, and truthful superseded-OAuth behavior
- adds bounded startup/periodic repair plus durable terminal retries
- reconciles Slack metadata at least once with `include_all_metadata: true` without replaying MCP work
- preserves #2566 generation/request/projection-digest fencing, provider truthfulness, authority/redaction, and no-replay guarantees
- preserves merged UUIDv4/v7 compatibility and current gateway/OAuth behavior from #2631/#2632

## Rebase / conflict adaptations

The single reviewed commit was rebased from `0052b0c..1ed8ecd` onto exact parent `de42e3e2`; the resulting commit remains one coherent change. Range-diff accounts for every Slack change. Conflicts were resolved by combining parent authority-aware task-result redaction and per-audience realtime topology with the Slack notice stripping, retaining RBAC-aware gateway construction, coexisting UI routes, renumbering migrations after current main, updating PostgreSQL identity fixtures for UUIDv4/v7 compatibility, and adapting the HA race/OAuth ordering tests to the current parent behavior.

## Validation

- focused core, daemon, UI, Slack, OAuth, gateway, UUID identity, and executor live-refresh suites: passed
- Playwright-backed Chromium browser suite across desktop/phone/tablet/short-landscape: 12 passed
- disposable PostgreSQL NOSUPERUSER/NOBYPASSRLS focused collection: 25 passed
- full PostgreSQL/RLS collection: 220 passed; one unrelated knowledge-embedding concurrency test hit its 10s timeout and passed isolated (9 passed)
- source-condition typechecks for git/core/daemon/UI: passed
- lint + frontend design rules: passed
- short-id, multitenancy, daemon-filesystem, and realtime boundary checks: passed
- `git diff --check`: passed

## Limitations

Normal workspace typecheck scripts require prebuilt workspace declarations; per repository instructions no build was run, so source-condition typechecks were used instead. A managed HA smoke was attempted: PostgreSQL/Redis/dev-launcher became healthy, but migration was blocked by another active agentic-tools install lock, leaving `/readyz` unavailable. No recovery-surface HA smoke is claimed. Playwright MCP was not attached; the repository's real Playwright Chromium browser tests were run instead.
