### PR TITLE
fix(ui): render markdown in on-board card descriptions

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,4 +1,6 @@
 {
-  "*.{ts,tsx,js,jsx,mjs,cjs}": ["biome ci --no-errors-on-unmatched --files-ignore-unknown=true"],
+  "*.{ts,tsx,js,jsx,mjs,cjs,svg}": [
+    "biome ci --no-errors-on-unmatched --files-ignore-unknown=true"
+  ],
   "*.{json,md,yaml,yml}": ["prettier --write"]
 }

--- a/apps/agor-ui/src/components/BranchCard/BranchCard.drag.test.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.drag.test.tsx
@@ -30,6 +30,25 @@ const branch = {
 const repo = { repo_id: 'repo-1', slug: 'preset-io/agor' } as unknown as Repo;
 
 describe('BranchCard drag handle', () => {
+  it('renders complete note Markdown through the non-draggable shared preview', () => {
+    const note = 'A long formatted branch note. '.repeat(12).trim();
+    render(
+      <ConnectionProvider value={connected}>
+        <BranchCard
+          branch={{ ...branch, notes: `**${note}**` }}
+          repo={repo}
+          sessions={[]}
+          userById={new Map()}
+          client={null}
+        />
+      </ConnectionProvider>
+    );
+
+    const content = screen.getByText(note.trim());
+    expect(content.closest(`.${REACT_FLOW_NO_DRAG_CLASS}`)).not.toBeNull();
+    expect(content.closest('.markdown-compact')).not.toBeNull();
+  });
+
   it('lets the branch title participate in the header drag handle', () => {
     render(
       <ConnectionProvider value={connected}>

--- a/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
@@ -31,7 +31,7 @@ import { ensureColorVisible, isDarkTheme } from '../../utils/theme';
 import { ArchiveActionButton } from '../ArchiveButton';
 import { ArchiveDeleteBranchModal } from '../ArchiveDeleteBranchModal';
 import { EnvironmentPill } from '../EnvironmentPill';
-import { MarkdownRenderer } from '../MarkdownRenderer';
+import { MarkdownPreview } from '../MarkdownRenderer';
 import { CreatedByTag } from '../metadata';
 import { IssuePill, PullRequestPill } from '../Pill';
 import { BranchSessionPeekSection } from './BranchSessionPeekSection';
@@ -39,7 +39,6 @@ import { BranchSessionSections } from './BranchSessionSections';
 import { estimateBranchSessionSectionsHeight } from './branchCardLayout';
 
 const _BRANCH_CARD_MAX_WIDTH = 600;
-const NOTES_MAX_LENGTH = 200; // Character limit for truncated notes
 const PEEK_SESSIONS_STORAGE_KEY_PREFIX = 'agor:branch-card:peeked-session-ids:';
 
 interface BranchCardProps {
@@ -134,8 +133,6 @@ const BranchCardComponent = ({
   const [archiveDeleteModalOpen, setArchiveDeleteModalOpen] = useState(false);
   const [archiveDeleteModalMounted, setArchiveDeleteModalMounted] = useState(false);
 
-  // Notes expansion state
-  const [notesExpanded, setNotesExpanded] = useState(false);
   const [storedPeekedSessionIds, setStoredPeekedSessionIds] = useLocalStorage<string[]>(
     `${PEEK_SESSIONS_STORAGE_KEY_PREFIX}${branch.branch_id}`,
     []
@@ -278,19 +275,6 @@ const BranchCardComponent = ({
     if (!zoneColor) return undefined;
     return ensureColorVisible(zoneColor, isDarkMode, 50, 50);
   }, [zoneColor, isDarkMode]);
-
-  // Determine if notes should show "See more" button
-  const notesNeedTruncation = branch.notes && branch.notes.length > NOTES_MAX_LENGTH;
-  const displayedNotes = useMemo(() => {
-    if (!branch.notes) return '';
-    if (!notesNeedTruncation || notesExpanded) return branch.notes;
-    // Truncate at word boundary for cleaner display
-    const truncated = branch.notes.slice(0, NOTES_MAX_LENGTH);
-    const lastSpace = truncated.lastIndexOf(' ');
-    return lastSpace > NOTES_MAX_LENGTH * 0.8
-      ? `${truncated.slice(0, lastSpace)}...`
-      : `${truncated}...`;
-  }, [branch.notes, notesNeedTruncation, notesExpanded]);
 
   // Compose card chrome from independent visual channels so multiple
   // states can stack cleanly:
@@ -544,39 +528,13 @@ const BranchCardComponent = ({
       {/* Notes */}
       {branch.notes && (
         <div className={REACT_FLOW_NO_DRAG_CLASS} style={{ marginBottom: 8 }}>
-          <div
-            className="markdown-compact"
-            style={{
-              maxHeight: notesExpanded ? 'none' : '120px',
-              overflow: 'hidden',
-              transition: 'max-height 0.3s ease',
-            }}
-          >
-            <MarkdownRenderer
-              content={displayedNotes}
-              style={{ fontSize: 12, color: token.colorTextSecondary, lineHeight: '1.5' }}
-              compact={false}
-              showControls={false}
-            />
-          </div>
-          {notesNeedTruncation && (
-            <Button
-              type="link"
-              size="small"
-              onClick={(e) => {
-                e.stopPropagation();
-                setNotesExpanded(!notesExpanded);
-              }}
-              style={{
-                padding: 0,
-                height: 'auto',
-                fontSize: 12,
-                color: token.colorLink,
-              }}
-            >
-              {notesExpanded ? 'See less' : 'See more'}
-            </Button>
-          )}
+          <MarkdownPreview
+            key={branch.branch_id}
+            content={branch.notes}
+            collapsedHeight={120}
+            moreLabel="See more"
+            lessLabel="See less"
+          />
         </div>
       )}
 

--- a/apps/agor-ui/src/components/CardNode/CardNode.markdown.browser.test.tsx
+++ b/apps/agor-ui/src/components/CardNode/CardNode.markdown.browser.test.tsx
@@ -1,0 +1,137 @@
+import type { BoardID, CardID, CardWithType } from '@agor/core/types';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import ReactFlow from 'reactflow';
+import 'reactflow/dist/style.css';
+import { afterEach, expect, it, vi } from 'vitest';
+import { userEvent } from 'vitest/browser';
+import {
+  REACT_FLOW_DRAG_HANDLE_SELECTOR,
+  REACT_FLOW_NO_WHEEL_CLASS,
+} from '../../utils/reactFlowDragClasses';
+import CardNode, { type CardNodeData } from './CardNode';
+
+const description = Array.from(
+  { length: 30 },
+  (_, i) => `Paragraph ${i}: a line of description.`
+).join('\n\n');
+const card: CardWithType = {
+  card_id: 'card-1' as CardID,
+  board_id: 'board-1' as BoardID,
+  title: 'Planning card',
+  description,
+  archived: false,
+  created_at: '2026-09-06T00:00:00.000Z',
+  updated_at: '2026-09-06T00:00:00.000Z',
+};
+const nodeTypes = { cardNode: CardNode };
+
+afterEach(cleanup);
+
+it('isolates Markdown links and disclosures while preserving ordinary open-card clicks', () => {
+  const onClick = vi.fn();
+  render(
+    <CardNode
+      data={{
+        card: {
+          ...card,
+          description:
+            '[Link](https://example.com)\n\n<details><summary>Details</summary>Body</details>\n\nPlain text',
+        },
+        onClick,
+      }}
+    />
+  );
+  const link = screen.getByRole('link', { name: 'Link' });
+  link.addEventListener('click', (event) => event.preventDefault());
+  fireEvent.click(link);
+  fireEvent.click(screen.getByText('Details'));
+  expect(onClick).not.toHaveBeenCalled();
+  fireEvent.click(screen.getByText('Plain text'));
+  expect(onClick).toHaveBeenCalledWith(card.card_id);
+});
+
+it('resets expansion after clearing content or switching card identity', () => {
+  const { rerender } = render(<CardNode data={{ card }} />);
+  fireEvent.click(screen.getByRole('button', { name: 'more' }));
+  rerender(<CardNode data={{ card: { ...card, description: '' } }} />);
+  rerender(<CardNode data={{ card }} />);
+  expect(screen.getByRole('button', { name: 'more' })).toHaveAttribute('aria-expanded', 'false');
+  fireEvent.click(screen.getByRole('button', { name: 'more' }));
+  rerender(<CardNode data={{ card: { ...card, card_id: 'card-2' as CardID } }} />);
+  expect(screen.getByRole('button', { name: 'more' })).toHaveAttribute('aria-expanded', 'false');
+});
+
+it('keeps executable markup and javascript links inert in descriptions', () => {
+  const { container } = render(
+    <CardNode
+      data={{
+        card: {
+          ...card,
+          description:
+            '<script>window.__xss=1</script>\n\n[x](javascript:alert(1))\n\n<img src="x" onerror="window.__xss=1">',
+        },
+      }}
+    />
+  );
+  expect(container.querySelector('script')).toBeNull();
+  expect(container.querySelector('[onerror]')).toBeNull();
+  expect(container.querySelector('a[href^="javascript:"]')).toBeNull();
+});
+
+it('keeps native wheel scrolling inside the expanded preview and dragging on the header', async () => {
+  const onNodeDragStop = vi.fn();
+  const { container } = render(
+    <>
+      <div style={{ width: '100%', height: 380 }}>
+        <ReactFlow
+          nodes={[
+            {
+              id: 'card',
+              type: 'cardNode',
+              position: { x: 0, y: 0 },
+              width: 380,
+              height: 120,
+              dragHandle: REACT_FLOW_DRAG_HANDLE_SELECTOR,
+              data: { card } satisfies CardNodeData,
+            },
+          ]}
+          nodeTypes={nodeTypes}
+          panOnScroll
+          panOnDrag
+          nodesConnectable={false}
+          disableKeyboardA11y
+          onNodeDragStop={onNodeDragStop}
+        />
+      </div>
+      <div
+        data-testid="drop-target"
+        style={{ position: 'fixed', left: 240, top: 350, width: 30, height: 20 }}
+      >
+        Drop
+      </div>
+    </>
+  );
+  const more = await screen.findByRole('button', { name: 'more' });
+  fireEvent.click(more);
+  const viewport = document.getElementById(more.getAttribute('aria-controls')!)!;
+  const canvas = container.querySelector('.react-flow__viewport') as HTMLElement;
+  const transform = canvas.style.transform;
+  expect(viewport).toHaveClass(REACT_FLOW_NO_WHEEL_CLASS);
+  await act(async () => userEvent.wheel(viewport, { delta: { y: 150 } }));
+  await waitFor(() => expect(viewport.scrollTop).toBeGreaterThan(0));
+  expect(canvas.style.transform).toBe(transform);
+  fireEvent.click(screen.getByRole('button', { name: 'less' }));
+  expect(viewport).not.toHaveClass(REACT_FLOW_NO_WHEEL_CLASS);
+  expect(viewport.scrollTop).toBe(0);
+  await act(async () =>
+    userEvent.dragAndDrop(
+      screen.getByText('Paragraph 0: a line of description.'),
+      screen.getByTestId('drop-target')
+    )
+  );
+  expect(onNodeDragStop).not.toHaveBeenCalled();
+  await act(async () =>
+    userEvent.dragAndDrop(screen.getByText('Planning card'), screen.getByTestId('drop-target'))
+  );
+  expect(onNodeDragStop).toHaveBeenCalledTimes(1);
+});

--- a/apps/agor-ui/src/components/CardNode/CardNode.tsx
+++ b/apps/agor-ui/src/components/CardNode/CardNode.tsx
@@ -6,7 +6,7 @@
  * - Zone border color when pinned to a zone (matching BranchCard pattern)
  * - CardType emoji + title (with optional URL link)
  * - Pin icon when in a zone (click to unpin)
- * - Description (markdown, collapsed after ~4 lines)
+ * - Description (markdown, collapsed after ~3 lines)
  * - Note (always shown in full, distinct background)
  */
 
@@ -23,20 +23,14 @@ function isSafeUrl(url: string): boolean {
   }
 }
 
-import React, { useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, { useMemo } from 'react';
 import {
   REACT_FLOW_DRAG_HANDLE_CLASS,
   REACT_FLOW_NO_DRAG_CLASS,
-  REACT_FLOW_NO_WHEEL_CLASS,
 } from '../../utils/reactFlowDragClasses';
 import { ensureColorVisible, isDarkTheme } from '../../utils/theme';
-import { MarkdownRenderer } from '../MarkdownRenderer';
+import { MarkdownPreview } from '../MarkdownRenderer';
 
-// ~3 lines of compact markdown (12px / 1.5 line-height) before offering "more".
-const DESCRIPTION_COLLAPSED_MAX_HEIGHT = 54;
-// Cap on expanded height so a very long description still scrolls instead of
-// growing the card without bound.
-const DESCRIPTION_EXPANDED_MAX_HEIGHT = 240;
 const CARD_WIDTH = 380;
 
 export interface CardNodeData {
@@ -51,9 +45,6 @@ export interface CardNodeData {
 const CardNodeComponent = ({ data }: { data: CardNodeData }) => {
   const { token } = theme.useToken();
   const { card, isPinned, zoneName, zoneColor, onClick, onUnpin } = data;
-  const [descExpanded, setDescExpanded] = useState(false);
-  const [canExpandDesc, setCanExpandDesc] = useState(false);
-  const descRef = useRef<HTMLDivElement>(null);
 
   const borderColor = card.effective_color || token.colorBorder;
   const emoji = card.effective_emoji;
@@ -64,20 +55,6 @@ const CardNodeComponent = ({ data }: { data: CardNodeData }) => {
     if (!zoneColor) return undefined;
     return ensureColorVisible(zoneColor, isDarkMode, 50, 50);
   }, [zoneColor, isDarkMode]);
-
-  // Measure against the collapsed height cap to decide whether "more" is
-  // needed. Only measured while collapsed: the rendered markdown (not a raw
-  // char count) is the source of truth, so we never cut off mid-syntax like
-  // `**bo` the old char-slicing truncation could.
-  useLayoutEffect(() => {
-    if (descExpanded || !card.description) {
-      if (!card.description) setCanExpandDesc(false);
-      return;
-    }
-    const el = descRef.current;
-    if (!el) return;
-    setCanExpandDesc(el.scrollHeight - el.clientHeight > 1);
-  }, [card.description, descExpanded]);
 
   return (
     <div
@@ -174,51 +151,8 @@ const CardNodeComponent = ({ data }: { data: CardNodeData }) => {
             padding: '8px 12px',
             borderBottom: card.note ? `1px solid ${token.colorBorderSecondary}` : 'none',
           }}
-          onClick={(e) => {
-            // Let interactive markdown elements (links, copy buttons) act on
-            // their own instead of also opening the card.
-            if ((e.target as HTMLElement).closest('a, button')) {
-              e.stopPropagation();
-            }
-          }}
         >
-          <div
-            ref={descRef}
-            className={descExpanded ? REACT_FLOW_NO_WHEEL_CLASS : undefined}
-            style={{
-              maxHeight: descExpanded
-                ? DESCRIPTION_EXPANDED_MAX_HEIGHT
-                : DESCRIPTION_COLLAPSED_MAX_HEIGHT,
-              overflow: descExpanded ? 'auto' : 'hidden',
-              color: token.colorTextSecondary,
-            }}
-          >
-            <MarkdownRenderer
-              content={card.description}
-              compact
-              boundHeight={false}
-              showControls={false}
-            />
-          </div>
-          {canExpandDesc && (
-            <Button
-              type="link"
-              size="small"
-              onClick={(e) => {
-                e.stopPropagation();
-                setDescExpanded(!descExpanded);
-              }}
-              style={{
-                padding: 0,
-                height: 'auto',
-                fontSize: 11,
-                color: token.colorLink,
-                marginLeft: 4,
-              }}
-            >
-              {descExpanded ? 'less' : 'more'}
-            </Button>
-          )}
+          <MarkdownPreview key={card.card_id} content={card.description} />
         </div>
       )}
 

--- a/apps/agor-ui/src/components/CardNode/CardNode.tsx
+++ b/apps/agor-ui/src/components/CardNode/CardNode.tsx
@@ -31,8 +31,11 @@ import {
 import { ensureColorVisible, isDarkTheme } from '../../utils/theme';
 import { MarkdownRenderer } from '../MarkdownRenderer';
 
-// ~4 lines of compact markdown (12px / 1.5 line-height) before offering "more".
-const DESCRIPTION_COLLAPSED_MAX_HEIGHT = 72;
+// ~3 lines of compact markdown (12px / 1.5 line-height) before offering "more".
+const DESCRIPTION_COLLAPSED_MAX_HEIGHT = 54;
+// Cap on expanded height so a very long description still scrolls instead of
+// growing the card without bound.
+const DESCRIPTION_EXPANDED_MAX_HEIGHT = 240;
 const CARD_WIDTH = 380;
 
 export interface CardNodeData {
@@ -181,12 +184,19 @@ const CardNodeComponent = ({ data }: { data: CardNodeData }) => {
           <div
             ref={descRef}
             style={{
-              maxHeight: descExpanded ? undefined : DESCRIPTION_COLLAPSED_MAX_HEIGHT,
-              overflow: descExpanded ? 'visible' : 'hidden',
+              maxHeight: descExpanded
+                ? DESCRIPTION_EXPANDED_MAX_HEIGHT
+                : DESCRIPTION_COLLAPSED_MAX_HEIGHT,
+              overflow: descExpanded ? 'auto' : 'hidden',
               color: token.colorTextSecondary,
             }}
           >
-            <MarkdownRenderer content={card.description} compact showControls={false} />
+            <MarkdownRenderer
+              content={card.description}
+              compact
+              boundHeight={false}
+              showControls={false}
+            />
           </div>
           {canExpandDesc && (
             <Button

--- a/apps/agor-ui/src/components/CardNode/CardNode.tsx
+++ b/apps/agor-ui/src/components/CardNode/CardNode.tsx
@@ -27,6 +27,7 @@ import React, { useLayoutEffect, useMemo, useRef, useState } from 'react';
 import {
   REACT_FLOW_DRAG_HANDLE_CLASS,
   REACT_FLOW_NO_DRAG_CLASS,
+  REACT_FLOW_NO_WHEEL_CLASS,
 } from '../../utils/reactFlowDragClasses';
 import { ensureColorVisible, isDarkTheme } from '../../utils/theme';
 import { MarkdownRenderer } from '../MarkdownRenderer';
@@ -183,6 +184,7 @@ const CardNodeComponent = ({ data }: { data: CardNodeData }) => {
         >
           <div
             ref={descRef}
+            className={descExpanded ? REACT_FLOW_NO_WHEEL_CLASS : undefined}
             style={{
               maxHeight: descExpanded
                 ? DESCRIPTION_EXPANDED_MAX_HEIGHT

--- a/apps/agor-ui/src/components/CardNode/CardNode.tsx
+++ b/apps/agor-ui/src/components/CardNode/CardNode.tsx
@@ -6,7 +6,7 @@
  * - Zone border color when pinned to a zone (matching BranchCard pattern)
  * - CardType emoji + title (with optional URL link)
  * - Pin icon when in a zone (click to unpin)
- * - Description (collapsed after ~100 chars)
+ * - Description (markdown, collapsed after ~4 lines)
  * - Note (always shown in full, distinct background)
  */
 
@@ -23,14 +23,16 @@ function isSafeUrl(url: string): boolean {
   }
 }
 
-import React, { useMemo, useState } from 'react';
+import React, { useLayoutEffect, useMemo, useRef, useState } from 'react';
 import {
   REACT_FLOW_DRAG_HANDLE_CLASS,
   REACT_FLOW_NO_DRAG_CLASS,
 } from '../../utils/reactFlowDragClasses';
 import { ensureColorVisible, isDarkTheme } from '../../utils/theme';
+import { MarkdownRenderer } from '../MarkdownRenderer';
 
-const DESCRIPTION_MAX_CHARS = 100;
+// ~4 lines of compact markdown (12px / 1.5 line-height) before offering "more".
+const DESCRIPTION_COLLAPSED_MAX_HEIGHT = 72;
 const CARD_WIDTH = 380;
 
 export interface CardNodeData {
@@ -46,6 +48,8 @@ const CardNodeComponent = ({ data }: { data: CardNodeData }) => {
   const { token } = theme.useToken();
   const { card, isPinned, zoneName, zoneColor, onClick, onUnpin } = data;
   const [descExpanded, setDescExpanded] = useState(false);
+  const [canExpandDesc, setCanExpandDesc] = useState(false);
+  const descRef = useRef<HTMLDivElement>(null);
 
   const borderColor = card.effective_color || token.colorBorder;
   const emoji = card.effective_emoji;
@@ -57,15 +61,19 @@ const CardNodeComponent = ({ data }: { data: CardNodeData }) => {
     return ensureColorVisible(zoneColor, isDarkMode, 50, 50);
   }, [zoneColor, isDarkMode]);
 
-  const truncatedDesc = useMemo(() => {
-    if (!card.description) return '';
-    if (card.description.length <= DESCRIPTION_MAX_CHARS || descExpanded) return card.description;
-    const truncated = card.description.slice(0, DESCRIPTION_MAX_CHARS);
-    const lastSpace = truncated.lastIndexOf(' ');
-    return `${lastSpace > DESCRIPTION_MAX_CHARS * 0.7 ? truncated.slice(0, lastSpace) : truncated}...`;
+  // Measure against the collapsed height cap to decide whether "more" is
+  // needed. Only measured while collapsed: the rendered markdown (not a raw
+  // char count) is the source of truth, so we never cut off mid-syntax like
+  // `**bo` the old char-slicing truncation could.
+  useLayoutEffect(() => {
+    if (descExpanded || !card.description) {
+      if (!card.description) setCanExpandDesc(false);
+      return;
+    }
+    const el = descRef.current;
+    if (!el) return;
+    setCanExpandDesc(el.scrollHeight - el.clientHeight > 1);
   }, [card.description, descExpanded]);
-
-  const needsTruncation = (card.description?.length ?? 0) > DESCRIPTION_MAX_CHARS;
 
   return (
     <div
@@ -162,19 +170,25 @@ const CardNodeComponent = ({ data }: { data: CardNodeData }) => {
             padding: '8px 12px',
             borderBottom: card.note ? `1px solid ${token.colorBorderSecondary}` : 'none',
           }}
+          onClick={(e) => {
+            // Let interactive markdown elements (links, copy buttons) act on
+            // their own instead of also opening the card.
+            if ((e.target as HTMLElement).closest('a, button')) {
+              e.stopPropagation();
+            }
+          }}
         >
-          <Typography.Text
+          <div
+            ref={descRef}
             style={{
-              fontSize: 12,
+              maxHeight: descExpanded ? undefined : DESCRIPTION_COLLAPSED_MAX_HEIGHT,
+              overflow: descExpanded ? 'visible' : 'hidden',
               color: token.colorTextSecondary,
-              lineHeight: '1.5',
-              whiteSpace: 'pre-wrap',
-              wordBreak: 'break-word',
             }}
           >
-            {truncatedDesc}
-          </Typography.Text>
-          {needsTruncation && (
+            <MarkdownRenderer content={card.description} compact showControls={false} />
+          </div>
+          {canExpandDesc && (
             <Button
               type="link"
               size="small"

--- a/apps/agor-ui/src/components/MarkdownRenderer/MarkdownPreview.browser.test.tsx
+++ b/apps/agor-ui/src/components/MarkdownRenderer/MarkdownPreview.browser.test.tsx
@@ -1,0 +1,150 @@
+// biome-ignore-all lint/plugin/noHardcodedColorLiteral: distinctive semantic theme token verifies preview color inheritance
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ConfigProvider, theme } from 'antd';
+import { afterEach, expect, it } from 'vitest';
+import imageUrl from './fixtures/preview-image.svg?no-inline';
+import { MarkdownPreview } from './MarkdownPreview';
+import { MarkdownRenderer } from './MarkdownRenderer';
+
+const longContent = Array.from(
+  { length: 30 },
+  (_, i) => `Paragraph ${i}: a line of description.`
+).join('\n\n');
+
+afterEach(cleanup);
+
+function viewportFor(button: HTMLElement) {
+  const viewport = document.getElementById(button.getAttribute('aria-controls')!);
+  if (!viewport) throw new Error('Disclosure must identify its content');
+  return viewport;
+}
+
+it('bounds rendered Markdown without slicing syntax, and resets scrolling on collapse', () => {
+  const { container } = render(
+    <div style={{ width: 300 }}>
+      <MarkdownPreview content={`**${longContent.replaceAll('\n\n', ' ')}**`} />
+    </div>
+  );
+  const more = screen.getByRole('button', { name: 'more' });
+  const viewport = viewportFor(more);
+  expect(more).toHaveAttribute('aria-expanded', 'false');
+  expect(viewport.clientHeight).toBe(54);
+  expect(
+    Number(getComputedStyle(screen.getByText(/Paragraph 29/)).fontWeight)
+  ).toBeGreaterThanOrEqual(600);
+  expect((container.querySelector('.markdown-compact') as HTMLElement).style.maxHeight).toBe('');
+  fireEvent.click(more);
+  expect(more).toHaveAttribute('aria-expanded', 'true');
+  expect(viewport.clientHeight).toBe(240);
+  viewport.scrollTop = 100;
+  fireEvent.click(screen.getByRole('button', { name: 'less' }));
+  expect(viewport.clientHeight).toBe(54);
+  expect(viewport.scrollTop).toBe(0);
+});
+
+it('offers expansion after an uncached image loads without a source change', async () => {
+  render(<MarkdownPreview content={`![Preview](${imageUrl}?run=${crypto.randomUUID()})`} />);
+  const image = screen.getByRole('img', { name: 'Preview' }) as HTMLImageElement;
+  await waitFor(() => expect(image.naturalHeight).toBe(300));
+  const more = await screen.findByRole('button', { name: 'more' });
+  expect(viewportFor(more).clientHeight).toBe(54);
+  fireEvent.click(more);
+  expect(viewportFor(more).clientHeight).toBe(240);
+});
+
+it('remeasures native disclosures and removes an unnecessary toggle after shrinking', async () => {
+  const { container } = render(
+    <MarkdownPreview
+      content={`<details><summary>Details</summary>\n\n${longContent}\n\n</details>`}
+    />
+  );
+  expect(screen.queryByRole('button', { name: 'more' })).not.toBeInTheDocument();
+  fireEvent.click(screen.getByText('Details'));
+  expect(await screen.findByRole('button', { name: 'more' })).toBeInTheDocument();
+  fireEvent.click(screen.getByText('Details'));
+  await waitFor(() =>
+    expect(screen.queryByRole('button', { name: 'more' })).not.toBeInTheDocument()
+  );
+  expect(container.querySelector('details')).not.toHaveAttribute('open');
+});
+
+it('retains a collapse action after updates, including clearing and restoring content', () => {
+  const { rerender } = render(<MarkdownPreview content={longContent} />);
+  fireEvent.click(screen.getByRole('button', { name: 'more' }));
+  rerender(<MarkdownPreview content="Short replacement" />);
+  fireEvent.click(screen.getByRole('button', { name: 'less' }));
+  expect(screen.queryByRole('button', { name: 'more' })).not.toBeInTheDocument();
+  rerender(<MarkdownPreview content={longContent} />);
+  fireEvent.click(screen.getByRole('button', { name: 'more' }));
+  rerender(<MarkdownPreview content="" />);
+  rerender(<MarkdownPreview content={longContent} />);
+  expect(screen.getByRole('button', { name: 'more' })).toHaveAttribute('aria-expanded', 'false');
+});
+
+it('expands when keyboard focus reaches clipped content but not a visible link', async () => {
+  render(
+    <MarkdownPreview
+      content={`[Visible](https://example.com)\n\n${longContent}\n\n[Hidden](https://example.com)`}
+    />
+  );
+  act(() => screen.getByRole('link', { name: 'Visible' }).focus());
+  expect(screen.getByRole('button', { name: 'more' })).toHaveAttribute('aria-expanded', 'false');
+  const hidden = screen.getByRole('link', { name: 'Hidden' });
+  act(() => hidden.focus());
+  const less = await screen.findByRole('button', { name: 'less' });
+  expect(less).toHaveAttribute('aria-expanded', 'true');
+  expect(hidden).toHaveFocus();
+  const viewport = viewportFor(less).getBoundingClientRect();
+  expect(hidden.getBoundingClientRect().top).toBeGreaterThanOrEqual(viewport.top);
+  expect(hidden.getBoundingClientRect().bottom).toBeLessThanOrEqual(viewport.bottom + 1);
+});
+
+it('uses layout pixels under canvas zoom and responds to width changes', async () => {
+  const { rerender } = render(
+    <div style={{ width: 800, transform: 'scale(0.5)' }}>
+      <MarkdownPreview content={'Word '.repeat(40)} />
+    </div>
+  );
+  expect(screen.queryByRole('button', { name: 'more' })).not.toBeInTheDocument();
+  rerender(
+    <div style={{ width: 200, transform: 'scale(0.5)' }}>
+      <MarkdownPreview content={'Word '.repeat(40)} />
+    </div>
+  );
+  expect(await screen.findByRole('button', { name: 'more' })).toBeInTheDocument();
+});
+
+it('supports branch-note sizing and labels, and keeps default renderer bounds unchanged', () => {
+  const { container } = render(
+    <>
+      <MarkdownPreview
+        content={longContent}
+        collapsedHeight={120}
+        moreLabel="See more"
+        lessLabel="See less"
+      />
+      <MarkdownRenderer content="Other compact caller" compact />
+    </>
+  );
+  const more = screen.getByRole('button', { name: 'See more' });
+  expect(viewportFor(more).clientHeight).toBe(120);
+  fireEvent.click(more);
+  expect(screen.getByRole('button', { name: 'See less' })).toBeInTheDocument();
+  expect((container.querySelectorAll('.markdown-compact')[1] as HTMLElement).style.maxHeight).toBe(
+    '200px'
+  );
+});
+
+it('uses the secondary text token in dark/custom themes', () => {
+  render(
+    <ConfigProvider
+      theme={{
+        algorithm: theme.darkAlgorithm,
+        token: { colorTextSecondary: 'rgb(123, 145, 167)' },
+      }}
+    >
+      <MarkdownPreview content="Themed preview" />
+    </ConfigProvider>
+  );
+  expect(getComputedStyle(screen.getByText('Themed preview')).color).toBe('rgb(123, 145, 167)');
+});

--- a/apps/agor-ui/src/components/MarkdownRenderer/MarkdownPreview.tsx
+++ b/apps/agor-ui/src/components/MarkdownRenderer/MarkdownPreview.tsx
@@ -1,0 +1,124 @@
+import { Button, theme } from 'antd';
+import React, { useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import {
+  REACT_FLOW_NO_DRAG_CLASS,
+  REACT_FLOW_NO_WHEEL_CLASS,
+} from '../../utils/reactFlowDragClasses';
+import { MarkdownRenderer } from './MarkdownRenderer';
+
+interface MarkdownPreviewProps {
+  content: string;
+  /** Rendered pixels, not source characters/lines (which can split Markdown syntax). */
+  collapsedHeight?: number;
+  expandedHeight?: number;
+  moreLabel?: string;
+  lessLabel?: string;
+}
+
+const INTERACTIVE_MARKDOWN_SELECTOR =
+  'a, button, input, select, textarea, summary, [role="button"], [role="link"]';
+
+/** Shared bounded Markdown preview for canvas cards, not streaming chat messages. */
+export const MarkdownPreview = React.memo(function MarkdownPreview({
+  content,
+  collapsedHeight = 54,
+  expandedHeight = 240,
+  moreLabel = 'more',
+  lessLabel = 'less',
+}: MarkdownPreviewProps) {
+  const { token } = theme.useToken();
+  const contentId = useId();
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [expanded, setExpanded] = useState(false);
+  const [canExpand, setCanExpand] = useState(false);
+  // Keep the renderer memoized when only the preview's disclosure state changes.
+  const markdownStyle = useMemo(
+    () => ({ color: token.colorTextSecondary }),
+    [token.colorTextSecondary]
+  );
+
+  useLayoutEffect(() => {
+    if (!content) {
+      setExpanded(false);
+      setCanExpand(false);
+      return;
+    }
+    const element = contentRef.current;
+    if (!element) return;
+    // Observe the unbounded content, not the viewport: an already-clamped
+    // viewport won't resize when an image, diagram, font, or disclosure grows.
+    // scrollHeight is in layout pixels, unaffected by React Flow's zoom transform.
+    const measure = () => setCanExpand(element.scrollHeight > collapsedHeight + 1);
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [content, collapsedHeight]);
+
+  if (!content) return null;
+
+  return (
+    <div
+      className={REACT_FLOW_NO_DRAG_CLASS}
+      onClick={(event) => {
+        if ((event.target as Element).closest(INTERACTIVE_MARKDOWN_SELECTOR)) {
+          event.stopPropagation();
+        }
+      }}
+    >
+      <div
+        id={contentId}
+        ref={viewportRef}
+        className={expanded ? REACT_FLOW_NO_WHEEL_CLASS : undefined}
+        style={{
+          maxHeight: expanded ? expandedHeight : collapsedHeight,
+          overflow: expanded ? 'auto' : 'hidden',
+        }}
+        onFocusCapture={(event) => {
+          if (expanded) return;
+          const viewport = event.currentTarget;
+          const target = event.target;
+          if (!viewport.contains(target)) return;
+          const visible = viewport.getBoundingClientRect();
+          const focused = target.getBoundingClientRect();
+          // Hidden-overflow content is still tabbable. Disclose it rather than
+          // letting focus silently scroll a supposedly collapsed preview.
+          if (
+            viewport.scrollTop > 0 ||
+            focused.top < visible.top ||
+            focused.bottom > visible.bottom
+          ) {
+            setExpanded(true);
+          }
+        }}
+      >
+        <div ref={contentRef} style={{ display: 'flow-root' }}>
+          <MarkdownRenderer
+            content={content}
+            compact
+            boundHeight={false}
+            showControls={false}
+            style={markdownStyle}
+          />
+        </div>
+      </div>
+      {(expanded || canExpand) && (
+        <Button
+          type="link"
+          size="small"
+          aria-expanded={expanded}
+          aria-controls={contentId}
+          onClick={(event) => {
+            event.stopPropagation();
+            if (expanded && viewportRef.current) viewportRef.current.scrollTop = 0;
+            setExpanded(!expanded);
+          }}
+          style={{ padding: 0, height: 'auto', fontSize: token.fontSizeSM }}
+        >
+          {expanded ? lessLabel : moreLabel}
+        </Button>
+      )}
+    </div>
+  );
+});

--- a/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/apps/agor-ui/src/components/MarkdownRenderer/MarkdownRenderer.tsx
@@ -61,6 +61,14 @@ interface MarkdownRendererProps {
    */
   compact?: boolean;
   /**
+   * If false, skips compact's own max-height/scroll cap (font size, line
+   * height, and heading/margin sizing still apply). Use when the caller
+   * clips or scrolls the content itself — e.g. a collapsible preview —
+   * so the two scroll containers don't nest and show a stray scrollbar
+   * inside a clipped box. Defaults to true (compact's usual behavior).
+   */
+  boundHeight?: boolean;
+  /**
    * If false, hides Streamdown controls (copy/download buttons)
    * Useful for compact contexts where controls add clutter
    */
@@ -96,6 +104,7 @@ const MarkdownRendererInner: React.FC<MarkdownRendererProps> = ({
   style,
   isStreaming = false,
   compact = false,
+  boundHeight = true,
   showControls = true,
   headingAnchors = false,
   enableVegaLite = false,
@@ -127,8 +136,7 @@ const MarkdownRendererInner: React.FC<MarkdownRendererProps> = ({
   // Compact mode: reduce spacing and size for card contexts
   const compactStyles: React.CSSProperties = compact
     ? {
-        maxHeight: '200px',
-        overflowY: 'auto',
+        ...(boundHeight ? { maxHeight: '200px', overflowY: 'auto' } : {}),
         fontSize: '12px',
         lineHeight: '1.5',
       }

--- a/apps/agor-ui/src/components/MarkdownRenderer/fixtures/preview-image.svg
+++ b/apps/agor-ui/src/components/MarkdownRenderer/fixtures/preview-image.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="300"><rect width="320" height="300" fill="blue"/></svg>

--- a/apps/agor-ui/src/components/MarkdownRenderer/fixtures/preview-image.svg
+++ b/apps/agor-ui/src/components/MarkdownRenderer/fixtures/preview-image.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="320" height="300"><rect width="320" height="300" fill="blue"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="300"><title>Blue rectangle for markdown preview layout tests</title><rect width="320" height="300" fill="blue"/></svg>

--- a/apps/agor-ui/src/components/MarkdownRenderer/index.ts
+++ b/apps/agor-ui/src/components/MarkdownRenderer/index.ts
@@ -1,1 +1,2 @@
+export { MarkdownPreview } from './MarkdownPreview';
 export { MarkdownRenderer } from './MarkdownRenderer';

--- a/apps/agor-ui/src/utils/reactFlowDragClasses.ts
+++ b/apps/agor-ui/src/utils/reactFlowDragClasses.ts
@@ -9,3 +9,8 @@
 export const REACT_FLOW_DRAG_HANDLE_CLASS = 'drag-handle';
 export const REACT_FLOW_DRAG_HANDLE_SELECTOR = `.${REACT_FLOW_DRAG_HANDLE_CLASS}`;
 export const REACT_FLOW_NO_DRAG_CLASS = 'nodrag';
+// React Flow's default zoom/pan-on-scroll intercepts every wheel event over
+// the canvas, including inside a node. Elements with this class are excluded,
+// so the browser's native scroll wheel works over a node's own scrollable
+// content instead of zooming/panning the board.
+export const REACT_FLOW_NO_WHEEL_CLASS = 'nowheel';


### PR DESCRIPTION
## Summary
- Collapsed board cards showed `card.description` as raw plain text (e.g. `***foo***` displayed literally with asterisks). The opened card modal already rendered markdown correctly via `MarkdownRenderer` (Streamdown) — this brings the collapsed card in line.
- `CardNode.tsx`'s description block now renders through the same `MarkdownRenderer` (`compact`, `showControls={false}`) instead of plain `Typography.Text`.
- Replaced the old character-based truncation (`slice(0, 100)`), which could cut mid-syntax (e.g. `**bo`) and render broken markdown, with a measured line-clamp: an outer wrapper caps the rendered markdown to ~4 lines (`maxHeight: 72px`, `overflow: hidden`) and a `useLayoutEffect` compares `scrollHeight` vs `clientHeight` to decide whether to show the "more" toggle. Expanding removes the cap (compact mode's own 200px scroll cap still bounds it, so it can't grow unbounded).
- Interactive markdown elements (links, copy buttons) `stopPropagation` on click via an ancestor check, so clicking them doesn't also trigger the card's open-modal handler; the drag-blocking `REACT_FLOW_NO_DRAG_CLASS` on the description container is preserved.

## Before / after
- Before: `***foo***` rendered literally as `***foo***` on the collapsed card.
- After: renders as **foo**, matching the opened-card modal.

(No local dev environment was running in this session — daemon/UI weren't started per repo convention that the user manages `pnpm dev`. Typecheck and lint were run instead; a manual screenshot pass in a running environment is recommended before merge.)

## Test plan
- [x] `tsc --noEmit` passes for `apps/agor-ui`
- [x] `biome check` passes for the changed file
- [ ] Manually verify in a running board: a card with `**bold**`/`*italic*`/links in its description renders markdown when collapsed, "more"/"less" toggle works, clicking a link doesn't open the card, and dragging the card still works