### PR TITLE
fix(gateway): bind final replies to exact tasks

### DIFF
--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -3186,6 +3186,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           const session = Array.isArray(context.result) ? context.result[0] : context.result;
 
           if (session && shouldRunSessionPostTurnHooks(session)) {
+            const terminalTaskId = session.tasks?.at(-1);
             // Flush the gateway outbound buffer (fire-and-forget).
             // When a GitHub/Shortcut-connected session finishes its turn, post
             // the last buffered message as a PR/issue/story comment. Must happen
@@ -3197,7 +3198,11 @@ export function registerHooks(ctx: RegisterHooksContext): void {
             deferWithTenantContext(context.params, async () => {
               try {
                 const gatewayService = context.app.service('gateway') as unknown as GatewayService;
-                await gatewayService.flushOutboundBuffer(session.session_id);
+                if (terminalTaskId) {
+                  await gatewayService.flushOutboundBuffer(session.session_id, {
+                    taskId: terminalTaskId,
+                  });
+                }
                 await gatewayService.updateProgress({
                   session_id: session.session_id,
                   state: 'done',

--- a/apps/agor-daemon/src/services/gateway.github.test.ts
+++ b/apps/agor-daemon/src/services/gateway.github.test.ts
@@ -614,6 +614,45 @@ describe('GatewayService GitHub integration', () => {
     );
   });
 
+  it('uses a preview-only assistant row as the exact task final response', async () => {
+    const mapping = githubMapping();
+    const harness = makeGitHubHarness(mapping);
+    const taskId = '019fd900-0000-7000-8000-000000000054';
+    harness.setTasks([
+      {
+        task_id: taskId,
+        session_id: mapping.session_id,
+        status: TaskStatus.COMPLETED,
+        created_at: '2026-08-14T00:00:01.000Z',
+        completed_at: '2026-08-14T00:00:03.000Z',
+        metadata: { gateway_reply_metadata: { processing_comment_id: 901 } },
+      } as unknown as Task,
+    ]);
+    harness.setMessages([
+      {
+        message_id: '019fd900-0000-7000-8000-000000000055',
+        session_id: mapping.session_id,
+        task_id: taskId,
+        role: 'assistant',
+        content: '',
+        content_preview: 'Final response retained in the durable preview.',
+        index: 1,
+      } as unknown as Message,
+    ]);
+
+    await runWithTenantContext(tenantId, () =>
+      harness.service.flushOutboundBuffer(mapping.session_id, { taskId })
+    );
+
+    expect(harness.sendMessage).toHaveBeenCalledOnce();
+    expect(harness.sendMessage).toHaveBeenCalledWith({
+      threadId,
+      text: 'Final response retained in the durable preview.',
+      blocks: undefined,
+      metadata: { edit_comment_id: 901 },
+    });
+  });
+
   it('fences concurrent terminal hooks so only one provider edit is sent', async () => {
     const mapping = githubMapping();
     const harness = makeGitHubHarness(mapping);
@@ -650,6 +689,68 @@ describe('GatewayService GitHub integration', () => {
 
     expect(harness.sendMessage).toHaveBeenCalledOnce();
     expect(harness.messagesRepo.mutateMetadataLocked).toHaveBeenCalledTimes(3);
+  });
+
+  it('reclaims a stale processing claim while an active claim remains fenced', async () => {
+    const mapping = githubMapping();
+    const harness = makeGitHubHarness(mapping);
+    const taskId = '019fd900-0000-7000-8000-000000000059';
+    const message = {
+      message_id: '019fd900-0000-7000-8000-00000000005a',
+      session_id: mapping.session_id,
+      task_id: taskId,
+      role: 'assistant',
+      content: 'Recoverable final answer.',
+      content_preview: 'Recoverable final answer.',
+      index: 1,
+      metadata: {
+        gateway_final_reply: {
+          status: 'processing',
+          claim_token: 'active-daemon-claim',
+          claimed_at: new Date().toISOString(),
+        },
+      },
+    } as unknown as Message;
+    harness.setTasks([
+      {
+        task_id: taskId,
+        session_id: mapping.session_id,
+        status: TaskStatus.COMPLETED,
+        created_at: '2026-08-14T00:00:01.000Z',
+        completed_at: '2026-08-14T00:00:03.000Z',
+        metadata: { gateway_reply_metadata: { processing_comment_id: 901 } },
+      } as unknown as Task,
+    ]);
+    harness.setMessages([message]);
+
+    await runWithTenantContext(tenantId, () =>
+      harness.service.flushOutboundBuffer(mapping.session_id, { taskId })
+    );
+    expect(harness.sendMessage).not.toHaveBeenCalled();
+
+    harness.setMessages([
+      {
+        ...message,
+        metadata: {
+          gateway_final_reply: {
+            status: 'processing',
+            claim_token: 'abandoned-daemon-claim',
+            claimed_at: '2000-01-01T00:00:00.000Z',
+          },
+        },
+      } as unknown as Message,
+    ]);
+    await runWithTenantContext(tenantId, () =>
+      harness.service.flushOutboundBuffer(mapping.session_id, { taskId })
+    );
+
+    expect(harness.sendMessage).toHaveBeenCalledOnce();
+    expect(harness.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: 'Recoverable final answer.',
+        metadata: { edit_comment_id: 901 },
+      })
+    );
   });
 
   it('fails closed instead of using the session acknowledgement when task metadata is missing', async () => {

--- a/apps/agor-daemon/src/services/gateway.github.test.ts
+++ b/apps/agor-daemon/src/services/gateway.github.test.ts
@@ -8,8 +8,15 @@ import {
   runWithTenantDatabaseScope,
 } from '@agor/core/db';
 import { getConnector } from '@agor/core/gateway';
-import type { GatewayChannel, Message, ThreadSessionMap, User, UserID } from '@agor/core/types';
-import { SessionStatus } from '@agor/core/types';
+import type {
+  GatewayChannel,
+  Message,
+  Task,
+  ThreadSessionMap,
+  User,
+  UserID,
+} from '@agor/core/types';
+import { SessionStatus, TaskStatus } from '@agor/core/types';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { GatewayService } from './gateway.js';
 
@@ -108,7 +115,7 @@ function githubMapping(overrides: Partial<ThreadSessionMap> = {}): ThreadSession
 function makeGitHubHarness(existingMapping: ThreadSessionMap | null = null) {
   let mapping = existingMapping;
   let messages: Message[] = [];
-  let taskMetadata: Record<string, unknown> | undefined;
+  let tasks: Task[] = [];
   const order: string[] = [];
   const db = { run: vi.fn() } as unknown as TenantScopeAwareDatabase;
   const usersGet = vi.fn(async (id: string) => {
@@ -117,7 +124,7 @@ function makeGitHubHarness(existingMapping: ThreadSessionMap | null = null) {
   });
   const sessionsCreate = vi.fn(async (data: Record<string, unknown>) => ({
     ...data,
-    session_id: data.session_id,
+    session_id: data.session_id ?? '019fd900-0000-7000-8000-0000000000e0',
     status: SessionStatus.IDLE,
   }));
   const sessionsGet = vi.fn(async (sessionId: string) => ({
@@ -130,7 +137,7 @@ function makeGitHubHarness(existingMapping: ThreadSessionMap | null = null) {
   const promptCreate = vi.fn(async (data: Record<string, unknown>, params: unknown) => {
     order.push('prompt');
     return {
-      task_id: data.idempotencyTaskId,
+      task_id: data.idempotencyTaskId ?? '019fd900-0000-7000-8000-0000000000f0',
       session_id: (params as { route: { id: string } }).route.id,
       status: 'running',
     };
@@ -197,7 +204,27 @@ function makeGitHubHarness(existingMapping: ThreadSessionMap | null = null) {
     }),
   };
   const findByEmailForAlignment = vi.fn(async () => alignedUser);
-  const messagesRepo = { findBySessionId: vi.fn(async () => messages) };
+  const messagesRepo = {
+    findBySessionId: vi.fn(async () => messages),
+    findByTaskId: vi.fn(async (taskId: string) =>
+      messages.filter((message) => message.task_id === taskId)
+    ),
+    mutateMetadataLocked: vi.fn(
+      async (
+        messageId: string,
+        mutation: (metadata: Message['metadata'], message: Message) => Message['metadata'] | null
+      ) => {
+        const index = messages.findIndex((message) => message.message_id === messageId);
+        const message = messages[index];
+        if (!message) throw new Error('Message not found');
+        const metadata = mutation(message.metadata, message);
+        if (metadata === null) return { changed: false, message };
+        const updated = { ...message, metadata };
+        messages[index] = updated;
+        return { changed: true, message: updated };
+      }
+    ),
+  };
   const inboundEventRepo = {
     claim: vi.fn(async () => {
       order.push('claim');
@@ -218,6 +245,11 @@ function makeGitHubHarness(existingMapping: ThreadSessionMap | null = null) {
       return true;
     }),
   };
+  const taskRepo = {
+    findById: vi.fn(
+      async (taskId: string) => tasks.find((task) => task.task_id === taskId) ?? null
+    ),
+  };
   Object.assign(service as unknown as Record<string, unknown>, {
     channelRepo,
     threadMapRepo,
@@ -225,9 +257,7 @@ function makeGitHubHarness(existingMapping: ThreadSessionMap | null = null) {
     outboundRepo: { findUnconsumedByChannelAndThread: vi.fn(async () => null) },
     inboundEventRepo,
     messagesRepo,
-    taskRepo: {
-      findById: vi.fn(async () => (taskMetadata ? { metadata: taskMetadata } : null)),
-    },
+    taskRepo,
     sessionRepo: {
       findById: vi.fn(async (sessionId: string) => ({
         session_id: sessionId,
@@ -251,12 +281,28 @@ function makeGitHubHarness(existingMapping: ThreadSessionMap | null = null) {
     messagesRepo,
     findByEmailForAlignment,
     inboundEventRepo,
+    taskRepo,
     getMapping: () => mapping,
     setMessages: (next: Message[]) => {
       messages = next;
     },
+    setTasks: (next: Task[]) => {
+      tasks = next;
+    },
     setTaskMetadata: (next: Record<string, unknown>) => {
-      taskMetadata = next;
+      const latestMessage = messages.at(-1);
+      if (latestMessage?.task_id) {
+        tasks = [
+          {
+            task_id: latestMessage.task_id,
+            session_id: latestMessage.session_id,
+            status: TaskStatus.COMPLETED,
+            created_at: '2026-08-14T00:00:01.000Z',
+            completed_at: '2026-08-14T00:00:03.000Z',
+            metadata: next,
+          } as unknown as Task,
+        ];
+      }
     },
   };
 }
@@ -393,6 +439,29 @@ describe('GatewayService GitHub integration', () => {
     );
   });
 
+  it('stores task-scoped acknowledgement metadata in standalone mode', async () => {
+    const harness = makeGitHubHarness();
+    Object.assign(harness.service as unknown as Record<string, unknown>, {
+      durableListenerOwnership: false,
+    });
+
+    await handleGitHubInbound(harness.service, {
+      providerEventId: 'github:preset-io/agor:comment:standalone',
+      text: '@agor standalone request',
+      prepareDelivery: vi.fn(async () => ({ processing_comment_id: 905 })),
+    });
+
+    expect(harness.promptCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: {
+          gateway_reply_metadata: { processing_comment_id: 905 },
+        },
+      }),
+      expect.anything()
+    );
+    expect(harness.inboundEventRepo.claim).not.toHaveBeenCalled();
+  });
+
   it('keeps follow-ups on the mapped issue and edits the latest ack with only the final reply', async () => {
     const mapping = githubMapping();
     const harness = makeGitHubHarness(mapping);
@@ -457,7 +526,9 @@ describe('GatewayService GitHub integration', () => {
     });
 
     await runWithTenantContext(tenantId, () =>
-      harness.service.flushOutboundBuffer(mapping.session_id)
+      harness.service.flushOutboundBuffer(mapping.session_id, {
+        taskId: promptData.idempotencyTaskId,
+      })
     );
 
     expect(harness.sendMessage).toHaveBeenCalledOnce();
@@ -469,18 +540,226 @@ describe('GatewayService GitHub integration', () => {
     });
     expect(harness.threadMapRepo.mergeMetadata).toHaveBeenCalledWith(mapping.id, {
       gateway_last_flushed_message_id: '019fd900-0000-7000-8000-000000000040',
+      gateway_last_flushed_task_id: promptData.idempotencyTaskId,
     });
+  });
+
+  it('binds a delayed flush to its exact task after a newer task also completes', async () => {
+    const mapping = githubMapping({
+      metadata: { ...githubMetadata, processing_comment_id: 902 },
+    });
+    const harness = makeGitHubHarness(mapping);
+    const completedTaskId = '019fd900-0000-7000-8000-000000000050';
+    const newerTaskId = '019fd900-0000-7000-8000-000000000051';
+
+    harness.setTasks([
+      {
+        task_id: completedTaskId,
+        session_id: mapping.session_id,
+        status: TaskStatus.COMPLETED,
+        created_at: '2026-08-14T00:00:01.000Z',
+        completed_at: '2026-08-14T00:00:03.000Z',
+        metadata: { gateway_reply_metadata: { processing_comment_id: 901 } },
+      } as unknown as Task,
+      {
+        task_id: newerTaskId,
+        session_id: mapping.session_id,
+        status: TaskStatus.COMPLETED,
+        created_at: '2026-08-14T00:00:02.000Z',
+        completed_at: '2026-08-14T00:00:04.000Z',
+        metadata: { gateway_reply_metadata: { processing_comment_id: 902 } },
+      } as unknown as Task,
+    ]);
+    harness.setMessages([
+      {
+        message_id: '019fd900-0000-7000-8000-000000000052',
+        session_id: mapping.session_id,
+        task_id: completedTaskId,
+        role: 'assistant',
+        content: 'Final answer for the completed task.',
+        index: 1,
+      } as unknown as Message,
+      {
+        message_id: '019fd900-0000-7000-8000-000000000053',
+        session_id: mapping.session_id,
+        task_id: newerTaskId,
+        role: 'assistant',
+        content: 'Starting the queued task...',
+        index: 2,
+      } as unknown as Message,
+    ]);
+
+    await runWithTenantContext(tenantId, () =>
+      harness.service.routeMessage({
+        session_id: mapping.session_id,
+        task_id: newerTaskId,
+        message: 'Starting the queued task...',
+      })
+    );
+    await runWithTenantContext(tenantId, () =>
+      harness.service.flushOutboundBuffer(mapping.session_id, {
+        taskId: completedTaskId,
+      })
+    );
+
+    expect(harness.sendMessage).toHaveBeenCalledOnce();
+    expect(harness.sendMessage).toHaveBeenCalledWith({
+      threadId,
+      text: 'Final answer for the completed task.',
+      blocks: undefined,
+      metadata: { edit_comment_id: 901 },
+    });
+    expect(harness.sendMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({ text: 'Starting the queued task...' })
+    );
+  });
+
+  it('fences concurrent terminal hooks so only one provider edit is sent', async () => {
+    const mapping = githubMapping();
+    const harness = makeGitHubHarness(mapping);
+    const taskId = '019fd900-0000-7000-8000-000000000057';
+    harness.setTasks([
+      {
+        task_id: taskId,
+        session_id: mapping.session_id,
+        status: TaskStatus.COMPLETED,
+        created_at: '2026-08-14T00:00:01.000Z',
+        completed_at: '2026-08-14T00:00:03.000Z',
+        metadata: {
+          gateway_reply_metadata: { processing_comment_id: 901 },
+        },
+      } as unknown as Task,
+    ]);
+    harness.setMessages([
+      {
+        message_id: '019fd900-0000-7000-8000-000000000058',
+        session_id: mapping.session_id,
+        task_id: taskId,
+        role: 'assistant',
+        content: 'One final answer.',
+        index: 1,
+      } as unknown as Message,
+    ]);
+
+    await runWithTenantContext(tenantId, () =>
+      Promise.all([
+        harness.service.flushOutboundBuffer(mapping.session_id, { taskId }),
+        harness.service.flushOutboundBuffer(mapping.session_id, { taskId }),
+      ])
+    );
+
+    expect(harness.sendMessage).toHaveBeenCalledOnce();
+    expect(harness.messagesRepo.mutateMetadataLocked).toHaveBeenCalledTimes(3);
+  });
+
+  it('fails closed instead of using the session acknowledgement when task metadata is missing', async () => {
+    const mapping = githubMapping({
+      metadata: { ...githubMetadata, processing_comment_id: 902 },
+    });
+    const harness = makeGitHubHarness(mapping);
+    const completedTaskId = '019fd900-0000-7000-8000-000000000054';
+    harness.setTasks([
+      {
+        task_id: completedTaskId,
+        session_id: mapping.session_id,
+        status: TaskStatus.COMPLETED,
+        created_at: '2026-08-14T00:00:01.000Z',
+        completed_at: '2026-08-14T00:00:03.000Z',
+      } as unknown as Task,
+    ]);
+    harness.setMessages([
+      {
+        message_id: '019fd900-0000-7000-8000-000000000056',
+        session_id: mapping.session_id,
+        task_id: completedTaskId,
+        role: 'assistant',
+        content: 'Final answer for the completed task.',
+        index: 1,
+      } as unknown as Message,
+    ]);
+
+    await runWithTenantContext(tenantId, () =>
+      harness.service.flushOutboundBuffer(mapping.session_id, {
+        taskId: completedTaskId,
+      })
+    );
+
+    expect(harness.sendMessage).not.toHaveBeenCalled();
+    expect(harness.messagesRepo.findByTaskId).not.toHaveBeenCalled();
+    expect(harness.messagesRepo.mutateMetadataLocked).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      taskStatus: TaskStatus.FAILED,
+      expected: 'session stopped with an error',
+    },
+    {
+      taskStatus: TaskStatus.STOPPED,
+      expected: 'stopped before it finished',
+    },
+  ])('does not publish partial work for a $taskStatus task', async ({ taskStatus, expected }) => {
+    const mapping = githubMapping();
+    const harness = makeGitHubHarness(mapping);
+    const taskId = '019fd900-0000-7000-8000-000000000060';
+    harness.setTasks([
+      {
+        task_id: taskId,
+        session_id: mapping.session_id,
+        status: taskStatus,
+        created_at: '2026-08-14T00:00:01.000Z',
+        completed_at: '2026-08-14T00:00:03.000Z',
+        metadata: { gateway_reply_metadata: { processing_comment_id: 901 } },
+      } as unknown as Task,
+    ]);
+    harness.setMessages([
+      {
+        message_id: '019fd900-0000-7000-8000-000000000061',
+        session_id: mapping.session_id,
+        task_id: taskId,
+        role: 'assistant',
+        content: 'Now invoking the reviewer...',
+        index: 1,
+      } as unknown as Message,
+    ]);
+
+    await runWithTenantContext(tenantId, () =>
+      harness.service.flushOutboundBuffer(mapping.session_id, {
+        taskId,
+      })
+    );
+    await runWithTenantContext(tenantId, () =>
+      harness.service.flushOutboundBuffer(mapping.session_id, {
+        taskId,
+      })
+    );
+
+    expect(harness.sendMessage).toHaveBeenCalledOnce();
+    expect(harness.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: expect.stringContaining(expected),
+        metadata: { edit_comment_id: 901 },
+      })
+    );
+    expect(harness.sendMessage.mock.calls[0][0].text).toContain(
+      '[View session](https://agor.example.com/ui/s/'
+    );
+    expect(harness.sendMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({ text: 'Now invoking the reviewer...' })
+    );
   });
 
   it('skips durable message reads when the session has no gateway mapping', async () => {
     const harness = makeGitHubHarness(null);
 
     await runWithTenantContext(tenantId, () =>
-      harness.service.flushOutboundBuffer('019fd900-0000-7000-8000-000000000099')
+      harness.service.flushOutboundBuffer('019fd900-0000-7000-8000-000000000099', {
+        taskId: '019fd900-0000-7000-8000-000000000098' as never,
+      })
     );
 
     expect(harness.threadMapRepo.findBySession).toHaveBeenCalledOnce();
-    expect(harness.messagesRepo.findBySessionId).not.toHaveBeenCalled();
+    expect(harness.messagesRepo.findByTaskId).not.toHaveBeenCalled();
     expect(harness.channelRepo.findById).not.toHaveBeenCalled();
   });
 });

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -216,6 +216,7 @@ interface FlushOutboundBufferOptions {
   taskId: TaskID;
 }
 
+const GATEWAY_FINAL_REPLY_CLAIM_TIMEOUT_MS = 5 * 60 * 1000;
 const GATEWAY_FAILED_TURN_REPLY =
   "I couldn't complete this request because the Agor session stopped with an error. Mention me again to retry.";
 const GATEWAY_STOPPED_TURN_REPLY =
@@ -223,7 +224,7 @@ const GATEWAY_STOPPED_TURN_REPLY =
 
 type GatewayFinalReplyState =
   | { status: 'pending' }
-  | { status: 'processing'; claim_token: string }
+  | { status: 'processing'; claim_token: string; claimed_at: string }
   | { status: 'delivered'; delivered_at: string };
 
 function gatewayFinalReplyState(metadata: Message['metadata']): GatewayFinalReplyState | undefined {
@@ -231,8 +232,12 @@ function gatewayFinalReplyState(metadata: Message['metadata']): GatewayFinalRepl
   if (!value || typeof value !== 'object') return undefined;
   const state = value as Record<string, unknown>;
   if (state.status === 'pending') return { status: 'pending' };
-  if (state.status === 'processing' && typeof state.claim_token === 'string') {
-    return { status: 'processing', claim_token: state.claim_token };
+  if (
+    state.status === 'processing' &&
+    typeof state.claim_token === 'string' &&
+    typeof state.claimed_at === 'string'
+  ) {
+    return { status: 'processing', claim_token: state.claim_token, claimed_at: state.claimed_at };
   }
   if (state.status === 'delivered' && typeof state.delivered_at === 'string') {
     return { status: 'delivered', delivered_at: state.delivered_at };
@@ -490,14 +495,18 @@ function previewText(text: string, maxChars = 500): string {
   return `${normalized.slice(0, Math.max(0, maxChars - 1))}…`;
 }
 
-function gatewayMessageText(content: Message['content']): string {
-  if (typeof content === 'string') return content;
-  if (!Array.isArray(content)) return '';
-  return content
-    .filter((block) => block.type === 'text')
-    .map((block) => (typeof block.text === 'string' ? block.text : ''))
-    .filter(Boolean)
-    .join('\n');
+function gatewayMessageText(message: Pick<Message, 'content' | 'content_preview'>): string {
+  const { content } = message;
+  if (typeof content === 'string' && content.trim()) return content;
+  if (Array.isArray(content)) {
+    const text = content
+      .filter((block) => block.type === 'text')
+      .map((block) => (typeof block.text === 'string' ? block.text : ''))
+      .filter(Boolean)
+      .join('\n');
+    if (text.trim()) return text;
+  }
+  return message.content_preview || '';
 }
 
 function quoteForPrompt(text: string, maxChars = 2000): string {
@@ -3699,11 +3708,11 @@ export class GatewayService {
     const messages = await this.messagesRepo.findByTaskId(taskId);
     const latestAssistant = [...messages]
       .reverse()
-      .find((message) => message.role === 'assistant' && gatewayMessageText(message.content));
+      .find((message) => message.role === 'assistant' && gatewayMessageText(message));
     const claimMessage = latestAssistant ?? messages.at(-1);
     if (!claimMessage) return;
 
-    let finalMessage = latestAssistant ? gatewayMessageText(latestAssistant.content) : undefined;
+    let finalMessage = latestAssistant ? gatewayMessageText(latestAssistant) : undefined;
     if (terminalTask.status === TaskStatus.FAILED || terminalTask.status === TaskStatus.TIMED_OUT) {
       finalMessage = await this.formatTerminalGatewayReply(
         GATEWAY_FAILED_TURN_REPLY,
@@ -3731,11 +3740,22 @@ export class GatewayService {
     const claim = await this.messagesRepo.mutateMetadataLocked(
       claimMessage.message_id,
       (metadata) => {
+        const claimedAt = new Date();
         const state = gatewayFinalReplyState(metadata);
-        if (state?.status === 'processing' || state?.status === 'delivered') return null;
+        if (state?.status === 'delivered') return null;
+        if (state?.status === 'processing') {
+          const claimAgeMs = claimedAt.getTime() - Date.parse(state.claimed_at);
+          if (Number.isFinite(claimAgeMs) && claimAgeMs < GATEWAY_FINAL_REPLY_CLAIM_TIMEOUT_MS) {
+            return null;
+          }
+        }
         return {
           ...(metadata ?? {}),
-          gateway_final_reply: { status: 'processing', claim_token: claimToken },
+          gateway_final_reply: {
+            status: 'processing',
+            claim_token: claimToken,
+            claimed_at: claimedAt.toISOString(),
+          },
         };
       }
     );

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -97,8 +97,10 @@ import {
   DEFAULT_DISCORD_CATCH_UP,
   hasMinimumRole,
   isDiscordSnowflake,
+  isTerminalTaskStatus,
   ROLES,
   SessionStatus,
+  TaskStatus,
   USER_DEFAULT_AGENTIC_CONFIGURATION,
   validateDiscordConfig,
 } from '@agor/core/types';
@@ -208,6 +210,34 @@ async function withGatewayTimeout<T>(promise: Promise<T>, timeoutMs: number): Pr
 interface RouteMessageResult {
   routed: boolean;
   channelType?: string;
+}
+
+interface FlushOutboundBufferOptions {
+  taskId: TaskID;
+}
+
+const GATEWAY_FAILED_TURN_REPLY =
+  "I couldn't complete this request because the Agor session stopped with an error. Mention me again to retry.";
+const GATEWAY_STOPPED_TURN_REPLY =
+  'This request was stopped before it finished. Mention me again to continue.';
+
+type GatewayFinalReplyState =
+  | { status: 'pending' }
+  | { status: 'processing'; claim_token: string }
+  | { status: 'delivered'; delivered_at: string };
+
+function gatewayFinalReplyState(metadata: Message['metadata']): GatewayFinalReplyState | undefined {
+  const value = metadata?.gateway_final_reply;
+  if (!value || typeof value !== 'object') return undefined;
+  const state = value as Record<string, unknown>;
+  if (state.status === 'pending') return { status: 'pending' };
+  if (state.status === 'processing' && typeof state.claim_token === 'string') {
+    return { status: 'processing', claim_token: state.claim_token };
+  }
+  if (state.status === 'delivered' && typeof state.delivered_at === 'string') {
+    return { status: 'delivered', delivered_at: state.delivered_at };
+  }
+  return undefined;
 }
 
 interface EmitGatewayMessageData {
@@ -883,15 +913,6 @@ export class GatewayService {
    * refresh must never suppress another tenant's delivery.
    */
   private activeChannelTenants = new Set<string>();
-
-  /**
-   * GitHub message buffer: keyed by session_id, stores the latest message text.
-   * For GitHub channels, we don't send every assistant message in real-time
-   * (unlike Slack). Instead, we buffer and only send the last message when
-   * the session turn completes (goes idle). Each new message overwrites the
-   * previous one — only the final message matters.
-   */
-  private lastMessageBuffer = new Map<string, string>();
 
   /**
    * Slack status updates are serialized and lightly throttled so concurrent
@@ -2086,7 +2107,7 @@ export class GatewayService {
 
   private async fetchExistingSessionUrlForGatewayUser(
     sessionId: SessionID,
-    user: User
+    user?: User
   ): Promise<string | null> {
     try {
       const baseUrl = await getBaseUrl();
@@ -2096,6 +2117,8 @@ export class GatewayService {
     } catch (_error) {
       console.warn('[gateway] Failed to build public session URL');
     }
+
+    if (!user) return null;
 
     try {
       const sessionsService = this.app.service('sessions') as {
@@ -2111,6 +2134,14 @@ export class GatewayService {
       console.warn('[gateway] Failed to fetch session URL');
       return null;
     }
+  }
+
+  private async formatTerminalGatewayReply(text: string, sessionId: SessionID): Promise<string> {
+    const sessionUrl = await this.fetchExistingSessionUrlForGatewayUser(sessionId);
+    const sessionReference = sessionUrl
+      ? `[View session](${sessionUrl})`
+      : `Session: \`${shortId(sessionId)}\``;
+    return `${text}\n\n${sessionReference}`;
   }
 
   /**
@@ -3331,25 +3362,25 @@ export class GatewayService {
 
       await this.requireInboundPromptAuthority(channel, sessionId, user.user_id);
 
+      const gatewayTaskMetadata = {
+        ...(data.gateway_inbound_event_id
+          ? { gateway_inbound_event_id: data.gateway_inbound_event_id }
+          : {}),
+        ...(typeof data.metadata?.processing_comment_id === 'number'
+          ? {
+              gateway_reply_metadata: {
+                processing_comment_id: data.metadata.processing_comment_id,
+              },
+            }
+          : {}),
+      };
+
       const task = await promptService.create(
         {
           prompt: promptText,
           permissionMode,
           messageSource: 'gateway',
-          ...(data.gateway_inbound_event_id
-            ? {
-                metadata: {
-                  gateway_inbound_event_id: data.gateway_inbound_event_id,
-                  ...(data.metadata?.processing_comment_id
-                    ? {
-                        gateway_reply_metadata: {
-                          processing_comment_id: data.metadata.processing_comment_id,
-                        },
-                      }
-                    : {}),
-                },
-              }
-            : {}),
+          ...(Object.keys(gatewayTaskMetadata).length > 0 ? { metadata: gatewayTaskMetadata } : {}),
           ...(data.idempotency_task_id ? { idempotencyTaskId: data.idempotency_task_id } : {}),
         },
         {
@@ -3545,14 +3576,11 @@ export class GatewayService {
     await this.threadMapRepo.updateLastMessage(mapping.id);
     await this.channelRepo.updateLastMessage(channel.id);
 
-    // GitHub and Shortcut channels buffer the message instead of sending
-    // immediately — only the last message is posted when the session goes idle
-    // (via flushOutboundBuffer). This keeps noisy intermediate agent messages
-    // out of PR/story threads; the agent's final message IS the reply.
+    // GitHub and Shortcut replies are resolved from durable, task-scoped
+    // messages when the session turn ends. Do not stream intermediate output.
     if (channel.channel_type === 'github' || channel.channel_type === 'shortcut') {
-      this.lastMessageBuffer.set(data.session_id, data.message);
       console.log(
-        `[gateway] Buffered ${channel.channel_type} message for session ${shortId(data.session_id)} (${data.message.length} chars)`
+        `[gateway] Deferred ${channel.channel_type} message for session ${shortId(data.session_id)} (${data.message.length} chars)`
       );
       return { routed: true, channelType: channel.channel_type };
     }
@@ -3632,110 +3660,139 @@ export class GatewayService {
     );
   }
 
-  /**
-   * Flush the buffered last message for a session (GitHub / Shortcut).
-   *
-   * Called when a session transitions to idle (turn complete). Posts the last
-   * buffered message as a PR/issue/story comment by editing the connector's
-   * processing acknowledgement. If no buffered message exists, this is a no-op.
-   */
-  async flushOutboundBuffer(sessionId: string): Promise<void> {
-    // This hook runs for every promptable Session, but only mapped GitHub and
-    // Shortcut Sessions have buffered outbound work. Reject the common no-op
-    // cases before reading durable Message history.
+  /** Deliver one task's terminal reply by editing its exact provider acknowledgement. */
+  async flushOutboundBuffer(sessionId: string, options: FlushOutboundBufferOptions): Promise<void> {
     const mapping = await this.threadMapRepo.findBySession(sessionId);
-    if (!mapping) {
-      this.lastMessageBuffer.delete(sessionId);
-      return;
-    }
+    if (!mapping) return;
 
     const channel = await this.channelRepo.findById(mapping.channel_id);
     if (
       !channel?.enabled ||
       (channel.channel_type !== 'github' && channel.channel_type !== 'shortcut')
     ) {
-      this.lastMessageBuffer.delete(sessionId);
       return;
     }
 
-    let bufferedMessage = this.lastMessageBuffer.get(sessionId);
-    let durableMessageId: string | undefined;
-    let durableReplyMetadata: Record<string, unknown> | undefined;
-    // The local buffer is only a latency cache. PostgreSQL/SQLite messages are
-    // the durable recovery source when creation and idle hooks land on
-    // different daemons or the message-producing daemon dies.
-    try {
-      const messages = await this.messagesRepo.findBySessionId(sessionId as SessionID);
-      const latest = [...messages]
-        .reverse()
-        .find((message) => message.role === 'assistant' && gatewayMessageText(message.content));
-      if (latest) {
-        bufferedMessage = gatewayMessageText(latest.content);
-        durableMessageId = latest.message_id;
-        if (latest.task_id) {
-          const task = await this.taskRepo.findById(latest.task_id);
-          durableReplyMetadata = task?.metadata?.gateway_reply_metadata;
-        }
-      }
-    } catch (error) {
-      if (!bufferedMessage) throw error;
-      console.warn('[gateway] Falling back to process-local outbound buffer');
+    const taskId = options.taskId;
+    const terminalTask = await this.taskRepo.findById(taskId);
+    if (
+      !terminalTask ||
+      terminalTask.session_id !== sessionId ||
+      !isTerminalTaskStatus(terminalTask.status)
+    ) {
+      return;
     }
-    if (!bufferedMessage) return;
-
-    this.lastMessageBuffer.delete(sessionId);
+    const processingCommentId =
+      terminalTask.metadata?.gateway_reply_metadata?.processing_comment_id;
+    if (typeof processingCommentId !== 'number') {
+      console.warn(
+        `[gateway] Task ${shortId(taskId)} has no provider acknowledgement; final reply was not sent`
+      );
+      return;
+    }
 
     const mappingMetadata = ((mapping.metadata as Record<string, unknown>) ?? {}) as Record<
       string,
       unknown
     >;
-    if (durableMessageId && mappingMetadata.gateway_last_flushed_message_id === durableMessageId) {
+
+    const messages = await this.messagesRepo.findByTaskId(taskId);
+    const latestAssistant = [...messages]
+      .reverse()
+      .find((message) => message.role === 'assistant' && gatewayMessageText(message.content));
+    const claimMessage = latestAssistant ?? messages.at(-1);
+    if (!claimMessage) return;
+
+    let finalMessage = latestAssistant ? gatewayMessageText(latestAssistant.content) : undefined;
+    if (terminalTask.status === TaskStatus.FAILED || terminalTask.status === TaskStatus.TIMED_OUT) {
+      finalMessage = await this.formatTerminalGatewayReply(
+        GATEWAY_FAILED_TURN_REPLY,
+        sessionId as SessionID
+      );
+    } else if (terminalTask.status === TaskStatus.STOPPED) {
+      finalMessage = await this.formatTerminalGatewayReply(
+        GATEWAY_STOPPED_TURN_REPLY,
+        sessionId as SessionID
+      );
+    }
+    if (!finalMessage) return;
+
+    if (
+      mappingMetadata.gateway_last_flushed_task_id === taskId ||
+      mappingMetadata.gateway_last_flushed_message_id === claimMessage.message_id
+    ) {
       return;
     }
 
+    // Reuse the existing Message metadata row-lock primitive. This is the
+    // same short claim/finish pattern used by widget resolution and avoids a
+    // new delivery table or Task-repository state machine.
+    const claimToken = generateId();
+    const claim = await this.messagesRepo.mutateMetadataLocked(
+      claimMessage.message_id,
+      (metadata) => {
+        const state = gatewayFinalReplyState(metadata);
+        if (state?.status === 'processing' || state?.status === 'delivered') return null;
+        return {
+          ...(metadata ?? {}),
+          gateway_final_reply: { status: 'processing', claim_token: claimToken },
+        };
+      }
+    );
+    if (!claim.changed) return;
+
     try {
       const connector = getConnector(channel.channel_type as ChannelType, channel.config);
-
       const { text, blocks } = normalizeOutbound(
-        connector.formatMessage ? connector.formatMessage(bufferedMessage) : bufferedMessage
+        connector.formatMessage ? connector.formatMessage(finalMessage) : finalMessage
       );
-
-      // Edit the "Processing..." comment with the final response
-      const outboundMetadata: Record<string, unknown> = {};
-      if (typeof durableReplyMetadata?.processing_comment_id === 'number') {
-        outboundMetadata.edit_comment_id = durableReplyMetadata.processing_comment_id;
-      } else if (
-        mapping.metadata &&
-        typeof (mapping.metadata as Record<string, unknown>).processing_comment_id === 'number'
-      ) {
-        outboundMetadata.edit_comment_id = (
-          mapping.metadata as Record<string, unknown>
-        ).processing_comment_id;
-      }
-
       await connector.sendMessage({
         threadId: mapping.thread_id,
         text,
         blocks,
-        metadata: outboundMetadata,
+        metadata: { edit_comment_id: processingCommentId },
       });
 
-      if (durableMessageId) {
+      const completed = await this.messagesRepo.mutateMetadataLocked(
+        claimMessage.message_id,
+        (metadata) => {
+          const state = gatewayFinalReplyState(metadata);
+          if (state?.status !== 'processing' || state.claim_token !== claimToken) return null;
+          return {
+            ...(metadata ?? {}),
+            gateway_final_reply: {
+              status: 'delivered',
+              delivered_at: new Date().toISOString(),
+            },
+          };
+        }
+      );
+      if (!completed.changed) throw new Error('Gateway final reply claim was lost');
+
+      try {
         await this.threadMapRepo.mergeMetadata(mapping.id, {
-          gateway_last_flushed_message_id: durableMessageId,
+          gateway_last_flushed_message_id: claimMessage.message_id,
+          gateway_last_flushed_task_id: taskId,
         });
+      } catch (_error) {
+        console.warn('[gateway] Failed to update legacy final reply markers');
       }
 
       console.log(
-        `[gateway] Flushed ${channel.channel_type} buffer for session ${shortId(sessionId)} → ${mapping.thread_id} (${bufferedMessage.length} chars)`
+        `[gateway] Flushed ${channel.channel_type} final reply for session ${shortId(sessionId)} → ${mapping.thread_id} (${finalMessage.length} chars)`
       );
     } catch (error) {
-      // Re-queue the message so it can be retried on next flush (e.g. session
-      // goes idle again, or daemon restarts). Without this, a transient GitHub
-      // API error would permanently lose the agent's final response.
-      this.lastMessageBuffer.set(sessionId, bufferedMessage);
+      try {
+        await this.messagesRepo.mutateMetadataLocked(claimMessage.message_id, (metadata) => {
+          const state = gatewayFinalReplyState(metadata);
+          if (state?.status !== 'processing' || state.claim_token !== claimToken) return null;
+          return { ...(metadata ?? {}), gateway_final_reply: { status: 'pending' } };
+        });
+      } catch (_releaseError) {
+        console.warn('[gateway] Failed to release final reply claim');
+      }
       console.error(
-        `[gateway] Failed to flush ${channel.channel_type} buffer for session ${shortId(sessionId)} (re-queued):`,
+        `[gateway] Failed to flush ${channel.channel_type} final reply for session ${shortId(sessionId)}:`,
         error
       );
     }


### PR DESCRIPTION
## Why this is a bug

Gateway final replies were resolved from session-wide state instead of the Task that actually finished. For example, if Task A finishes after Task B has started, Task A's callback can put Task B's progress text into Task B's acknowledgement instead of putting Task A's final answer into Task A's acknowledgement.

Concurrent completion callbacks could also send the same provider edit twice.

## What this changes

- Capture the terminal Task ID before deferred work can observe a newer Task.
- Read only that Task's messages and edit only its stored GitHub or Shortcut acknowledgement.
- Use full assistant content when available, with `content_preview` as the durable fallback.
- Use the existing locked Message-metadata primitive so concurrent callbacks have one sender across daemons.
- Fence an active delivery claim, but allow a later exact-Task invocation to reclaim an abandoned claim after five minutes.
- Return a failed provider call to `pending` so a later exact-Task invocation can retry it.
- Fail closed when the exact Task acknowledgement is unavailable; never fall back to a newer session-level acknowledgement.
- Replace failed, timed-out, and stopped Task acknowledgements with short terminal copy instead of partial agent output.

The implementation is limited to three daemon files. It adds no schema, migration, delivery table, Task-repository state machine, polling loop, or background worker.

## Local before/after evidence

Using the same regression tests against latest `origin/main` (`31ad6fd36`):

- **Main: 2 failed.** A delayed Task A flush edited acknowledgement `902` with Task B's progress instead of acknowledgement `901` with Task A's final answer; concurrent callbacks sent two provider edits instead of one.
- **This PR: 4 passed.** Exact-Task selection, concurrent fencing, preview-only delivery, and stale-claim recovery all pass.

The two review regressions were also run directly against the reviewed head (`1c96ef49`):

- **Reviewed head: 2 failed.** Both preview-only delivery and stale-claim retry sent zero provider edits.
- **Current head: 2 passed.** The preview edits the exact acknowledgement, an active claim remains fenced, and the stale claim is reclaimed and delivered once.

## Validation

- Focused gateway, route, and hook suites: **279/279 passed**.
- Message-repository suite: **29/29 passed**, including concurrent SQLite metadata claims.
- Core and daemon TypeScript checks passed with `--customConditions source`.
- Biome and `git diff --check` passed.
- All required GitHub CI checks passed. The first UI-1 attempt completed all 1,020 assertions but leaked one React callback after teardown; its isolated test passed locally 7/7 and the unchanged rerun passed.

No configuration or schema migration is required. The branch is rebased on current `main`, and the PR remains a draft.

## Deliberately out of scope

This PR does not add a polling/recovery worker or change Slack delivery. Crash recovery occurs when a later exact-Task delivery invocation sees that the five-minute claim lease has expired.
