### PR TITLE
fix(files): propagate per-user sandbox home

### DIFF
--- a/apps/agor-daemon/src/services/file.test.ts
+++ b/apps/agor-daemon/src/services/file.test.ts
@@ -143,7 +143,7 @@ describe('FileService executor failures', () => {
   );
 
   it('passes the caller-scoped canonical home and tenant mounts to the per-user sandbox', async () => {
-    vi.spyOn(UsersRepository.prototype, 'findById').mockResolvedValue({
+    vi.spyOn(UsersRepository.prototype, 'getFilesystemHomeProjection').mockResolvedValue({
       user_id: 'user-1',
       filesystem_home: null,
     } as never);
@@ -184,7 +184,7 @@ describe('FileService executor failures', () => {
         templateVariables: expect.objectContaining({ user_id: 'user-1' }),
       })
     );
-    expect(UsersRepository.prototype.findById).toHaveBeenCalledWith('user-1');
+    expect(UsersRepository.prototype.getFilesystemHomeProjection).toHaveBeenCalledWith('user-1');
     expect(JSON.stringify(vi.mocked(requestExecutor).mock.calls[0])).not.toContain('branch-owner');
   });
 
@@ -192,7 +192,17 @@ describe('FileService executor failures', () => {
     const db = { run: vi.fn() } as never;
     const findById = vi.fn(async () => {
       expect(getCurrentTenantDatabaseScope()?.tenantId).toBe('tenant-a');
-      return { branch_id: 'branch-1' };
+      return branch;
+    });
+    vi.spyOn(UsersRepository.prototype, 'getFilesystemHomeProjection').mockImplementation(
+      async (userId) => {
+        expect(getCurrentTenantDatabaseScope()?.tenantId).toBe('tenant-a');
+        return { user_id: userId as never, filesystem_home: null };
+      }
+    );
+    vi.spyOn(RepoRepository.prototype, 'findById').mockImplementation(async () => {
+      expect(getCurrentTenantDatabaseScope()?.tenantId).toBe('tenant-a');
+      return { local_path: '/srv/agor/repos/org/repo' } as never;
     });
     impersonationMocks.resolveDelegatedExecutionHomeKey.mockImplementation(async () => {
       expect(getCurrentTenantDatabaseScope()?.tenantId).toBe('tenant-a');
@@ -202,7 +212,14 @@ describe('FileService executor failures', () => {
       expect(getCurrentTenantDatabaseScope()).toBeUndefined();
       return { success: true, data: { files: [] } };
     });
-    const service = new FileService(createBranchRepo(findById), db, createApp());
+    const service = new FileService(
+      createBranchRepo(findById),
+      db,
+      createApp({
+        paths: { data_home: '/srv/agor' },
+        execution: { sandbox: { enabled: true, home_mode: 'per_user' } },
+      })
+    );
 
     await runWithTenantContext('tenant-a', () =>
       service.find({
@@ -212,6 +229,8 @@ describe('FileService executor failures', () => {
     );
 
     expect(findById).toHaveBeenCalledOnce();
+    expect(UsersRepository.prototype.getFilesystemHomeProjection).toHaveBeenCalledOnce();
+    expect(RepoRepository.prototype.findById).toHaveBeenCalledOnce();
     expect(requestExecutor).toHaveBeenCalledOnce();
   });
 

--- a/apps/agor-daemon/src/services/file.test.ts
+++ b/apps/agor-daemon/src/services/file.test.ts
@@ -1,4 +1,9 @@
-import { getCurrentTenantDatabaseScope, runWithTenantContext } from '@agor/core/db';
+import {
+  getCurrentTenantDatabaseScope,
+  RepoRepository,
+  runWithTenantContext,
+  UsersRepository,
+} from '@agor/core/db';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { requestExecutor } from '../utils/spawn-executor.js';
 import { FileService } from './file.js';
@@ -16,14 +21,20 @@ vi.mock('../utils/spawn-executor.js', () => ({
   requestExecutor: vi.fn(),
 }));
 
-function createApp() {
+function createApp(config = {}) {
   return {
-    get: () => ({}),
+    get: () => config,
     sessionTokenService: { generateCommandToken: vi.fn(async () => 'user-token') },
   } as never;
 }
 
-const branch = { branch_id: 'branch-1', path: '/tenant-a/branch-1' };
+const branch = {
+  branch_id: 'branch-1',
+  path: '/tenant-a/branch-1',
+  repo_id: 'repo-1',
+  storage_mode: 'worktree',
+  primary_owner_user_id: 'branch-owner',
+};
 
 function createBranchRepo(
   findById = vi.fn().mockResolvedValue(branch),
@@ -43,6 +54,7 @@ function createBranchRepo(
 describe('FileService executor failures', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.restoreAllMocks();
     impersonationMocks.resolveDelegatedExecutionHomeKey.mockResolvedValue(undefined);
   });
 
@@ -129,6 +141,52 @@ describe('FileService executor failures', () => {
       );
     }
   );
+
+  it('passes the caller-scoped canonical home and tenant mounts to the per-user sandbox', async () => {
+    vi.spyOn(UsersRepository.prototype, 'findById').mockResolvedValue({
+      user_id: 'user-1',
+      filesystem_home: null,
+    } as never);
+    vi.spyOn(RepoRepository.prototype, 'findById').mockResolvedValue({
+      local_path: '/srv/tenants/tenant-a/repos/org/repo',
+    } as never);
+    vi.mocked(requestExecutor).mockResolvedValue({ success: true, data: { files: [] } });
+    const service = new FileService(
+      createBranchRepo(),
+      { run: vi.fn() } as never,
+      createApp({
+        paths: { data_home: '/srv/agor' },
+        multi_tenancy: {
+          mode: 'required_from_auth',
+          filesystem_isolation_enabled: true,
+          tenants_base_folder: '/srv/tenants',
+        },
+        execution: { sandbox: { enabled: true, home_mode: 'per_user' } },
+      })
+    );
+
+    await runWithTenantContext('tenant-a', () =>
+      service.find({
+        query: { branch_id: 'branch-1' },
+        user: { user_id: 'user-1', email: 'member@example.com', role: 'member' },
+      })
+    );
+
+    expect(requestExecutor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          sandboxHomeStore: '/srv/tenants/tenant-a/homes/user-1',
+          sandboxWorktreesRoot: '/srv/tenants/tenant-a/worktrees',
+          sandboxBaseRepoPath: '/srv/tenants/tenant-a/repos/org/repo',
+        }),
+      }),
+      expect.objectContaining({
+        templateVariables: expect.objectContaining({ user_id: 'user-1' }),
+      })
+    );
+    expect(UsersRepository.prototype.findById).toHaveBeenCalledWith('user-1');
+    expect(JSON.stringify(vi.mocked(requestExecutor).mock.calls[0])).not.toContain('branch-owner');
+  });
 
   it('scopes database reads but leaves executor work outside the transaction', async () => {
     const db = { run: vi.fn() } as never;

--- a/apps/agor-daemon/src/services/file.ts
+++ b/apps/agor-daemon/src/services/file.ts
@@ -16,10 +16,15 @@ import type {
   QueryParams,
   RBACParams,
   ServiceMethods,
+  UserID,
   UserRole,
 } from '@agor/core/types';
 import { ROLES } from '@agor/core/types';
 import { ensureMinimumRole } from '../utils/authorization';
+import {
+  type BranchExecutorSandboxMounts,
+  resolveBranchExecutorSandboxMounts,
+} from '../utils/branch-executor-sandbox.js';
 import { ensureBranchWorkspaceAccess } from '../utils/branch-workspace-path.js';
 import { resolveDelegatedExecutionHomeKey } from '../utils/executor-delegated-home.js';
 import { getDaemonUrl, requestExecutor } from '../utils/spawn-executor.js';
@@ -60,7 +65,8 @@ export class FileService
       resolved.userId,
       resolved.delegatedHomeKey,
       resolved.branchPath,
-      resolved.fsAccess
+      resolved.fsAccess,
+      resolved.sandboxMounts
     );
     if (!result.success) {
       throw new Error(
@@ -83,6 +89,7 @@ export class FileService
       resolved.delegatedHomeKey,
       resolved.branchPath,
       resolved.fsAccess,
+      resolved.sandboxMounts,
       {
         filePath: id.toString(),
       }
@@ -102,6 +109,7 @@ export class FileService
     delegatedHomeKey: string | undefined,
     branchPath: string,
     fsAccess: 'read' | 'write',
+    sandboxMounts: BranchExecutorSandboxMounts,
     extraParams: Record<string, unknown> = {}
   ) {
     const sessionToken = await issueExecutorCommandToken(this.app, command, userId, branchId);
@@ -115,6 +123,7 @@ export class FileService
           ...extraParams,
           cwd: branchPath,
           principalBranchAccess: fsAccess,
+          ...sandboxMounts,
         },
       },
       {
@@ -156,12 +165,22 @@ export class FileService
         userId,
         this.app.get('config')
       );
+      // Branch browsing is stateless executor work. Its private home belongs
+      // to the authenticated caller, never the branch or Session owner.
+      const sandboxMounts = await resolveBranchExecutorSandboxMounts({
+        config: this.app.get('config'),
+        tenantId,
+        executionUserId: userId as UserID,
+        branch,
+        db: this.db,
+      });
       return {
         branchId: branch.branch_id,
         branchPath: branch.path,
         delegatedHomeKey,
         fsAccess,
         userId,
+        sandboxMounts,
       };
     });
   }

--- a/apps/agor-daemon/src/services/files.test.ts
+++ b/apps/agor-daemon/src/services/files.test.ts
@@ -41,7 +41,7 @@ describe('FilesService tenant scope', () => {
   });
 
   it('passes the authenticated caller home into sandboxed autocomplete requests', async () => {
-    vi.spyOn(UsersRepository.prototype, 'findById').mockResolvedValue({
+    vi.spyOn(UsersRepository.prototype, 'getFilesystemHomeProjection').mockResolvedValue({
       user_id: 'user-1',
       filesystem_home: '/home/user-1',
     } as never);
@@ -101,17 +101,38 @@ describe('FilesService tenant scope', () => {
   });
 
   it('uses RBAC-preloaded records in a short database scope and executes afterward', async () => {
+    vi.spyOn(UsersRepository.prototype, 'getFilesystemHomeProjection').mockImplementation(
+      async (userId) => {
+        expect(getCurrentTenantDatabaseScope()?.tenantId).toBe('tenant-a');
+        return { user_id: userId as never, filesystem_home: null };
+      }
+    );
+    vi.spyOn(RepoRepository.prototype, 'findById').mockImplementation(async () => {
+      expect(getCurrentTenantDatabaseScope()?.tenantId).toBe('tenant-a');
+      return { local_path: '/srv/agor/repos/org/repo' } as never;
+    });
     vi.mocked(requestExecutor).mockImplementation(async () => {
       expect(getCurrentTenantDatabaseScope()).toBeUndefined();
       return { success: true, data: { results: [] } };
     });
-    const service = new FilesService({ run: vi.fn() } as never, app);
+    const service = new FilesService(
+      { run: vi.fn() } as never,
+      createApp({
+        paths: { data_home: '/srv/agor' },
+        execution: { sandbox: { enabled: true, home_mode: 'per_user' } },
+      })
+    );
 
     await runWithTenantContext('tenant-a', () =>
       service.find({
         query: { sessionId: 'session-1' as never, search: 'readme' },
         session: { session_id: 'session-1', branch_id: 'branch-1' },
-        branch: { branch_id: 'branch-1', path: '/tenant-a/branch-1' },
+        branch: {
+          branch_id: 'branch-1',
+          path: '/tenant-a/branch-1',
+          repo_id: 'repo-1',
+          storage_mode: 'worktree',
+        },
         user: { user_id: 'user-1', email: 'member@example.com', role: 'member' },
       } as never)
     );
@@ -132,6 +153,8 @@ describe('FilesService tenant scope', () => {
         },
       })
     );
+    expect(UsersRepository.prototype.getFilesystemHomeProjection).toHaveBeenCalledOnce();
+    expect(RepoRepository.prototype.findById).toHaveBeenCalledOnce();
   });
 
   it('does not swallow a conflicting tenant scope as empty autocomplete', async () => {

--- a/apps/agor-daemon/src/services/files.test.ts
+++ b/apps/agor-daemon/src/services/files.test.ts
@@ -1,7 +1,9 @@
 import {
   BranchRepository,
   getCurrentTenantDatabaseScope,
+  RepoRepository,
   runWithTenantContext,
+  UsersRepository,
 } from '@agor/core/db';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { requestExecutor } from '../utils/spawn-executor.js';
@@ -16,21 +18,74 @@ vi.mock('../utils/spawn-executor.js', () => ({
   requestExecutor: vi.fn(),
 }));
 
-const app = {
-  get: () => ({}),
-  sessionTokenService: { generateCommandToken: vi.fn(async () => 'user-token') },
-  settings: { authentication: { secret: 'test' } },
-} as never;
+function createApp(config = {}) {
+  return {
+    get: () => config,
+    sessionTokenService: { generateCommandToken: vi.fn(async () => 'user-token') },
+    settings: { authentication: { secret: 'test' } },
+  } as never;
+}
+
+const app = createApp();
 
 describe('FilesService tenant scope', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.restoreAllMocks();
     vi.spyOn(BranchRepository.prototype, 'resolveUserAccess').mockResolvedValue({
       can: 'view',
       fs_access: 'read',
       is_owner: false,
       source: 'others',
     });
+  });
+
+  it('passes the authenticated caller home into sandboxed autocomplete requests', async () => {
+    vi.spyOn(UsersRepository.prototype, 'findById').mockResolvedValue({
+      user_id: 'user-1',
+      filesystem_home: '/home/user-1',
+    } as never);
+    vi.spyOn(RepoRepository.prototype, 'findById').mockResolvedValue({
+      local_path: '/srv/agor/repos/org/repo',
+    } as never);
+    vi.mocked(requestExecutor).mockResolvedValue({ success: true, data: { results: [] } });
+    const service = new FilesService(
+      { run: vi.fn() } as never,
+      createApp({
+        paths: { data_home: '/srv/agor' },
+        execution: { sandbox: { enabled: true, home_mode: 'per_user' } },
+      })
+    );
+
+    await runWithTenantContext('tenant-a', () =>
+      service.find({
+        query: { sessionId: 'session-1' as never, search: 'readme' },
+        session: { session_id: 'session-1', branch_id: 'branch-1' },
+        branch: {
+          branch_id: 'branch-1',
+          path: '/tenant-a/branch-1',
+          repo_id: 'repo-1',
+          storage_mode: 'worktree',
+          primary_owner_user_id: 'owner-2',
+        },
+        user: { user_id: 'user-1', email: 'member@example.com', role: 'member' },
+      } as never)
+    );
+
+    expect(requestExecutor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: 'branch.files.list',
+        params: expect.objectContaining({
+          sandboxHomeStore: '/home/user-1',
+          sandboxWorktreesRoot: '/srv/agor/worktrees',
+          sandboxBaseRepoPath: '/srv/agor/repos/org/repo',
+        }),
+      }),
+      expect.objectContaining({
+        templateVariables: expect.objectContaining({ user_id: 'user-1' }),
+      })
+    );
+    expect(JSON.stringify(vi.mocked(requestExecutor).mock.calls[0])).not.toContain('owner-2');
   });
 
   it('fails before repository access when tenant identity is missing', async () => {

--- a/apps/agor-daemon/src/services/files.ts
+++ b/apps/agor-daemon/src/services/files.ts
@@ -22,6 +22,7 @@ import type {
   UserID,
   UserRole,
 } from '@agor/core/types';
+import { resolveBranchExecutorSandboxMounts } from '../utils/branch-executor-sandbox.js';
 import { ensureBranchWorkspaceAccess } from '../utils/branch-workspace-path.js';
 import { resolveDelegatedExecutionHomeKey } from '../utils/executor-delegated-home.js';
 import { getDaemonUrl, requestExecutor } from '../utils/spawn-executor.js';
@@ -131,12 +132,22 @@ export class FilesService {
         currentUserId,
         this.app.get('config')
       );
+      // Autocomplete is a caller-initiated, stateless read. Use the caller's
+      // sandbox home rather than the Session/branch owner's credential home.
+      const sandboxMounts = await resolveBranchExecutorSandboxMounts({
+        config: this.app.get('config'),
+        tenantId,
+        executionUserId: currentUserId,
+        branch,
+        db: this.db,
+      });
       return {
         branchId: branch.branch_id,
         branchPath: branch.path,
         delegatedHomeKey,
         fsAccess,
         userId: currentUserId,
+        sandboxMounts,
       };
     });
     if (!resolved) return [];
@@ -160,6 +171,7 @@ export class FilesService {
             limit: MAX_FILE_RESULTS,
             cwd: resolved.branchPath,
             principalBranchAccess: resolved.fsAccess,
+            ...resolved.sandboxMounts,
           },
         },
         {

--- a/apps/agor-daemon/src/utils/branch-executor-sandbox.test.ts
+++ b/apps/agor-daemon/src/utils/branch-executor-sandbox.test.ts
@@ -1,0 +1,130 @@
+import type { AgorConfig } from '@agor/core/config';
+import { RepoRepository, UsersRepository } from '@agor/core/db';
+import type { UserID } from '@agor/core/types';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { resolveBranchExecutorSandboxMounts } from './branch-executor-sandbox.js';
+
+const db = { run: vi.fn() } as never;
+const executionUserId = 'user-caller' as UserID;
+
+function resolve(config: AgorConfig, overrides: Record<string, unknown> = {}) {
+  return resolveBranchExecutorSandboxMounts({
+    config,
+    tenantId: 'tenant-a',
+    executionUserId,
+    branch: {
+      repo_id: 'repo-1' as never,
+      storage_mode: 'worktree',
+    },
+    db,
+    ...overrides,
+  });
+}
+
+describe('resolveBranchExecutorSandboxMounts', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('does not resolve local mounts in simple or delegated execution', async () => {
+    const userLookup = vi.spyOn(UsersRepository.prototype, 'findById');
+    const repoLookup = vi.spyOn(RepoRepository.prototype, 'findById');
+
+    await expect(resolve({ execution: { unix_user_mode: 'simple' } })).resolves.toEqual({});
+    await expect(
+      resolve({
+        execution: {
+          unix_user_mode: 'delegated',
+          executor_command_template: 'launcher --user {user_id}',
+        },
+      })
+    ).resolves.toEqual({});
+    expect(userLookup).not.toHaveBeenCalled();
+    expect(repoLookup).not.toHaveBeenCalled();
+  });
+
+  it('resolves shared-sandbox storage mounts without requiring an owner home', async () => {
+    vi.spyOn(RepoRepository.prototype, 'findById').mockResolvedValue({
+      local_path: '/srv/agor/repos/org/repo',
+    } as never);
+    const userLookup = vi.spyOn(UsersRepository.prototype, 'findById');
+
+    await expect(
+      resolve({
+        paths: { data_home: '/srv/agor' },
+        execution: { sandbox: { enabled: true, home_mode: 'shared' } },
+      })
+    ).resolves.toEqual({
+      sandboxWorktreesRoot: '/srv/agor/worktrees',
+      sandboxBaseRepoPath: '/srv/agor/repos/org/repo',
+    });
+    expect(userLookup).not.toHaveBeenCalled();
+  });
+
+  it('derives the canonical tenant/user home for the execution caller', async () => {
+    vi.spyOn(RepoRepository.prototype, 'findById').mockResolvedValue({
+      local_path: '/srv/agor-tenants/tenant-a/repos/org/repo',
+    } as never);
+    vi.spyOn(UsersRepository.prototype, 'findById').mockImplementation(
+      async (userId) =>
+        ({
+          user_id: userId,
+          filesystem_home: null,
+        }) as never
+    );
+
+    await expect(
+      resolve({
+        paths: { data_home: '/srv/agor' },
+        multi_tenancy: {
+          mode: 'required_from_auth',
+          filesystem_isolation_enabled: true,
+          tenants_base_folder: '/srv/agor-tenants',
+        },
+        execution: {
+          unix_user_mode: 'sandbox',
+          sandbox: { enabled: true, home_mode: 'per_user' },
+        },
+      })
+    ).resolves.toEqual({
+      sandboxHomeStore: '/srv/agor-tenants/tenant-a/homes/user-caller',
+      sandboxWorktreesRoot: '/srv/agor-tenants/tenant-a/worktrees',
+      sandboxBaseRepoPath: '/srv/agor-tenants/tenant-a/repos/org/repo',
+    });
+    expect(UsersRepository.prototype.findById).toHaveBeenCalledWith('user-caller');
+  });
+
+  it('honors a validated filesystem_home override and omits a base-repo mount for clones', async () => {
+    vi.spyOn(UsersRepository.prototype, 'findById').mockResolvedValue({
+      user_id: executionUserId,
+      filesystem_home: '/home/caller',
+    } as never);
+    const repoLookup = vi.spyOn(RepoRepository.prototype, 'findById');
+
+    await expect(
+      resolve(
+        {
+          paths: { data_home: '/srv/agor' },
+          execution: { sandbox: { enabled: true, home_mode: 'per_user' } },
+        },
+        { branch: { repo_id: 'repo-1', storage_mode: 'clone' } }
+      )
+    ).resolves.toEqual({
+      sandboxHomeStore: '/home/caller',
+      sandboxWorktreesRoot: '/srv/agor/worktrees',
+    });
+    expect(repoLookup).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when the execution caller no longer has a tenant user row', async () => {
+    vi.spyOn(RepoRepository.prototype, 'findById').mockResolvedValue(null);
+    vi.spyOn(UsersRepository.prototype, 'findById').mockResolvedValue(null);
+
+    await expect(
+      resolve({
+        paths: { data_home: '/srv/agor' },
+        execution: { sandbox: { enabled: true, home_mode: 'per_user' } },
+      })
+    ).rejects.toThrow(
+      'Cannot resolve per-user sandbox home: execution user user-caller was not found'
+    );
+  });
+});

--- a/apps/agor-daemon/src/utils/branch-executor-sandbox.test.ts
+++ b/apps/agor-daemon/src/utils/branch-executor-sandbox.test.ts
@@ -25,7 +25,7 @@ describe('resolveBranchExecutorSandboxMounts', () => {
   afterEach(() => vi.restoreAllMocks());
 
   it('does not resolve local mounts in simple or delegated execution', async () => {
-    const userLookup = vi.spyOn(UsersRepository.prototype, 'findById');
+    const userLookup = vi.spyOn(UsersRepository.prototype, 'getFilesystemHomeProjection');
     const repoLookup = vi.spyOn(RepoRepository.prototype, 'findById');
 
     await expect(resolve({ execution: { unix_user_mode: 'simple' } })).resolves.toEqual({});
@@ -45,7 +45,7 @@ describe('resolveBranchExecutorSandboxMounts', () => {
     vi.spyOn(RepoRepository.prototype, 'findById').mockResolvedValue({
       local_path: '/srv/agor/repos/org/repo',
     } as never);
-    const userLookup = vi.spyOn(UsersRepository.prototype, 'findById');
+    const userLookup = vi.spyOn(UsersRepository.prototype, 'getFilesystemHomeProjection');
 
     await expect(
       resolve({
@@ -63,7 +63,7 @@ describe('resolveBranchExecutorSandboxMounts', () => {
     vi.spyOn(RepoRepository.prototype, 'findById').mockResolvedValue({
       local_path: '/srv/agor-tenants/tenant-a/repos/org/repo',
     } as never);
-    vi.spyOn(UsersRepository.prototype, 'findById').mockImplementation(
+    vi.spyOn(UsersRepository.prototype, 'getFilesystemHomeProjection').mockImplementation(
       async (userId) =>
         ({
           user_id: userId,
@@ -89,11 +89,13 @@ describe('resolveBranchExecutorSandboxMounts', () => {
       sandboxWorktreesRoot: '/srv/agor-tenants/tenant-a/worktrees',
       sandboxBaseRepoPath: '/srv/agor-tenants/tenant-a/repos/org/repo',
     });
-    expect(UsersRepository.prototype.findById).toHaveBeenCalledWith('user-caller');
+    expect(UsersRepository.prototype.getFilesystemHomeProjection).toHaveBeenCalledWith(
+      'user-caller'
+    );
   });
 
   it('honors a validated filesystem_home override and omits a base-repo mount for clones', async () => {
-    vi.spyOn(UsersRepository.prototype, 'findById').mockResolvedValue({
+    vi.spyOn(UsersRepository.prototype, 'getFilesystemHomeProjection').mockResolvedValue({
       user_id: executionUserId,
       filesystem_home: '/home/caller',
     } as never);
@@ -116,7 +118,7 @@ describe('resolveBranchExecutorSandboxMounts', () => {
 
   it('fails closed when the execution caller no longer has a tenant user row', async () => {
     vi.spyOn(RepoRepository.prototype, 'findById').mockResolvedValue(null);
-    vi.spyOn(UsersRepository.prototype, 'findById').mockResolvedValue(null);
+    vi.spyOn(UsersRepository.prototype, 'getFilesystemHomeProjection').mockResolvedValue(null);
 
     await expect(
       resolve({

--- a/apps/agor-daemon/src/utils/branch-executor-sandbox.ts
+++ b/apps/agor-daemon/src/utils/branch-executor-sandbox.ts
@@ -2,9 +2,10 @@
  * Resolve the local filesystem-sandbox mounts for a short-lived branch command.
  *
  * Callers must invoke this while their trusted tenant database scope is active
- * and must pass the authenticated execution actor, not the branch or Session
- * owner. The returned paths are daemon-derived payload fields consumed only by
- * the local bubblewrap launch path; delegated launchers receive identity and
+ * and select the authoritative execution principal for the operation. This
+ * helper deliberately does not infer that principal from the Branch or a
+ * Session. The returned paths are daemon-derived payload fields consumed only
+ * by the local bubblewrap launch path; delegated launchers receive identity and
  * filesystem access through template variables instead.
  */
 
@@ -42,7 +43,7 @@ export async function resolveBranchExecutorSandboxMounts(params: {
   }
 
   if (sandbox.home_mode === 'per_user') {
-    const user = await new UsersRepository(db).findById(executionUserId);
+    const user = await new UsersRepository(db).getFilesystemHomeProjection(executionUserId);
     if (!user) {
       throw new Error(
         `Cannot resolve per-user sandbox home: execution user ${executionUserId} was not found`

--- a/apps/agor-daemon/src/utils/branch-executor-sandbox.ts
+++ b/apps/agor-daemon/src/utils/branch-executor-sandbox.ts
@@ -1,0 +1,60 @@
+/**
+ * Resolve the local filesystem-sandbox mounts for a short-lived branch command.
+ *
+ * Callers must invoke this while their trusted tenant database scope is active
+ * and must pass the authenticated execution actor, not the branch or Session
+ * owner. The returned paths are daemon-derived payload fields consumed only by
+ * the local bubblewrap launch path; delegated launchers receive identity and
+ * filesystem access through template variables instead.
+ */
+
+import type { AgorConfig } from '@agor/core/config';
+import { RepoRepository, type TenantScopeAwareDatabase, UsersRepository } from '@agor/core/db';
+import type { Branch, DeepReadonly, UserID } from '@agor/core/types';
+import { resolveOwnerHomeStore, resolveSandboxStoragePaths } from './sandbox-context.js';
+
+export interface BranchExecutorSandboxMounts {
+  sandboxHomeStore?: string;
+  sandboxWorktreesRoot?: string;
+  sandboxBaseRepoPath?: string;
+}
+
+export async function resolveBranchExecutorSandboxMounts(params: {
+  config: DeepReadonly<AgorConfig>;
+  tenantId: string;
+  executionUserId: UserID;
+  branch: Pick<Branch, 'repo_id' | 'storage_mode'>;
+  db: TenantScopeAwareDatabase;
+}): Promise<BranchExecutorSandboxMounts> {
+  const { config, tenantId, executionUserId, branch, db } = params;
+  const sandbox = config.execution?.sandbox;
+  if (sandbox?.enabled !== true) return {};
+
+  const mounts: BranchExecutorSandboxMounts = {
+    sandboxWorktreesRoot: resolveSandboxStoragePaths(config, tenantId).worktreesRoot,
+  };
+
+  // A linked worktree's .git file points into the base repository. Clone-mode
+  // branches carry their own .git and must not receive this additional mount.
+  if (branch.storage_mode !== 'clone' && branch.repo_id) {
+    mounts.sandboxBaseRepoPath =
+      (await new RepoRepository(db).findById(branch.repo_id))?.local_path ?? undefined;
+  }
+
+  if (sandbox.home_mode === 'per_user') {
+    const user = await new UsersRepository(db).findById(executionUserId);
+    if (!user) {
+      throw new Error(
+        `Cannot resolve per-user sandbox home: execution user ${executionUserId} was not found`
+      );
+    }
+    mounts.sandboxHomeStore = resolveOwnerHomeStore({
+      config,
+      tenantId,
+      ownerUserId: executionUserId,
+      filesystemHome: user.filesystem_home,
+    });
+  }
+
+  return mounts;
+}

--- a/docs/internal/branch-scoped-executor-sandbox-home-audit-2026-09-03.md
+++ b/docs/internal/branch-scoped-executor-sandbox-home-audit-2026-09-03.md
@@ -1,0 +1,199 @@
+# Branch-scoped executor sandbox-home audit (2026-09-03)
+
+## Incident and exact error path
+
+The Branch modal's **Files** tab calls `client.service('file').findAll` with a
+client-supplied `branch_id`. The daemon's `/file` hooks authenticate the
+request, load the tenant-scoped Branch, and enforce Branch view access.
+`FileService.find` then enforces normalized filesystem `read` access and
+launches the bounded `branch.files.browse` executor command through
+`requestExecutor`.
+
+On a local executor deployment, the call chain is:
+
+1. `requestExecutor`
+2. `requestExecutorLocal`
+3. `sandboxLocalExecutorCommand`
+4. `prepareLocalSandboxSources`
+5. `buildSandboxWrap` / `resolveBwrapArgs`
+6. bubblewrap, then the executor's `branch.files.browse` handler
+
+`execution.unix_user_mode: sandbox` is resolved at startup to
+`sandbox.enabled: true`, `sandbox.home_mode: per_user`, and
+`sandbox.fail_if_unavailable: true`. Step 4 therefore requires the authoritative
+per-execution-user home source in `payload.params.sandboxHomeStore`. It creates
+and validates the home-side credential-authority layout and pins the actor's
+persistent `tmp` directory before bubblewrap uses either path. This common
+preflight applies to every local branch-scoped command with a `cwd`, even when
+the bounded command itself does not consume a provider credential.
+
+Before this fix, `/file` passed the Branch path and RBAC file-access projection
+but did not pass `sandboxHomeStore`. `prepareLocalSandboxSources` deliberately
+threw:
+
+> sandbox home_mode=per_user requires an owner home store before credential authority preparation
+
+`requestExecutorLocal` converted that into `EXECUTOR_SPAWN_ERROR` with the
+prefix `Executor sandbox setup failed:`. `FileService.find` added `Failed to
+browse files:`, and `FilesTab` rendered the resulting service error. The
+executor and bubblewrap never started. This is a fail-closed programming error,
+not evidence that an operator omitted a required home setting.
+
+The Session file autocomplete path (`/files` -> `branch.files.list`) had the
+same missing handoff. File preview/download uses `/file/:path` ->
+`branch.files.read` and failed for the same reason.
+
+## Root cause and ownership choice
+
+The per-user home resolver existed, and prompt, terminal, environment, upload,
+and artifact paths had acquired variants of the required handoff over several
+changes. The two file services were older request-mode call sites and were not
+updated when request-mode branch commands joined the common credential/tmp
+preflight. Recent related fixes were PR #2637 (upload materialization) and PR
+#2653 (artifact publish/validate/land); both intentionally called for a later
+audit of sibling executor call sites.
+
+File browse, read, and autocomplete are stateless actions by the authenticated
+request actor. Their sandbox home must therefore be the **caller**'s home, not
+the Branch primary owner's or the referenced Session owner's home. Selecting an
+owner home would unnecessarily expose or mutate another principal's cache,
+temporary files, and credential-authority leaves. The Branch and optional base
+Repo are resolved in the same trusted tenant database scope, and RBAC still
+controls whether the Branch mount is read-only or writable.
+
+## Configuration conclusions
+
+No new `config.yaml` key and no `users.filesystem_home` value is required for
+this incident.
+
+- `execution.unix_user_mode: sandbox` intentionally forces a fail-closed,
+  per-user local sandbox. Operators cannot weaken it with `home_mode: shared`.
+- When `users.filesystem_home` is empty, Agor derives the canonical store:
+  - filesystem tenancy off:
+    `<data_home>/tenants/<tenant-id>/homes/<user-id>`;
+  - filesystem tenancy on:
+    `<tenants_base_folder>/<tenant-id>/homes/<user-id>`.
+- `users.filesystem_home` is an admin-only migration override for an existing
+  absolute home outside every protected Agor data root. Setting it does not fix
+  an omitted `sandboxHomeStore` payload.
+- `paths.data_home` / `AGOR_DATA_HOME` and
+  `multi_tenancy.tenants_base_folder` choose storage roots; they do not opt a
+  user into the feature. The daemon account must be able to create the
+  canonical home and its authority/tmp leaves.
+- `execution.unix_user_mode: delegated` requires an external executor template
+  and a per-user `unix_username` execution-home key. The external substrate,
+  not local bubblewrap, resolves and enforces its homes.
+
+Do not change a shared production deployment to `simple`, disable the sandbox,
+or enable a shared home to hide this error. Those changes trade away the
+filesystem boundary and may expose daemon or cross-user state. `simple` is a
+reasonable development-only choice only for a trusted single-user machine.
+
+## Supported-mode matrix
+
+| Deployment shape                                            | Home authority for branch file reads                                               | Before this change                                 | After this change                                                                    |
+| ----------------------------------------------------------- | ---------------------------------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| Local `simple`, no standalone sandbox                       | Daemon home; no OS file isolation                                                  | Worked                                             | Unchanged                                                                            |
+| Local standalone sandbox with `home_mode: shared`           | Masked shared daemon home                                                          | Worked; not suitable as a multi-user home boundary | Unchanged; tenant worktree/base-Repo mounts are explicit                             |
+| Local `sandbox` / per-user, SQLite                          | Authenticated caller; canonical store or `filesystem_home`                         | Failed before spawn                                | Supported, fail closed                                                               |
+| Local `sandbox` / per-user, PostgreSQL shared-filesystem HA | Authenticated caller under RLS tenant scope; tenant filesystem root                | Failed before spawn                                | Supported when the HA storage/locking profile passes startup validation              |
+| PostgreSQL HA with `execution_topology: external`           | External substrate binds trusted tenant/user identity to durable storage           | Did not enter local credential-authority preflight | Unchanged; requires request-response protocol/origin and reviewed launcher isolation |
+| `delegated` external executor                               | `{tenant_id}`, `{user_id}`, `{branch_fs_access}`, and legacy `{unix_user}` handoff | Did not enter local preflight                      | Unchanged                                                                            |
+
+The documented Cloud topology is PostgreSQL HA with an external/delegated
+executor substrate. That explains why the local per-user error is not expected
+there. The incident report did not include the live Cloud or production
+configuration, so this is a configuration-path comparison, not a claim based
+on inspecting either deployment.
+
+## Branch-scoped executor inventory
+
+All local executor payloads with a Branch `cwd` share the per-user sandbox
+preflight. The owner semantics differ, so the spawn utility must not guess an
+identity from a Branch ID or client payload.
+
+| Operation family                            | Commands / entry points                                | Required identity and status at this audit                                                                                                                                                                                                               |
+| ------------------------------------------- | ------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Branch modal browse, preview, download      | `branch.files.browse`, `branch.files.read` via `/file` | **Fixed here:** authenticated caller, read projection, full tenant/home/base-Repo mounts                                                                                                                                                                 |
+| Prompt file autocomplete                    | `branch.files.list` via `/files`                       | **Fixed here:** authenticated caller, read projection, full mounts                                                                                                                                                                                       |
+| Agent/provider prompt launch                | `prompt` in `register-services`                        | Already supplies full mounts. Historical execution-home Sessions use their immutable owner; branch-home Sessions use the prompt actor                                                                                                                    |
+| Web terminal                                | `terminals`                                            | Already supplies the caller's full mounts and process environment. Live authorization revalidation remains a documented gap                                                                                                                              |
+| Managed environment lifecycle/logs          | `environment.lifecycle`, `environment.logs`            | Already supplies the resolved execution actor and full mounts                                                                                                                                                                                            |
+| Artifact/runtime helpers                    | `branch.artifact.publish`, `.validate`, `.land`        | Already supplies the authenticated actor's full mounts (PR #2653)                                                                                                                                                                                        |
+| Opaque upload materialization               | `branch.upload.materialize`                            | Supplies the canonical Session execution user and owner home (PR #2637). Tenant-root/base-Repo completeness should be aligned with the shared helper                                                                                                     |
+| Branch Knowledge materialization/read       | `branch.knowledge.write`, `.read`                      | **Known residual:** has `cwd` but omits the owner-home mount; fails with the same preflight error in local per-user mode                                                                                                                                 |
+| `.agor.yml` import/export                   | `branch.agor-yml.import`, `.export`                    | **Known residual:** has `cwd` but omits the owner-home mount; fails similarly                                                                                                                                                                            |
+| Gateway branch-file upload to Slack         | `branch.gateway.slack-file-upload`                     | **Known residual:** has `cwd` but omits the owner-home mount; fails similarly. Opaque staged uploads that do not read a Branch are a different path                                                                                                      |
+| Git clean during archive                    | `git.branch.clean`                                     | **Known residual:** has `cwd` but omits the owner-home mount; local per-user dispatch fails. Branch add/remove/status, Repo inspect/delete, and startup Git reconciliation have no Branch `cwd` and intentionally stay outside this sandbox prerequisite |
+| Credential import/logout/inspection helpers | Claude/Codex auth-file commands                        | No Branch `cwd`; they use an explicit credential-home authority and have different HA routing/locking requirements                                                                                                                                       |
+
+Static inventory found 9 affected command IDs across six branch-command
+families. This change closes 3 IDs in the two user-facing file services; four
+residual families account for the other 6 IDs. No
+eligible production daemon logs or customer session records were available in
+the investigation workspace, so there is no defensible runtime occurrence or
+unique-user count. The exact text was present only in this investigation's own
+prompt transcript and was excluded from incident quantification.
+
+## Implementation and forward plan
+
+### Implemented now (smallest safe incident fix)
+
+`resolveBranchExecutorSandboxMounts` centralizes the mount family for bounded
+file services. While the trusted tenant DB scope is active it:
+
+1. resolves the tenant worktrees root;
+2. resolves a linked worktree's base Repo path (clone storage omits it);
+3. resolves the authenticated caller's user row and canonical/override home in
+   per-user mode;
+4. fails before executor dispatch if that tenant user no longer exists; and
+5. returns no local mounts when the filesystem sandbox is disabled (including
+   supported delegated execution).
+
+The service leaves the database scope before waiting for the executor response.
+No secret bytes are read, logged, copied, or returned.
+
+### Follow-up
+
+1. Move Knowledge, `.agor.yml`, gateway Branch upload, Git clean, and upload
+   mount completeness onto the same helper one family at a time. Each must first
+   state whether its authority is the caller, Session execution user, or a
+   narrowly scoped system identity, and add a cross-user negative test.
+2. Replace the structurally optional `cwd` + mount fields with a typed
+   server-only `BranchExecutorContext` so a local branch command cannot compile
+   without an explicit execution user, tenant root, and file-access projection.
+   Keep the final missing-home check in `prepareLocalSandboxSources` as defense
+   in depth; never auto-derive identity in the spawn utility.
+3. Add a low-cardinality metric for sandbox setup failures by command/error code
+   (no paths, user IDs, or credential data) so operators can quantify affected
+   families without searching transcripts.
+4. Add live bubblewrap smoke coverage for browse/read/list in the managed
+   sandbox-per-user profile and external request-response coverage for the same
+   commands.
+
+## Operator remediation, rollout, and rollback
+
+1. Confirm the effective mode locally with `pnpm agor config --yaml` (do not
+   share the full output; it may contain deployment details). If the effective
+   mode is `sandbox`, retain it.
+2. Run `pnpm agor doctor` on each local executor host and verify Linux,
+   bubblewrap 0.12.0+ with functional `--bind-fd`, user namespaces, and access
+   to the configured tenant/data volumes.
+3. Upgrade to a release containing this fix and restart/drain daemons according
+   to the deployment's normal rolling policy. No schema migration or data move
+   is needed. In HA, keep all replicas on one version during the shortest
+   practical rollout window.
+4. Verify browse, preview/download, and `@` file autocomplete as two different
+   users with read-only versus read/write Branch grants. A user with filesystem
+   `none` must remain denied.
+5. If home creation fails after the fix, check ownership and mount availability
+   for the canonical tenant home root, or validate an intentionally migrated
+   `users.filesystem_home`. Do not point an override into `data_home`, another
+   tenant, `/`, or a sibling user's home.
+
+Rollback is an application rollback only: stop/drain the new daemons and return
+to the prior release. The change adds no migration and creates only the same
+lazy per-user authority/tmp directories already created by normal prompts and
+terminals. Those directories may be retained. Rolling back restores the Files
+failure; it must not be paired with a sandbox downgrade as a production
+workaround.

--- a/docs/internal/branch-scoped-executor-sandbox-home-audit-2026-09-03.md
+++ b/docs/internal/branch-scoped-executor-sandbox-home-audit-2026-09-03.md
@@ -151,7 +151,8 @@ file services. While the trusted tenant DB scope is active it:
    supported delegated execution).
 
 The service leaves the database scope before waiting for the executor response.
-No secret bytes are read, logged, copied, or returned.
+The user lookup selects only the nonsecret user ID and filesystem-home fields;
+no credential material is decrypted, logged, copied, or returned.
 
 ### Follow-up
 

--- a/packages/core/src/db/repositories/users.test.ts
+++ b/packages/core/src/db/repositories/users.test.ts
@@ -106,6 +106,25 @@ describe('UsersRepository execution home key validation', () => {
   });
 });
 
+describe('UsersRepository.getFilesystemHomeProjection', () => {
+  dbTest('returns only the nonsecret filesystem-home authority fields', async ({ db }) => {
+    const repo = new UsersRepository(db);
+    const user = await repo.create({
+      email: `filesystem-home-${Date.now()}-${Math.random()}@example.com`,
+      filesystem_home: '/home/filesystem-owner',
+    });
+    await repo.setToolConfigField(user.user_id, 'codex', 'OPENAI_API_KEY', 'encrypted-secret');
+
+    await expect(repo.getFilesystemHomeProjection(user.user_id)).resolves.toEqual({
+      user_id: user.user_id,
+      filesystem_home: '/home/filesystem-owner',
+    });
+    await expect(
+      repo.getFilesystemHomeProjection('00000000-0000-0000-0000-000000000000')
+    ).resolves.toBeNull();
+  });
+});
+
 describe('UsersRepository.findByEmailForAlignment', () => {
   dbTest('matches external-provider emails case-insensitively', async ({ db }) => {
     const repo = new UsersRepository(db);

--- a/packages/core/src/db/repositories/users.ts
+++ b/packages/core/src/db/repositories/users.ts
@@ -153,6 +153,37 @@ export class UsersRepository
   }
 
   /**
+   * Nonsecret projection used to resolve a user's filesystem sandbox home.
+   * Tenant scoping comes from the current database unit of work; callers do
+   * not hydrate password or encrypted credential/environment columns merely
+   * to locate the user's home store.
+   */
+  async getFilesystemHomeProjection(
+    userId: UserID | string
+  ): Promise<{ user_id: UserID; filesystem_home: string | null } | null> {
+    try {
+      const row = await select(this.db, {
+        user_id: users.user_id,
+        filesystem_home: users.filesystem_home,
+      })
+        .from(users)
+        .where(eq(users.user_id, userId))
+        .one();
+      return row
+        ? {
+            user_id: row.user_id as UserID,
+            filesystem_home: row.filesystem_home ?? null,
+          }
+        : null;
+    } catch (error) {
+      throw new RepositoryError(
+        `Failed to read user filesystem home: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
+  /**
    * Lock and reload only the caller identity fields used by a write
    * authorizer. Role changes use the same users row, so a concurrent demotion
    * is ordered either before this read (and is observed) or after the guarded


### PR DESCRIPTION
## Summary

- fix BranchModal browse/read and prompt file autocomplete in local `sandbox` / `home_mode=per_user`
- resolve the authenticated caller's canonical or migrated home store, tenant worktree root, and linked base repository while the trusted tenant DB scope is active
- keep delegated/simple behavior unchanged and retain the fail-closed missing-home guard
- document the exact failure path, supported deployment matrix, operator remediation, and the remaining branch-command audit

## Root cause

`/file` and `/files` supplied `cwd` and the RBAC filesystem projection to `requestExecutor`, but omitted the server-derived `sandboxHomeStore`. Local per-user sandbox preparation requires that path before it can prepare and pin the credential-authority and persistent-tmp sources, so it failed before bubblewrap or the bounded executor command started.

This is a missing internal payload handoff, not a missing `config.yaml` setting. File operations are stateless caller actions, so the correct home authority is the authenticated caller—not the Branch or Session owner.

## Configuration / security

No config or schema migration is required. This change does **not** fall back to `simple`, disable sandboxing, or use a shared home. Branch RBAC remains authoritative, tenant resources are resolved under the current trusted DB scope, and no credential contents are read or returned.

The implementation is local-sandbox-only. Supported delegated/external executor modes continue to receive trusted identity and filesystem access via their existing protocol/template path.

## Residual audit

The audit found 9 branch-`cwd` command IDs across six families that share the local preflight. This PR closes the three file commands (`browse`, `read`, `list`). Knowledge, `.agor.yml`, Slack branch-file upload, and archive Git-clean remain explicit follow-ups because each needs an authority decision and negative isolation test. Upload materialization already supplies its owner home but should later align its tenant/base-repo mounts with the common helper.

Full findings and exact operator steps: `docs/internal/branch-scoped-executor-sandbox-home-audit-2026-09-03.md`.

## Validation

- `pnpm typecheck` — passed (21/21 workspace tasks)
- `pnpm lint` — passed (2,712 files)
- daemon suite — 311 files passed, 29 skipped; 4,138 tests passed, 183 skipped
- focused sandbox/file tests — 84 tests passed, including live bubblewrap request integration
- executor unit suite with inherited `CODEX_HOME` removed — 66 files / 713 tests passed
- executor runtime and Claude auth-precedence smoke tests — passed
- `FilesTab.test.tsx` — passed
- `pnpm check:multitenancy-boundaries` — passed
- `pnpm check:daemon-filesystem-boundaries` — passed
- `pnpm check:realtime-boundaries` — passed
- `git diff --check` — passed
