### PR TITLE
feat(multitenancy): arm tenant DB-scope guard in every mode (Stage A)

### DIFF
--- a/apps/agor-cli/src/commands/local/create-admin.test.ts
+++ b/apps/agor-cli/src/commands/local/create-admin.test.ts
@@ -1,5 +1,6 @@
+import { BootstrapTenantUnsupportedError } from '@agor/core/config';
 import { describe, expect, it } from 'vitest';
-import { assertDevelopmentDefaultAdminCliRequest } from './create-admin';
+import { assertDevelopmentDefaultAdminCliRequest, presentCreateAdminFailure } from './create-admin';
 
 const exactRequest = {
   email: 'admin@agor.live',
@@ -48,5 +49,26 @@ describe('local create-admin development default', () => {
         }
       )
     ).toThrow(/exact admin@agor.live/);
+  });
+});
+
+describe('create-admin failure presentation', () => {
+  it('surfaces the single-tenant rejection verbatim (not flattened by DB sanitization)', () => {
+    const error = new BootstrapTenantUnsupportedError(
+      'This command operates on the static single tenant and is not supported when ' +
+        'multi_tenancy.mode=required_from_auth.'
+    );
+    // The message must survive create-admin's catch path, which otherwise routes
+    // errors through sanitizeDbError → "Database operation failed".
+    expect(presentCreateAdminFailure(error)).toBe(error.message);
+    expect(presentCreateAdminFailure(error)).not.toMatch(/Database operation failed/);
+  });
+
+  it('flattens ordinary database errors through the sanitizer', () => {
+    const dbError = Object.assign(new Error('duplicate key value violates unique constraint'), {
+      code: '23505',
+    });
+    expect(presentCreateAdminFailure(dbError)).not.toMatch(/duplicate key/);
+    expect(presentCreateAdminFailure(dbError)).toMatch(/Database/);
   });
 });

--- a/apps/agor-cli/src/commands/local/create-admin.ts
+++ b/apps/agor-cli/src/commands/local/create-admin.ts
@@ -3,7 +3,12 @@
  */
 
 import { join } from 'node:path';
-import { getConfigPath, loadConfig, resolveBootstrapTenantId } from '@agor/core/config';
+import {
+  BootstrapTenantUnsupportedError,
+  getConfigPath,
+  loadConfig,
+  resolveBootstrapTenantId,
+} from '@agor/core/config';
 import {
   assertDevelopmentDefaultAdminEnvironment,
   assertUsableBootstrapAdminPassword,
@@ -60,6 +65,15 @@ export default class LocalCreateAdmin extends Command {
     const { flags } = await this.parse(LocalCreateAdmin);
 
     try {
+      // Bootstrap admin creation is single-tenant. Resolve the target tenant
+      // FIRST (before opening the DB or running migrations): in
+      // required_from_auth this throws a typed BootstrapTenantUnsupportedError
+      // with a clear, actionable message. Doing it here — outside the DB work —
+      // keeps that message from being flattened by `sanitizeDbError` below, and
+      // avoids entering an undefined-tenant scope that would trip the armed guard.
+      const config = await loadConfig();
+      const tenantId = resolveBootstrapTenantId(config);
+
       // Get database connection URL
       // Priority: DATABASE_URL env var > default SQLite file path
       let databaseUrl = process.env.DATABASE_URL;
@@ -82,12 +96,6 @@ export default class LocalCreateAdmin extends Command {
       // scope — the armed DB guard requires either a tenant or system scope for
       // any access to the guarded proxy.
       await runWithSystemDatabaseScope(db, 'cli create-admin migrations', () => runMigrations(db));
-
-      const config = await loadConfig();
-      // Bootstrap admin creation is single-tenant: use the static tenant, or
-      // fail closed with a clear message in required_from_auth (rather than
-      // entering an undefined-tenant scope that would trip the armed guard).
-      const tenantId = resolveBootstrapTenantId(config);
 
       await runWithTenantDatabaseScope(db, tenantId, async () => {
         // Check if admin user already exists in the active tenant.
@@ -186,11 +194,23 @@ export default class LocalCreateAdmin extends Command {
     } catch (error) {
       this.log('');
       this.log(chalk.red('✗ Failed to create admin user'));
-      const safeError = sanitizeDbError(error);
-      this.log(chalk.red(`  ${safeError.message}`));
+      this.log(chalk.red(`  ${presentCreateAdminFailure(error)}`));
       process.exit(1);
     }
   }
+}
+
+/**
+ * Choose the user-facing failure message.
+ *
+ * A single-tenant-mode rejection ({@link BootstrapTenantUnsupportedError}) is an
+ * actionable configuration message and is surfaced verbatim. Everything else is
+ * assumed to be a database/driver error and is flattened through
+ * {@link sanitizeDbError} so no rejected values or driver internals leak.
+ */
+export function presentCreateAdminFailure(error: unknown): string {
+  if (error instanceof BootstrapTenantUnsupportedError) return error.message;
+  return sanitizeDbError(error).message;
 }
 
 /** Validate the CLI-specific shape, then delegate environment policy to core. */

--- a/apps/agor-cli/src/commands/local/create-admin.ts
+++ b/apps/agor-cli/src/commands/local/create-admin.ts
@@ -14,6 +14,7 @@ import {
   DEVELOPMENT_DEFAULT_ADMIN_USER,
   getUserByEmail,
   runMigrations,
+  runWithSystemDatabaseScope,
   runWithTenantDatabaseScope,
   sanitizeDbError,
   shortId,
@@ -76,8 +77,11 @@ export default class LocalCreateAdmin extends Command {
 
       // Ensure migrations are run (idempotent, safe to run multiple times)
       // This is critical for Docker environments where init --skip-if-exists
-      // might skip migrations if the directory already exists
-      await runMigrations(db);
+      // might skip migrations if the directory already exists. Migrations are
+      // schema DDL, not tenant data, so they run under an explicit system
+      // scope — the armed DB guard requires either a tenant or system scope for
+      // any access to the guarded proxy.
+      await runWithSystemDatabaseScope(db, 'cli create-admin migrations', () => runMigrations(db));
 
       const config = await loadConfig();
       const multiTenancy = resolveMultiTenancyConfig(config);

--- a/apps/agor-cli/src/commands/local/create-admin.ts
+++ b/apps/agor-cli/src/commands/local/create-admin.ts
@@ -3,7 +3,7 @@
  */
 
 import { join } from 'node:path';
-import { getConfigPath, loadConfig, resolveMultiTenancyConfig } from '@agor/core/config';
+import { getConfigPath, loadConfig, resolveBootstrapTenantId } from '@agor/core/config';
 import {
   assertDevelopmentDefaultAdminEnvironment,
   assertUsableBootstrapAdminPassword,
@@ -84,8 +84,10 @@ export default class LocalCreateAdmin extends Command {
       await runWithSystemDatabaseScope(db, 'cli create-admin migrations', () => runMigrations(db));
 
       const config = await loadConfig();
-      const multiTenancy = resolveMultiTenancyConfig(config);
-      const tenantId = multiTenancy.mode === 'static' ? multiTenancy.static_tenant_id : undefined;
+      // Bootstrap admin creation is single-tenant: use the static tenant, or
+      // fail closed with a clear message in required_from_auth (rather than
+      // entering an undefined-tenant scope that would trip the armed guard).
+      const tenantId = resolveBootstrapTenantId(config);
 
       await runWithTenantDatabaseScope(db, tenantId, async () => {
         // Check if admin user already exists in the active tenant.

--- a/apps/agor-daemon/src/index.ts
+++ b/apps/agor-daemon/src/index.ts
@@ -751,7 +751,6 @@ async function startDaemonWithOwnedMetrics(
 
   const { db } = await initializeDatabase(databaseUrl, {
     tenantId: multiTenancy.mode === 'static' ? multiTenancy.static_tenant_id : undefined,
-    requireTenantScope: multiTenancy.mode === 'required_from_auth',
     skipFirstRunAdminBootstrap:
       !resolveIdentityAuthority(effectiveConfig).capabilities.users.create,
     // The URL may come from DATABASE_URL, but operators still need to size the

--- a/apps/agor-daemon/src/mcp/tools/guard-regression.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/guard-regression.test.ts
@@ -1,0 +1,95 @@
+import {
+  createTenantScopedDatabaseProxy,
+  runWithTenantContext,
+  runWithTenantDatabaseScope,
+} from '@agor/core/db';
+import type { Application } from '@agor/core/feathers';
+import { expect } from 'vitest';
+import { dbTest } from '../../../../../packages/core/src/db/test-helpers';
+import { CardsService } from '../../services/cards.js';
+import { SessionsService } from '../../services/sessions.js';
+
+/**
+ * Deliverable A3 — prove the armed guard, exercised through a REAL guarded
+ * SQLite proxy (not the old `db: {}` stub + mocked services), would have caught
+ * the two pre-#2612 misses in their OWN unit environment.
+ *
+ * Both `agor_cards_get` and `agor_sessions_archive` used to call a custom
+ * (non-transport) service method DIRECTLY from the MCP tool handler. The MCP
+ * tool boundary (`tenantScopedToolProxy`) enters tenant *context* only — never a
+ * DB scope — so the very first `this.db` touch in the custom method ran outside
+ * any tenant/system database scope. Under HA that threw
+ * `MissingTenantDatabaseScopeError`; in SQLite/tests the guard was disarmed, so
+ * nothing failed and the bug reached production.
+ *
+ * These tests reproduce the exact boundary (tenant context, no DB scope) over a
+ * real guarded proxy and assert:
+ *   1. the pre-fix shape (unwrapped custom-method call) throws the guard error —
+ *      i.e. it would now fail in the cheapest environment; and
+ *   2. wrapping the same call in a tenant DB scope (the #2612 fix, and the
+ *      Stage-B service-side self-scoping) satisfies the guard and reaches the DB.
+ *
+ * No rows are seeded: even a lookup for a missing id issues a SELECT against the
+ * guarded proxy, which is enough to trip the scope guard.
+ */
+
+dbTest(
+  'guarded harness would catch the pre-fix unscoped agor_cards_get (cardsService.getWithType)',
+  async ({ db }) => {
+    const guardedDb = createTenantScopedDatabaseProxy(db, { label: 'guarded MCP test database' });
+    const cardsService = new CardsService(guardedDb);
+
+    // Reproduce the MCP tool boundary: tenant identity is ambient, but no tenant
+    // DATABASE scope is active — exactly what `tenantScopedToolProxy` provides.
+    await runWithTenantContext('tenant-a', async () => {
+      // PRE-FIX agor_cards_get: called getWithType directly, unscoped. The
+      // repository wraps the guard error, so assert on its stable message.
+      await expect(cardsService.getWithType('card-missing' as never)).rejects.toThrow(
+        /Missing tenant database scope/
+      );
+
+      // POST-FIX / Stage-B: the same call inside a tenant DB scope reaches the
+      // DB and returns null for a missing card — the guard is satisfied.
+      const result = await runWithTenantDatabaseScope(guardedDb, 'tenant-a', () =>
+        cardsService.getWithType('card-missing' as never)
+      );
+      expect(result).toBeNull();
+    });
+  }
+);
+
+dbTest(
+  'guarded harness would catch the pre-fix unscoped agor_sessions_archive (setArchiveStateForTree)',
+  async ({ db }) => {
+    const guardedDb = createTenantScopedDatabaseProxy(db, { label: 'guarded MCP test database' });
+    // setArchiveStateForTree touches the DB (this.get) before any app.service
+    // use, so a stub application suffices for this scope-presence proof.
+    const app = {
+      service: () => {
+        throw new Error('unexpected app.service use in scope-presence proof');
+      },
+    } as unknown as Application;
+    const sessionsService = new SessionsService(guardedDb, app);
+
+    await runWithTenantContext('tenant-a', async () => {
+      // PRE-FIX agor_sessions_archive: archive → setArchiveStateForTree →
+      // this.get(id) ran unscoped.
+      await expect(sessionsService.archive('session-missing')).rejects.toThrow(
+        /Missing tenant database scope/
+      );
+
+      // POST-FIX / Stage-B: inside a tenant DB scope the read reaches the DB and
+      // fails with an ordinary not-found — NOT the scope guard.
+      let wrappedError: unknown;
+      try {
+        await runWithTenantDatabaseScope(guardedDb, 'tenant-a', () =>
+          sessionsService.archive('session-missing')
+        );
+      } catch (error) {
+        wrappedError = error;
+      }
+      expect(wrappedError).toBeDefined();
+      expect(String((wrappedError as Error)?.message)).not.toMatch(/Missing tenant database scope/);
+    });
+  }
+);

--- a/apps/agor-daemon/src/register-hooks.static-scope.test.ts
+++ b/apps/agor-daemon/src/register-hooks.static-scope.test.ts
@@ -1,0 +1,71 @@
+import type { AgorConfig } from '@agor/core/config';
+import {
+  createTenantScopedDatabaseProxy,
+  getCurrentTenantDatabaseScope,
+  MissingTenantDatabaseScopeError,
+} from '@agor/core/db';
+import type { HookContext } from '@agor/core/types';
+import { describe, expect, it } from 'vitest';
+import { createTenantDatabaseScopeAroundHook } from './utils/tenant-db-scope.js';
+
+/**
+ * Regression coverage for the static/SQLite scope-presence invariant (deliverable
+ * A1). With the DB-scope guard armed in EVERY mode, a tenant-owned service
+ * request in static single-tenant mode must enter a tenant DATABASE scope — not
+ * merely tenant identity — or the first `this.db` touch trips
+ * `MissingTenantDatabaseScopeError`. The daemon wires
+ * `createTenantDatabaseScopeAroundHook(...)` (the transaction-capable variant,
+ * a no-op scope on SQLite) around owned services in static mode for exactly this
+ * reason; the identity-only variant (`transaction: false`) does NOT satisfy the
+ * guard and is what this test proves would have failed.
+ */
+describe('static-mode tenant DB scope for owned services', () => {
+  // Minimal config → resolveMultiTenancyConfig defaults to static mode with the
+  // 'default' static tenant id. A SQLite handle is modeled as a plain object
+  // (no `transaction`), so runWithTenantDatabaseScope opens the no-op scope.
+  const staticConfig = {} as AgorConfig;
+  const jwtSecret = 'test-secret';
+
+  const makeGuardedSqliteDb = () =>
+    createTenantScopedDatabaseProxy({ run: () => undefined } as never, {
+      label: 'static daemon database',
+    });
+
+  const makeContext = (): HookContext => ({ params: {} }) as unknown as HookContext;
+
+  it('the DB-scope around hook lets an owned-service handler touch the guarded db', async () => {
+    const db = makeGuardedSqliteDb();
+    const around = createTenantDatabaseScopeAroundHook({ db, config: staticConfig, jwtSecret });
+
+    let observedScopeKind: string | undefined;
+    let observedTenantId: string | undefined;
+    await around(makeContext(), async () => {
+      const scope = getCurrentTenantDatabaseScope();
+      observedScopeKind = scope?.kind;
+      observedTenantId = scope?.kind === 'tenant' ? (scope.tenantId as string) : undefined;
+      // The first real DB touch a service would make. Must NOT throw.
+      expect(() => (db as unknown as { run(): void }).run()).not.toThrow();
+    });
+
+    expect(observedScopeKind).toBe('tenant');
+    expect(observedTenantId).toBe('default');
+  });
+
+  it('the identity-only variant leaves the guard unsatisfied (why A1 was needed)', async () => {
+    const db = makeGuardedSqliteDb();
+    const identityOnly = createTenantDatabaseScopeAroundHook({
+      db,
+      config: staticConfig,
+      jwtSecret,
+      transaction: false,
+    });
+
+    await expect(
+      identityOnly(makeContext(), async () => {
+        // Identity is present but no DB scope is active, so the guarded proxy
+        // throws on the first touch — the exact pre-A1 static failure.
+        (db as unknown as { run(): void }).run();
+      })
+    ).rejects.toBeInstanceOf(MissingTenantDatabaseScopeError);
+  });
+});

--- a/apps/agor-daemon/src/register-hooks.static-scope.test.ts
+++ b/apps/agor-daemon/src/register-hooks.static-scope.test.ts
@@ -6,6 +6,7 @@ import {
 } from '@agor/core/db';
 import type { HookContext } from '@agor/core/types';
 import { describe, expect, it } from 'vitest';
+import { type RegisterHooksContext, registerHooks } from './register-hooks.js';
 import { createTenantDatabaseScopeAroundHook } from './utils/tenant-db-scope.js';
 
 /**
@@ -67,5 +68,88 @@ describe('static-mode tenant DB scope for owned services', () => {
         (db as unknown as { run(): void }).run();
       })
     ).rejects.toBeInstanceOf(MissingTenantDatabaseScopeError);
+  });
+});
+
+/**
+ * End-to-end wiring guard: prove `registerHooks` actually installs the
+ * DB-scope around hook (not the identity-only variant) for tenant-owned
+ * services in static/SQLite mode. The factory-level tests above would still
+ * pass if `registerHooks` were reverted to `tenantIdentityAround`, so this test
+ * captures the around hook the real registration installs and runs it.
+ */
+describe('registerHooks static-mode owned-service scope wiring', () => {
+  type AroundHook = (ctx: HookContext, next: () => Promise<void>) => Promise<void>;
+
+  /** Run registerHooks against a recorder app and return around hooks per path. */
+  function captureAroundHooks(): Map<string, AroundHook[]> {
+    const captured = new Map<string, AroundHook[]>();
+    const app = {
+      service(path: string) {
+        return {
+          hooks(hooks: { around?: { all?: AroundHook[] } }) {
+            const key = path.replace(/^\//, '');
+            const chain = hooks?.around?.all ?? [];
+            captured.set(key, [...(captured.get(key) ?? []), ...chain]);
+          },
+        };
+      },
+      use() {},
+      publish() {},
+      io: { to: () => ({ emit() {} }) },
+    };
+
+    registerHooks({
+      // Unguarded stub: registerHooks constructs repositories over this db at
+      // registration time, which must not trip the guard. The scope assertion
+      // below uses a SEPARATE guarded probe. `run` marks it as SQLite
+      // (isPostgresDatabase keys off the absence of `.run`), so the around hook
+      // opens a no-op scope rather than a native transaction.
+      db: { run: () => undefined } as unknown as RegisterHooksContext['db'],
+      app: app as unknown as RegisterHooksContext['app'],
+      config: {
+        database: { dialect: 'sqlite' },
+        multi_tenancy: { mode: 'static', static_tenant_id: 'static-scope-test' },
+        execution: { branch_rbac: false },
+      } as RegisterHooksContext['config'],
+      jwtSecret: 'static-scope-test-secret',
+      deployment: { mode: 'standalone' },
+      requireAuth: async (context) => context,
+      superadminOpts: { allowSuperadmin: true },
+      sessionsService: {} as RegisterHooksContext['sessionsService'],
+      messagesService: {} as RegisterHooksContext['messagesService'],
+      boardsService: undefined,
+      branchRepository: {
+        findById: async () => null,
+      } as unknown as RegisterHooksContext['branchRepository'],
+      usersRepository: {} as unknown as RegisterHooksContext['usersRepository'],
+      sessionsRepository: {} as RegisterHooksContext['sessionsRepository'],
+    });
+
+    return captured;
+  }
+
+  it('installs an around hook that enters a DB scope for a tenant-owned service', async () => {
+    const around = captureAroundHooks().get('boards') ?? [];
+    expect(around.length).toBeGreaterThan(0);
+
+    // A guarded probe touched inside the composed around chain: it succeeds only
+    // if a tenant DB scope is active. A revert to identity-only would leave no
+    // scope, so this touch would throw MissingTenantDatabaseScopeError.
+    const probe = createTenantScopedDatabaseProxy({ run: () => undefined } as never, {
+      label: 'wiring probe db',
+    });
+    let scopeKind: string | undefined;
+    const innermost = async () => {
+      scopeKind = getCurrentTenantDatabaseScope()?.kind;
+      (probe as unknown as { run(): void }).run();
+    };
+    const composed = around.reduceRight<() => Promise<void>>(
+      (next, hook) => () => hook({ params: {} } as unknown as HookContext, next),
+      innermost
+    );
+
+    await expect(composed()).resolves.toBeUndefined();
+    expect(scopeKind).toBe('tenant');
   });
 });

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -1215,14 +1215,17 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   };
 
   // Without tenant columns (SQLite / single-tenant), tenant-owned services skip
-  // the full RLS-transaction hooks — but they must still carry ambient tenant
-  // identity for tenant-aware call sites. MCP session-token issuance can
-  // resolve the configured tenant without ambient identity in static mode,
-  // while required_from_auth remains fail-closed. Identity only: no data
-  // stamping or DB transaction, which are Postgres tenant-column mechanics.
-  const registerTenantIdentityForOwnedServices = (): void => {
+  // the Postgres RLS/tenant-column mechanics (data stamping, transaction-local
+  // RLS GUC) — but they must still enter a tenant DATABASE scope, not merely
+  // tenant identity. The scope guard is armed in every mode now, so a
+  // tenant-owned request that touched `this.db` with identity alone would trip
+  // `MissingTenantDatabaseScopeError`. On SQLite `runWithTenantDatabaseScope`
+  // opens no transaction — the scope is a cheap AsyncLocalStorage store — so
+  // this satisfies the guard at zero runtime cost and stamps/writes nothing.
+  // (`required_from_auth` still runs the full `registerTenantHooks` path.)
+  const registerTenantDatabaseScopeForOwnedServices = (): void => {
     for (const path of tenantOwnedServicePaths) {
-      safeService(path)?.hooks({ around: { all: [tenantIdentityAround] } });
+      safeService(path)?.hooks({ around: { all: [tenantDatabaseScopeAround] } });
     }
   };
 
@@ -3877,7 +3880,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   if (tenantColumnsEnabled) {
     registerTenantHooks();
   } else {
-    registerTenantIdentityForOwnedServices();
+    registerTenantDatabaseScopeForOwnedServices();
   }
   registerTenantIdentityHooks();
 }

--- a/apps/agor-daemon/src/services/repos-removal-transaction.sqlite.test.ts
+++ b/apps/agor-daemon/src/services/repos-removal-transaction.sqlite.test.ts
@@ -3,6 +3,7 @@ import {
   createTenantScopedDatabaseProxy,
   generateId,
   RepoRepository,
+  runWithTenantDatabaseScope,
 } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
 import type { BranchID, UUID } from '@agor/core/types';
@@ -57,10 +58,17 @@ dbTest(
       new Error('forced final repository deletion failure')
     );
 
+    // Production reaches `remove` through the Feathers tenant around-hook, which
+    // wraps the whole call in an ambient tenant DB scope. Reproduce that here so
+    // the armed scope guard sees the same declared tenancy intent the HTTP path
+    // provides; `remove`'s prologue reads run in this scope, then it opens its
+    // own native transaction for the atomic delete.
     await expect(
-      reposService.remove(repo.repo_id, {
-        tenant: { tenant_id: 'tenant-a', source: 'explicit' },
-      } as never)
+      runWithTenantDatabaseScope(serviceDb, 'tenant-a', () =>
+        reposService.remove(repo.repo_id, {
+          tenant: { tenant_id: 'tenant-a', source: 'explicit' },
+        } as never)
+      )
     ).rejects.toThrow('forced final repository deletion failure');
 
     expect(await repoRepository.findById(repo.repo_id)).not.toBeNull();

--- a/apps/agor-daemon/src/setup/database.ts
+++ b/apps/agor-daemon/src/setup/database.ts
@@ -126,7 +126,6 @@ export async function initializeDatabase(
   dbPath: string,
   options: {
     tenantId?: TenantID | string;
-    requireTenantScope?: boolean;
     skipFirstRunAdminBootstrap?: boolean;
     /** PostgreSQL per-replica connection limit. PostgreSQL only. */
     pool?: { max: number };
@@ -154,8 +153,12 @@ export async function initializeDatabase(
   const db = tracer
     ? await createDatabaseAsync(databaseConfig, { tracer })
     : await createDatabaseAsync(databaseConfig);
+  // The scope guard is armed in every mode (SQLite/static included), not only
+  // HA `required_from_auth`. A missing tenant/system scope is a bug in any
+  // deployment; catching it here (and in tests) is what makes the invariant
+  // structural instead of HA-only. On non-Postgres this is free — a scope is a
+  // cheap AsyncLocalStorage store with no transaction.
   const scopedDb = createTenantScopedDatabaseProxy(db, {
-    requireScope: options.requireTenantScope === true,
     label: 'daemon database',
   });
 

--- a/docs/internal/tenant-db-scope-structural-hardening-plan-2026-08-30.md
+++ b/docs/internal/tenant-db-scope-structural-hardening-plan-2026-08-30.md
@@ -1,0 +1,209 @@
+# Making tenant DB scope structurally unforgettable — implementation plan
+
+**Date:** 2026-08-30
+**Branch:** `harden-tenant-db-scope-invariant`
+**Root-cause follow-up to:** PR #2612 (design note
+`mcp-tenant-db-scope-createbranch-2026-08-29.md`, "Durable follow-up").
+
+## Goal (restated)
+
+Make "touch tenant data without declaring tenancy intent" a structural
+impossibility, caught in the cheapest environment (SQLite/dev/tests), so the
+per-call-site MCP wraps and the static audit test are no longer needed.
+
+Two independent boundaries, kept strictly separate throughout:
+
+- **(i) scope presence** — is _any_ tenant/system DB scope active. Arming
+  `requireScope` everywhere makes a MISSING scope fail in every mode. Subsumes
+  the original bug and the scope-presence half of the audit. **Deliverable A.**
+- **(ii) write-freeze gate** — a write during a freeze must be rejected
+  (`assertTenantWritable` → `Unavailable`). Orthogonal to (i): a write can be
+  perfectly scoped and still skip the gate. Only folding the gate into a
+  service-side write primitive retires the read/write helper split and the
+  `MUTATION_TOKENS` check. **Deliverables B + C.**
+
+## Current-state facts established by exploration
+
+- Guard is armed only in HA: `setup/database.ts:158`
+  `requireScope: options.requireTenantScope === true`, driven by
+  `index.ts:754` `requireTenantScope: multiTenancy.mode === 'required_from_auth'`.
+- Mode selection (`register-hooks.ts:3877`): Postgres → `registerTenantHooks()`
+  (`tenantDatabaseScopeAround`, enters `runWithTenantDatabaseScope`). SQLite →
+  `registerTenantIdentityForOwnedServices()` (`tenantIdentityAround`,
+  `transaction:false` — enters tenant **context** only, NO DB scope).
+  → **Arming `requireScope` in SQLite breaks every standard Feathers DB op**
+  unless static mode also enters the (cheap, no-op) DB scope. On non-Postgres,
+  `runWithTenantDatabaseScope` opens no transaction — a scope is just an
+  AsyncLocalStorage store, so this is cheap.
+- Test harness gap (the real silence): `dbTest`
+  (`packages/core/src/db/test-helpers.ts`) creates real temp-file SQLite via
+  `createDatabase` — **not** wrapped in `createTenantScopedDatabaseProxy`, and
+  repository tests call repos with no scope. Service tests use a mock
+  `createTenantScopeTestDb()` (`run`/`transaction` stubs). MCP tool tests use
+  `db: {}`. None exercises the guard.
+- Non-request DB entry points: daemon runtime is already fully scoped (all
+  background reconcilers/queues/schedulers/health/token/OAuth workers wrap in
+  `runWithSystemDatabaseScope` + per-tenant `runWithTenantDatabaseScope`/
+  `withFreshTenantWrite`; `setup/database.ts` seeds under system/tenant scope).
+  **Unscoped and would throw once armed:** CLI `init`, `db migrate`,
+  `db status`, `tenant delete|export|import|verify`; dev `scripts/setup-db.ts`.
+- Services: Repos/Boards/Cards/Sessions/Branches extend `DrizzleService`
+  (`adapters/drizzle.ts:87`); BoardObjects and Gateway do not. BranchesService
+  already has private `withTenantDatabase(params, work)` (short scope).
+  Gateway/artifacts bind every repo via `bindRepositoryToTenantUnitOfWork`.
+  ReposService.remove / SessionsService.remove use
+  `runWithTenantDatabaseTransaction` for atomic cascades; sessions
+  `setArchiveStateForTree` does a multi-target write that must stay in ONE scope.
+- MCP scaffolding to retire: **59** `runWithMcpTenantDatabase{Scope,Write}`
+  wraps across 11 tool files; `tenant-scope-audit.test.ts`;
+  `branches.tenant-scope.test.ts`. Un-gated MCP mutations found:
+  `SessionRelationshipRepository.setCallbackEnabled` and `.create` (wrapped in
+  the READ helper — mutations with no gate!), `appendSystemMessage` in
+  `widgets.ts`, and env mutators (`startEnvironment` et al. — need the
+  ADMISSION pattern, not a held transaction).
+
+## Progress (2026-08-30)
+
+**Stage A core landed and verified green (core 4053 / daemon 3939 tests, boundary
+check ok):**
+
+- Guard armed by default (opt-out) — `createTenantScopedDatabaseProxy`
+  (`packages/core/src/db/tenant-scope.ts`).
+- Production daemon path armed unconditionally — `setup/database.ts` (+ removed
+  the now-dead `requireTenantScope` option there and in `index.ts`).
+- **A1 done:** static/SQLite tenant-owned services now enter the (no-op) DB
+  scope via `tenantDatabaseScopeAround` (`register-hooks.ts`
+  `registerTenantDatabaseScopeForOwnedServices`), + regression test
+  `register-hooks.static-scope.test.ts`.
+- Fallout fixed: `tenant-scope.test.ts` (2 routing tests → explicit
+  `requireScope:false`), `repos-removal-transaction.sqlite.test.ts` (wrap direct
+  `remove` in the ambient scope production supplies).
+- **A4 (guarded-proxy entry points):** `create-admin.ts` migrations wrapped in
+  `runWithSystemDatabaseScope`; `dev-fixtures.ts` already scoped. Raw-handle CLI
+  commands (`init`, `db migrate|status`, `tenant delete|export|import|verify`)
+  are unaffected (they never wrap in the guarded proxy) — converting them to
+  guarded proxies is optional defense-in-depth, deferred.
+
+**A3 done:** `mcp/tools/guard-regression.test.ts` proves — over a REAL guarded
+SQLite proxy, at the exact MCP boundary (tenant context, no DB scope) — that the
+pre-#2612 unscoped `agor_cards_get` (`cardsService.getWithType`) and
+`agor_sessions_archive` (`setArchiveStateForTree`) throw the guard error, while
+wrapping the same call in a tenant DB scope satisfies it. No seeding needed (a
+missing-id lookup still issues a guarded SELECT).
+
+**A2 finding — arming the repository-layer `dbTest` fixture is NOT viable, by
+design:** Two independent blockers, both confirmed empirically:
+
+1. Vitest runs the test body on the fixture's async resource, but
+   AsyncLocalStorage `.run(cb)` does NOT propagate across the `use()` boundary
+   (only `.enterWith()` does).
+2. More fundamentally, yielding a _guarded proxy_ as the fixture value fails:
+   Vitest/Node probe the value (thenable `.then` check, etc.) OUTSIDE our scope,
+   tripping the guard during fixture plumbing before the test body runs.
+   Conclusion: the guard is a CALLER concern (services / MCP tools / request
+   hooks); repositories are the callee, legitimately unit-tested in isolation on a
+   raw handle. `dbTest` stays raw. Scope-presence is enforced (a) in production
+   (armed by default), and (b) at the service/tool test layer by wrapping the raw
+   handle in `createTenantScopedDatabaseProxy` and entering a scope INSIDE the test
+   body — the pattern `guard-regression.test.ts` uses and that Stage B's service
+   self-scoping will make the default.
+
+**Remaining (Stage A wind-down / defer to B):** the ~10 MCP-tool tests using
+`db: {}` + mocked services still don't exercise the guard; converting them to
+real guarded services is large and lower-value (they test tool arg/realtime
+logic, not scoping) — best folded into Stage B, where services self-scope and a
+handful of service-level scope tests replace per-tool proof.
+
+## Staging
+
+Each stage lands as its own PR. A is independently valuable and mergeable alone.
+
+### Stage A — Arm the guard universally (dev + tests first)
+
+**A1. Static mode enters the (no-op) DB scope.** Make tenant-owned services in
+SQLite/static enter `runWithTenantDatabaseScope` (via `tenantDatabaseScopeAround`
+or an armed variant) instead of identity-only, so scope presence holds in every
+mode. `TENANT_IDENTITY_ONLY_SERVICE_PATHS` keep identity-only (they self-scope
+at the call site) — verify each such path's DB touches are wrapped.
+
+**A2. Guarded test harness — armed EVERYWHERE (decided 2026-08-30).**
+`requireScope` is always on: SQLite, tests, dev, prod. No mode conditional, no
+escape hatch. Fail fast, fail early — the more protection the better.
+
+- Flip `createTenantScopedDatabaseProxy` to default `requireScope: true`
+  (opt-out only), and drop the `requireTenantScope` conditional in
+  `setup/database.ts` / `index.ts`.
+- Arm the shared `dbTest` fixture: wrap the yielded db in
+  `createTenantScopedDatabaseProxy({requireScope:true})` and run the test body
+  inside a scope (a default tenant scope) so the ~410 repository tests pass via
+  ONE fixture change, not per-test edits. The small subset that deliberately
+  switch tenants (isolation tests) get targeted fixes — discovered empirically
+  ("turn it on, fix what throws"), not guessed.
+- Replace `db: {}` (MCP tool tests) and the `createTenantScopeTestDb()` mock
+  (service tests) with a real guarded proxy via a `makeGuardedMcpContext(...)` /
+  service-test factory whose tool boundary enters tenant **context only**
+  (mirroring production), so an unwrapped service.method call throws.
+
+**A3. Proof.** Add tests showing the PRE-FIX `agor_cards_get`
+(`cardsService.getWithType`) and `agor_sessions_archive`
+(`setArchiveStateForTree`) would FAIL their own unit tests under the guarded
+harness (missing scope throws in SQLite too).
+
+**A4. Production single-tenant — flip ON, no escape hatch (decided
+2026-08-30).** Wrap the unscoped CLI/dev entry points (`init`, `db migrate`,
+`db status`, `tenant *`, `scripts/setup-db.ts`) in `runWithSystemDatabaseScope`
+/ tenant scope, then leave `requireScope` on for static production too (the
+daemon runtime is already clean). Requires A1 (static services enter the DB
+scope) to land together so static request handling works.
+
+### Stage B — Collapse scoping into one service-side primitive
+
+Add a `TenantScopedService` base/mixin (extending or composed with
+`DrizzleService`) exposing:
+
+- `this.tenantRead(params, work)` — enter scope (join ambient if present).
+- `this.tenantWrite(params, work)` — enter scope AND `assertTenantWritable`,
+  mapping `TenantWriteGateActiveError` → `Unavailable` (mirrors
+  `tenantWriteGateAround` / `runWithMcpTenantDatabaseWrite`).
+- `this.tenantTransaction(params, work)` — atomic multi-write
+  (`runWithTenantDatabaseTransaction`) for cascades.
+
+Route the custom methods on Repos/Boards/BoardObjects/Cards/Sessions through
+these so they self-defend regardless of caller (HTTP/MCP/gateway/scheduler).
+Generalize BranchesService's `withTenantDatabase` into the base.
+
+**Atomicity discipline (non-negotiable):** DEFAULT one scope per method
+(multi-write atomicity, e.g. sessions `setArchiveStateForTree`, cards
+`createWithPlacement`). Opt into per-call `bindRepositoryToTenantUnitOfWork`
+(gateway/artifacts) ONLY for genuinely single ops. Do NOT bind every repo.
+NEVER hold a Postgres transaction across executor/network I/O — long env/provider
+methods keep the short-unit / admission pattern.
+
+### Stage C — Retire the scaffolding
+
+- Remove the 59 per-call-site `runWithMcpTenantDatabase{Scope,Write}` wraps in
+  `mcp/tools/*.ts` (redundant once services self-scope). Retire the helpers
+  (and `tenantScopedToolProxy` keeps only the context entry).
+- Delete/trivialize `tenant-scope-audit.test.ts` (invariant no longer exists);
+  keep at most a check that services use the base primitive.
+- Fold `branches.tenant-scope.test.ts` into the Stage-A guarded-harness proofs.
+- Extend the write gate to EVERY MCP tenant mutation (criterion = "is it a
+  tenant write", not HTTP-route parity): direct-repo writes
+  (`SessionRelationshipRepository.setCallbackEnabled`/`.create`), utility writes
+  (`appendSystemMessage`), and env mutators via the ADMISSION pattern.
+
+## Constraints / proof obligations (every stage)
+
+- Preserve tenant/RBAC/RLS boundaries; never suppress scope or gate errors; no
+  global runner reuse; never hold a Postgres tx across executor/network I/O.
+- Prove: unscoped DB op fails in SQLite too; tenant-B cannot reach tenant-A
+  rows; a frozen tenant's write is rejected with `Unavailable` WITHOUT running;
+  static single-tenant behavior still works.
+- Run `pnpm check` and `pnpm check:multitenancy-boundaries`.
+- Verify against the branch's HA env (variant `ha`) via
+  `scripts/test-ha-mcp-branch-create.mjs` and the minted-MCP-token technique.
+- Guard local `pnpm install` (shared host disk ~97% full) — prefer Docker/HA.
+
+```
+
+```

--- a/docs/internal/tenant-db-scope-structural-hardening-plan-2026-08-30.md
+++ b/docs/internal/tenant-db-scope-structural-hardening-plan-2026-08-30.md
@@ -116,6 +116,15 @@ handful of service-level scope tests replace per-tool proof.
 
 ## Staging
 
+> **Note:** the subsections below are the ORIGINAL plan. Where they differ from
+> the **Progress (2026-08-30)** section above, Progress is authoritative — it
+> records the as-built outcome. Specifically: A2's "arm the `dbTest` fixture" and
+> "convert every CLI/dev entry point" did NOT land as written (arming the
+> repo-layer fixture proved infeasible; only the guarded-proxy entry points
+> needed scoping — raw-handle CLIs are unaffected). Bootstrap tools
+> (`create-admin`, dev-fixtures, `get-admin-id`) now resolve a single tenant via
+> `resolveBootstrapTenantId` and fail closed in `required_from_auth`.
+
 Each stage lands as its own PR. A is independently valuable and mergeable alone.
 
 ### Stage A — Arm the guard universally (dev + tests first)
@@ -203,7 +212,3 @@ methods keep the short-unit / admission pattern.
 - Verify against the branch's HA env (variant `ha`) via
   `scripts/test-ha-mcp-branch-create.mjs` and the minted-MCP-token technique.
 - Guard local `pnpm install` (shared host disk ~97% full) — prefer Docker/HA.
-
-```
-
-```

--- a/packages/core/src/config/multitenancy.test.ts
+++ b/packages/core/src/config/multitenancy.test.ts
@@ -3,6 +3,7 @@ import { MAX_TENANT_ID_LENGTH } from '../types/tenant';
 import {
   assertValidMultiTenancyConfig,
   DEFAULT_STATIC_TENANT_ID,
+  resolveBootstrapTenantId,
   resolveMultiTenancyConfig,
   resolveTenantContext,
   TenantResolutionError,
@@ -316,5 +317,28 @@ describe('multi-tenancy config and tenant resolution', () => {
       { params: { tenant_id: 'tenant-job' } }
     );
     expect(ctx).toEqual({ tenant_id: 'tenant-job', source: 'explicit' });
+  });
+
+  describe('resolveBootstrapTenantId (single-tenant bootstrap tooling)', () => {
+    it('returns the default static tenant for a single-tenant install', () => {
+      expect(resolveBootstrapTenantId({})).toBe(DEFAULT_STATIC_TENANT_ID);
+    });
+
+    it('returns the configured static tenant', () => {
+      expect(
+        resolveBootstrapTenantId({ multi_tenancy: { mode: 'static', static_tenant_id: 'acme' } })
+      ).toBe('acme');
+    });
+
+    it('fails closed in required_from_auth instead of yielding an undefined tenant', () => {
+      // The prior `mode === static ? id : undefined` shape produced an
+      // undefined-tenant scope that trips the armed DB-scope guard mid-operation
+      // with an opaque error. This must reject up front with a clear message.
+      expect(() =>
+        resolveBootstrapTenantId({
+          multi_tenancy: { mode: 'required_from_auth', auth_claim: 'tenant_id' },
+        })
+      ).toThrow(/required_from_auth/);
+    });
   });
 });

--- a/packages/core/src/config/multitenancy.test.ts
+++ b/packages/core/src/config/multitenancy.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { MAX_TENANT_ID_LENGTH } from '../types/tenant';
 import {
   assertValidMultiTenancyConfig,
+  BootstrapTenantUnsupportedError,
   DEFAULT_STATIC_TENANT_ID,
   resolveBootstrapTenantId,
   resolveMultiTenancyConfig,
@@ -334,6 +335,11 @@ describe('multi-tenancy config and tenant resolution', () => {
       // The prior `mode === static ? id : undefined` shape produced an
       // undefined-tenant scope that trips the armed DB-scope guard mid-operation
       // with an opaque error. This must reject up front with a clear message.
+      expect(() =>
+        resolveBootstrapTenantId({
+          multi_tenancy: { mode: 'required_from_auth', auth_claim: 'tenant_id' },
+        })
+      ).toThrow(BootstrapTenantUnsupportedError);
       expect(() =>
         resolveBootstrapTenantId({
           multi_tenancy: { mode: 'required_from_auth', auth_claim: 'tenant_id' },

--- a/packages/core/src/config/multitenancy.ts
+++ b/packages/core/src/config/multitenancy.ts
@@ -125,6 +125,28 @@ export function resolveMultiTenancyConfig(
   };
 }
 
+/**
+ * Resolve the tenant id for local bootstrap / single-tenant CLI tooling
+ * (`local create-admin`, dev fixtures, admin-id lookup). These tools operate on
+ * exactly one tenant — the static tenant.
+ *
+ * In `required_from_auth` there is no implicit bootstrap tenant: users are
+ * provisioned per authenticated tenant (typically via external launch), so
+ * these tools FAIL CLOSED with a clear message here rather than entering a
+ * tenant database scope with an undefined tenant id. The latter would trip the
+ * armed scope guard mid-operation with an opaque "Missing tenant database scope"
+ * error instead of explaining that the command is single-tenant only.
+ */
+export function resolveBootstrapTenantId(config: Pick<AgorConfig, 'multi_tenancy'>): TenantID {
+  const resolved = resolveMultiTenancyConfig(config);
+  if (resolved.mode === 'static') return resolved.static_tenant_id;
+  throw new Error(
+    'This command operates on the static single tenant and is not supported when ' +
+      'multi_tenancy.mode=required_from_auth. Provision users through the authenticated ' +
+      'per-tenant path (external launch) instead.'
+  );
+}
+
 export function assertValidMultiTenancyConfig(
   config: Pick<AgorConfig, 'multi_tenancy' | 'database' | 'execution'>
 ): void {

--- a/packages/core/src/config/multitenancy.ts
+++ b/packages/core/src/config/multitenancy.ts
@@ -126,21 +126,35 @@ export function resolveMultiTenancyConfig(
 }
 
 /**
+ * Thrown by {@link resolveBootstrapTenantId} when a single-tenant bootstrap tool
+ * is run under `required_from_auth`. A distinct type so CLI callers can present
+ * this actionable message directly instead of routing it through database-error
+ * sanitization (which would flatten it to a generic "operation failed").
+ */
+export class BootstrapTenantUnsupportedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BootstrapTenantUnsupportedError';
+  }
+}
+
+/**
  * Resolve the tenant id for local bootstrap / single-tenant CLI tooling
  * (`local create-admin`, dev fixtures, admin-id lookup). These tools operate on
  * exactly one tenant — the static tenant.
  *
  * In `required_from_auth` there is no implicit bootstrap tenant: users are
  * provisioned per authenticated tenant (typically via external launch), so
- * these tools FAIL CLOSED with a clear message here rather than entering a
- * tenant database scope with an undefined tenant id. The latter would trip the
- * armed scope guard mid-operation with an opaque "Missing tenant database scope"
- * error instead of explaining that the command is single-tenant only.
+ * these tools FAIL CLOSED with a clear {@link BootstrapTenantUnsupportedError}
+ * here rather than entering a tenant database scope with an undefined tenant id.
+ * The latter would trip the armed scope guard mid-operation with an opaque
+ * "Missing tenant database scope" error instead of explaining that the command
+ * is single-tenant only.
  */
 export function resolveBootstrapTenantId(config: Pick<AgorConfig, 'multi_tenancy'>): TenantID {
   const resolved = resolveMultiTenancyConfig(config);
   if (resolved.mode === 'static') return resolved.static_tenant_id;
-  throw new Error(
+  throw new BootstrapTenantUnsupportedError(
     'This command operates on the static single tenant and is not supported when ' +
       'multi_tenancy.mode=required_from_auth. Provision users through the authenticated ' +
       'per-tenant path (external launch) instead.'

--- a/packages/core/src/db/tenant-scope.test.ts
+++ b/packages/core/src/db/tenant-scope.test.ts
@@ -108,7 +108,12 @@ describe('tenant-scoped database proxy', () => {
       transaction: vi.fn(async (callback: (tx: unknown) => Promise<unknown>) => callback(tx)),
       marker: vi.fn(() => 'base'),
     };
-    const db = createTenantScopedDatabaseProxy(base as unknown as Database);
+    // Opt out of the guard: this test asserts the proxy's routing target
+    // (base vs. active transaction) by reading it OUTSIDE a scope, which is
+    // exactly what the armed guard forbids. The guard itself is covered below.
+    const db = createTenantScopedDatabaseProxy(base as unknown as Database, {
+      requireScope: false,
+    });
 
     expect((db as unknown as { marker(): string }).marker()).toBe('base');
 
@@ -264,7 +269,13 @@ describe('tenant-scoped database proxy', () => {
       transaction: vi.fn(),
       marker: vi.fn(() => 'base'),
     };
-    const db = createTenantScopedDatabaseProxy(base as unknown as Database);
+    // Opt out of the guard: a tenant scope with an undefined tenantId is
+    // deliberately NOT sufficient for the armed guard (fail-closed: in HA that
+    // would mean no RLS tenant filter). This test only asserts the routing
+    // target for the undefined-tenant case, so it isolates from the guard.
+    const db = createTenantScopedDatabaseProxy(base as unknown as Database, {
+      requireScope: false,
+    });
 
     await runWithTenantDatabaseScope(db, undefined, async () => {
       expect((db as unknown as { marker(): string }).marker()).toBe('base');

--- a/packages/core/src/db/tenant-scope.test.ts
+++ b/packages/core/src/db/tenant-scope.test.ts
@@ -354,6 +354,35 @@ describe('tenant-scoped database proxy', () => {
       'Missing tenant database scope for test db access'
     );
   });
+
+  it('arms the guard by default (opt-out only)', () => {
+    const base = { marker: vi.fn(() => 'base') };
+    const db = createTenantScopedDatabaseProxy(base as unknown as Database);
+    expect(() => (db as unknown as { marker(): string }).marker()).toThrow(
+      MissingTenantDatabaseScopeError
+    );
+  });
+
+  it('keeps guard options per-proxy: an opt-out wrapper cannot disarm a guarded proxy over the same base', () => {
+    const base = { marker: vi.fn(() => 'base') };
+    // Guarded proxy created first...
+    const guarded = createTenantScopedDatabaseProxy(base as unknown as Database, {
+      requireScope: true,
+      label: 'guarded db',
+    });
+    // ...then a second proxy over the SAME base handle with the guard disabled.
+    // Options must be proxy-local, so this must not retroactively disarm the
+    // first proxy (regression: options were once keyed by the base handle).
+    const unguarded = createTenantScopedDatabaseProxy(base as unknown as Database, {
+      requireScope: false,
+    });
+
+    expect(() => (unguarded as unknown as { marker(): string }).marker()).not.toThrow();
+    expect(() => (guarded as unknown as { marker(): string }).marker()).toThrow(
+      MissingTenantDatabaseScopeError
+    );
+  });
+
   it('guarded proxies allow tenant-scoped and explicit system-scoped DB access', async () => {
     const base = {
       run: vi.fn(),

--- a/packages/core/src/db/tenant-scope.ts
+++ b/packages/core/src/db/tenant-scope.ts
@@ -33,7 +33,6 @@ import type {
 import { isPostgresDatabase, runDatabaseTransaction } from './database-wrapper';
 
 const tenantScopedProxyTargets = new WeakMap<object, RawDatabase | Database>();
-const tenantScopedProxyOptions = new WeakMap<object, TenantScopedDatabaseProxyOptions>();
 
 export interface TenantScopedDatabaseProxyOptions {
   /**
@@ -59,23 +58,17 @@ export class MissingTenantDatabaseScopeError extends Error {
   }
 }
 
-function assertDatabaseScopeAllowed(base: Database): void {
-  const options = tenantScopedProxyOptions.get(base as unknown as object);
-  if (!options?.requireScope) return;
+function assertDatabaseScopeAllowed(options: TenantScopedDatabaseProxyOptions): void {
+  if (!options.requireScope) return;
   const store = tenantDatabaseScope.getStore();
   if (store?.kind === 'system') return;
   if (store?.kind === 'tenant' && store.tenantId) return;
   throw new MissingTenantDatabaseScopeError(options.label);
 }
 
-function scopedTarget(base: Database): Database {
-  const scoped = tenantDatabaseScope.getStore()?.db;
-  if (scoped) {
-    assertDatabaseScopeAllowed(base);
-    return scoped;
-  }
-  assertDatabaseScopeAllowed(base);
-  return base;
+function scopedTarget(base: Database, options: TenantScopedDatabaseProxyOptions): Database {
+  assertDatabaseScopeAllowed(options);
+  return tenantDatabaseScope.getStore()?.db ?? base;
 }
 
 function unwrapTenantScopedDatabaseProxy(db: Database): RawDatabase | Database {
@@ -98,28 +91,35 @@ export function createTenantScopedDatabaseProxy(
   base: RawDatabase | Database,
   options: TenantScopedDatabaseProxyOptions = {}
 ): TenantScopeAwareDatabase {
+  // Normalize once and close over it PER PROXY. Options must not be keyed by the
+  // shared base handle: two proxies can wrap the same handle with different
+  // guard settings, and a later opt-out wrapper must never disarm an earlier
+  // guarded proxy. Arm the guard by default (opt-out only) — see
+  // TenantScopedDatabaseProxyOptions.
+  const proxyOptions: TenantScopedDatabaseProxyOptions = {
+    ...options,
+    requireScope: options.requireScope !== false,
+  };
   const proxy = new Proxy(base as object, {
     get(_target, property, receiver) {
-      const target = scopedTarget(base) as unknown as Record<PropertyKey, unknown>;
+      const target = scopedTarget(base, proxyOptions) as unknown as Record<PropertyKey, unknown>;
       const value = Reflect.get(target, property, receiver);
       return typeof value === 'function' ? value.bind(target) : value;
     },
     has(_target, property) {
-      return property in (scopedTarget(base) as unknown as object);
+      return property in (scopedTarget(base, proxyOptions) as unknown as object);
     },
     ownKeys() {
-      return Reflect.ownKeys(scopedTarget(base) as unknown as object);
+      return Reflect.ownKeys(scopedTarget(base, proxyOptions) as unknown as object);
     },
     getOwnPropertyDescriptor(_target, property) {
-      return Reflect.getOwnPropertyDescriptor(scopedTarget(base) as unknown as object, property);
+      return Reflect.getOwnPropertyDescriptor(
+        scopedTarget(base, proxyOptions) as unknown as object,
+        property
+      );
     },
   }) as TenantScopeAwareDatabase;
   tenantScopedProxyTargets.set(proxy as unknown as object, base);
-  // Arm the guard by default (opt-out only). See TenantScopedDatabaseProxyOptions.
-  tenantScopedProxyOptions.set(base as unknown as object, {
-    ...options,
-    requireScope: options.requireScope !== false,
-  });
   return proxy;
 }
 
@@ -257,10 +257,11 @@ export async function runWithTenantDatabaseScope<T>(
  * Run one short tenant-owned metadata unit in a native database transaction on
  * both supported dialects.
  *
- * Normal SQLite request scopes intentionally carry identity only, because a
- * whole Feathers request can include slow network/process work. Callers use
- * this narrower primitive for metadata phases that must commit atomically. If
- * a PostgreSQL request already owns a transaction, the work joins it. Queued
+ * Normal SQLite request scopes are intentionally NON-TRANSACTIONAL (they carry
+ * tenant identity and a scope, but no native transaction) because a whole
+ * Feathers request can include slow network/process work. Callers use this
+ * narrower primitive for metadata phases that must commit atomically. If a
+ * PostgreSQL request already owns a transaction, the work joins it. Queued
  * realtime/deferred callbacks drain only after the native transaction commits.
  */
 export async function runWithTenantDatabaseTransaction<T>(
@@ -294,8 +295,8 @@ export async function runWithTenantDatabaseTransaction<T>(
       { sqliteImmediate: true, postgresIsolationLevel: options.postgresIsolationLevel }
     );
 
-  // SQLite requests normally have an identity-only DB scope. Temporarily leave
-  // it so the repository proxy targets the new native transaction handle.
+  // SQLite requests normally have a non-transactional DB scope. Temporarily
+  // leave it so the repository proxy targets the new native transaction handle.
   const result = existingScope ? await runWithoutTenantDatabaseScope(execute) : await execute();
   await drainTenantCommitCallbacks(baseDb, effectiveTenantId, callbacks);
   return result;

--- a/packages/core/src/db/tenant-scope.ts
+++ b/packages/core/src/db/tenant-scope.ts
@@ -36,7 +36,17 @@ const tenantScopedProxyTargets = new WeakMap<object, RawDatabase | Database>();
 const tenantScopedProxyOptions = new WeakMap<object, TenantScopedDatabaseProxyOptions>();
 
 export interface TenantScopedDatabaseProxyOptions {
-  /** Throw on DB access unless a tenant or explicit system DB scope is active. */
+  /**
+   * Throw on DB access unless a tenant or explicit system DB scope is active.
+   *
+   * Defaults to `true`: the guard is armed in EVERY mode — SQLite, tests, dev,
+   * and production — so that "touch tenant data without declaring tenancy
+   * intent" fails in the cheapest environment rather than only under HA
+   * `required_from_auth`. On non-Postgres a scope is a cheap AsyncLocalStorage
+   * store (`runWithTenantDatabaseScope` opens no transaction), so arming it
+   * everywhere costs nothing at runtime. Pass `false` only for a deliberate,
+   * documented raw-access path.
+   */
   requireScope?: boolean;
   /** Human-readable label included in guard errors. */
   label?: string;
@@ -105,7 +115,11 @@ export function createTenantScopedDatabaseProxy(
     },
   }) as TenantScopeAwareDatabase;
   tenantScopedProxyTargets.set(proxy as unknown as object, base);
-  tenantScopedProxyOptions.set(base as unknown as object, options);
+  // Arm the guard by default (opt-out only). See TenantScopedDatabaseProxyOptions.
+  tenantScopedProxyOptions.set(base as unknown as object, {
+    ...options,
+    requireScope: options.requireScope !== false,
+  });
   return proxy;
 }
 

--- a/packages/core/src/db/test-helpers.ts
+++ b/packages/core/src/db/test-helpers.ts
@@ -59,6 +59,15 @@ export const dbTest = test.extend<{ db: Database }>({
     // which breaks any code under test that starts a transaction after
     // creating schema on the initial connection. A unique file path per
     // test gives us identical isolation with a single shared DB.
+    //
+    // The handle is deliberately RAW (unguarded): repository unit tests
+    // exercise the callee in isolation, and the armed tenant-scope guard is a
+    // CALLER concern (services / MCP tools / request hooks). Tests that verify
+    // scope-presence do so at that layer — wrap the handle in
+    // `createTenantScopedDatabaseProxy` and enter a scope INSIDE the test body
+    // (see `mcp/tools/guard-regression.test.ts`). Yielding a guarded proxy as a
+    // fixture value does not work: Vitest probes the value (thenable check)
+    // outside our scope, tripping the guard during fixture plumbing.
     const dir = mkdtempSync(join(tmpdir(), 'agor-core-test-'));
     const dbPath = join(dir, 'test.db');
     const db = createDatabase({ url: `file:${dbPath}` });

--- a/packages/core/src/seed/dev-fixtures.ts
+++ b/packages/core/src/seed/dev-fixtures.ts
@@ -13,7 +13,7 @@ import os from 'node:os';
 import path from 'node:path';
 import type { BranchID, UUID } from '@agor/core/types';
 import { getBranchesDir, loadConfigSync } from '../config/config-manager';
-import { resolveMultiTenancyConfig } from '../config/multitenancy';
+import { resolveBootstrapTenantId } from '../config/multitenancy';
 import {
   BoardObjectRepository,
   BoardRepository,
@@ -78,8 +78,9 @@ export async function seedDevFixtures(options: SeedOptions): Promise<SeedResult>
   );
   const db = createTenantScopedDatabaseProxy(createDatabase({ url: databaseUrl }));
   const config = loadConfigSync();
-  const multiTenancy = resolveMultiTenancyConfig(config);
-  const tenantId = multiTenancy.mode === 'static' ? multiTenancy.static_tenant_id : undefined;
+  // Dev fixtures seed exactly one tenant: the static tenant (or a clear failure
+  // in required_from_auth, rather than an undefined-tenant scope).
+  const tenantId = resolveBootstrapTenantId(config);
 
   return runWithTenantDatabaseScope(db, tenantId, async () => {
     const repoRepo = new RepoRepository(db);

--- a/scripts/get-admin-id.ts
+++ b/scripts/get-admin-id.ts
@@ -7,7 +7,7 @@
 
 import os from 'node:os';
 import path from 'node:path';
-import { loadConfig, resolveMultiTenancyConfig } from '@agor/core/config';
+import { loadConfig, resolveBootstrapTenantId } from '@agor/core/config';
 import {
   createDatabase,
   createTenantScopedDatabaseProxy,
@@ -31,8 +31,7 @@ async function main() {
   try {
     const db = createTenantScopedDatabaseProxy(createDatabase({ url: databaseUrl }));
     const config = await loadConfig();
-    const multiTenancy = resolveMultiTenancyConfig(config);
-    const tenantId = multiTenancy.mode === 'static' ? multiTenancy.static_tenant_id : undefined;
+    const tenantId = resolveBootstrapTenantId(config);
 
     // Find admin user in the active static tenant when configured.
     const adminUser = await runWithTenantDatabaseScope(db, tenantId, async () => {


### PR DESCRIPTION
## Summary

Root-cause follow-up to #2612. The **"Missing tenant database scope"** bug class was silent until production because the guarded DB proxy only set `requireScope: true` under `multi_tenancy=required_from_auth` (HA/Postgres). In SQLite/static/tests the guard was a no-op, so a missing tenant scope could only fail in HA.

This PR (**Stage A**) locks in **boundary (i): scope-presence** — a DB op is legal only inside a tenant scope OR an explicit `runWithSystemDatabaseScope(...)`. On non-Postgres a scope is a cheap AsyncLocalStorage store (no transaction), so arming it everywhere is free.

> This is the first of a staged effort. It deliberately does **not** touch **boundary (ii)**, the tenant write-freeze gate — that's orthogonal to scope-presence and lands in Stage B (a `TenantScopedService` primitive that folds the gate into a service-side write op) and Stage C (retire the 59 per-call-site MCP wraps + the static audit test). See `docs/internal/tenant-db-scope-structural-hardening-plan-2026-08-30.md`.

## What changed

- **Guard armed by default** (opt-out only) in `createTenantScopedDatabaseProxy`. New call sites are protected automatically.
- **Production daemon armed unconditionally** (`setup/database.ts`); removed the now-dead `requireTenantScope` option here and in `index.ts`.
- **A1** — static/SQLite tenant-owned services enter the (no-op, zero-cost) DB scope via `tenantDatabaseScopeAround` instead of identity-only. Without this the armed static daemon would throw on the first request. Regression: `register-hooks.static-scope.test.ts`.
- **A4** — `create-admin` migrations wrapped in `runWithSystemDatabaseScope` (schema DDL, not tenant data); `dev-fixtures` already scoped. Raw-handle CLIs never touch the guarded proxy, so they're unaffected.
- **A3 proof** — `mcp/tools/guard-regression.test.ts` shows, over a **real guarded SQLite proxy** at the exact MCP boundary (tenant context, no DB scope), that the pre-#2612 unscoped `agor_cards_get` (`getWithType`) and `agor_sessions_archive` (`setArchiveStateForTree`) throw the guard error, while wrapping the same call in a tenant DB scope satisfies it.
- **Fallout fixed** — two proxy-routing unit tests opt out explicitly (`requireScope:false`); the repos-removal test wraps its direct `remove()` in the ambient scope production supplies via hooks (a real instance of the bug class).

## Design note: why `dbTest` stays a raw (unguarded) handle

Arming the repository-layer `dbTest` fixture is infeasible, confirmed empirically:
1. Vitest runs the test body on the fixture's async resource, but `AsyncLocalStorage.run(cb)` does not cross the `use()` boundary (only `.enterWith()` does); and
2. more fundamentally, yielding a **guarded proxy as a fixture value** fails — Vitest/Node probe the value (thenable `.then` check) *outside* our scope, tripping the guard during fixture plumbing before the test runs.

This is correct by design: the guard is a **caller** concern (services / MCP tools / request hooks); a repository is the **callee**, legitimately unit-tested in isolation. Test-layer enforcement therefore lives at the service/tool layer (the A3 pattern), which Stage B's service self-scoping makes the default.

## Verification

- `packages/core`: **4053 passed**
- `apps/agor-daemon`: **3941 passed** (incl. the two new tests)
- `pnpm check:multitenancy-boundaries`: **ok**
- `biome` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)