### PR TITLE
fix(upload): resolve per-user sandbox home

### DIFF
--- a/apps/agor-daemon/src/mcp/tenant-scope.test.ts
+++ b/apps/agor-daemon/src/mcp/tenant-scope.test.ts
@@ -1,9 +1,17 @@
 import { getCurrentTenantId } from '@agor/core/db';
 import { describe, expect, it, vi } from 'vitest';
 import type { McpContext } from './server';
-import { tenantScopedToolProxy } from './tenant-scope';
+import { runWithMcpTenantDatabaseUnit, tenantScopedToolProxy } from './tenant-scope';
 
 describe('tenantScopedToolProxy', () => {
+  it('refuses to open a typed tenant database unit without trusted tenant identity', async () => {
+    const work = vi.fn();
+    await expect(
+      runWithMcpTenantDatabaseUnit({ db: {}, baseServiceParams: {} } as unknown as McpContext, work)
+    ).rejects.toThrow('requires tenant identity');
+    expect(work).not.toHaveBeenCalled();
+  });
+
   it('runs the complete tool handler with tenant identity but no DB transaction', async () => {
     let registeredHandler: ((args: unknown, extra?: unknown) => unknown) | undefined;
     const server = {

--- a/apps/agor-daemon/src/mcp/tenant-scope.ts
+++ b/apps/agor-daemon/src/mcp/tenant-scope.ts
@@ -1,4 +1,4 @@
-import type { TenantScopeAwareDatabase } from '@agor/core/db';
+import type { TenantScopeAwareDatabase, TenantScopedDatabase } from '@agor/core/db';
 import {
   assertTenantWritable,
   bindRepositoryToTenantUnitOfWork,
@@ -28,6 +28,21 @@ export async function runWithMcpTenantDatabaseScope<T>(
   const tenantId = ctx.baseServiceParams.tenant?.tenant_id;
   if (!tenantId) return work(ctx.db);
   return runWithTenantDatabaseScope(ctx.db, tenantId, () => work(ctx.db));
+}
+
+/**
+ * Open one short, positively tenant-bound database unit for helpers whose type
+ * contract requires a {@link TenantScopedDatabase}. Unlike the compatibility
+ * wrapper above, this cannot fall back to an unscoped handle when MCP tenant
+ * identity is absent.
+ */
+export async function runWithMcpTenantDatabaseUnit<T>(
+  ctx: McpContext,
+  work: (db: TenantScopedDatabase) => Promise<T>
+): Promise<T> {
+  const tenantId = ctx.baseServiceParams.tenant?.tenant_id;
+  if (!tenantId) throw new Error('MCP tenant database unit requires tenant identity');
+  return runWithTenantDatabaseScope(ctx.db, tenantId, work);
 }
 
 /**

--- a/apps/agor-daemon/src/mcp/tools/gateway-channels.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/gateway-channels.test.ts
@@ -7,6 +7,7 @@ import {
   GatewayChannelRepository,
   SessionRepository,
   ThreadSessionMapRepository,
+  UsersRepository,
 } from '@agor/core/db';
 import {
   buildSlackManifest,
@@ -71,9 +72,9 @@ vi.mock('../../utils/upload-staging.js', () => ({
 }));
 
 type ServiceStub = Record<string, (...args: unknown[]) => unknown>;
-function makeFakeApp(services: Record<string, ServiceStub>) {
+function makeFakeApp(services: Record<string, ServiceStub>, config: Record<string, unknown> = {}) {
   return {
-    get: () => ({}),
+    get: (name: string) => (name === 'config' ? config : {}),
     service: (name: string) => {
       const svc = services[name];
       if (!svc) throw new Error(`Unexpected service call: ${name}`);
@@ -164,10 +165,21 @@ async function captureTools(
  * resolves to a session on the given branch. null simulates a stale/missing
  * session, which the binding must treat as fail-closed.
  */
-function spyCallerSessionBranch(branchId: string | null) {
-  return vi
-    .spyOn(SessionRepository.prototype, 'findById')
-    .mockResolvedValue((branchId ? { session_id: 'sess-1', branch_id: branchId } : null) as any);
+function spyCallerSessionBranch(
+  branchId: string | null,
+  session: { created_by?: string; sdk_home_scope?: 'execution_home' | 'branch' } = {}
+) {
+  return vi.spyOn(SessionRepository.prototype, 'findById').mockResolvedValue(
+    (branchId
+      ? {
+          session_id: 'sess-1',
+          branch_id: branchId,
+          created_by: 'user-1',
+          sdk_home_scope: 'execution_home',
+          ...session,
+        }
+      : null) as any
+  );
 }
 
 const slackChannel = {
@@ -190,6 +202,7 @@ const branch = {
   branch_id: 'branch-1',
   name: 'slack-work',
   path: '/tenant-test/branch-1',
+  primary_owner_user_id: 'branch-owner',
   others_can: 'view',
 };
 
@@ -216,6 +229,11 @@ beforeEach(() => {
     fs_access: 'write',
     is_owner: false,
     source: 'others',
+  });
+  vi.spyOn(BranchRepository.prototype, 'resolveSessionPromptAuthority').mockResolvedValue({
+    allowed: true,
+    execution_user_id: 'user-1' as any,
+    source: 'own_session',
   });
 });
 
@@ -2003,17 +2021,25 @@ describe('gateway agent-tool capability gating (MCP)', () => {
 
   describe('agor_upload_materialize', () => {
     const uploadRef = 'upl_00000000-0000-4000-8000-000000000001';
+    const stagedUpload = {
+      ref: uploadRef,
+      name: 'brief.txt',
+      mimeType: 'text/plain',
+      size: 16,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      expiresAt: '2026-01-02T00:00:00.000Z',
+      provenance: 'browser',
+    } as const;
+    const perUserSandboxConfig = {
+      paths: { data_home: '/srv/agor-data' },
+      execution: {
+        unix_user_mode: 'sandbox',
+        sandbox: { enabled: true, home_mode: 'per_user' },
+      },
+    };
 
     it('projects normalized branch write access into the executor command', async () => {
-      uploadStoreMock.inspect.mockResolvedValue({
-        ref: uploadRef,
-        name: 'brief.txt',
-        mimeType: 'text/plain',
-        size: 16,
-        createdAt: '2026-01-01T00:00:00.000Z',
-        expiresAt: '2026-01-02T00:00:00.000Z',
-        provenance: 'browser',
-      });
+      uploadStoreMock.inspect.mockResolvedValue(stagedUpload);
       vi.mocked(requestExecutor).mockResolvedValue({
         success: true,
         data: { path: '.agor/session-staging/brief.txt' },
@@ -2041,6 +2067,117 @@ describe('gateway agent-tool capability gating (MCP)', () => {
           },
         })
       );
+    });
+
+    it('resolves the owner-scoped sandbox home for a private RBAC branch', async () => {
+      uploadStoreMock.inspect.mockResolvedValue(stagedUpload);
+      vi.spyOn(UsersRepository.prototype, 'findById').mockResolvedValue({
+        user_id: 'user-1',
+        filesystem_home: null,
+      } as any);
+      vi.mocked(requestExecutor).mockImplementation(async (payload: any) =>
+        payload.params?.sandboxHomeStore
+          ? { success: true, data: { path: '.agor/session-staging/brief.txt' } }
+          : {
+              success: false,
+              error: {
+                code: 'EXECUTOR_SPAWN_ERROR',
+                message:
+                  'Executor sandbox setup failed: sandbox home_mode=per_user requires an owner home store, but none was resolved. Refusing to fall back to a shared home (fail closed).',
+              },
+            }
+      );
+      spyCallerSessionBranch('branch-1');
+      vi.spyOn(BranchRepository.prototype, 'findById').mockResolvedValue(branch as any);
+
+      const tools = await captureTools('member', makeFakeApp({}, perUserSandboxConfig));
+      await expect(tools.agor_upload_materialize.handler({ uploadRef })).resolves.toBeDefined();
+
+      expect(requestExecutor).toHaveBeenCalledWith(
+        expect.objectContaining({
+          params: expect.objectContaining({
+            sandboxHomeStore: '/srv/agor-data/tenants/tenant-test/homes/user-1',
+          }),
+        }),
+        expect.objectContaining({
+          templateVariables: expect.objectContaining({ user_id: 'user-1' }),
+        })
+      );
+    });
+
+    it('uses prompt authority for a shared branch-home session, not its foreign owner home', async () => {
+      uploadStoreMock.inspect.mockResolvedValue(stagedUpload);
+      vi.spyOn(BranchRepository.prototype, 'resolveSessionPromptAuthority').mockResolvedValue({
+        allowed: true,
+        execution_user_id: 'user-1' as any,
+        source: 'branch_session',
+      });
+      const findUser = vi
+        .spyOn(UsersRepository.prototype, 'findById')
+        .mockResolvedValue({ user_id: 'user-1', filesystem_home: null } as any);
+      vi.mocked(requestExecutor).mockResolvedValue({
+        success: true,
+        data: { path: '.agor/session-staging/brief.txt' },
+      });
+      spyCallerSessionBranch('branch-1', {
+        created_by: 'foreign-session-owner',
+        sdk_home_scope: 'branch',
+      });
+      vi.spyOn(BranchRepository.prototype, 'findById').mockResolvedValue(branch as any);
+
+      const tools = await captureTools('member', makeFakeApp({}, perUserSandboxConfig));
+      await tools.agor_upload_materialize.handler({ uploadRef });
+
+      expect(findUser).toHaveBeenCalledWith('user-1');
+      expect(requestExecutor).toHaveBeenCalledWith(
+        expect.objectContaining({
+          params: expect.objectContaining({
+            sandboxHomeStore: '/srv/agor-data/tenants/tenant-test/homes/user-1',
+          }),
+        }),
+        expect.objectContaining({
+          templateVariables: expect.objectContaining({ user_id: 'user-1' }),
+        })
+      );
+      expect(JSON.stringify(vi.mocked(requestExecutor).mock.calls[0])).not.toContain(
+        'foreign-session-owner'
+      );
+    });
+
+    it('rejects unresolved or denied execution-home authority without spawning', async () => {
+      spyCallerSessionBranch('branch-1', {
+        created_by: 'foreign-session-owner',
+        sdk_home_scope: 'execution_home',
+      });
+      vi.spyOn(BranchRepository.prototype, 'findById').mockResolvedValue(branch as any);
+      vi.spyOn(BranchRepository.prototype, 'resolveSessionPromptAuthority').mockResolvedValue({
+        allowed: false,
+        source: 'denied',
+        denial_reason: 'execution_home_sharing_disabled',
+      });
+
+      const tools = await captureTools('member', makeFakeApp({}, perUserSandboxConfig));
+      await expect(tools.agor_upload_materialize.handler({ uploadRef })).rejects.toThrow(
+        "uses its owner's execution home and cannot be shared"
+      );
+      expect(uploadStoreMock.inspect).not.toHaveBeenCalled();
+      expect(requestExecutor).not.toHaveBeenCalled();
+    });
+
+    it('fails closed when prompt authority omits the execution-home owner', async () => {
+      spyCallerSessionBranch('branch-1');
+      vi.spyOn(BranchRepository.prototype, 'findById').mockResolvedValue(branch as any);
+      vi.spyOn(BranchRepository.prototype, 'resolveSessionPromptAuthority').mockResolvedValue({
+        allowed: true,
+        source: 'own_session',
+      });
+
+      const tools = await captureTools('member');
+      await expect(tools.agor_upload_materialize.handler({ uploadRef })).rejects.toThrow(
+        'refusing to use a shared home (fail closed)'
+      );
+      expect(uploadStoreMock.inspect).not.toHaveBeenCalled();
+      expect(requestExecutor).not.toHaveBeenCalled();
     });
 
     it('rejects materialization when the caller has only branch filesystem read access', async () => {

--- a/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
+++ b/apps/agor-daemon/src/mcp/tools/gateway-channels.ts
@@ -56,9 +56,13 @@ import {
   gatewaySlackUploadExecutorCommandId,
   uploadMaterializeExecutorCommandId,
 } from '../../auth/executor-command-ids.js';
+import { resolveExecutionCredentialHome } from '../../services/credential-home-identity.js';
 import type { GatewayService } from '../../services/gateway.js';
 import { issueExecutorCommandToken } from '../../services/session-token-service.js';
-import { hasBranchPermission } from '../../utils/branch-authorization.js';
+import {
+  hasBranchPermission,
+  sessionPromptDeniedMessage,
+} from '../../utils/branch-authorization.js';
 import { ensureBranchWorkspaceAccess } from '../../utils/branch-workspace-path.js';
 import { resolveDelegatedExecutionHomeKey } from '../../utils/executor-delegated-home.js';
 import { ingestInboundAttachments, isIngestableFile } from '../../utils/gateway-attachments.js';
@@ -78,6 +82,7 @@ import { textResult } from '../server.js';
 import {
   bindMcpRepositoryToTenantUnitOfWork,
   runWithMcpTenantDatabaseScope,
+  runWithMcpTenantDatabaseUnit,
 } from '../tenant-scope.js';
 
 function requireAdmin(ctx: McpContext, action: string): void {
@@ -1468,10 +1473,30 @@ export function registerGatewayChannelTools(server: McpServer, ctx: McpContext):
       if (!tenantId || !session || !ctx.sessionId) {
         throw new Error('Upload materialization requires tenant-bound session context');
       }
+      const config = ctx.app.get('config');
       const workspace = await runWithMcpTenantDatabaseScope(ctx, async (db) => {
         const branchRepo = new BranchRepository(db);
         const branch = await branchRepo.findById(session.branch_id);
         if (!branch) throw new Error(`Branch not found: ${session.branch_id}`);
+        // Reuse the canonical Session prompt authority instead of inferring an
+        // execution-home owner from the Branch or raw request identity. It is
+        // the owner/caller compatibility seam used by normal executor
+        // admission, including private branches and shared branch-home
+        // Sessions, and rejects foreign execution-home Sessions fail closed.
+        const authority = await branchRepo.resolveSessionPromptAuthority(
+          branch.branch_id,
+          ctx.userId,
+          session.created_by as UUID,
+          session.sdk_home_scope
+        );
+        if (!authority.allowed) {
+          throw new Error(sessionPromptDeniedMessage(authority));
+        }
+        if (!authority.execution_user_id) {
+          throw new Error(
+            'Upload materialization could not resolve an execution-home owner; refusing to use a shared home (fail closed).'
+          );
+        }
         const fsAccess = await ensureBranchWorkspaceAccess(
           branchRepo,
           branch,
@@ -1479,10 +1504,31 @@ export function registerGatewayChannelTools(server: McpServer, ctx: McpContext):
           ctx.authenticatedUser.role as UserRole,
           'session',
           'write',
-          ctx.app.get('config').execution?.allow_superadmin === true
+          config.execution?.allow_superadmin === true
         );
-        return { branch, fsAccess };
+        return { branch, fsAccess, executionUserId: authority.execution_user_id };
       });
+      const sandboxCfg = config.execution?.sandbox;
+      const sandboxHomeStore =
+        sandboxCfg?.enabled === true && sandboxCfg.home_mode === 'per_user'
+          ? (
+              await resolveExecutionCredentialHome({
+                userId: workspace.executionUserId,
+                tenantId,
+                config,
+                withTenantDatabase: (work) => runWithMcpTenantDatabaseUnit(ctx, work),
+              })
+            ).homeStore
+          : null;
+      if (
+        sandboxCfg?.enabled === true &&
+        sandboxCfg.home_mode === 'per_user' &&
+        !sandboxHomeStore
+      ) {
+        throw new Error(
+          'Upload materialization could not resolve an owner home store; refusing to use a shared home (fail closed).'
+        );
+      }
       const ref = args.uploadRef as import('@agor/core/types').UploadRef;
       const store = getUploadStagingStore();
       const metadata = await store.inspect({
@@ -1508,20 +1554,17 @@ export function registerGatewayChannelTools(server: McpServer, ctx: McpContext):
             filename: metadata.name,
             cwd: workspace.branch.path,
             principalBranchAccess: workspace.fsAccess,
+            ...(sandboxHomeStore ? { sandboxHomeStore } : {}),
           },
         },
         {
           logPrefix: `[Upload materialize ${ctx.sessionId}]`,
           delegatedHomeKey: await runWithMcpTenantDatabaseScope(ctx, (db) =>
-            resolveDelegatedExecutionHomeKey(
-              db,
-              ctx.authenticatedUser.user_id,
-              ctx.app.get('config')
-            )
+            resolveDelegatedExecutionHomeKey(db, workspace.executionUserId, config)
           ),
           templateVariables: {
             branch_id: workspace.branch.branch_id,
-            user_id: ctx.userId,
+            user_id: workspace.executionUserId,
             branch_fs_access: workspace.fsAccess,
           },
         }

--- a/apps/agor-daemon/src/utils/spawn-executor.configured.test.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.configured.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { Writable } from 'node:stream';
@@ -34,6 +34,8 @@ vi.mock('../executor-tracking.js', () => ({
 
 vi.mock('@agor/core/unix', () => ({
   isValidExecutionHomeKey: (username: string) => /^[a-z_][a-z0-9_-]{0,31}$/.test(username),
+  probeBwrapPidNamespace: () => true,
+  probeBwrapSecurityBaseline: () => true,
 }));
 
 vi.mock('./build-resolved-config-slice.js', () => ({
@@ -676,6 +678,107 @@ describe('configured executor spawning', () => {
         stdio: ['pipe', 'pipe', 'pipe'],
       })
     );
+  });
+
+  it('carries the per-user home store through local request handoff into bubblewrap', async () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'agor-owner-home-handoff-'));
+    const homeDir = path.join(root, 'home');
+    const dataHome = path.join(homeDir, '.agor');
+    const branchPath = path.join(dataHome, 'worktrees', 'tenant-a', 'repo', 'feature');
+    const ownerHomeStore = path.join(dataHome, 'tenants', 'tenant-a', 'homes', 'owner-a');
+    mkdirSync(branchPath, { recursive: true });
+
+    try {
+      const actualSandboxWrap =
+        await vi.importActual<typeof import('./sandbox-wrap.js')>('./sandbox-wrap.js');
+      sandboxWrapMock.mockImplementation(actualSandboxWrap.buildSandboxWrap);
+      const { configureExecutor, requestExecutor } = await import('./spawn-executor');
+      configureExecutor(
+        {
+          sandbox: {
+            enabled: true,
+            fail_if_unavailable: true,
+            home_mode: 'per_user',
+          },
+        },
+        {
+          ...LOCAL_RESPONSE_OPTIONS,
+          sandboxRuntimePaths: {
+            homeDir,
+            dataHome,
+            protectedDataRoots: [dataHome],
+            worktreesRoot: path.join(dataHome, 'worktrees', 'tenant-a'),
+            agenticToolsPath: path.join(dataHome, 'agentic-tools'),
+            agorConfigPath: path.join(dataHome, 'config.yaml'),
+            agorDbPath: path.join(dataHome, 'agor.db'),
+          },
+        }
+      );
+
+      await expect(
+        requestExecutor({
+          command: 'upload.materialize:session-a:upload-a',
+          params: { cwd: branchPath, principalBranchAccess: 'write' },
+        })
+      ).resolves.toMatchObject({
+        success: false,
+        error: {
+          code: 'EXECUTOR_SPAWN_ERROR',
+          message: expect.stringContaining(
+            'sandbox home_mode=per_user requires an owner home store'
+          ),
+        },
+      });
+      expect(spawnMock).not.toHaveBeenCalled();
+
+      const proc = createMockProcess();
+      spawnMock.mockReturnValue(proc);
+      const resultPromise = requestExecutor({
+        command: 'upload.materialize:session-a:upload-a',
+        params: {
+          cwd: branchPath,
+          principalBranchAccess: 'write',
+          sandboxHomeStore: ownerHomeStore,
+        },
+      });
+
+      await deliverExecutorResponse(proc, {
+        success: true,
+        data: { path: '.agor/session-staging/brief.txt' },
+      });
+      proc.emit('exit', 0);
+
+      await expect(resultPromise).resolves.toEqual({
+        success: true,
+        data: { path: '.agor/session-staging/brief.txt' },
+      });
+      expect(spawnMock).toHaveBeenCalledOnce();
+      const bwrapArgs = spawnMock.mock.calls[0]?.[1] as string[];
+      const homeBindIndex = bwrapArgs.findIndex(
+        (arg, index) =>
+          arg === '--bind' &&
+          bwrapArgs[index + 1] === ownerHomeStore &&
+          bwrapArgs[index + 2] === homeDir
+      );
+      const tmpBindIndex = bwrapArgs.findIndex(
+        (arg, index) =>
+          arg === '--bind' &&
+          bwrapArgs[index + 1] === path.join(ownerHomeStore, 'tmp') &&
+          bwrapArgs[index + 2] === '/tmp'
+      );
+      expect(homeBindIndex).toBeGreaterThanOrEqual(0);
+      expect(tmpBindIndex).toBeGreaterThan(homeBindIndex);
+      expect(spawnMock).toHaveBeenCalledWith(
+        'bwrap',
+        expect.any(Array),
+        expect.objectContaining({
+          env: expect.objectContaining({ AGOR_OUTER_SANDBOX: '1' }),
+          stdio: ['pipe', 'pipe', 'pipe'],
+        })
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it('maps a pinned credential source onto child fd 3 without serializing it', async () => {


### PR DESCRIPTION
## Summary

- resolve upload materialization's execution-home owner through the same canonical session prompt-authority path used by normal executor admission
- resolve and pass the owner-scoped `sandboxHomeStore` for `sandbox` + `per_user` execution, and use that owner consistently for delegated-home and template variables
- add focused coverage for private RBAC branches, shared branch-home sessions, denied/unresolved authority, tenant-bound DB units, and the local request-to-bubblewrap handoff

## Root cause and security invariant

`agor_upload_materialize` launched its one-shot executor without resolving the canonical execution-home owner or forwarding that owner's per-user sandbox home store. It could therefore hand off a cwd/home combination inconsistent with normal session execution.

The fix preserves a fail-closed invariant: materialization requires trusted tenant/session context and an allowed prompt authority with a resolved execution user; per-user sandbox mode must resolve that user's home store. It never falls back to a shared home or a caller/branch identity when owner resolution fails.

## Validation

- focused executor tests: **61 passed**
- full daemon suite: **3,958 passed, 146 skipped**
- daemon typecheck, Biome, and multitenancy/filesystem-boundary checks passed
- managed `sandbox` + `per_user` `agor_upload_materialize` E2E passed with bubblewrap confirmed; environment restored and stopped
- gating correctness/security review: clean
- architecture review: **SHIP**

## Follow-up (advisory, intentionally out of scope)

Centralize executor-home resolution and make the source-level cwd invariant explicit, then audit sibling executor call sites separately. This PR deliberately avoids that broader refactor.
