### PR TITLE
feat(mcp-catalog): list Preset gateway

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -426,8 +426,10 @@ differences implemented in `oauth-mcp-transport.ts`, while retaining
 same-origin bounds on those fallbacks, resource/issuer binding, the exact MCP
 URL as the RFC 8707 resource, PKCE S256, and callback issuer validation. An
 explicit saved-row `strict` or `legacy` mode always wins. The catalog explicitly
-keeps Monday, Cloudflare, and ClickUp on `strict`; an edited/imported install, a
-removed entry, or any catalog configuration drift falls back to `strict`.
+keeps Monday, Cloudflare, ClickUp, and Preset on `strict`. Preset is pinned
+defensively pending production OAuth validation, not asserted to have passed it;
+an edited/imported install, a removed entry, or any catalog configuration drift
+falls back to `strict`.
 GitHub, Prisma, MongoDB, Box, HubSpot, Slack, PagerDuty, and Kagi were removed
 from the shelf because the review could not establish a safely bound
 client-registration or issuer path; do not re-add one merely because its

--- a/packages/core/src/mcp-catalog/curated-loader.test.ts
+++ b/packages/core/src/mcp-catalog/curated-loader.test.ts
@@ -531,19 +531,40 @@ describe('the shipped catalog', () => {
     );
   });
 
-  it('opts the providers that pass the strict production boundary into strict mode', async () => {
+  it('keeps the explicit strict-mode policy inventory', async () => {
     // Marketplace installs with no statement use the daemon's bounded
-    // interoperability profile. These three publish the exact PRM/issuer,
+    // interoperability profile. Monday, Cloudflare and ClickUp publish the exact PRM/issuer,
     // S256 and RFC 9207 contracts, so keep the stronger policy explicit and
-    // make any later expansion a reviewed curation change.
+    // make any later expansion a reviewed curation change. Preset is pinned
+    // defensively pending production validation, not claimed to have passed it.
     const entries = await loadCuratedCatalog();
     expect(
       entries.filter((entry) => entry.oauth !== undefined).map((entry) => [entry.name, entry.oauth])
     ).toEqual([
       ['com.monday/monday.com', { compatibility_mode: 'strict' }],
       ['com.cloudflare/mcp', { compatibility_mode: 'strict' }],
+      ['io.preset/mcp-gateway', { compatibility_mode: 'strict' }],
       ['com.clickup/mcp', { compatibility_mode: 'strict' }],
     ]);
+  });
+
+  it('preserves Preset install identity and requires strict OAuth without hiding write authority', async () => {
+    const entries = await loadCuratedCatalog();
+    // catalog_entry_name is persisted on installs: this is a release identity,
+    // not display copy. A rename requires an explicit migration decision.
+    const preset = entries.find((entry) => entry.name === 'io.preset/mcp-gateway');
+    expect(preset).toMatchObject({
+      remote_url: 'https://mcp.app.preset.io/mcp',
+      transport: 'streamable-http',
+      auth_type: 'oauth',
+      oauth: { compatibility_mode: 'strict' },
+    });
+    // The initial task is intentionally read-only, not an authorization limit.
+    expect(preset!.starter_prompt).toContain('Do not change any data.');
+    expect(preset!.permission_disclosure).toContain('run SQL');
+    expect(preset!.permission_disclosure).toContain(
+      'create, edit, soft-delete, or restore Knowledge documents'
+    );
   });
 
   it('does not advertise OAuth endpoints that cannot reach a safely bound client-registration boundary', async () => {

--- a/packages/core/src/mcp-catalog/curated.yaml
+++ b/packages/core/src/mcp-catalog/curated.yaml
@@ -541,6 +541,10 @@ unpublished:
     remote_url: https://mcp.app.preset.io/mcp
     transport: streamable-http
     auth_type: oauth
+    # Fail closed rather than opt into marketplace interoperability before
+    # production callback/registration compatibility has been verified.
+    oauth:
+      compatibility_mode: strict
     website_url: https://preset.io/
 
   - name: com.dropbox/mcp

--- a/packages/core/src/mcp-catalog/curated.yaml
+++ b/packages/core/src/mcp-catalog/curated.yaml
@@ -530,6 +530,19 @@ unpublished:
     transport: streamable-http
     auth_type: oauth
 
+  - name: io.preset/mcp-gateway
+    title: Preset
+    category: data-storage
+    capabilities: [databases, sql, schema, datasets, analytics, notes]
+    benefit: Explore governed Preset workspaces from an agent using the same roles and data access you have in Preset.
+    starter_prompt: List my Preset workspaces and the MCP service families available in each. Do not change any data.
+    permission_disclosure: Acts as your Preset user across every Preset workspace you can access. It can read workspace metadata, datasets, charts, dashboards, database schemas, SQL query results, and Knowledge documents; run SQL and other workspace tools; and create, edit, soft-delete, or restore Knowledge documents where your Preset permissions allow. Data returned by Preset is sent to the agent and AI provider running this Agor session.
+    icon_url: https://preset.io/icons/icon-192x192.png
+    remote_url: https://mcp.app.preset.io/mcp
+    transport: streamable-http
+    auth_type: oauth
+    website_url: https://preset.io/
+
   - name: com.dropbox/mcp
     category: data-storage
     capabilities: [files, web-search]


### PR DESCRIPTION
## Summary

- List Preset MCP Gateway under `unpublished` as `io.preset/mcp-gateway`.
- Describe governed analytics capabilities and write authority, with an intentionally read-only starter prompt.
- Explicitly pin OAuth to `strict`; do not opt an unverified production provider into the internal `marketplace` compatibility profile.
- Add regression coverage for the stable install identity, production endpoint, strict policy, and read-only prompt / write-disclosure distinction.

## Reviewer follow-up — `2e50319a`

### Medium: implicit marketplace OAuth policy — code fixed; live validation still blocked

The catalog now sets `oauth: { compatibility_mode: strict }`. The strict-policy inventory and Preset-specific regression test protect this decision. This is a defensive policy, **not evidence that production OAuth works**; it does not bypass discovery, registration, PKCE, resource/issuer binding, or callback validation.

The production callback issue is now concrete rather than merely unknown: the gateway's [production values at f4268bad](https://github.com/preset-io/mcp-gateway/blob/f4268baddac533b214f328244c06bed3740d9c75/helm/config/environments/production/aws/us-west-2/production-aws-us1a/values.yaml) explicitly leave the production Agor callback as a TODO. The configured allowlist contains no production Agor HTTPS callback. Its comment requires an exact production hostname and rejects wildcarding `preset.zone` to avoid handing production codes to lower-environment hosts.

Required external fix: establish the actual production Agor origin, add its exact `/mcp-servers/oauth-callback` URI through the gateway's reviewed production configuration, deploy, and verify a complete Agor OAuth flow under strict policy. Do not substitute a sandbox URL, guess a hostname, or relax compatibility to bypass the allowlist.

### High: production endpoint — unresolved external deployment blocker

A fresh unauthenticated `initialize` POST on 2026-09-06, using the Agor probe's protocol version `2025-06-18`, still returns **HTTP 404** at `https://mcp.app.preset.io/mcp`. Earlier same-day GET also returned HTML 404; the default pinned Agor probe separately reported `unreachable` in this environment. None is a successful connect observation.

The endpoint matches the gateway's checked-in production hostname; replacing it with an invented or lower-environment endpoint would not fix production. The production deployment/routing owner must bring it live, then obtain a successful Agor connect probe and authenticated OAuth validation. **Hold merge pending this evidence. PR stays ready for review.**

### Low: identity and starter prompt — addressed

- Keep `io.preset/mcp-gateway` as the stable install identity; regression coverage makes a rename an explicit migration/review decision. The 2026-09-06 Official MCP Registry search returned no matching record, so `unpublished` remains appropriate.
- Keep the discovery-only starter prompt deliberately read-only. Tests preserve the separate disclosure of SQL execution and Knowledge create/edit/soft-delete/restore authority; the prompt is not an authorization restriction.

## Validation

- `pnpm --filter @agor/core exec vitest run src/mcp-catalog/curated-loader.test.ts src/mcp-catalog/catalog.test.ts src/mcp-catalog/auth-probe.test.ts src/tools/mcp/oauth-mcp-transport.test.ts`: **4 files, 198 tests passed**.
- Biome check passed for the changed test; Prettier passed for YAML and `AGENTS.md`.
- Normal commit hooks passed (Biome CI and Prettier); no bypass. An initial lint-staged backup failure was traced to an inherited `PWD` mismatch and corrected for the commit process.
- Multi-tenancy: intentional system/global public catalog policy only; no secrets, tenant-owned rows, or authorization boundary changes. The policy narrows compatibility for future Preset installs; existing transport tests cover strict fail-closed behavior.
- No build, DCR registration, authenticated tool invocation, merge, or deployment performed. Production success is not asserted.
