### PR TITLE
Simplify zone toolbox controls

### DIFF
--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -539,9 +539,8 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
   } as any);
   app.use(
     '/boards',
-    createBoardsService(
-      db,
-      (boardObject, params) => {
+    createBoardsService(db, {
+      emitBoardObjectPatched: (boardObject, params) => {
         emitServiceEvent(app, {
           path: 'board-objects',
           event: 'patched',
@@ -550,16 +549,16 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
           id: boardObject.object_id,
         });
       },
-      (event) => emitServiceEvent(app, { path: 'boards', ...event }),
-      (comment, params) =>
+      emitBoardEvent: (event) => emitServiceEvent(app, { path: 'boards', ...event }),
+      emitBoardCommentPatched: (comment, params) =>
         emitServiceEvent(app, {
           path: 'board-comments',
           event: 'patched',
           data: comment,
           params,
           id: comment.comment_id,
-        })
-    ),
+        }),
+    }),
     {
       methods: [
         'find',

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -550,7 +550,15 @@ export async function registerServices(ctx: RegisterServicesContext): Promise<Re
           id: boardObject.object_id,
         });
       },
-      (event) => emitServiceEvent(app, { path: 'boards', ...event })
+      (event) => emitServiceEvent(app, { path: 'boards', ...event }),
+      (comment, params) =>
+        emitServiceEvent(app, {
+          path: 'board-comments',
+          event: 'patched',
+          data: comment,
+          params,
+          id: comment.comment_id,
+        })
     ),
     {
       methods: [

--- a/apps/agor-daemon/src/services/boards.test.ts
+++ b/apps/agor-daemon/src/services/boards.test.ts
@@ -245,12 +245,10 @@ describe('BoardsService - Custom Methods', () => {
     async ({ db }) => {
       const emitBoardObjectPatched = vi.fn();
       const emitBoardCommentPatched = vi.fn();
-      const service = new BoardsService(
-        db,
+      const service = new BoardsService(db, {
         emitBoardObjectPatched,
-        undefined,
-        emitBoardCommentPatched
-      );
+        emitBoardCommentPatched,
+      });
       const repoRepo = new RepoRepository(db);
       const branchRepo = new BranchRepository(db);
       const boardObjectRepo = new BoardObjectRepository(db);
@@ -320,6 +318,71 @@ describe('BoardsService - Custom Methods', () => {
       );
     }
   );
+
+  dbTest('deleteZone rolls back every unpin when one child update fails', async ({ db }) => {
+    const service = new BoardsService(db);
+    const repoRepo = new RepoRepository(db);
+    const branchRepo = new BranchRepository(db);
+    const boardRepo = new BoardRepository(db);
+    const boardObjectRepo = new BoardObjectRepository(db);
+    const commentsRepo = new BoardCommentsRepository(db);
+
+    const repo = await repoRepo.create(createRepoData());
+    const branch = await branchRepo.create(createBranchData({ repo_id: repo.repo_id }));
+    const board = (await service.create({
+      name: 'Atomic Zone Cleanup Board',
+      slug: `atomic-zone-cleanup-${generateId()}`,
+      created_by: TEST_USER,
+      objects: {
+        'zone-review': {
+          type: 'zone',
+          x: 100,
+          y: 200,
+          width: 400,
+          height: 300,
+          label: 'Review',
+        },
+      },
+    })) as Board;
+    const boardObject = await boardObjectRepo.create({
+      board_id: board.board_id,
+      branch_id: branch.branch_id,
+      position: { x: 10, y: 20 },
+      zone_id: 'zone-review',
+    });
+    const comment = await commentsRepo.create({
+      board_id: board.board_id,
+      created_by: TEST_USER,
+      content: 'Still pinned after rollback',
+      position: {
+        relative: {
+          parent_id: 'review',
+          parent_type: 'zone',
+          offset_x: 7,
+          offset_y: 8,
+        },
+      },
+    });
+    const updateSpy = vi
+      .spyOn(BoardCommentsRepository.prototype, 'update')
+      .mockRejectedValueOnce(new Error('simulated comment update failure'));
+
+    try {
+      await expect(service.deleteZone(board.board_id, 'zone-review', false)).rejects.toThrow(
+        'simulated comment update failure'
+      );
+    } finally {
+      updateSpy.mockRestore();
+    }
+
+    const preservedBoard = await boardRepo.findById(board.board_id);
+    const preservedBoardObject = await boardObjectRepo.findByObjectId(boardObject.object_id);
+    const preservedComment = await commentsRepo.findById(comment.comment_id);
+    expect(preservedBoard?.objects?.['zone-review']).toBeDefined();
+    expect(preservedBoardObject?.zone_id).toBe('zone-review');
+    expect(preservedBoardObject?.position).toEqual({ x: 10, y: 20 });
+    expect(preservedComment?.position).toEqual(comment.position);
+  });
 
   dbTest(
     'ensureTeammateWelcomeNote creates rendered static markdown server-side',
@@ -500,7 +563,7 @@ describe('BoardsService - Custom Methods', () => {
 
   dbTest('manually emits archive transitions from the custom method', async ({ db }) => {
     const emitBoardEvent = vi.fn();
-    const service = new BoardsService(db, undefined, emitBoardEvent);
+    const service = new BoardsService(db, { emitBoardEvent });
     const board = (await service.create({
       name: 'Archive realtime',
       slug: 'archive-realtime',

--- a/apps/agor-daemon/src/services/boards.test.ts
+++ b/apps/agor-daemon/src/services/boards.test.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+  BoardCommentsRepository,
   BoardObjectRepository,
   BoardRepository,
   BranchRepository,
@@ -240,13 +241,20 @@ describe('BoardsService - Custom Methods', () => {
   });
 
   dbTest(
-    'removeBoardObject clears zone-pinned entities with absolute positions',
+    'deleteZone keeps pinned entities and comments at their absolute board positions',
     async ({ db }) => {
       const emitBoardObjectPatched = vi.fn();
-      const service = new BoardsService(db, emitBoardObjectPatched);
+      const emitBoardCommentPatched = vi.fn();
+      const service = new BoardsService(
+        db,
+        emitBoardObjectPatched,
+        undefined,
+        emitBoardCommentPatched
+      );
       const repoRepo = new RepoRepository(db);
       const branchRepo = new BranchRepository(db);
       const boardObjectRepo = new BoardObjectRepository(db);
+      const commentsRepo = new BoardCommentsRepository(db);
 
       const repo = await repoRepo.create(createRepoData());
       const branch = await branchRepo.create(createBranchData({ repo_id: repo.repo_id }));
@@ -272,17 +280,42 @@ describe('BoardsService - Custom Methods', () => {
         position: { x: 10, y: 20 },
         zone_id: 'zone-review',
       });
+      const comment = await commentsRepo.create({
+        board_id: board.board_id,
+        created_by: TEST_USER,
+        content: 'Keep this comment',
+        position: {
+          relative: {
+            parent_id: 'review',
+            parent_type: 'zone',
+            offset_x: 7,
+            offset_y: 8,
+          },
+        },
+      });
 
-      await service.removeBoardObject(board.board_id, 'zone-review');
+      const result = await service.deleteZone(board.board_id, 'zone-review', false);
 
       const updatedBoardObject = await boardObjectRepo.findByObjectId(boardObject.object_id);
+      const updatedComment = await commentsRepo.findById(comment.comment_id);
+      const preservedBranch = await branchRepo.findById(branch.branch_id);
+      expect(result.board.objects?.['zone-review']).toBeUndefined();
+      expect(result.affectedSessions).toEqual([]);
+      expect(preservedBranch?.branch_id).toBe(branch.branch_id);
       expect(updatedBoardObject?.zone_id).toBeUndefined();
       expect(updatedBoardObject?.position).toEqual({ x: 110, y: 220 });
+      expect(updatedComment?.position).toEqual({ absolute: { x: 107, y: 208 } });
       expect(emitBoardObjectPatched).toHaveBeenCalledWith(
         expect.objectContaining({
           object_id: boardObject.object_id,
           position: { x: 110, y: 220 },
           zone_id: null,
+        })
+      );
+      expect(emitBoardCommentPatched).toHaveBeenCalledWith(
+        expect.objectContaining({
+          comment_id: comment.comment_id,
+          position: { absolute: { x: 107, y: 208 } },
         })
       );
     }

--- a/apps/agor-daemon/src/services/boards.ts
+++ b/apps/agor-daemon/src/services/boards.ts
@@ -440,9 +440,9 @@ export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardPa
     boardId: string,
     objectId: string,
     _deleteAssociatedSessions: boolean,
-    _params?: BoardParams
+    params?: BoardParams
   ): Promise<{ board: Board; affectedSessions: string[] }> {
-    const board = await this.removeBoardObject(boardId, objectId);
+    const board = await this.removeBoardObject(boardId, objectId, params);
     return {
       board,
       affectedSessions: [],

--- a/apps/agor-daemon/src/services/boards.ts
+++ b/apps/agor-daemon/src/services/boards.ts
@@ -7,6 +7,7 @@
 
 import { PAGINATION } from '@agor/core/config';
 import {
+  BoardCommentsRepository,
   BoardObjectRepository,
   BoardRepository,
   mapBoardExportBlobToCreateData,
@@ -18,15 +19,17 @@ import {
   buildTeammateWelcomeNoteObject,
   TEAMMATE_WELCOME_NOTE_OBJECT_ID,
 } from '@agor/core/templates/teammate-welcome-note';
-import type {
-  AuthenticatedParams,
-  Board,
-  BoardExportBlob,
-  BoardID,
-  BoardObject,
-  QueryParams,
-  TeammateWelcomeNoteRequest,
-  UUID,
+import {
+  type AuthenticatedParams,
+  type Board,
+  type BoardComment,
+  type BoardExportBlob,
+  type BoardID,
+  type BoardObject,
+  boardCommentZoneParentObjectKey,
+  type QueryParams,
+  type TeammateWelcomeNoteRequest,
+  type UUID,
 } from '@agor/core/types';
 import { NotFoundError } from '@agor/core/utils/errors';
 import { DrizzleService, type Query } from '../adapters/drizzle';
@@ -90,11 +93,13 @@ function shouldSqlPageBoardQuery(query?: Record<string, unknown>): boolean {
 export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardParams> {
   private boardRepo: BoardRepository;
   private boardObjectRepo: BoardObjectRepository;
+  private boardCommentsRepo: BoardCommentsRepository;
   private emitBoardObjectPatched?: (
     boardObject: BoardObjectPatchedEventPayload,
     params?: BoardParams
   ) => void;
   private emitBoardEvent?: (event: Omit<ManualServiceEvent, 'path'>) => void;
+  private emitBoardCommentPatched?: (comment: BoardComment, params?: BoardParams) => void;
 
   constructor(
     db: TenantScopeAwareDatabase,
@@ -102,7 +107,8 @@ export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardPa
       boardObject: BoardObjectPatchedEventPayload,
       params?: BoardParams
     ) => void,
-    emitBoardEvent?: (event: Omit<ManualServiceEvent, 'path'>) => void
+    emitBoardEvent?: (event: Omit<ManualServiceEvent, 'path'>) => void,
+    emitBoardCommentPatched?: (comment: BoardComment, params?: BoardParams) => void
   ) {
     const boardRepo = new BoardRepository(db);
     super(boardRepo, {
@@ -116,8 +122,10 @@ export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardPa
 
     this.boardRepo = boardRepo;
     this.boardObjectRepo = new BoardObjectRepository(db);
+    this.boardCommentsRepo = new BoardCommentsRepository(db);
     this.emitBoardObjectPatched = emitBoardObjectPatched;
     this.emitBoardEvent = emitBoardEvent;
+    this.emitBoardCommentPatched = emitBoardCommentPatched;
   }
 
   /**
@@ -300,6 +308,31 @@ export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardPa
         const payload = toBoardObjectPatchedEventPayload(boardObject);
         if (_params) this.emitBoardObjectPatched?.(payload, _params);
         else this.emitBoardObjectPatched?.(payload);
+      }
+
+      // Spatial comments can also be pinned to a zone. Keep them visible by
+      // converting their relative offsets to absolute board coordinates before
+      // the parent zone disappears. Replies have no position and are unaffected.
+      const comments = await this.boardCommentsRepo.findByBoard(board.board_id);
+      for (const comment of comments) {
+        const relative = comment.position?.relative;
+        if (
+          relative?.parent_type !== 'zone' ||
+          boardCommentZoneParentObjectKey(relative.parent_id) !== objectId
+        ) {
+          continue;
+        }
+
+        const updated = await this.boardCommentsRepo.update(comment.comment_id, {
+          position: {
+            absolute: {
+              x: object.x + relative.offset_x,
+              y: object.y + relative.offset_y,
+            },
+          },
+        });
+        if (_params) this.emitBoardCommentPatched?.(updated, _params);
+        else this.emitBoardCommentPatched?.(updated);
       }
     }
 
@@ -597,7 +630,8 @@ export function createBoardsService(
     boardObject: BoardObjectPatchedEventPayload,
     params?: BoardParams
   ) => void,
-  emitBoardEvent?: (event: Omit<ManualServiceEvent, 'path'>) => void
+  emitBoardEvent?: (event: Omit<ManualServiceEvent, 'path'>) => void,
+  emitBoardCommentPatched?: (comment: BoardComment, params?: BoardParams) => void
 ): BoardsService {
-  return new BoardsService(db, emitBoardObjectPatched, emitBoardEvent);
+  return new BoardsService(db, emitBoardObjectPatched, emitBoardEvent, emitBoardCommentPatched);
 }

--- a/apps/agor-daemon/src/services/boards.ts
+++ b/apps/agor-daemon/src/services/boards.ts
@@ -10,7 +10,9 @@ import {
   BoardCommentsRepository,
   BoardObjectRepository,
   BoardRepository,
+  getCurrentTenantId,
   mapBoardExportBlobToCreateData,
+  runWithTenantDatabaseTransaction,
   type TenantScopeAwareDatabase,
 } from '@agor/core/db';
 import { BadRequest } from '@agor/core/feathers';
@@ -48,6 +50,7 @@ export interface BoardParams
     name?: string;
   }> {
   user?: AuthenticatedParams['user'];
+  tenant?: AuthenticatedParams['tenant'];
   /** Internal hook signal; set only when ensureTeammateWelcomeNote writes. */
   teammateWelcomeNoteMutated?: boolean;
   /** Internal RBAC SQL pushdown marker set by register-hooks for external regular users. */
@@ -87,13 +90,21 @@ function shouldSqlPageBoardQuery(query?: Record<string, unknown>): boolean {
   return true;
 }
 
+export interface BoardsServiceEvents {
+  emitBoardObjectPatched?: (
+    boardObject: BoardObjectPatchedEventPayload,
+    params?: BoardParams
+  ) => void;
+  emitBoardEvent?: (event: Omit<ManualServiceEvent, 'path'>) => void;
+  emitBoardCommentPatched?: (comment: BoardComment, params?: BoardParams) => void;
+}
+
 /**
  * Extended boards service with custom methods
  */
 export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardParams> {
+  private db: TenantScopeAwareDatabase;
   private boardRepo: BoardRepository;
-  private boardObjectRepo: BoardObjectRepository;
-  private boardCommentsRepo: BoardCommentsRepository;
   private emitBoardObjectPatched?: (
     boardObject: BoardObjectPatchedEventPayload,
     params?: BoardParams
@@ -101,15 +112,7 @@ export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardPa
   private emitBoardEvent?: (event: Omit<ManualServiceEvent, 'path'>) => void;
   private emitBoardCommentPatched?: (comment: BoardComment, params?: BoardParams) => void;
 
-  constructor(
-    db: TenantScopeAwareDatabase,
-    emitBoardObjectPatched?: (
-      boardObject: BoardObjectPatchedEventPayload,
-      params?: BoardParams
-    ) => void,
-    emitBoardEvent?: (event: Omit<ManualServiceEvent, 'path'>) => void,
-    emitBoardCommentPatched?: (comment: BoardComment, params?: BoardParams) => void
-  ) {
+  constructor(db: TenantScopeAwareDatabase, events: BoardsServiceEvents = {}) {
     const boardRepo = new BoardRepository(db);
     super(boardRepo, {
       id: 'board_id',
@@ -120,12 +123,11 @@ export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardPa
       },
     });
 
+    this.db = db;
     this.boardRepo = boardRepo;
-    this.boardObjectRepo = new BoardObjectRepository(db);
-    this.boardCommentsRepo = new BoardCommentsRepository(db);
-    this.emitBoardObjectPatched = emitBoardObjectPatched;
-    this.emitBoardEvent = emitBoardEvent;
-    this.emitBoardCommentPatched = emitBoardCommentPatched;
+    this.emitBoardObjectPatched = events.emitBoardObjectPatched;
+    this.emitBoardEvent = events.emitBoardEvent;
+    this.emitBoardCommentPatched = events.emitBoardCommentPatched;
   }
 
   /**
@@ -290,53 +292,61 @@ export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardPa
     objectId: string,
     _params?: BoardParams
   ): Promise<Board> {
-    const board = await this.boardRepo.findBySlugOrId(boardId);
-    const object = board?.objects?.[objectId];
+    const tenantId = _params?.tenant?.tenant_id ?? getCurrentTenantId();
+    return runWithTenantDatabaseTransaction(this.db, tenantId, async (operationDb) => {
+      const boardRepo = new BoardRepository(operationDb);
+      const boardObjectRepo = new BoardObjectRepository(operationDb);
+      const boardCommentsRepo = new BoardCommentsRepository(operationDb);
+      const board = await boardRepo.findBySlugOrId(boardId);
+      const object = board?.objects?.[objectId];
 
-    // A generic removeObject path can remove zones too (e.g. MCP
-    // agor_boards_update.removeObjects). Clear entity zone references first so
-    // future board renders do not construct React Flow children with a missing
-    // parent. Convert zone-relative positions to absolute while the zone origin
-    // is still available.
-    if (board && object?.type === 'zone') {
-      const cleared = await this.boardObjectRepo.clearZoneReferences(board.board_id, objectId, {
-        x: object.x,
-        y: object.y,
-      });
+      // A generic removeObject path can remove zones too (e.g. MCP
+      // agor_boards_update.removeObjects). Clear entity zone references first so
+      // future board renders do not construct React Flow children with a missing
+      // parent. Convert zone-relative positions to absolute while the zone origin
+      // is still available.
+      if (board && object?.type === 'zone') {
+        const cleared = await boardObjectRepo.clearZoneReferences(board.board_id, objectId, {
+          x: object.x,
+          y: object.y,
+        });
 
-      for (const boardObject of cleared) {
-        const payload = toBoardObjectPatchedEventPayload(boardObject);
-        if (_params) this.emitBoardObjectPatched?.(payload, _params);
-        else this.emitBoardObjectPatched?.(payload);
-      }
-
-      // Spatial comments can also be pinned to a zone. Keep them visible by
-      // converting their relative offsets to absolute board coordinates before
-      // the parent zone disappears. Replies have no position and are unaffected.
-      const comments = await this.boardCommentsRepo.findByBoard(board.board_id);
-      for (const comment of comments) {
-        const relative = comment.position?.relative;
-        if (
-          relative?.parent_type !== 'zone' ||
-          boardCommentZoneParentObjectKey(relative.parent_id) !== objectId
-        ) {
-          continue;
+        for (const boardObject of cleared) {
+          const payload = toBoardObjectPatchedEventPayload(boardObject);
+          if (_params) this.emitBoardObjectPatched?.(payload, _params);
+          else this.emitBoardObjectPatched?.(payload);
         }
 
-        const updated = await this.boardCommentsRepo.update(comment.comment_id, {
-          position: {
-            absolute: {
-              x: object.x + relative.offset_x,
-              y: object.y + relative.offset_y,
-            },
-          },
-        });
-        if (_params) this.emitBoardCommentPatched?.(updated, _params);
-        else this.emitBoardCommentPatched?.(updated);
-      }
-    }
+        // Spatial comments can also be pinned to a zone. Keep them visible by
+        // converting their relative offsets to absolute board coordinates before
+        // the parent zone disappears. Replies have no position and are unaffected.
+        const comments = await boardCommentsRepo.findByBoard(board.board_id);
+        for (const comment of comments) {
+          const relative = comment.position?.relative;
+          if (
+            relative?.parent_type !== 'zone' ||
+            boardCommentZoneParentObjectKey(relative.parent_id) !== objectId
+          ) {
+            continue;
+          }
 
-    return this.boardRepo.removeBoardObject(boardId, objectId);
+          const updated = await boardCommentsRepo.update(comment.comment_id, {
+            position: {
+              absolute: {
+                x: object.x + relative.offset_x,
+                y: object.y + relative.offset_y,
+              },
+            },
+          });
+          if (_params) this.emitBoardCommentPatched?.(updated, _params);
+          else this.emitBoardCommentPatched?.(updated);
+        }
+      }
+
+      // The registered emitters delegate to emitServiceEvent, whose
+      // transaction-aware queue publishes these patches only after commit.
+      return boardRepo.removeBoardObject(boardId, objectId);
+    });
   }
 
   /**
@@ -626,12 +636,7 @@ export class BoardsService extends DrizzleService<Board, Partial<Board>, BoardPa
  */
 export function createBoardsService(
   db: TenantScopeAwareDatabase,
-  emitBoardObjectPatched?: (
-    boardObject: BoardObjectPatchedEventPayload,
-    params?: BoardParams
-  ) => void,
-  emitBoardEvent?: (event: Omit<ManualServiceEvent, 'path'>) => void,
-  emitBoardCommentPatched?: (comment: BoardComment, params?: BoardParams) => void
+  events: BoardsServiceEvents = {}
 ): BoardsService {
-  return new BoardsService(db, emitBoardObjectPatched, emitBoardEvent, emitBoardCommentPatched);
+  return new BoardsService(db, events);
 }

--- a/apps/agor-docs/content/guide/boards.mdx
+++ b/apps/agor-docs/content/guide/boards.mdx
@@ -51,9 +51,9 @@ Zones turn your board into a workflow engine. Spatial position _means something_
 Select a zone to show its compact board toolbar:
 
 - **Rename**, **appearance**, and **lock position and size** cover the common edits.
-- **Zone settings** opens the full editor. **General** contains the name, border and fill colors, label size, and placement lock; **Automation** contains trigger behavior and the prompt template.
+- **Zone settings** opens on **Automation**, where you configure the prompt and how it starts. **Appearance & placement** contains the name, border and fill colors, label size, and placement lock.
 - **More → Arrange** contains the less common layer controls (bring forward/front and send backward/back). When zones overlap, the visually topmost zone is also the drop target.
-- **More → Delete zone** keeps the existing confirmation flow.
+- **More → Delete zone** removes only the zone. Pinned branches, cards, and comments are unpinned at the same visible board positions; their content and sessions are kept.
 
 Locking a zone prevents moving and resizing it; it does not prevent renaming it or changing its settings. Viewers do not see editing controls. Editors, managers, and the board owner can edit zones.
 

--- a/apps/agor-docs/content/guide/boards.mdx
+++ b/apps/agor-docs/content/guide/boards.mdx
@@ -46,14 +46,24 @@ Drag into "Ship It" → auto-prompts for changelog + PR description.
 
 Zones turn your board into a workflow engine. Spatial position _means something_. It triggers behavior.
 
+### Editing a zone
+
+Select a zone to show its compact board toolbar:
+
+- **Rename**, **appearance**, and **lock position and size** cover the common edits.
+- **Zone settings** opens the full editor. **General** contains the name, border and fill colors, label size, and placement lock; **Automation** contains trigger behavior and the prompt template.
+- **More → Arrange** contains the less common layer controls (bring forward/front and send backward/back). When zones overlap, the visually topmost zone is also the drop target.
+- **More → Delete zone** keeps the existing confirmation flow.
+
+Locking a zone prevents moving and resizing it; it does not prevent renaming it or changing its settings. Viewers do not see editing controls. Editors, managers, and the board owner can edit zones.
+
 ### How zone triggers work
 
 When you drop a branch into a zone:
 
 1. **Session selection**: which session gets the prompt?
-   - **Always create new session** (default): clean slate for the zone's task
-   - **Let me pick**: choose which session in the tree has the right context
-   - **Most recently active**: usually the session you were just working in
+   - **Show picker** (default): choose a session and action when the branch is dropped
+   - **Always new**: create a new root session automatically
 
 2. **Templated prompt executes**: the zone's Handlebars template renders with dynamic data from the branch, board, repo, and environment.
 

--- a/apps/agor-ui/src/components/BoardSwitcher/BoardSwitcher.test.tsx
+++ b/apps/agor-ui/src/components/BoardSwitcher/BoardSwitcher.test.tsx
@@ -1,6 +1,7 @@
 import type { AgorClient, Board, User } from '@agor-live/client';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { __resetAuthConfigForTests, __setAuthConfigForTests } from '../../hooks/useAuthConfig';
 import { BoardSwitcher } from './BoardSwitcher';
 
 const modalProps = vi.hoisted(() => ({ current: null as Record<string, unknown> | null }));
@@ -22,16 +23,26 @@ const board = {
 } as Board;
 const owner = { user_id: 'owner-1', role: 'member' } as User;
 
-function clientFor({ reject }: { reject?: unknown } = {}) {
+function clientFor({ reject, findResult }: { reject?: unknown; findResult?: unknown } = {}) {
   return {
     service: () => ({
       find: vi
         .fn()
-        .mockImplementation(() => (reject ? Promise.reject(reject) : Promise.resolve([]))),
+        .mockImplementation(() =>
+          reject ? Promise.reject(reject) : Promise.resolve(findResult ?? [])
+        ),
       findAll: vi.fn().mockResolvedValue([]),
     }),
   } as unknown as AgorClient;
 }
+
+beforeEach(() => {
+  __setAuthConfigForTests({ requireAuth: true }, { branchRbac: false });
+});
+
+afterEach(() => {
+  __resetAuthConfigForTests();
+});
 
 function renderSwitcher(client = clientFor(), user: User = owner) {
   const onBoardChange = vi.fn();
@@ -150,7 +161,11 @@ describe('BoardSwitcher current-board edit shortcut', () => {
   });
 
   it('hides the action when normalized policy resolution denies management', async () => {
-    renderSwitcher(clientFor(), { user_id: 'member-2', role: 'member' } as User);
+    __setAuthConfigForTests({ requireAuth: true }, { branchRbac: true });
+    renderSwitcher(clientFor({ findResult: { capabilities: ['board.view'] } }), {
+      user_id: 'member-2',
+      role: 'member',
+    } as User);
     await waitFor(() =>
       expect(screen.queryByRole('button', { name: /Edit current board:/ })).not.toBeInTheDocument()
     );

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.rerender.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.rerender.test.tsx
@@ -19,6 +19,10 @@ import { sessionPatched } from '../../store/agorRealtimeActions';
 import { agorStore } from '../../store/agorStore';
 import SessionCanvas from './SessionCanvas';
 
+vi.mock('../../hooks/useCanManageBoard', () => ({
+  useCanManageBoard: () => true,
+}));
+
 // ── Render counters ──────────────────────────────────────────────────────────
 // Leaf node components are mocked to count renders per entity. This isolates the
 // memo boundaries the store migration is meant to protect: a `session:patched`

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -727,6 +727,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
     // Handler to open edit modal for existing markdown note
     const handleEditMarkdownNote = useCallback(
       (objectId: string, content: string, width: number) => {
+        if (!canMutateBoard) return;
         const node = reactFlowInstanceRef.current?.getNode(objectId);
         if (!node) return;
 
@@ -738,7 +739,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
         });
         setActiveTool('markdown');
       },
-      []
+      [canMutateBoard]
     );
 
     // Board objects hook
@@ -2277,6 +2278,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                 height,
                 borderColor: defaultBorderColor,
                 backgroundColor: defaultBackgroundColor,
+                canEdit: canEditBoard,
                 onUpdate: (id: string, data: BoardObject) => {
                   if (board && client) {
                     client
@@ -2321,7 +2323,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
         setDrawingZone(null);
         setActiveTool('select');
       }
-    }, [activeTool, drawingZone, board, client, setNodes, canMutateBoard]);
+    }, [activeTool, drawingZone, board, client, setNodes, canMutateBoard, canEditBoard]);
 
     const openMarkdownPlacementModal = useCallback(
       (event: Pick<React.MouseEvent, 'clientX' | 'clientY'>): boolean => {
@@ -2473,6 +2475,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
               objectId,
               content: markdownContent,
               width: markdownWidth,
+              canEdit: canEditBoard,
               onUpdate: (id: string, data: BoardObject) => {
                 if (board && client) {
                   client
@@ -2528,6 +2531,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       handleEditMarkdownNote,
       deleteObject,
       canMutateBoard,
+      canEditBoard,
     ]);
 
     // Node click handler for eraser mode and comment placement
@@ -2616,7 +2620,8 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
         setDrawingZone(null);
         setCommentPlacement(null);
         setCommentInput('');
-        setMarkdownModal(null);
+        // Preserve an already-open Markdown editor and its draft. Its Save
+        // action is permission-gated below until editing becomes available.
       }
     }, [canMutateBoard, canMutateComments, activeTool]);
 
@@ -2976,7 +2981,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
             }}
             onOk={handleCreateMarkdownNote}
             okText={markdownModal.objectId ? 'Save' : 'Create'}
-            okButtonProps={{ disabled: !markdownContent.trim() }}
+            okButtonProps={{ disabled: !markdownContent.trim() || !canMutateBoard }}
             width={1000}
           >
             <div style={{ display: 'flex', flexDirection: 'column', gap: 16, marginBottom: 16 }}>

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -51,7 +51,7 @@ import {
 } from 'reactflow';
 import 'reactflow/dist/style.css';
 import './SessionCanvas.css';
-import { boardCommentZoneParentObjectKey, shortId } from '@agor-live/client';
+import { boardCommentZoneParentObjectKey, hasMinimumRole, ROLES, shortId } from '@agor-live/client';
 import { mapToArray } from '@/utils/mapHelpers';
 import { DEFAULT_BACKGROUNDS } from '../../constants/ui';
 import {
@@ -93,6 +93,7 @@ import { RemoteCursorLayer, type StaticRemoteCursor } from './canvas/RemoteCurso
 import { useBoardObjects } from './canvas/useBoardObjects';
 import { findIntersectingObjects, findZoneAtPosition } from './canvas/utils/collisionDetection';
 import {
+  canRepositionBoardComment,
   getBranchParentInfo,
   getZoneParentInfo,
   planBoardCommentReposition,
@@ -471,9 +472,17 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
     const currentUser = currentUserId ? userById.get(currentUserId) : undefined;
     const canEditBoard = useCanManageBoard(client, board ?? undefined, currentUser);
     const canMutateBoard = canEditBoard && mutationGate.canMutate;
+    // Board Viewers may collaborate through comments even though structural
+    // canvas mutations require board.edit. The daemon applies the same global
+    // member floor plus board-view authorization on comment creation.
+    const canComment = Boolean(currentUser && hasMinimumRole(currentUser.role, ROLES.MEMBER));
+    const canMutateComments = canComment && mutationGate.canMutate;
     const boardMutationMessage = canEditBoard
       ? mutationGate.message
       : 'You do not have permission to edit this board';
+    const commentMutationMessage = canComment
+      ? mutationGate.message
+      : 'You do not have permission to comment on this board';
 
     const isDarkMode = isDarkTheme(token);
     const defaultBackground = DEFAULT_BACKGROUNDS[isDarkMode ? 'dark' : 'light'];
@@ -885,7 +894,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
           type: 'branchNode',
           dragHandle: REACT_FLOW_DRAG_HANDLE_SELECTOR,
           position, // When pinned (parentId set), this is relative to zone; otherwise absolute
-          // draggable inherits from canvas-level nodesDraggable (canMutateBoard)
+          draggable: canMutateBoard,
           zIndex: 500, // Above zones, below comments
           // Set dimensions for collision detection (matches BranchCard size)
           width: 500,
@@ -953,6 +962,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       zoneLabels,
       warnInvalidZoneRef,
       client,
+      canMutateBoard,
     ]);
 
     // Handler to open card modal. Identity-stabilized so card-map churn does
@@ -1020,7 +1030,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
           type: 'cardNode',
           dragHandle: REACT_FLOW_DRAG_HANDLE_SELECTOR,
           position,
-          // draggable inherits from canvas-level nodesDraggable (canMutateBoard)
+          draggable: canMutateBoard,
           zIndex: 500, // Same level as branches
           width: 380,
           height: 120,
@@ -1046,6 +1056,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       handleCardClick,
       handleUnpinCard,
       warnInvalidZoneRef,
+      canMutateBoard,
     ]);
 
     // No edges needed for branch-centric boards
@@ -1315,7 +1326,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
           position,
           parentId, // Set parent for relative positioning (moves with parent)
           // No extent constraint - comments can be dragged anywhere and re-pinned
-          // draggable inherits from canvas-level nodesDraggable (canMutateBoard)
+          draggable: mutationGate.canMutate && canRepositionBoardComment(comment, currentUser),
           selectable: true,
           zIndex: 1000, // Always on top (elevateNodesOnSelect is disabled)
           data: {
@@ -1350,6 +1361,8 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       onOpenCommentsPanel,
       onCommentHover,
       onCommentSelect,
+      currentUser,
+      mutationGate.canMutate,
     ]);
 
     // Helper: Apply local position overrides to a set of incoming nodes (branches or cards).
@@ -2254,7 +2267,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
               id: objectId,
               type: 'zone',
               position,
-              // draggable inherits from canvas-level nodesDraggable (canMutateBoard)
+              draggable: canMutateBoard,
               zIndex: DEFAULT_BOARD_OBJECT_Z_INDEX.zone, // Zones behind branches and comments
               style: { width, height },
               data: {
@@ -2330,7 +2343,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
     // Pane click handler for comment placement
     const handlePaneClick = useCallback(
       (event: React.MouseEvent) => {
-        if (activeTool === 'comment' && reactFlowInstanceRef.current) {
+        if (activeTool === 'comment' && canMutateComments && reactFlowInstanceRef.current) {
           // Use screenToFlowPosition which automatically handles all offsets (including CommentsPanel)
           const position = reactFlowInstanceRef.current.screenToFlowPosition({
             x: event.clientX,
@@ -2348,7 +2361,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
           openMarkdownPlacementModal(event);
         }
       },
-      [activeTool, openMarkdownPlacementModal]
+      [activeTool, canMutateComments, openMarkdownPlacementModal]
     );
 
     // Handler to create spatial comment
@@ -2356,7 +2369,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       if (!commentPlacement || !board || !client || !currentUserId || !commentInput.trim()) {
         return;
       }
-      if (!canMutateBoard) {
+      if (!canMutateComments) {
         return;
       }
 
@@ -2415,7 +2428,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       } catch (error) {
         console.error('Failed to create spatial comment:', error);
       }
-    }, [commentPlacement, board, client, currentUserId, commentInput, canMutateBoard]);
+    }, [commentPlacement, board, client, currentUserId, commentInput, canMutateComments]);
 
     // Handler to create/update markdown note
     const handleCreateMarkdownNote = useCallback(async () => {
@@ -2454,7 +2467,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
             id: objectId,
             type: 'markdown',
             position,
-            // draggable inherits from canvas-level nodesDraggable (canMutateBoard)
+            draggable: canMutateBoard,
             zIndex: 300, // Above zones (100), below branches (500)
             data: {
               objectId,
@@ -2531,7 +2544,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
           return;
         }
 
-        if (activeTool === 'comment' && reactFlowInstanceRef.current) {
+        if (activeTool === 'comment' && canMutateComments && reactFlowInstanceRef.current) {
           // Allow comment placement on sessions and zones
           if (node.type === 'branchNode' || node.type === 'zone') {
             // Use screenToFlowPosition which automatically handles all offsets (including CommentsPanel)
@@ -2573,7 +2586,14 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
           });
         }
       },
-      [activeTool, deleteObject, canMutateBoard, openMarkdownPlacementModal, setNodes]
+      [
+        activeTool,
+        deleteObject,
+        canMutateBoard,
+        canMutateComments,
+        openMarkdownPlacementModal,
+        setNodes,
+      ]
     );
 
     // Clear comment placement state when switching away from comment tool
@@ -2588,14 +2608,17 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
     // half-engaged mode (e.g. mid-drag zone) doesn't sit armed during the
     // disconnect/grace/out-of-sync window.
     useEffect(() => {
-      if (!canMutateBoard && activeTool !== 'select') {
+      const toolIsUnavailable =
+        (activeTool === 'comment' && !canMutateComments) ||
+        (activeTool !== 'select' && activeTool !== 'comment' && !canMutateBoard);
+      if (toolIsUnavailable) {
         setActiveTool('select');
         setDrawingZone(null);
         setCommentPlacement(null);
         setCommentInput('');
         setMarkdownModal(null);
       }
-    }, [canMutateBoard, activeTool]);
+    }, [canMutateBoard, canMutateComments, activeTool]);
 
     return (
       <div
@@ -2654,11 +2677,10 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
             snapGrid={[20, 20]}
             minZoom={0.1}
             maxZoom={1.5}
-            // Disconnected: gate node dragging only. Drag is the only
-            // canvas gesture that mutates server state (zone/branch
-            // position). Selection/focus stay enabled so click handlers
-            // and keyboard a11y keep working in read-only mode.
-            nodesDraggable={canMutateBoard}
+            // The connection gate is global; each node carries its narrower
+            // authorization (board.edit for structure, author/admin for
+            // comments). Selection/focus remain available in read-only mode.
+            nodesDraggable={mutationGate.canMutate}
             nodesConnectable={false}
             elementsSelectable={true}
             elevateNodesOnSelect={false}
@@ -2749,6 +2771,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
               >
                 <span>
                   <ControlButton
+                    aria-label="Add Zone"
                     disabled={!canMutateBoard}
                     onClick={(e) => {
                       e.stopPropagation();
@@ -2768,13 +2791,16 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                 </span>
               </Tooltip>
               <Tooltip
-                title={canMutateBoard ? 'Add Comment' : (boardMutationMessage ?? 'Add Comment')}
+                title={
+                  canMutateComments ? 'Add Comment' : (commentMutationMessage ?? 'Add Comment')
+                }
                 placement="right"
                 mouseEnterDelay={0.3}
               >
                 <span>
                   <ControlButton
-                    disabled={!canMutateBoard}
+                    aria-label="Add Comment"
+                    disabled={!canMutateComments}
                     onClick={(e) => {
                       e.stopPropagation();
                       setActiveTool('comment');
@@ -2784,8 +2810,8 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                         activeTool === 'comment'
                           ? `${token.lineWidth * 3}px ${token.lineType} ${token.colorPrimary}`
                           : 'none',
-                      opacity: canMutateBoard ? 1 : 0.4,
-                      cursor: canMutateBoard ? 'pointer' : 'not-allowed',
+                      opacity: canMutateComments ? 1 : 0.4,
+                      cursor: canMutateComments ? 'pointer' : 'not-allowed',
                     }}
                   >
                     <CommentOutlined style={{ fontSize: '16px' }} />
@@ -2831,6 +2857,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
               >
                 <span>
                   <ControlButton
+                    aria-label="Eraser"
                     disabled={!canMutateBoard}
                     onClick={(e) => {
                       e.stopPropagation();

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.tsx
@@ -59,6 +59,7 @@ import {
   useRegisterRecenter,
 } from '../../contexts/CanvasNavigationContext';
 import { useMutationGate } from '../../contexts/ConnectionContext';
+import { useCanManageBoard } from '../../hooks/useCanManageBoard';
 import { useCursorTracking } from '../../hooks/useCursorTracking';
 import { useStableCallback } from '../../hooks/useStableCallback';
 import { agorStore, useAgorStore } from '../../store/agorStore';
@@ -467,6 +468,12 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
     const commentById = useAgorStore(selectCommentById);
     const cardById = useAgorStore(selectCardById);
     const userById = useAgorStore(selectUserById);
+    const currentUser = currentUserId ? userById.get(currentUserId) : undefined;
+    const canEditBoard = useCanManageBoard(client, board ?? undefined, currentUser);
+    const canMutateBoard = canEditBoard && mutationGate.canMutate;
+    const boardMutationMessage = canEditBoard
+      ? mutationGate.message
+      : 'You do not have permission to edit this board';
 
     const isDarkMode = isDarkTheme(token);
     const defaultBackground = DEFAULT_BACKGROUNDS[isDarkMode ? 'dark' : 'light'];
@@ -735,6 +742,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       eraserMode: activeTool === 'eraser',
       activeUrlTargetArtifactId,
       onEditMarkdown: handleEditMarkdownNote,
+      canEdit: canEditBoard,
     });
 
     // Extract zone labels - memoized to only change when labels actually change
@@ -877,7 +885,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
           type: 'branchNode',
           dragHandle: REACT_FLOW_DRAG_HANDLE_SELECTOR,
           position, // When pinned (parentId set), this is relative to zone; otherwise absolute
-          // draggable inherits from canvas-level nodesDraggable (mutationGate.canMutate)
+          // draggable inherits from canvas-level nodesDraggable (canMutateBoard)
           zIndex: 500, // Above zones, below comments
           // Set dimensions for collision detection (matches BranchCard size)
           width: 500,
@@ -1012,7 +1020,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
           type: 'cardNode',
           dragHandle: REACT_FLOW_DRAG_HANDLE_SELECTOR,
           position,
-          // draggable inherits from canvas-level nodesDraggable (mutationGate.canMutate)
+          // draggable inherits from canvas-level nodesDraggable (canMutateBoard)
           zIndex: 500, // Same level as branches
           width: 380,
           height: 120,
@@ -1307,7 +1315,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
           position,
           parentId, // Set parent for relative positioning (moves with parent)
           // No extent constraint - comments can be dragged anywhere and re-pinned
-          // draggable inherits from canvas-level nodesDraggable (mutationGate.canMutate)
+          // draggable inherits from canvas-level nodesDraggable (canMutateBoard)
           selectable: true,
           zIndex: 1000, // Always on top (elevateNodesOnSelect is disabled)
           data: {
@@ -2205,7 +2213,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       if (activeTool === 'zone' && drawingZone && reactFlowInstanceRef.current) {
         // Bail out if the daemon isn't usable — the in-flight gesture is
         // discarded rather than persisted as a half-formed zone.
-        if (!mutationGate.canMutate) {
+        if (!canMutateBoard) {
           setDrawingZone(null);
           setActiveTool('select');
           return;
@@ -2246,7 +2254,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
               id: objectId,
               type: 'zone',
               position,
-              // draggable inherits from canvas-level nodesDraggable (mutationGate.canMutate)
+              // draggable inherits from canvas-level nodesDraggable (canMutateBoard)
               zIndex: DEFAULT_BOARD_OBJECT_Z_INDEX.zone, // Zones behind branches and comments
               style: { width, height },
               data: {
@@ -2300,11 +2308,11 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
         setDrawingZone(null);
         setActiveTool('select');
       }
-    }, [activeTool, drawingZone, board, client, setNodes, mutationGate.canMutate]);
+    }, [activeTool, drawingZone, board, client, setNodes, canMutateBoard]);
 
     const openMarkdownPlacementModal = useCallback(
       (event: Pick<React.MouseEvent, 'clientX' | 'clientY'>): boolean => {
-        if (!mutationGate.canMutate || !reactFlowInstanceRef.current) {
+        if (!canMutateBoard || !reactFlowInstanceRef.current) {
           return false;
         }
 
@@ -2316,7 +2324,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
         setMarkdownModal({ position });
         return true;
       },
-      [mutationGate.canMutate]
+      [canMutateBoard]
     );
 
     // Pane click handler for comment placement
@@ -2348,7 +2356,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       if (!commentPlacement || !board || !client || !currentUserId || !commentInput.trim()) {
         return;
       }
-      if (!mutationGate.canMutate) {
+      if (!canMutateBoard) {
         return;
       }
 
@@ -2407,14 +2415,14 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       } catch (error) {
         console.error('Failed to create spatial comment:', error);
       }
-    }, [commentPlacement, board, client, currentUserId, commentInput, mutationGate.canMutate]);
+    }, [commentPlacement, board, client, currentUserId, commentInput, canMutateBoard]);
 
     // Handler to create/update markdown note
     const handleCreateMarkdownNote = useCallback(async () => {
       if (!markdownModal || !board || !client || !markdownContent.trim()) {
         return;
       }
-      if (!mutationGate.canMutate) {
+      if (!canMutateBoard) {
         return;
       }
 
@@ -2446,7 +2454,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
             id: objectId,
             type: 'markdown',
             position,
-            // draggable inherits from canvas-level nodesDraggable (mutationGate.canMutate)
+            // draggable inherits from canvas-level nodesDraggable (canMutateBoard)
             zIndex: 300, // Above zones (100), below branches (500)
             data: {
               objectId,
@@ -2506,14 +2514,14 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
       setNodes,
       handleEditMarkdownNote,
       deleteObject,
-      mutationGate.canMutate,
+      canMutateBoard,
     ]);
 
     // Node click handler for eraser mode and comment placement
     const handleNodeClick = useCallback(
       (event: React.MouseEvent, node: Node) => {
         if (activeTool === 'eraser') {
-          if (!mutationGate.canMutate) {
+          if (!canMutateBoard) {
             return;
           }
           // Only delete board objects (zones, markdown), not branches
@@ -2565,7 +2573,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
           });
         }
       },
-      [activeTool, deleteObject, mutationGate.canMutate, openMarkdownPlacementModal, setNodes]
+      [activeTool, deleteObject, canMutateBoard, openMarkdownPlacementModal, setNodes]
     );
 
     // Clear comment placement state when switching away from comment tool
@@ -2580,14 +2588,14 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
     // half-engaged mode (e.g. mid-drag zone) doesn't sit armed during the
     // disconnect/grace/out-of-sync window.
     useEffect(() => {
-      if (!mutationGate.canMutate && activeTool !== 'select') {
+      if (!canMutateBoard && activeTool !== 'select') {
         setActiveTool('select');
         setDrawingZone(null);
         setCommentPlacement(null);
         setCommentInput('');
         setMarkdownModal(null);
       }
-    }, [mutationGate.canMutate, activeTool]);
+    }, [canMutateBoard, activeTool]);
 
     return (
       <div
@@ -2650,7 +2658,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
             // canvas gesture that mutates server state (zone/branch
             // position). Selection/focus stay enabled so click handlers
             // and keyboard a11y keep working in read-only mode.
-            nodesDraggable={mutationGate.canMutate}
+            nodesDraggable={canMutateBoard}
             nodesConnectable={false}
             elementsSelectable={true}
             elevateNodesOnSelect={false}
@@ -2735,13 +2743,13 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                 </span>
               </Tooltip>
               <Tooltip
-                title={mutationGate.canMutate ? 'Add Zone' : (mutationGate.message ?? 'Add Zone')}
+                title={canMutateBoard ? 'Add Zone' : (boardMutationMessage ?? 'Add Zone')}
                 placement="right"
                 mouseEnterDelay={0.3}
               >
                 <span>
                   <ControlButton
-                    disabled={!mutationGate.canMutate}
+                    disabled={!canMutateBoard}
                     onClick={(e) => {
                       e.stopPropagation();
                       setActiveTool('zone');
@@ -2751,8 +2759,8 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                         activeTool === 'zone'
                           ? `${token.lineWidth * 3}px ${token.lineType} ${token.colorPrimary}`
                           : 'none',
-                      opacity: mutationGate.canMutate ? 1 : 0.4,
-                      cursor: mutationGate.canMutate ? 'pointer' : 'not-allowed',
+                      opacity: canMutateBoard ? 1 : 0.4,
+                      cursor: canMutateBoard ? 'pointer' : 'not-allowed',
                     }}
                   >
                     <BorderOutlined style={{ fontSize: '16px' }} />
@@ -2760,15 +2768,13 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                 </span>
               </Tooltip>
               <Tooltip
-                title={
-                  mutationGate.canMutate ? 'Add Comment' : (mutationGate.message ?? 'Add Comment')
-                }
+                title={canMutateBoard ? 'Add Comment' : (boardMutationMessage ?? 'Add Comment')}
                 placement="right"
                 mouseEnterDelay={0.3}
               >
                 <span>
                   <ControlButton
-                    disabled={!mutationGate.canMutate}
+                    disabled={!canMutateBoard}
                     onClick={(e) => {
                       e.stopPropagation();
                       setActiveTool('comment');
@@ -2778,8 +2784,8 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                         activeTool === 'comment'
                           ? `${token.lineWidth * 3}px ${token.lineType} ${token.colorPrimary}`
                           : 'none',
-                      opacity: mutationGate.canMutate ? 1 : 0.4,
-                      cursor: mutationGate.canMutate ? 'pointer' : 'not-allowed',
+                      opacity: canMutateBoard ? 1 : 0.4,
+                      cursor: canMutateBoard ? 'pointer' : 'not-allowed',
                     }}
                   >
                     <CommentOutlined style={{ fontSize: '16px' }} />
@@ -2788,9 +2794,9 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
               </Tooltip>
               <Tooltip
                 title={
-                  mutationGate.canMutate
+                  canMutateBoard
                     ? 'Add Markdown Note — click canvas to place'
-                    : (mutationGate.message ?? 'Add Markdown Note — click canvas to place')
+                    : (boardMutationMessage ?? 'Add Markdown Note — click canvas to place')
                 }
                 placement="right"
                 mouseEnterDelay={0.3}
@@ -2798,7 +2804,7 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                 <span>
                   <ControlButton
                     aria-label="Add Markdown Note"
-                    disabled={!mutationGate.canMutate}
+                    disabled={!canMutateBoard}
                     onClick={(e) => {
                       e.stopPropagation();
                       setActiveTool('markdown');
@@ -2808,8 +2814,8 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                         activeTool === 'markdown'
                           ? `${token.lineWidth * 3}px ${token.lineType} ${token.colorPrimary}`
                           : 'none',
-                      opacity: mutationGate.canMutate ? 1 : 0.4,
-                      cursor: mutationGate.canMutate ? 'pointer' : 'not-allowed',
+                      opacity: canMutateBoard ? 1 : 0.4,
+                      cursor: canMutateBoard ? 'pointer' : 'not-allowed',
                     }}
                   >
                     <FileMarkdownOutlined style={{ fontSize: '16px' }} />
@@ -2818,16 +2824,14 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
               </Tooltip>
               <Tooltip
                 title={
-                  mutationGate.canMutate
-                    ? 'Eraser - Click to toggle'
-                    : (mutationGate.message ?? 'Eraser')
+                  canMutateBoard ? 'Eraser - Click to toggle' : (boardMutationMessage ?? 'Eraser')
                 }
                 placement="right"
                 mouseEnterDelay={0.3}
               >
                 <span>
                   <ControlButton
-                    disabled={!mutationGate.canMutate}
+                    disabled={!canMutateBoard}
                     onClick={(e) => {
                       e.stopPropagation();
                       setActiveTool(activeTool === 'eraser' ? 'select' : 'eraser');
@@ -2838,8 +2842,8 @@ const SessionCanvasInner = forwardRef<SessionCanvasRef, SessionCanvasProps>(
                       color: activeTool === 'eraser' ? token.colorError : 'inherit',
                       backgroundColor:
                         activeTool === 'eraser' ? `${token.colorError}15` : 'transparent',
-                      opacity: mutationGate.canMutate ? 1 : 0.4,
-                      cursor: mutationGate.canMutate ? 'pointer' : 'not-allowed',
+                      opacity: canMutateBoard ? 1 : 0.4,
+                      cursor: canMutateBoard ? 'pointer' : 'not-allowed',
                     }}
                   >
                     <DeleteOutlined style={{ fontSize: '16px' }} />

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.zoom.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.zoom.test.tsx
@@ -6,6 +6,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ConnectionProvider } from '../../contexts/ConnectionContext';
 import SessionCanvas from './SessionCanvas';
 
+vi.mock('../../hooks/useCanManageBoard', () => ({
+  useCanManageBoard: () => true,
+}));
+
 let reactFlowProps: Record<string, unknown> | null = null;
 // Stable spy for the `useNodesState` setter (onNodesChangeInternal). Lets tests
 // assert that onNodesChange forwards changes to React Flow's internal handler.

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.zoom.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.zoom.test.tsx
@@ -1,13 +1,15 @@
 // biome-ignore-all lint/plugin/noHardcodedColorLiteral: persisted zone palette fixtures verify canvas creation behavior
-import type { AgorClient, Board } from '@agor-live/client';
+import type { AgorClient, Board, BoardComment, User } from '@agor-live/client';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ButtonHTMLAttributes, MouseEventHandler, ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ConnectionProvider } from '../../contexts/ConnectionContext';
+import { agorStore } from '../../store/agorStore';
 import SessionCanvas from './SessionCanvas';
 
+const permissionState = vi.hoisted(() => ({ canEdit: true }));
 vi.mock('../../hooks/useCanManageBoard', () => ({
-  useCanManageBoard: () => true,
+  useCanManageBoard: () => permissionState.canEdit,
 }));
 
 let reactFlowProps: Record<string, unknown> | null = null;
@@ -58,9 +60,11 @@ vi.mock('./canvas/ArtifactNode', () => ({
 }));
 
 beforeEach(() => {
+  permissionState.canEdit = true;
   reactFlowProps = null;
   onNodesChangeInternalSpy.mockClear();
   setNodesUnsafeSpy.mockClear();
+  agorStore.setState({ userById: new Map(), commentById: new Map() });
 });
 
 describe('SessionCanvas zoom shortcuts', () => {
@@ -69,6 +73,73 @@ describe('SessionCanvas zoom shortcuts', () => {
 
     expect(reactFlowProps?.panOnScroll).toBe(true);
     expect(reactFlowProps?.zoomActivationKeyCode).toEqual(['Meta', 'Control']);
+  });
+
+  it('lets a board Viewer add and move their own comments without unlocking structure', async () => {
+    permissionState.canEdit = false;
+    const viewer = { user_id: 'viewer-1', role: 'member', username: 'viewer' } as User;
+    const ownComment = {
+      comment_id: 'comment-own',
+      board_id: 'board-1',
+      created_by: viewer.user_id,
+      content: 'Mine',
+      position: { absolute: { x: 20, y: 30 } },
+      resolved: false,
+    } as BoardComment;
+    const foreignComment = {
+      ...ownComment,
+      comment_id: 'comment-foreign',
+      created_by: 'user-elsewhere',
+      content: 'Not mine',
+      position: { absolute: { x: 40, y: 50 } },
+    } as BoardComment;
+    agorStore.setState({
+      userById: new Map([[viewer.user_id, viewer]]),
+      commentById: new Map([
+        [ownComment.comment_id, ownComment],
+        [foreignComment.comment_id, foreignComment],
+      ]),
+    });
+
+    render(
+      <ConnectionProvider
+        value={{
+          connected: true,
+          connecting: false,
+          outOfSync: false,
+          capturedSha: null,
+          currentSha: null,
+        }}
+      >
+        <SessionCanvas
+          board={
+            {
+              board_id: 'board-1',
+              name: 'Board',
+              slug: 'board',
+              objects: {
+                'zone-1': {
+                  type: 'zone',
+                  x: 0,
+                  y: 0,
+                  width: 500,
+                  height: 300,
+                  label: 'Review',
+                },
+              },
+              archived: false,
+            } as Board
+          }
+          client={null}
+          branches={[]}
+          currentUserId={viewer.user_id}
+        />
+      </ConnectionProvider>
+    );
+
+    expect(screen.getByRole('button', { name: 'Add Comment' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'Add Zone' })).toBeDisabled();
+    expect(reactFlowProps?.nodesDraggable).toBe(true);
   });
 
   it('opens the markdown note modal when the markdown tool clicks a board node', async () => {

--- a/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.zoom.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/SessionCanvas.zoom.test.tsx
@@ -143,7 +143,7 @@ describe('SessionCanvas zoom shortcuts', () => {
   });
 
   it('opens the markdown note modal when the markdown tool clicks a board node', async () => {
-    render(
+    const canvas = () => (
       <ConnectionProvider
         value={{
           connected: true,
@@ -183,6 +183,7 @@ describe('SessionCanvas zoom shortcuts', () => {
         />
       </ConnectionProvider>
     );
+    const { rerender } = render(canvas());
 
     act(() => {
       (reactFlowProps?.onInit as (instance: unknown) => void)?.({
@@ -201,6 +202,17 @@ describe('SessionCanvas zoom shortcuts', () => {
     });
 
     expect(await screen.findByText('Add Markdown Note')).toBeInTheDocument();
+
+    const draft = screen.getByPlaceholderText(/# Title/);
+    fireEvent.change(draft, { target: { value: 'Keep this draft' } });
+    expect(screen.getByRole('button', { name: 'Create' })).toBeEnabled();
+
+    permissionState.canEdit = false;
+    rerender(canvas());
+
+    expect(screen.getByText('Add Markdown Note')).toBeInTheDocument();
+    expect(draft).toHaveValue('Keep this draft');
+    expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled();
   });
 
   describe('onNodesChange zone resize via O(1) getNode lookup', () => {

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/AppNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/AppNode.tsx
@@ -4,6 +4,7 @@ import { SandpackPreview, SandpackProvider, type SandpackSetup } from '@codesand
 import { Button, Card, Tooltip, Typography, theme } from 'antd';
 import { useCallback, useRef, useState } from 'react';
 import { NodeResizer } from 'reactflow';
+import { useMutationGate } from '../../../contexts/ConnectionContext';
 import { useStableSandpackProviderInputs } from './utils/sandpackDefaults';
 
 export interface AppNodeData {
@@ -18,6 +19,7 @@ export interface AppNodeData {
   showConsole?: boolean;
   width: number;
   height: number;
+  canEdit: boolean;
   onUpdate: (id: string, data: BoardObject) => void;
   onDelete?: (id: string) => void;
 }
@@ -27,6 +29,8 @@ const MIN_HEIGHT = 200;
 
 export const AppNode = ({ data, selected }: { data: AppNodeData; selected?: boolean }) => {
   const { token } = theme.useToken();
+  const mutationGate = useMutationGate();
+  const layoutMutationDisabled = !mutationGate.canMutate || !data.canEdit;
   const [interactMode, setInteractMode] = useState(false);
   const iframeContainerRef = useRef<HTMLDivElement>(null);
   const sandpackInputs = useStableSandpackProviderInputs({
@@ -38,6 +42,7 @@ export const AppNode = ({ data, selected }: { data: AppNodeData; selected?: bool
 
   const handleResize = useCallback(
     (_event: unknown, params: { x: number; y: number; width: number; height: number }) => {
+      if (layoutMutationDisabled) return;
       const objectData: AppBoardObject = {
         type: 'app',
         x: params.x,
@@ -55,7 +60,7 @@ export const AppNode = ({ data, selected }: { data: AppNodeData; selected?: bool
       };
       data.onUpdate(data.objectId, objectData);
     },
-    [data]
+    [data, layoutMutationDisabled]
   );
 
   const toggleInteract = useCallback(() => {
@@ -68,7 +73,7 @@ export const AppNode = ({ data, selected }: { data: AppNodeData; selected?: bool
   return (
     <>
       <NodeResizer
-        isVisible={selected}
+        isVisible={selected && !layoutMutationDisabled}
         minWidth={MIN_WIDTH}
         minHeight={MIN_HEIGHT}
         onResize={handleResize}
@@ -123,8 +128,11 @@ export const AppNode = ({ data, selected }: { data: AppNodeData; selected?: bool
                   size="small"
                   danger
                   icon={<DeleteOutlined />}
+                  aria-label="Delete app"
+                  disabled={layoutMutationDisabled}
                   onClick={(e) => {
                     e.stopPropagation();
+                    if (layoutMutationDisabled) return;
                     data.onDelete?.(data.objectId);
                   }}
                 />

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
@@ -182,6 +182,7 @@ export const ArtifactNode = ({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [consentOpen, setConsentOpen] = useState(false);
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
   const lastHashRef = useRef<string | null>(null);
   const sandpackConfig = payload?.sandpack_config;
   const sandpackOptions = sandpackConfig?.options;
@@ -222,6 +223,10 @@ export const ArtifactNode = ({
   useEffect(() => {
     fetchPayload();
   }, [fetchPayload]);
+
+  useEffect(() => {
+    if (!mutationGate.canMutate) setDeleteConfirmOpen(false);
+  }, [mutationGate.canMutate]);
 
   // Re-fetch payload when the artifact is updated (via WebSocket 'patched' event)
   useEffect(() => {
@@ -423,16 +428,23 @@ export const ArtifactNode = ({
         )}
         {data.onDeleteArtifact && (
           <Popconfirm
+            open={deleteConfirmOpen}
+            destroyOnHidden
+            onOpenChange={(open) => {
+              if (!open || mutationGate.canMutate) setDeleteConfirmOpen(open);
+            }}
             title="Delete artifact?"
             description={`This will delete "${payload?.name ?? fallbackName}" and its files.`}
             onConfirm={(e) => {
               e?.stopPropagation();
+              if (!mutationGate.canMutate) return;
               data.onDeleteArtifact?.(data.objectId, data.artifactId);
             }}
             onCancel={(e) => e?.stopPropagation()}
             okText="Delete"
             cancelText="Cancel"
-            okButtonProps={{ danger: true }}
+            okButtonProps={{ danger: true, disabled: !mutationGate.canMutate }}
+            disabled={!mutationGate.canMutate}
           >
             <Tooltip title="Delete artifact">
               <Button
@@ -441,6 +453,7 @@ export const ArtifactNode = ({
                 danger
                 icon={<DeleteOutlined />}
                 aria-label="Delete artifact"
+                disabled={!mutationGate.canMutate}
                 onClick={(e) => e.stopPropagation()}
               />
             </Tooltip>

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ArtifactNode.tsx
@@ -45,6 +45,7 @@ import { copyToClipboard } from '@/utils/clipboard';
 import { useThemedMessage } from '@/utils/message';
 import { ensureSandpackCryptoSubtle } from '@/utils/sandpackCrypto';
 import { uiRouteHref } from '@/utils/uiRoutes';
+import { useMutationGate } from '../../../contexts/ConnectionContext';
 import { ArtifactConsentModal } from '../../ArtifactConsentModal/ArtifactConsentModal';
 import { useStableSandpackProviderInputs } from './utils/sandpackDefaults';
 
@@ -55,6 +56,7 @@ export interface ArtifactNodeData {
   artifactId: string;
   width: number;
   height: number;
+  canEdit: boolean;
   /** True when this artifact is the deep-link target of the current URL
    *  (`/a/<artifactShort>/`). Renders the same dashed "selected"
    *  outline used on BranchCard, layered on top of React Flow's
@@ -173,6 +175,8 @@ export const ArtifactNode = ({
   selected?: boolean;
 }) => {
   const { token } = theme.useToken();
+  const mutationGate = useMutationGate();
+  const layoutMutationDisabled = !mutationGate.canMutate || !data.canEdit;
   const [interactMode, setInteractMode] = useState(false);
   const [payload, setPayload] = useState<ArtifactPayload | null>(null);
   const [loading, setLoading] = useState(true);
@@ -233,6 +237,7 @@ export const ArtifactNode = ({
 
   const handleResize = useCallback(
     (_event: unknown, params: { x: number; y: number; width: number; height: number }) => {
+      if (layoutMutationDisabled) return;
       const objectData: ArtifactBoardObject = {
         type: 'artifact',
         x: params.x,
@@ -244,7 +249,7 @@ export const ArtifactNode = ({
       };
       data.onUpdate(data.objectId, objectData);
     },
-    [data]
+    [data, layoutMutationDisabled]
   );
 
   // The actual form-POST work happens inside <CodeSandboxExporter/>, which
@@ -256,6 +261,7 @@ export const ArtifactNode = ({
   // sandbox boots empty (no entry, no DOM root).
 
   const handleToggleLock = useCallback(() => {
+    if (layoutMutationDisabled) return;
     const objectData: ArtifactBoardObject = {
       type: 'artifact',
       x: data.x,
@@ -266,7 +272,7 @@ export const ArtifactNode = ({
       locked: !data.locked,
     };
     data.onUpdate(data.objectId, objectData);
-  }, [data]);
+  }, [data, layoutMutationDisabled]);
 
   const handleOpenInCodeSandbox = useCallback(() => {
     window.dispatchEvent(new CustomEvent(`agor:export-codesandbox-${data.artifactId}`));
@@ -341,7 +347,9 @@ export const ArtifactNode = ({
           <Button
             type="text"
             size="small"
+            aria-label={data.locked ? 'Unlock artifact card' : 'Lock artifact card'}
             icon={data.locked ? <LockOutlined /> : <UnlockOutlined />}
+            disabled={layoutMutationDisabled}
             onClick={(e) => {
               e.stopPropagation();
               handleToggleLock();
@@ -432,6 +440,7 @@ export const ArtifactNode = ({
                 size="small"
                 danger
                 icon={<DeleteOutlined />}
+                aria-label="Delete artifact"
                 onClick={(e) => e.stopPropagation()}
               />
             </Tooltip>
@@ -474,7 +483,7 @@ export const ArtifactNode = ({
   // Shared resizer — same across loading / error / normal states.
   const resizer = (
     <NodeResizer
-      isVisible={selected && !data.locked}
+      isVisible={selected && !data.locked && !layoutMutationDisabled}
       minWidth={MIN_WIDTH}
       minHeight={MIN_HEIGHT}
       onResize={handleResize}

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/BoardObjectNodes.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/BoardObjectNodes.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { App as AntApp } from 'antd';
 import type { ReactNode } from 'react';
 import { ReactFlowProvider } from 'reactflow';
@@ -11,7 +11,7 @@ const zoneConfigModalRenderSpy = vi.hoisted(() => vi.fn());
 vi.mock('./ZoneConfigModal', () => ({
   ZoneConfigModal: (props: { zoneName: string }) => {
     zoneConfigModalRenderSpy(props);
-    return <div data-testid="zone-config-modal">Configure Zone: {props.zoneName}</div>;
+    return <div data-testid="zone-config-modal">Zone settings: {props.zoneName}</div>;
   },
 }));
 
@@ -27,7 +27,7 @@ const DISCONNECTED = { ...CONNECTED, connected: false };
 function renderZone(
   onReorder: ReturnType<typeof vi.fn>,
   connection: typeof CONNECTED,
-  extra?: { selected?: boolean }
+  extra?: { selected?: boolean; canEdit?: boolean; onUpdate?: ReturnType<typeof vi.fn> }
 ) {
   const wrapper = ({ children }: { children: ReactNode }) => (
     <ConnectionProvider value={connection}>
@@ -47,6 +47,9 @@ function renderZone(
         x: 0,
         y: 0,
         zIndex: 100,
+        overlappingZoneCount: 2,
+        canEdit: extra?.canEdit,
+        onUpdate: extra?.onUpdate,
         onReorder,
       }}
     />,
@@ -54,82 +57,90 @@ function renderZone(
   );
 }
 
-describe('ZoneNode layer toolbar', () => {
-  it('exposes the layer buttons with accessible labels', () => {
+async function openArrangeMenu() {
+  fireEvent.click(screen.getByRole('button', { name: 'More zone actions' }));
+  const arrange = await screen.findByText('Arrange (2 overlapping)');
+  fireEvent.mouseEnter(arrange);
+  return screen.findByText('Bring to front');
+}
+
+describe('ZoneNode compact toolbar', () => {
+  it('keeps common actions top-level and buries layer controls in More', () => {
     renderZone(vi.fn(), CONNECTED);
-    expect(screen.getByLabelText('Send to back')).toBeTruthy();
-    expect(screen.getByLabelText('Send backward')).toBeTruthy();
-    expect(screen.getByLabelText('Bring forward')).toBeTruthy();
-    expect(screen.getByLabelText('Bring to front')).toBeTruthy();
+
+    expect(screen.getByRole('toolbar', { name: 'Zone actions' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Rename zone' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Zone appearance' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Lock position and size' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Zone settings' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'More zone actions' })).toBeInTheDocument();
+    expect(screen.queryByText('Bring to front')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Smaller label')).not.toBeInTheDocument();
   });
 
-  it('fires onReorder exactly once for a mouse gesture (pointerUp only, never click)', () => {
+  it('runs an arrange action once from the nested More menu', async () => {
     const onReorder = vi.fn();
     renderZone(onReorder, CONNECTED);
-    const btn = screen.getByLabelText('Bring to front');
-    // A full mouse tap: pointerDown → pointerUp → click. The action runs on
-    // pointerUp; the trailing click (detail 1) must NOT also fire it. Some touch
-    // engines emit a detail-0 synthesized click on tap too — assert that path is
-    // inert as well so touch can't double-step.
-    fireEvent.pointerDown(btn);
-    fireEvent.pointerUp(btn);
-    fireEvent.click(btn, { detail: 1 });
-    fireEvent.click(btn, { detail: 0 });
+
+    fireEvent.click(await openArrangeMenu());
+
+    await waitFor(() => expect(onReorder).toHaveBeenCalledWith('zone-1', 'front'));
     expect(onReorder).toHaveBeenCalledTimes(1);
-    expect(onReorder).toHaveBeenCalledWith('zone-1', 'front');
   });
 
-  it('fires onReorder exactly once on keyboard activation (Enter / Space)', () => {
-    const onReorder = vi.fn();
-    renderZone(onReorder, CONNECTED);
-    const btn = screen.getByLabelText('Bring forward');
-    fireEvent.keyDown(btn, { key: 'Enter' });
-    expect(onReorder).toHaveBeenCalledTimes(1);
-    expect(onReorder).toHaveBeenLastCalledWith('zone-1', 'forward');
+  it('uses native keyboard-focusable buttons for common actions', () => {
+    const onUpdate = vi.fn();
+    renderZone(vi.fn(), CONNECTED, { onUpdate });
 
-    fireEvent.keyDown(btn, { key: ' ' });
-    expect(onReorder).toHaveBeenCalledTimes(2);
-    expect(onReorder).toHaveBeenLastCalledWith('zone-1', 'forward');
+    const lock = screen.getByRole('button', { name: 'Lock position and size' });
+    lock.focus();
+    expect(lock).toHaveFocus();
+    fireEvent.click(lock);
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    expect(onUpdate.mock.calls[0][1]).toMatchObject({ locked: true });
   });
 
-  it('does not compound keyboard + the click the browser synthesizes after it', () => {
-    const onReorder = vi.fn();
-    renderZone(onReorder, CONNECTED);
-    const btn = screen.getByLabelText('Send to back');
-    // Real browsers fire a detail-0 click after Enter on a button. onKeyDown
-    // handles activation; onClick is inert — so the pair must total ONE call.
-    fireEvent.keyDown(btn, { key: 'Enter' });
-    fireEvent.click(btn, { detail: 0 });
-    expect(onReorder).toHaveBeenCalledTimes(1);
-    expect(onReorder).toHaveBeenCalledWith('zone-1', 'back');
+  it('removes mutating controls from the focus order while disconnected', () => {
+    renderZone(vi.fn(), DISCONNECTED);
+    expect(screen.queryByRole('toolbar', { name: 'Zone actions' })).not.toBeInTheDocument();
   });
 
-  it('does NOT fire onReorder when the mutation gate is closed (disconnected)', () => {
-    const onReorder = vi.fn();
-    renderZone(onReorder, DISCONNECTED);
-    const btn = screen.getByLabelText('Bring to front');
-    fireEvent.pointerDown(btn);
-    fireEvent.pointerUp(btn);
-    fireEvent.keyDown(btn, { key: 'Enter' });
-    fireEvent.click(btn, { detail: 0 });
-    expect(onReorder).not.toHaveBeenCalled();
+  it('does not expose editing chrome to viewers or when unselected', () => {
+    const { rerender } = renderZone(vi.fn(), CONNECTED, { canEdit: false });
+    expect(screen.queryByRole('toolbar', { name: 'Zone actions' })).not.toBeInTheDocument();
+
+    rerender(
+      <ZoneNode
+        selected={false}
+        data={{
+          objectId: 'zone-1',
+          label: 'My Zone',
+          width: 400,
+          height: 300,
+          x: 0,
+          y: 0,
+          canEdit: true,
+        }}
+      />
+    );
+    expect(screen.queryByRole('toolbar', { name: 'Zone actions' })).not.toBeInTheDocument();
   });
 });
 
-describe('ZoneNode config modal', () => {
+describe('ZoneNode settings modal', () => {
   beforeEach(() => {
     zoneConfigModalRenderSpy.mockClear();
   });
 
-  it('mounts the configuration modal only when the user opens it', () => {
+  it('mounts the settings modal only when the user opens it', () => {
     renderZone(vi.fn(), CONNECTED);
 
     expect(zoneConfigModalRenderSpy).not.toHaveBeenCalled();
     expect(screen.queryByTestId('zone-config-modal')).not.toBeInTheDocument();
 
-    fireEvent.pointerUp(screen.getByTitle('Configure zone'));
+    fireEvent.click(screen.getByRole('button', { name: 'Zone settings' }));
 
     expect(zoneConfigModalRenderSpy).toHaveBeenCalledTimes(1);
-    expect(screen.getByTestId('zone-config-modal')).toHaveTextContent('Configure Zone: My Zone');
+    expect(screen.getByTestId('zone-config-modal')).toHaveTextContent('Zone settings: My Zone');
   });
 });

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/BoardObjectNodes.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/BoardObjectNodes.tsx
@@ -19,7 +19,6 @@ import {
 } from '@ant-design/icons';
 import { Button, ColorPicker, Dropdown, Flex, Popover, Space, Typography, theme } from 'antd';
 import type { Color } from 'antd/es/color-picker';
-import { AggregationColor } from 'antd/es/color-picker/color';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { NodeResizer, useViewport } from 'reactflow';
 import { useMutationGate } from '../../../contexts/ConnectionContext';
@@ -28,7 +27,7 @@ import { getUserInitials } from '../../UserIdentityAvatar';
 import { DeleteZoneModal } from './DeleteZoneModal';
 import { ZoneConfigModal } from './ZoneConfigModal';
 import type { LayerOp } from './zOrder';
-import { ZONE_CONTENT_OPACITY } from './zoneAppearance';
+import { toTranslucentZoneFill, ZONE_CONTENT_OPACITY } from './zoneAppearance';
 import { effectiveLabelFontSize, statusFontSizeFor } from './zoneFontSize';
 
 // Preserve the existing import surface for CommentsPanel and external callers.
@@ -196,7 +195,9 @@ const ZoneNodeComponent = ({ data, selected }: { data: ZoneNodeData; selected?: 
           // before introducing borderColor, whose historical fallback is
           // opaque, so changing only the border has no surprise side effect.
           ...(data.color && !data.borderColor && !data.backgroundColor
-            ? { backgroundColor: colorToRgba(data.color, ZONE_CONTENT_OPACITY) }
+            ? {
+                backgroundColor: toTranslucentZoneFill(data.color, `${token.colorBgContainer}40`),
+              }
             : {}),
         })
       );
@@ -238,28 +239,13 @@ const ZoneNodeComponent = ({ data, selected }: { data: ZoneNodeData; selected?: 
   // Backwards compatibility: fall back to `color` if new fields not set
   const borderColor = data.borderColor || data.color || token.colorBorder;
 
-  // Helper to convert color to rgba with custom alpha (for backwards compatibility with old `color` field)
-  const colorToRgba = (colorStr: string, alpha: number): string => {
-    try {
-      const color = new AggregationColor(colorStr);
-      const rgb = color.toRgb();
-      // If the color already has alpha, multiply it with the requested alpha
-      const finalAlpha = rgb.a * alpha;
-      // biome-ignore lint/plugin/noHardcodedColorLiteral: persisted user color resolver emits CSS syntax from parsed channels
-      return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${finalAlpha})`;
-    } catch {
-      // Fallback to token if parsing fails
-      return `${token.colorBgContainer}40`;
-    }
-  };
-
   // Backwards compatibility: derive background from border if backgroundColor not set
   const backgroundColor =
     data.backgroundColor ||
     (data.borderColor
       ? data.borderColor // Use borderColor directly if set (supports alpha)
       : data.color
-        ? colorToRgba(data.color, ZONE_CONTENT_OPACITY) // Old behavior for backwards compat
+        ? toTranslucentZoneFill(data.color, `${token.colorBgContainer}40`)
         : `${token.colorBgContainer}40`);
 
   const getTextColor = (background: string): string => getContrastingTextColor(background, token);

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/BoardObjectNodes.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/BoardObjectNodes.tsx
@@ -4,6 +4,7 @@
 
 import type { BoardComment, BoardObject, User } from '@agor-live/client';
 import {
+  BgColorsOutlined,
   CaretDownOutlined,
   CaretUpOutlined,
   CommentOutlined,
@@ -435,14 +436,25 @@ const ZoneNodeComponent = ({ data, selected }: { data: ZoneNodeData; selected?: 
                   <span
                     aria-hidden="true"
                     style={{
-                      width: 16,
-                      height: 16,
-                      borderRadius: token.borderRadiusSM,
-                      border: `2px solid ${borderColor}`,
-                      background: backgroundColor,
-                      display: 'inline-block',
+                      position: 'relative',
+                      display: 'inline-flex',
+                      fontSize: token.fontSizeLG,
                     }}
-                  />
+                  >
+                    <BgColorsOutlined />
+                    <span
+                      style={{
+                        position: 'absolute',
+                        right: -4,
+                        bottom: -2,
+                        width: 9,
+                        height: 9,
+                        borderRadius: '50%',
+                        border: `1px solid ${token.colorBorder}`,
+                        background: backgroundColor,
+                      }}
+                    />
+                  </span>
                 }
                 style={{ width: 32, height: 32 }}
               />
@@ -645,10 +657,10 @@ const ZoneNodeComponent = ({ data, selected }: { data: ZoneNodeData; selected?: 
         <DeleteZoneModal
           open={deleteModalOpen}
           onCancel={() => setDeleteModalOpen(false)}
-          onConfirm={(deleteAssociatedSessions) => {
+          onConfirm={() => {
             setDeleteModalOpen(false);
             if (data.onDelete) {
-              data.onDelete(data.objectId, deleteAssociatedSessions);
+              data.onDelete(data.objectId, false);
             }
           }}
           zoneName={data.label}

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/BoardObjectNodes.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/BoardObjectNodes.tsx
@@ -48,6 +48,7 @@ const getColorPalette = (token: ReturnType<typeof theme.useToken>['token']) => [
 ];
 
 type ZoneBoardObject = Extract<BoardObject, { type: 'zone' }>;
+type BoardObjectUpdateResult = boolean | undefined | Promise<boolean | undefined>;
 
 /**
  * ZoneNode - Resizable rectangle for organizing sessions visually
@@ -55,7 +56,7 @@ type ZoneBoardObject = Extract<BoardObject, { type: 'zone' }>;
 interface ZoneNodeData extends Omit<ZoneBoardObject, 'type'> {
   objectId: string;
   pinnedItemCount?: number;
-  onUpdate?: (objectId: string, objectData: BoardObject) => void;
+  onUpdate?: (objectId: string, objectData: BoardObject) => BoardObjectUpdateResult;
   onDelete?: (objectId: string, deleteAssociatedSessions: boolean) => void;
   onReorder?: (objectId: string, op: LayerOp) => void;
   /** Effective board.edit capability. Omitted only by isolated tests/fixtures. */
@@ -634,7 +635,7 @@ const ZoneNodeComponent = ({ data, selected }: { data: ZoneNodeData; selected?: 
           onCancel={() => setConfigModalOpen(false)}
           zoneName={data.label}
           objectId={data.objectId}
-          onUpdate={data.onUpdate || (() => {})}
+          onUpdate={data.onUpdate || (() => undefined)}
           zoneData={zoneData}
           canEdit={data.canEdit !== false}
         />
@@ -651,6 +652,7 @@ const ZoneNodeComponent = ({ data, selected }: { data: ZoneNodeData; selected?: 
           }}
           zoneName={data.label}
           pinnedItemCount={data.pinnedItemCount || 0}
+          canEdit={data.canEdit !== false}
         />
       )}
     </>

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/BoardObjectNodes.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/BoardObjectNodes.tsx
@@ -8,14 +8,15 @@ import {
   CaretUpOutlined,
   CommentOutlined,
   DeleteOutlined,
-  FontSizeOutlined,
+  EditOutlined,
   LockOutlined,
+  MoreOutlined,
   SettingOutlined,
   UnlockOutlined,
   VerticalAlignBottomOutlined,
   VerticalAlignTopOutlined,
 } from '@ant-design/icons';
-import { ColorPicker, theme } from 'antd';
+import { Button, ColorPicker, Dropdown, Flex, Popover, Space, Typography, theme } from 'antd';
 import type { Color } from 'antd/es/color-picker';
 import { AggregationColor } from 'antd/es/color-picker/color';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
@@ -26,17 +27,11 @@ import { getUserInitials } from '../../UserIdentityAvatar';
 import { DeleteZoneModal } from './DeleteZoneModal';
 import { ZoneConfigModal } from './ZoneConfigModal';
 import type { LayerOp } from './zOrder';
-import {
-  clampZoneFontSize,
-  effectiveLabelFontSize,
-  statusFontSizeFor,
-  ZONE_FONT_SIZE_MAX,
-  ZONE_FONT_SIZE_MIN,
-  ZONE_FONT_SIZE_STEP,
-} from './zoneFontSize';
+import { ZONE_CONTENT_OPACITY } from './zoneAppearance';
+import { effectiveLabelFontSize, statusFontSizeFor } from './zoneFontSize';
 
-// Zone content opacity constant - used for zone background and color indicator
-export const ZONE_CONTENT_OPACITY = 0.1;
+// Preserve the existing import surface for CommentsPanel and external callers.
+export { ZONE_CONTENT_OPACITY } from './zoneAppearance';
 
 /**
  * Get color palette from Ant Design preset colors
@@ -63,6 +58,12 @@ interface ZoneNodeData extends Omit<ZoneBoardObject, 'type'> {
   onUpdate?: (objectId: string, objectData: BoardObject) => void;
   onDelete?: (objectId: string, deleteAssociatedSessions: boolean) => void;
   onReorder?: (objectId: string, op: LayerOp) => void;
+  /** Effective board.edit capability. Omitted only by isolated tests/fixtures. */
+  canEdit?: boolean;
+  /** Number of other zones whose rectangles intersect this zone. */
+  overlappingZoneCount?: number;
+  /** Whether each relative layer operation would change persisted order. */
+  layerAvailability?: Record<LayerOp, boolean>;
 }
 
 // Local storage key for recent colors
@@ -99,17 +100,15 @@ const ZoneNodeComponent = ({ data, selected }: { data: ZoneNodeData; selected?: 
   const [label, setLabel] = useState(data.label);
   const [configModalOpen, setConfigModalOpen] = useState(false);
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
-  const [toolbarVisible, setToolbarVisible] = useState(false);
   const [recentColors, setRecentColors] = useState<string[]>(getRecentColors());
   const labelInputRef = useRef<HTMLInputElement>(null);
   const colors = getColorPalette(token);
 
-  // Connection gate: when disconnected / reconnecting / out-of-sync, every
-  // mutator inside the zone (resize, label edit, color, lock, config, delete)
-  // short-circuits. The toolbar is still rendered for read-only signal but
-  // its controls visually dim and silently no-op on click.
+  // Both connectivity and effective board.edit permission gate every zone
+  // mutation. Production callers always provide canEdit; omission keeps old
+  // isolated fixtures backwards compatible.
   const mutationGate = useMutationGate();
-  const mutationDisabled = !mutationGate.canMutate;
+  const mutationDisabled = !mutationGate.canMutate || data.canEdit === false;
 
   // Inverse scale to keep toolbar at constant size regardless of zoom
   const scale = 1 / zoom;
@@ -118,17 +117,6 @@ const ZoneNodeComponent = ({ data, selected }: { data: ZoneNodeData; selected?: 
   useEffect(() => {
     setLabel(data.label);
   }, [data.label]);
-
-  // Sync toolbar visibility with selected state
-  useEffect(() => {
-    if (selected) {
-      setToolbarVisible(true);
-    } else {
-      // Delay hiding to prevent flicker during re-renders
-      const timer = setTimeout(() => setToolbarVisible(false), 100);
-      return () => clearTimeout(timer);
-    }
-  }, [selected]);
 
   // Auto-focus input when entering edit mode
   useEffect(() => {
@@ -199,7 +187,18 @@ const ZoneNodeComponent = ({ data, selected }: { data: ZoneNodeData; selected?: 
     if (mutationDisabled) return;
     const hexColor = color.toHexString();
     if (data.onUpdate) {
-      data.onUpdate(data.objectId, createObjectData({ borderColor: hexColor }));
+      data.onUpdate(
+        data.objectId,
+        createObjectData({
+          borderColor: hexColor,
+          // A legacy `color` drove a translucent fill. Materialize that fill
+          // before introducing borderColor, whose historical fallback is
+          // opaque, so changing only the border has no surprise side effect.
+          ...(data.color && !data.borderColor && !data.backgroundColor
+            ? { backgroundColor: colorToRgba(data.color, ZONE_CONTENT_OPACITY) }
+            : {}),
+        })
+      );
     }
     // Save to recent colors and update state
     saveRecentColor(hexColor);
@@ -230,106 +229,9 @@ const ZoneNodeComponent = ({ data, selected }: { data: ZoneNodeData; selected?: 
   const labelFontSize = effectiveLabelFontSize(data.fontSize, token.fontSize);
   // Status keeps its smaller relative size, scaled from the label size when set.
   const statusFontSize = statusFontSizeFor(data.fontSize, token.fontSize, token.fontSizeSM);
-  const atMinFontSize = labelFontSize <= ZONE_FONT_SIZE_MIN;
-  const atMaxFontSize = labelFontSize >= ZONE_FONT_SIZE_MAX;
-
-  const handleFontSizeStep = (delta: number) => {
-    if (mutationDisabled) return;
-    const next = clampZoneFontSize(labelFontSize, delta);
-    if (next !== labelFontSize && data.onUpdate) {
-      data.onUpdate(data.objectId, createObjectData({ fontSize: next }));
-    }
-  };
-
   const handleReorder = (op: LayerOp) => {
     if (mutationDisabled) return;
     data.onReorder?.(data.objectId, op);
-  };
-
-  // Shared style for the compact square icon buttons in the toolbar.
-  const iconButtonStyle: React.CSSProperties = {
-    width: '20px',
-    height: '20px',
-    borderRadius: '3px',
-    backgroundColor: token.colorBgContainer,
-    border: `1px solid ${token.colorBorder}`,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    userSelect: 'none',
-    cursor: 'pointer',
-    padding: 0,
-    color: token.colorText,
-  };
-
-  const verticalDivider = (
-    <div
-      style={{
-        width: '1px',
-        height: '24px',
-        backgroundColor: token.colorBorder,
-        margin: '0 2px',
-        alignSelf: 'center',
-      }}
-    />
-  );
-
-  // A toolbar icon button that runs `action` on pointer-up (matching the
-  // existing lock/settings/delete buttons' event handling). Pointer-up covers
-  // both mouse and touch (a tap synthesizes a click, but we never act on click).
-  // Keyboard activation is driven EXPLICITLY from onKeyDown (Enter/Space) — we
-  // deliberately do NOT infer keyboard from a `detail === 0` click, because some
-  // touch engines also report detail === 0 for tap-synthesized clicks, which
-  // would double-fire (pointerUp + click). onClick only swallows propagation.
-  const renderActionButton = (
-    key: string,
-    title: string,
-    icon: React.ReactNode,
-    action: () => void,
-    disabled = false
-  ) => (
-    <button
-      key={key}
-      type="button"
-      aria-label={title}
-      disabled={disabled}
-      onPointerDown={(e) => {
-        e.preventDefault();
-        e.stopPropagation();
-      }}
-      onPointerUp={(e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        if (mutationDisabled || disabled) return;
-        action();
-      }}
-      onKeyDown={(e) => {
-        if (e.key !== 'Enter' && e.key !== ' ') return;
-        e.preventDefault();
-        e.stopPropagation();
-        if (mutationDisabled || disabled) return;
-        action();
-      }}
-      onClick={(e) => {
-        e.preventDefault();
-        e.stopPropagation();
-      }}
-      style={{
-        ...iconButtonStyle,
-        ...(disabled ? { opacity: 0.4, cursor: 'not-allowed' } : {}),
-      }}
-      title={title}
-    >
-      {icon}
-    </button>
-  );
-
-  const layerIconStyle: React.CSSProperties = {
-    fontSize: '12px',
-    color: token.colorText,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
   };
 
   // Backwards compatibility: fall back to `color` if new fields not set
@@ -395,410 +297,257 @@ const ZoneNodeComponent = ({ data, selected }: { data: ZoneNodeData; selected?: 
           position: 'relative',
         }}
       >
-        {/* Toolbar - ALWAYS rendered, visibility controlled by CSS only */}
-        <div
-          className="nodrag nopan"
-          onPointerDown={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-          }}
-          onPointerUp={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-          }}
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-          }}
-          style={{
-            position: 'absolute',
-            top: '-44px',
-            left: '50%',
-            transform: `translateX(-50%) scale(${scale})`,
-            transformOrigin: 'center bottom',
-            display: 'flex',
-            alignItems: 'center',
-            gap: '8px',
-            padding: '6px',
-            background: token.colorBgElevated,
-            border: `1px solid ${token.colorBorder}`,
-            borderRadius: token.borderRadius,
-            boxShadow: token.boxShadowSecondary,
-            zIndex: 1000,
-            userSelect: 'none',
-            // CSS-only visibility control (no DOM changes). When the
-            // connection gate is closed we also dim and block clicks so the
-            // toolbar reads as read-only and never accidentally fires.
-            opacity: toolbarVisible ? (mutationDisabled ? 0.5 : 1) : 0,
-            pointerEvents: toolbarVisible && !mutationDisabled ? 'auto' : 'none',
-            transition: 'opacity 0.15s ease',
-          }}
-        >
-          {/* Border Color Picker */}
+        {selected && !mutationDisabled && (
           <div
             className="nodrag nopan"
-            onPointerDown={(e) => {
-              e.stopPropagation();
-            }}
-            onPointerUp={(e) => {
-              e.stopPropagation();
-            }}
-            style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
-          >
-            <span
-              style={{
-                fontSize: '11px',
-                color: token.colorTextSecondary,
-                fontWeight: 500,
-                userSelect: 'none',
-                lineHeight: 1,
-              }}
-            >
-              Border
-            </span>
-            <ColorPicker
-              value={borderColor}
-              onChange={handleBorderColorChange}
-              trigger="click"
-              destroyTooltipOnHide
-              showText={false}
-              format="hex"
-              presets={[
-                {
-                  label: 'Presets',
-                  colors: colors,
-                },
-                ...(recentColors.length > 0
-                  ? [
-                      {
-                        label: 'Recent',
-                        colors: recentColors,
-                      },
-                    ]
-                  : []),
-              ]}
-            >
-              <button
-                type="button"
-                style={{
-                  width: '20px',
-                  height: '20px',
-                  borderRadius: '3px',
-                  backgroundColor: borderColor,
-                  border: `1px solid ${token.colorBorder}`,
-                  userSelect: 'none',
-                  cursor: 'pointer',
-                  padding: 0,
-                  boxShadow: token.boxShadowSecondary,
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                }}
-                title="Change border color"
-              />
-            </ColorPicker>
-          </div>
-          <div
+            role="toolbar"
+            aria-label="Zone actions"
+            onPointerDown={(event) => event.stopPropagation()}
+            onPointerUp={(event) => event.stopPropagation()}
+            onClick={(event) => event.stopPropagation()}
             style={{
-              width: '1px',
-              height: '24px',
-              backgroundColor: token.colorBorder,
-              margin: '0 2px',
-              alignSelf: 'center',
-            }}
-          />
-          {/* Background Color Picker */}
-          <div
-            className="nodrag nopan"
-            onPointerDown={(e) => {
-              e.stopPropagation();
-            }}
-            onPointerUp={(e) => {
-              e.stopPropagation();
-            }}
-            style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
-          >
-            <span
-              style={{
-                fontSize: '11px',
-                color: token.colorTextSecondary,
-                fontWeight: 500,
-                userSelect: 'none',
-                lineHeight: 1,
-              }}
-            >
-              Fill
-            </span>
-            <ColorPicker
-              value={backgroundColor}
-              onChange={handleBackgroundColorChange}
-              trigger="click"
-              destroyTooltipOnHide
-              showText={false}
-              format="hex"
-              presets={[
-                {
-                  label: 'Presets',
-                  colors: colors.map(
-                    (c) =>
-                      `${c}${Math.round(ZONE_CONTENT_OPACITY * 255)
-                        .toString(16)
-                        .padStart(2, '0')}`
-                  ),
-                },
-                ...(recentColors.length > 0
-                  ? [
-                      {
-                        label: 'Recent',
-                        colors: recentColors,
-                      },
-                    ]
-                  : []),
-              ]}
-            >
-              <button
-                type="button"
-                style={{
-                  width: '20px',
-                  height: '20px',
-                  borderRadius: '3px',
-                  backgroundColor: backgroundColor,
-                  border: `1px solid ${token.colorBorder}`,
-                  userSelect: 'none',
-                  cursor: 'pointer',
-                  padding: 0,
-                  boxShadow: token.boxShadowSecondary,
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                }}
-                title="Change background color"
-              />
-            </ColorPicker>
-          </div>
-          <div
-            style={{
-              width: '1px',
-              height: '24px',
-              backgroundColor: token.colorBorder,
-              margin: '0 2px',
-              alignSelf: 'center',
-            }}
-          />
-          {/* Lock/Unlock Button */}
-          <button
-            type="button"
-            onPointerDown={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-            }}
-            onPointerUp={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              if (mutationDisabled) return;
-              handleToggleLock();
-            }}
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-            }}
-            style={{
-              width: '20px',
-              height: '20px',
-              borderRadius: '3px',
-              backgroundColor: data.locked ? token.colorWarningBg : token.colorBgContainer,
-              border: `1px solid ${data.locked ? token.colorWarning : token.colorBorder}`,
+              position: 'absolute',
+              top: '-48px',
+              left: '50%',
+              transform: `translateX(-50%) scale(${scale})`,
+              transformOrigin: 'center bottom',
               display: 'flex',
               alignItems: 'center',
-              justifyContent: 'center',
-              userSelect: 'none',
-              cursor: 'pointer',
-              padding: 0,
-            }}
-            title={data.locked ? 'Unlock zone' : 'Lock zone'}
-          >
-            {data.locked ? (
-              <LockOutlined
-                style={{
-                  fontSize: '12px',
-                  color: token.colorWarning,
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                }}
-              />
-            ) : (
-              <UnlockOutlined
-                style={{
-                  fontSize: '12px',
-                  color: token.colorText,
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                }}
-              />
-            )}
-          </button>
-          {verticalDivider}
-          {/* Layer (z-order) controls */}
-          <div
-            className="nodrag nopan"
-            style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
-          >
-            {renderActionButton(
-              'to-back',
-              'Send to back',
-              <VerticalAlignBottomOutlined style={layerIconStyle} />,
-              () => handleReorder('back')
-            )}
-            {renderActionButton(
-              'send-backward',
-              'Send backward',
-              <CaretDownOutlined style={layerIconStyle} />,
-              () => handleReorder('backward')
-            )}
-            {renderActionButton(
-              'bring-forward',
-              'Bring forward',
-              <CaretUpOutlined style={layerIconStyle} />,
-              () => handleReorder('forward')
-            )}
-            {renderActionButton(
-              'to-front',
-              'Bring to front',
-              <VerticalAlignTopOutlined style={layerIconStyle} />,
-              () => handleReorder('front')
-            )}
-          </div>
-          {verticalDivider}
-          {/* Label font-size stepper */}
-          <div
-            className="nodrag nopan"
-            style={{ display: 'flex', alignItems: 'center', gap: '4px' }}
-          >
-            <FontSizeOutlined
-              style={{ fontSize: '12px', color: token.colorTextSecondary }}
-              title="Label font size"
-            />
-            {renderActionButton(
-              'font-smaller',
-              'Smaller label',
-              <span style={{ fontSize: '13px', lineHeight: 1, fontWeight: 600 }}>−</span>,
-              () => handleFontSizeStep(-ZONE_FONT_SIZE_STEP),
-              atMinFontSize
-            )}
-            <span
-              style={{
-                fontSize: '11px',
-                color: token.colorTextSecondary,
-                fontVariantNumeric: 'tabular-nums',
-                minWidth: '20px',
-                textAlign: 'center',
-                userSelect: 'none',
-              }}
-            >
-              {Math.round(labelFontSize)}
-            </span>
-            {renderActionButton(
-              'font-larger',
-              'Larger label',
-              <span style={{ fontSize: '13px', lineHeight: 1, fontWeight: 600 }}>+</span>,
-              () => handleFontSizeStep(ZONE_FONT_SIZE_STEP),
-              atMaxFontSize
-            )}
-          </div>
-          {verticalDivider}
-          <button
-            type="button"
-            onPointerDown={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-            }}
-            onPointerUp={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              if (mutationDisabled) return;
-              setConfigModalOpen(true);
-            }}
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-            }}
-            style={{
-              width: '20px',
-              height: '20px',
-              borderRadius: '3px',
-              backgroundColor: token.colorBgContainer,
+              gap: token.marginXXS,
+              padding: token.paddingXXS,
+              background: token.colorBgElevated,
               border: `1px solid ${token.colorBorder}`,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
+              borderRadius: token.borderRadiusLG,
+              boxShadow: token.boxShadowSecondary,
+              zIndex: 1000,
               userSelect: 'none',
-              cursor: 'pointer',
-              padding: 0,
+              whiteSpace: 'nowrap',
+              pointerEvents: 'auto',
             }}
-            title="Configure zone"
           >
-            <SettingOutlined
+            <Button
+              type="text"
+              size="small"
+              aria-label="Rename zone"
+              title="Rename zone"
+              icon={<EditOutlined />}
+              disabled={mutationDisabled}
+              onClick={() => setIsEditingLabel(true)}
+              style={{ width: 32, height: 32 }}
+            />
+
+            <Popover
+              trigger="click"
+              placement="bottom"
+              title="Appearance"
+              content={
+                <Space orientation="vertical" size="middle" style={{ width: 240 }}>
+                  <Flex justify="space-between" align="center" gap="middle">
+                    <Typography.Text>Border</Typography.Text>
+                    <ColorPicker
+                      value={borderColor}
+                      onChangeComplete={handleBorderColorChange}
+                      trigger="click"
+                      showText
+                      format="hex"
+                      presets={[
+                        { label: 'Presets', colors },
+                        ...(recentColors.length > 0
+                          ? [{ label: 'Recent', colors: recentColors }]
+                          : []),
+                      ]}
+                    >
+                      <Button
+                        aria-label="Zone border color"
+                        icon={
+                          <span
+                            aria-hidden="true"
+                            style={{
+                              width: 14,
+                              height: 14,
+                              borderRadius: token.borderRadiusSM,
+                              background: borderColor,
+                              display: 'inline-block',
+                            }}
+                          />
+                        }
+                      >
+                        {borderColor.toUpperCase()}
+                      </Button>
+                    </ColorPicker>
+                  </Flex>
+                  <Flex justify="space-between" align="center" gap="middle">
+                    <Typography.Text>Fill</Typography.Text>
+                    <ColorPicker
+                      value={backgroundColor}
+                      onChangeComplete={handleBackgroundColorChange}
+                      trigger="click"
+                      showText
+                      format="hex"
+                      presets={[
+                        {
+                          label: 'Presets',
+                          colors: colors.map(
+                            (color) =>
+                              `${color}${Math.round(ZONE_CONTENT_OPACITY * 255)
+                                .toString(16)
+                                .padStart(2, '0')}`
+                          ),
+                        },
+                        ...(recentColors.length > 0
+                          ? [{ label: 'Recent', colors: recentColors }]
+                          : []),
+                      ]}
+                    >
+                      <Button
+                        aria-label="Zone fill color"
+                        icon={
+                          <span
+                            aria-hidden="true"
+                            style={{
+                              width: 14,
+                              height: 14,
+                              borderRadius: token.borderRadiusSM,
+                              border: `1px solid ${token.colorBorder}`,
+                              background: backgroundColor,
+                              display: 'inline-block',
+                            }}
+                          />
+                        }
+                      >
+                        {backgroundColor.toUpperCase()}
+                      </Button>
+                    </ColorPicker>
+                  </Flex>
+                  <Typography.Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
+                    Label size and theme defaults are in Zone settings.
+                  </Typography.Text>
+                </Space>
+              }
+            >
+              <Button
+                type="text"
+                size="small"
+                aria-label="Zone appearance"
+                title="Zone appearance"
+                disabled={mutationDisabled}
+                icon={
+                  <span
+                    aria-hidden="true"
+                    style={{
+                      width: 16,
+                      height: 16,
+                      borderRadius: token.borderRadiusSM,
+                      border: `2px solid ${borderColor}`,
+                      background: backgroundColor,
+                      display: 'inline-block',
+                    }}
+                  />
+                }
+                style={{ width: 32, height: 32 }}
+              />
+            </Popover>
+
+            <Button
+              type={data.locked ? 'default' : 'text'}
+              size="small"
+              aria-label={data.locked ? 'Unlock position and size' : 'Lock position and size'}
+              title={data.locked ? 'Unlock position and size' : 'Lock position and size'}
+              icon={data.locked ? <LockOutlined /> : <UnlockOutlined />}
+              disabled={mutationDisabled}
+              onClick={handleToggleLock}
               style={{
-                fontSize: '12px',
-                color: token.colorText,
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
+                width: 32,
+                height: 32,
+                ...(data.locked
+                  ? { color: token.colorWarning, borderColor: token.colorWarning }
+                  : {}),
               }}
             />
-          </button>
-          <button
-            type="button"
-            onPointerDown={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-            }}
-            onPointerUp={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              if (mutationDisabled) return;
-              setDeleteModalOpen(true);
-            }}
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-            }}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.color = token.colorError;
-              e.currentTarget.style.borderColor = token.colorError;
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.color = token.colorTextSecondary;
-              e.currentTarget.style.borderColor = token.colorBorder;
-            }}
-            style={{
-              width: '20px',
-              height: '20px',
-              borderRadius: '3px',
-              backgroundColor: token.colorBgContainer,
-              border: `1px solid ${token.colorBorder}`,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              userSelect: 'none',
-              cursor: 'pointer',
-              padding: 0,
-              color: token.colorTextSecondary,
-            }}
-            title="Delete zone"
-          >
-            <DeleteOutlined
-              style={{
-                fontSize: '12px',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-              }}
+
+            <Button
+              type="text"
+              size="small"
+              aria-label="Zone settings"
+              title="Zone settings"
+              icon={<SettingOutlined />}
+              disabled={mutationDisabled}
+              onClick={() => setConfigModalOpen(true)}
+              style={{ width: 32, height: 32 }}
             />
-          </button>
-        </div>
+
+            <Dropdown
+              trigger={['click']}
+              placement="bottomRight"
+              menu={{
+                items: [
+                  {
+                    key: 'arrange',
+                    label:
+                      data.overlappingZoneCount && data.overlappingZoneCount > 0
+                        ? `Arrange (${data.overlappingZoneCount} overlapping)`
+                        : 'Arrange',
+                    icon: <VerticalAlignTopOutlined />,
+                    children: [
+                      {
+                        key: 'front',
+                        label: 'Bring to front',
+                        icon: <VerticalAlignTopOutlined />,
+                        disabled: data.layerAvailability?.front === false,
+                      },
+                      {
+                        key: 'forward',
+                        label: 'Bring forward',
+                        icon: <CaretUpOutlined />,
+                        disabled: data.layerAvailability?.forward === false,
+                      },
+                      {
+                        key: 'backward',
+                        label: 'Send backward',
+                        icon: <CaretDownOutlined />,
+                        disabled: data.layerAvailability?.backward === false,
+                      },
+                      {
+                        key: 'back',
+                        label: 'Send to back',
+                        icon: <VerticalAlignBottomOutlined />,
+                        disabled: data.layerAvailability?.back === false,
+                      },
+                    ],
+                  },
+                  { type: 'divider' },
+                  { key: 'delete', label: 'Delete zone', icon: <DeleteOutlined />, danger: true },
+                ],
+                onClick: ({ key, domEvent }) => {
+                  domEvent.stopPropagation();
+                  if (mutationDisabled) return;
+                  if (key === 'delete') {
+                    setDeleteModalOpen(true);
+                    return;
+                  }
+                  if (
+                    key === 'front' ||
+                    key === 'forward' ||
+                    key === 'backward' ||
+                    key === 'back'
+                  ) {
+                    handleReorder(key);
+                  }
+                },
+              }}
+            >
+              <Button
+                type="text"
+                size="small"
+                aria-label="More zone actions"
+                title="More zone actions"
+                icon={<MoreOutlined />}
+                disabled={mutationDisabled}
+                style={{ width: 32, height: 32 }}
+              />
+            </Dropdown>
+          </div>
+        )}
         <div
           style={{
             pointerEvents: 'auto',
@@ -889,6 +638,7 @@ const ZoneNodeComponent = ({ data, selected }: { data: ZoneNodeData; selected?: 
           objectId={data.objectId}
           onUpdate={data.onUpdate || (() => {})}
           zoneData={zoneData}
+          canEdit={data.canEdit !== false}
         />
       )}
       {deleteModalOpen && (

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/BoardStructuralControls.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/BoardStructuralControls.test.tsx
@@ -1,0 +1,142 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { App as AntApp } from 'antd';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ConnectionProvider } from '../../../contexts/ConnectionContext';
+import { AppNode } from './AppNode';
+import { ArtifactNode } from './ArtifactNode';
+import { MarkdownNode } from './MarkdownNode';
+
+const resizerSpy = vi.hoisted(() => vi.fn());
+
+vi.mock('reactflow', () => ({
+  NodeResizer: (props: { isVisible?: boolean }) => {
+    resizerSpy(props);
+    return <div data-testid="node-resizer" data-visible={String(Boolean(props.isVisible))} />;
+  },
+}));
+
+vi.mock('@codesandbox/sandpack-react', () => ({
+  SandpackProvider: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  SandpackPreview: () => <div data-testid="sandpack-preview" />,
+  useSandpack: () => ({ sandpack: { files: {}, environment: 'react' } }),
+}));
+
+vi.mock('@/utils/sandpackCrypto', () => ({
+  ensureSandpackCryptoSubtle: vi.fn(),
+}));
+
+const connection = {
+  connected: true,
+  connecting: false,
+  authGeneration: 1,
+  outOfSync: false,
+  capturedSha: null,
+  currentSha: null,
+};
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <ConnectionProvider value={connection}>
+    <AntApp>{children}</AntApp>
+  </ConnectionProvider>
+);
+
+beforeEach(() => {
+  resizerSpy.mockClear();
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(() => new Promise(() => undefined))
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('structural board-object controls', () => {
+  it('disables Markdown edit and delete controls when board.edit is revoked', () => {
+    const onEdit = vi.fn();
+    const onDelete = vi.fn();
+    const data = {
+      objectId: 'note-1',
+      content: 'Review notes',
+      width: 400,
+      canEdit: true,
+      onUpdate: vi.fn(),
+      onEdit,
+      onDelete,
+    };
+    const { container, rerender } = render(<MarkdownNode data={data} />, { wrapper });
+
+    expect(container.querySelector('button[aria-label="Edit note"]')).toBeEnabled();
+    rerender(<MarkdownNode data={{ ...data, canEdit: false }} />);
+
+    const edit = container.querySelector<HTMLButtonElement>('button[aria-label="Edit note"]');
+    const remove = container.querySelector<HTMLButtonElement>('button[aria-label="Delete note"]');
+    expect(edit).toBeDisabled();
+    expect(remove).toBeDisabled();
+    fireEvent.click(edit!);
+    fireEvent.click(remove!);
+    expect(onEdit).not.toHaveBeenCalled();
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it('hides the App resizer and disables deletion when board.edit is revoked', () => {
+    const onDelete = vi.fn();
+    const data = {
+      objectId: 'app-1',
+      title: 'Preview',
+      template: 'react' as const,
+      files: { '/src.tsx': 'export default null' },
+      width: 400,
+      height: 300,
+      canEdit: true,
+      onUpdate: vi.fn(),
+      onDelete,
+    };
+    const { container, rerender } = render(<AppNode data={data} selected />, { wrapper });
+
+    expect(screen.getByTestId('node-resizer')).toHaveAttribute('data-visible', 'true');
+    rerender(<AppNode data={{ ...data, canEdit: false }} selected />);
+
+    const remove = container.querySelector<HTMLButtonElement>('button[aria-label="Delete app"]');
+    expect(screen.getByTestId('node-resizer')).toHaveAttribute('data-visible', 'false');
+    expect(remove).toBeDisabled();
+    fireEvent.click(remove!);
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it('hides the Artifact resizer and disables layout locking after revocation', () => {
+    const onUpdate = vi.fn();
+    const data = {
+      objectId: 'artifact-object-1',
+      artifactId: 'artifact-1',
+      width: 400,
+      height: 300,
+      canEdit: true,
+      onUpdate,
+      x: 10,
+      y: 20,
+      locked: false,
+      onDeleteArtifact: vi.fn(),
+    };
+    const { container, rerender } = render(<ArtifactNode data={data} selected />, { wrapper });
+
+    expect(screen.getByTestId('node-resizer')).toHaveAttribute('data-visible', 'true');
+    rerender(<ArtifactNode data={{ ...data, canEdit: false }} selected />);
+
+    const lock = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Lock artifact card"]'
+    );
+    const remove = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Delete artifact"]'
+    );
+    expect(screen.getByTestId('node-resizer')).toHaveAttribute('data-visible', 'false');
+    expect(lock).toBeDisabled();
+    // Artifact lifecycle deletion keeps its creator/admin authorization path;
+    // board.edit gates only layout controls here.
+    expect(remove).toBeEnabled();
+    fireEvent.click(lock!);
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/BoardStructuralControls.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/BoardStructuralControls.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { App as AntApp } from 'antd';
 import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -43,6 +43,9 @@ const wrapper = ({ children }: { children: ReactNode }) => (
 
 beforeEach(() => {
   resizerSpy.mockClear();
+  connection.connected = true;
+  connection.connecting = false;
+  connection.outOfSync = false;
   vi.stubGlobal(
     'fetch',
     vi.fn(() => new Promise(() => undefined))
@@ -106,8 +109,9 @@ describe('structural board-object controls', () => {
     expect(onDelete).not.toHaveBeenCalled();
   });
 
-  it('hides the Artifact resizer and disables layout locking after revocation', () => {
+  it('keeps artifact deletion independent of board.edit but gates its open confirmation on connection state', async () => {
     const onUpdate = vi.fn();
+    const onDeleteArtifact = vi.fn();
     const data = {
       objectId: 'artifact-object-1',
       artifactId: 'artifact-1',
@@ -118,7 +122,7 @@ describe('structural board-object controls', () => {
       x: 10,
       y: 20,
       locked: false,
-      onDeleteArtifact: vi.fn(),
+      onDeleteArtifact,
     };
     const { container, rerender } = render(<ArtifactNode data={data} selected />, { wrapper });
 
@@ -138,5 +142,30 @@ describe('structural board-object controls', () => {
     expect(remove).toBeEnabled();
     fireEvent.click(lock!);
     expect(onUpdate).not.toHaveBeenCalled();
+
+    fireEvent.click(remove!);
+    await screen.findByText('Delete artifact?');
+    const findConfirm = () =>
+      Array.from(document.querySelectorAll<HTMLButtonElement>('button')).find(
+        (button) => button.textContent === 'Delete'
+      );
+    expect(findConfirm()).toBeEnabled();
+
+    connection.connecting = true;
+    rerender(<ArtifactNode data={{ ...data, canEdit: false }} selected />);
+
+    expect(
+      container.querySelector<HTMLButtonElement>('button[aria-label="Delete artifact"]')
+    ).toBeDisabled();
+    await waitFor(() => expect(screen.queryByText('Delete artifact?')).not.toBeInTheDocument());
+    expect(onDeleteArtifact).not.toHaveBeenCalled();
+
+    connection.connecting = false;
+    connection.outOfSync = true;
+    rerender(<ArtifactNode data={{ ...data, canEdit: false }} selected />);
+    expect(
+      container.querySelector<HTMLButtonElement>('button[aria-label="Delete artifact"]')
+    ).toBeDisabled();
+    expect(findConfirm()).toBeUndefined();
   });
 });

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/DeleteZoneModal.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/DeleteZoneModal.test.tsx
@@ -26,7 +26,7 @@ describe('DeleteZoneModal', () => {
     expect(
       screen.getByText(/Branches, cards, comments, notes, and sessions are kept/)
     ).toBeInTheDocument();
-    expect(screen.getByText('2 pinned items will be unpinned')).toBeInTheDocument();
+    expect(screen.getByText('2 pinned branches/cards will be unpinned')).toBeInTheDocument();
     expect(screen.queryByText(/Delete pinned items too/)).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Delete zone' }));

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/DeleteZoneModal.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/DeleteZoneModal.test.tsx
@@ -1,0 +1,35 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { App as AntdApp } from 'antd';
+import { describe, expect, it, vi } from 'vitest';
+import { DeleteZoneModal } from './DeleteZoneModal';
+
+vi.mock('../../../contexts/ConnectionContext', () => ({
+  useMutationGate: () => ({ canMutate: true }),
+}));
+
+describe('DeleteZoneModal', () => {
+  it('makes the non-destructive orphaning behavior explicit', () => {
+    const onConfirm = vi.fn();
+    render(
+      <AntdApp>
+        <DeleteZoneModal
+          open
+          onCancel={vi.fn()}
+          onConfirm={onConfirm}
+          zoneName="Review"
+          pinnedItemCount={2}
+        />
+      </AntdApp>
+    );
+
+    expect(screen.getByText(/This removes only the zone/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Branches, cards, comments, notes, and sessions are kept/)
+    ).toBeInTheDocument();
+    expect(screen.getByText('2 pinned items will be unpinned')).toBeInTheDocument();
+    expect(screen.queryByText(/Delete pinned items too/)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete zone' }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/DeleteZoneModal.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/DeleteZoneModal.test.tsx
@@ -18,6 +18,7 @@ describe('DeleteZoneModal', () => {
           onConfirm={onConfirm}
           zoneName="Review"
           pinnedItemCount={2}
+          canEdit
         />
       </AntdApp>
     );
@@ -31,5 +32,39 @@ describe('DeleteZoneModal', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Delete zone' }));
     expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables an already-open confirmation when edit permission is revoked', () => {
+    const onConfirm = vi.fn();
+    const { rerender } = render(
+      <AntdApp>
+        <DeleteZoneModal
+          open
+          onCancel={vi.fn()}
+          onConfirm={onConfirm}
+          zoneName="Review"
+          pinnedItemCount={0}
+          canEdit
+        />
+      </AntdApp>
+    );
+
+    rerender(
+      <AntdApp>
+        <DeleteZoneModal
+          open
+          onCancel={vi.fn()}
+          onConfirm={onConfirm}
+          zoneName="Review"
+          pinnedItemCount={0}
+          canEdit={false}
+        />
+      </AntdApp>
+    );
+
+    const deleteButton = screen.getByRole('button', { name: 'Delete zone' });
+    expect(deleteButton).toBeDisabled();
+    fireEvent.click(deleteButton);
+    expect(onConfirm).not.toHaveBeenCalled();
   });
 });

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/DeleteZoneModal.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/DeleteZoneModal.tsx
@@ -50,7 +50,7 @@ export const DeleteZoneModal = ({
         <Alert
           type="info"
           showIcon
-          title={`${pinnedItemCount} pinned ${pinnedItemCount === 1 ? 'item' : 'items'} will be unpinned`}
+          title={`${pinnedItemCount} pinned ${pinnedItemCount === 1 ? 'branch/card' : 'branches/cards'} will be unpinned`}
           description="They will remain on the board at the same visible positions. Their content and session history are not changed."
         />
       ) : (

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/DeleteZoneModal.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/DeleteZoneModal.tsx
@@ -1,15 +1,14 @@
 /**
- * Modal for confirming zone deletion with options for handling associated pinned items
+ * Modal for confirming zone deletion and explaining its non-destructive scope.
  */
 
-import { Modal, Radio, theme } from 'antd';
-import { useState } from 'react';
+import { Alert, Modal, Typography } from 'antd';
 import { useMutationGate } from '../../../contexts/ConnectionContext';
 
 interface DeleteZoneModalProps {
   open: boolean;
   onCancel: () => void;
-  onConfirm: (deleteAssociatedSessions: boolean) => void;
+  onConfirm: () => void;
   zoneName: string;
   pinnedItemCount: number;
 }
@@ -21,22 +20,20 @@ export const DeleteZoneModal = ({
   zoneName,
   pinnedItemCount,
 }: DeleteZoneModalProps) => {
-  const { token } = theme.useToken();
-  const [deleteAssociatedSessions, setDeleteAssociatedSessions] = useState(false);
   const mutationGate = useMutationGate();
 
   const handleOk = () => {
     if (!mutationGate.canMutate) return;
-    onConfirm(deleteAssociatedSessions);
+    onConfirm();
   };
 
   return (
     <Modal
-      title="Delete Zone"
+      title="Delete zone?"
       open={open}
       onCancel={onCancel}
       onOk={handleOk}
-      okText="Delete Zone"
+      okText="Delete zone"
       okButtonProps={{
         danger: true,
         disabled: !mutationGate.canMutate,
@@ -44,52 +41,23 @@ export const DeleteZoneModal = ({
       cancelText="Cancel"
       width={480}
     >
-      <div style={{ marginBottom: 16 }}>
-        <p style={{ margin: 0, marginBottom: 16 }}>Are you sure you want to delete this zone?</p>
+      <Typography.Paragraph>
+        Delete <Typography.Text strong>{zoneName}</Typography.Text>? This removes only the zone.
+        Branches, cards, comments, notes, and sessions are kept.
+      </Typography.Paragraph>
 
-        {pinnedItemCount > 0 && (
-          <>
-            <p style={{ margin: 0, marginBottom: 16, color: token.colorTextSecondary }}>
-              This zone has {pinnedItemCount} pinned item{pinnedItemCount !== 1 ? 's' : ''}.
-            </p>
-
-            <Radio.Group
-              value={deleteAssociatedSessions}
-              onChange={(e) => setDeleteAssociatedSessions(e.target.value)}
-            >
-              <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-                <Radio value={false}>
-                  <div>
-                    <div style={{ fontWeight: 500 }}>Unpin items (keep on board)</div>
-                    <div style={{ fontSize: 12, color: token.colorTextSecondary }}>
-                      Pinned items will remain on the board at their current positions
-                    </div>
-                  </div>
-                </Radio>
-                <Radio value={true} disabled>
-                  <div>
-                    <div style={{ fontWeight: 500 }}>
-                      Delete pinned items too{' '}
-                      <span style={{ fontSize: 11, color: token.colorTextTertiary }}>
-                        [coming soon]
-                      </span>
-                    </div>
-                    <div style={{ fontSize: 12, color: token.colorTextSecondary }}>
-                      Remove pinned items from board entirely
-                    </div>
-                  </div>
-                </Radio>
-              </div>
-            </Radio.Group>
-          </>
-        )}
-
-        {pinnedItemCount === 0 && (
-          <p style={{ margin: 0, color: token.colorTextSecondary }}>
-            This zone has no pinned items.
-          </p>
-        )}
-      </div>
+      {pinnedItemCount > 0 ? (
+        <Alert
+          type="info"
+          showIcon
+          title={`${pinnedItemCount} pinned ${pinnedItemCount === 1 ? 'item' : 'items'} will be unpinned`}
+          description="They will remain on the board at the same visible positions. Their content and session history are not changed."
+        />
+      ) : (
+        <Typography.Paragraph type="secondary">
+          Nothing else on the board will be removed.
+        </Typography.Paragraph>
+      )}
     </Modal>
   );
 };

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/DeleteZoneModal.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/DeleteZoneModal.tsx
@@ -11,6 +11,7 @@ interface DeleteZoneModalProps {
   onConfirm: () => void;
   zoneName: string;
   pinnedItemCount: number;
+  canEdit: boolean;
 }
 
 export const DeleteZoneModal = ({
@@ -19,11 +20,12 @@ export const DeleteZoneModal = ({
   onConfirm,
   zoneName,
   pinnedItemCount,
+  canEdit,
 }: DeleteZoneModalProps) => {
   const mutationGate = useMutationGate();
 
   const handleOk = () => {
-    if (!mutationGate.canMutate) return;
+    if (!mutationGate.canMutate || !canEdit) return;
     onConfirm();
   };
 
@@ -36,7 +38,7 @@ export const DeleteZoneModal = ({
       okText="Delete zone"
       okButtonProps={{
         danger: true,
-        disabled: !mutationGate.canMutate,
+        disabled: !mutationGate.canMutate || !canEdit,
       }}
       cancelText="Cancel"
       width={480}

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/MarkdownNode.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/MarkdownNode.tsx
@@ -8,6 +8,7 @@ interface MarkdownNodeData {
   objectId: string;
   content: string;
   width: number;
+  canEdit: boolean;
   onUpdate: (id: string, data: BoardObject) => void;
   onEdit?: (objectId: string, content: string, width: number) => void;
   onDelete?: (objectId: string) => void;
@@ -17,7 +18,7 @@ export const MarkdownNode = ({ data }: { data: MarkdownNodeData }) => {
   const { token } = theme.useToken();
   const { modal } = App.useApp();
   const mutationGate = useMutationGate();
-  const mutationDisabled = !mutationGate.canMutate;
+  const mutationDisabled = !mutationGate.canMutate || !data.canEdit;
 
   const handleEdit = () => {
     if (mutationDisabled) return;
@@ -69,6 +70,7 @@ export const MarkdownNode = ({ data }: { data: MarkdownNodeData }) => {
               type="text"
               size="small"
               icon={<EditOutlined />}
+              aria-label="Edit note"
               onClick={(e) => {
                 e.stopPropagation();
                 handleEdit();
@@ -82,6 +84,7 @@ export const MarkdownNode = ({ data }: { data: MarkdownNodeData }) => {
               size="small"
               danger
               icon={<DeleteOutlined />}
+              aria-label="Delete note"
               onClick={(e) => {
                 e.stopPropagation();
                 handleDelete();

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneConfigModal.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneConfigModal.test.tsx
@@ -1,8 +1,39 @@
+// biome-ignore-all lint/plugin/noHardcodedColorLiteral: persisted color fixtures verify legacy zone migration
 import type { BoardObject } from '@agor-live/client';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { App as AntdApp } from 'antd';
 import { describe, expect, it, vi } from 'vitest';
 import { ZoneConfigModal } from './ZoneConfigModal';
+
+vi.mock('antd', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('antd')>();
+  const React = await import('react');
+  return {
+    ...actual,
+    ColorPicker: ({
+      children,
+      onChange,
+    }: {
+      children?: React.ReactNode;
+      onChange?: (color: { toHexString: () => string }) => void;
+    }) => {
+      const childProps = React.isValidElement(children)
+        ? (children.props as { 'aria-label'?: string })
+        : undefined;
+      const label = childProps?.['aria-label'] ?? 'color';
+      return (
+        <div>
+          {children}
+          <button
+            type="button"
+            aria-label={`Set ${label}`}
+            onClick={() => onChange?.({ toHexString: () => '#123456' })}
+          />
+        </div>
+      );
+    },
+  };
+});
 
 vi.mock('../../../contexts/ConnectionContext', () => ({
   useMutationGate: () => ({ canMutate: true }),
@@ -125,5 +156,39 @@ describe('ZoneConfigModal historical tool migration', () => {
     await waitFor(() => expect(onUpdate).toHaveBeenCalledTimes(1));
     expect(onUpdate.mock.calls[0][1]).toMatchObject({ fontSize: 20 });
     expect(onUpdate.mock.calls[0][1].trigger).toBeUndefined();
+  });
+
+  it('preserves a legacy translucent fill when the Appearance tab changes its border', async () => {
+    const onUpdate = vi.fn();
+    render(
+      <AntdApp>
+        <ZoneConfigModal
+          open
+          onCancel={vi.fn()}
+          zoneName="Legacy"
+          objectId="zone-legacy"
+          onUpdate={onUpdate}
+          zoneData={{
+            type: 'zone',
+            x: 0,
+            y: 0,
+            width: 200,
+            height: 100,
+            label: 'Legacy',
+            color: '#ff0000',
+          }}
+        />
+      </AntdApp>
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Appearance & placement' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Set Zone border color' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(onUpdate).toHaveBeenCalledTimes(1));
+    expect(onUpdate.mock.calls[0][1]).toMatchObject({
+      borderColor: '#123456',
+      backgroundColor: 'rgba(255, 0, 0, 0.1)',
+    });
   });
 });

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneConfigModal.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneConfigModal.test.tsx
@@ -191,4 +191,37 @@ describe('ZoneConfigModal historical tool migration', () => {
       backgroundColor: 'rgba(255, 0, 0, 0.1)',
     });
   });
+
+  it('keeps automation edits open when persistence reports failure', async () => {
+    const onCancel = vi.fn();
+    const onUpdate = vi.fn().mockResolvedValue(false);
+    render(
+      <AntdApp>
+        <ZoneConfigModal
+          open
+          onCancel={onCancel}
+          zoneName="Review"
+          objectId="zone-1"
+          onUpdate={onUpdate}
+          zoneData={{
+            type: 'zone',
+            x: 0,
+            y: 0,
+            width: 200,
+            height: 100,
+            label: 'Review',
+          }}
+        />
+      </AntdApp>
+    );
+
+    const template = screen.getByLabelText('Prompt template');
+    fireEvent.change(template, { target: { value: 'Review this branch carefully' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(onUpdate).toHaveBeenCalledTimes(1));
+    expect(onCancel).not.toHaveBeenCalled();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(template).toHaveValue('Review this branch carefully');
+  });
 });

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneConfigModal.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneConfigModal.test.tsx
@@ -62,8 +62,10 @@ describe('ZoneConfigModal historical tool migration', () => {
       </AntdApp>
     );
 
-    expect(screen.getByRole('tab', { name: 'General' })).toHaveAttribute('aria-selected', 'true');
-    fireEvent.click(screen.getByRole('tab', { name: /Automation/ }));
+    expect(screen.getByRole('tab', { name: /Automation/ })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
     expect(await screen.findByText('This zone uses a removed agentic tool')).toBeInTheDocument();
     const save = screen.getByRole('button', { name: 'Save' });
     expect(save).toBeDisabled();
@@ -83,7 +85,7 @@ describe('ZoneConfigModal historical tool migration', () => {
     });
   });
 
-  it('moves appearance and label size into General without changing automation defaults', async () => {
+  it('prioritizes automation and keeps appearance settings in a secondary tab', async () => {
     const onUpdate = vi.fn();
     render(
       <AntdApp>
@@ -105,11 +107,17 @@ describe('ZoneConfigModal historical tool migration', () => {
       </AntdApp>
     );
 
-    expect(screen.getByText('Appearance')).toBeInTheDocument();
+    expect(screen.getByText('No prompt configured')).toBeInTheDocument();
+    expect(screen.getByLabelText('Prompt template')).toBeInTheDocument();
+    expect(screen.getByLabelText('Trigger behavior')).toBeInTheDocument();
+    expect(screen.queryByText('Appearance')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Appearance & placement' }));
+    expect(await screen.findByText('Appearance')).toBeInTheDocument();
     expect(screen.getByLabelText('Zone border color')).toBeInTheDocument();
     expect(screen.getByLabelText('Zone fill color')).toBeInTheDocument();
     expect(screen.getByLabelText('Zone label size')).toHaveValue('14');
-    expect(screen.queryByLabelText('Trigger behavior')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Prompt template')).not.toBeVisible();
 
     fireEvent.change(screen.getByLabelText('Zone label size'), { target: { value: '20' } });
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneConfigModal.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneConfigModal.test.tsx
@@ -62,6 +62,8 @@ describe('ZoneConfigModal historical tool migration', () => {
       </AntdApp>
     );
 
+    expect(screen.getByRole('tab', { name: 'General' })).toHaveAttribute('aria-selected', 'true');
+    fireEvent.click(screen.getByRole('tab', { name: /Automation/ }));
     expect(await screen.findByText('This zone uses a removed agentic tool')).toBeInTheDocument();
     const save = screen.getByRole('button', { name: 'Save' });
     expect(save).toBeDisabled();
@@ -79,5 +81,41 @@ describe('ZoneConfigModal historical tool migration', () => {
         agent: 'codex',
       },
     });
+  });
+
+  it('moves appearance and label size into General without changing automation defaults', async () => {
+    const onUpdate = vi.fn();
+    render(
+      <AntdApp>
+        <ZoneConfigModal
+          open
+          onCancel={vi.fn()}
+          zoneName="Review"
+          objectId="zone-1"
+          onUpdate={onUpdate}
+          zoneData={{
+            type: 'zone',
+            x: 0,
+            y: 0,
+            width: 200,
+            height: 100,
+            label: 'Review',
+          }}
+        />
+      </AntdApp>
+    );
+
+    expect(screen.getByText('Appearance')).toBeInTheDocument();
+    expect(screen.getByLabelText('Zone border color')).toBeInTheDocument();
+    expect(screen.getByLabelText('Zone fill color')).toBeInTheDocument();
+    expect(screen.getByLabelText('Zone label size')).toHaveValue('14');
+    expect(screen.queryByLabelText('Trigger behavior')).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Zone label size'), { target: { value: '20' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(onUpdate).toHaveBeenCalledTimes(1));
+    expect(onUpdate.mock.calls[0][1]).toMatchObject({ fontSize: 20 });
+    expect(onUpdate.mock.calls[0][1].trigger).toBeUndefined();
   });
 });

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneConfigModal.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneConfigModal.tsx
@@ -75,6 +75,8 @@ export const ZoneConfigModal = ({
   const mutationGate = useMutationGate();
 
   const triggerBehavior = Form.useWatch('triggerBehavior', form);
+  const triggerTemplate = Form.useWatch('triggerTemplate', form);
+  const automationActive = Boolean(triggerTemplate?.trim());
   const zone = zoneData.type === 'zone' ? zoneData : undefined;
   const zoneTrigger = zone?.trigger;
   const hasZoneTrigger = Boolean(zoneTrigger);
@@ -334,18 +336,21 @@ export const ZoneConfigModal = ({
 
   const automationContent = (
     <>
-      <Form.Item name="triggerBehavior" label="Trigger behavior">
-        <Select
-          style={{ width: '100%' }}
-          options={[
-            {
-              value: 'show_picker',
-              label: 'Show picker — choose session and action when dropped',
-            },
-            { value: 'always_new', label: 'Always new — auto-create a new root session' },
-          ]}
-        />
-      </Form.Item>
+      <Typography.Paragraph>
+        Configure the prompt that runs when a branch enters this zone and how Agor starts it.
+      </Typography.Paragraph>
+
+      <Alert
+        type={automationActive ? 'success' : 'info'}
+        showIcon
+        title={automationActive ? 'Automation active' : 'No prompt configured'}
+        description={
+          automationActive
+            ? 'Dropping a branch into this zone will use the prompt below.'
+            : 'This zone is organizational only until you add a prompt.'
+        }
+        style={{ marginBottom: token.margin }}
+      />
 
       {requiresSupportedToolSelection && (
         <Alert
@@ -357,26 +362,10 @@ export const ZoneConfigModal = ({
         />
       )}
 
-      {(triggerBehavior === 'always_new' || requiresSupportedToolSelection) && (
-        <Form.Item
-          label="Agent"
-          help="New sessions will use the dropping user's default configuration for this agent."
-        >
-          <AgentSelectionGrid
-            agents={AVAILABLE_AGENTS}
-            selectedAgentId={triggerAgent}
-            onSelect={(id) => setTriggerAgent(id as AgenticToolName)}
-            columns={2}
-            showHelperText={false}
-            showComparisonLink={false}
-          />
-        </Form.Item>
-      )}
-
       <Form.Item
         name="triggerTemplate"
-        label="Trigger template"
-        help="Leave empty for an organizational-only zone (no trigger fires on drop)."
+        label="Prompt template"
+        help="Leave empty to keep this as an organizational-only zone."
         extra={
           <ExpandableAlert
             key={`${objectId}:${open}`}
@@ -428,6 +417,36 @@ export const ZoneConfigModal = ({
           rows={6}
         />
       </Form.Item>
+
+      <Form.Item name="triggerBehavior" label="When a branch enters this zone">
+        <Select
+          aria-label="Trigger behavior"
+          style={{ width: '100%' }}
+          options={[
+            {
+              value: 'show_picker',
+              label: 'Show picker — choose session and action when dropped',
+            },
+            { value: 'always_new', label: 'Always new — auto-create a new root session' },
+          ]}
+        />
+      </Form.Item>
+
+      {(triggerBehavior === 'always_new' || requiresSupportedToolSelection) && (
+        <Form.Item
+          label="Agent"
+          help="New sessions will use the dropping user's default configuration for this agent."
+        >
+          <AgentSelectionGrid
+            agents={AVAILABLE_AGENTS}
+            selectedAgentId={triggerAgent}
+            onSelect={(id) => setTriggerAgent(id as AgenticToolName)}
+            columns={2}
+            showHelperText={false}
+            showComparisonLink={false}
+          />
+        </Form.Item>
+      )}
     </>
   );
 
@@ -446,13 +465,17 @@ export const ZoneConfigModal = ({
     >
       <Form form={form} layout="vertical">
         <Tabs
-          defaultActiveKey="general"
+          defaultActiveKey="automation"
           items={[
-            { key: 'general', label: 'General', children: generalContent },
             {
               key: 'automation',
               label: requiresSupportedToolSelection ? 'Automation (action required)' : 'Automation',
               children: automationContent,
+            },
+            {
+              key: 'appearance',
+              label: 'Appearance & placement',
+              children: generalContent,
             },
           ]}
         />

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneConfigModal.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneConfigModal.tsx
@@ -38,7 +38,10 @@ interface ZoneConfigModalProps {
   onCancel: () => void;
   zoneName: string;
   objectId: string;
-  onUpdate: (objectId: string, objectData: BoardObject) => void | Promise<void>;
+  onUpdate: (
+    objectId: string,
+    objectData: BoardObject
+  ) => boolean | undefined | Promise<boolean | undefined>;
   zoneData: BoardObject;
   canEdit?: boolean;
 }
@@ -197,7 +200,7 @@ export const ZoneConfigModal = ({
         triggerAgent !== (zone.trigger?.agent || 'claude-code');
 
       if (hasChanges) {
-        await onUpdate(objectId, {
+        const saved = await onUpdate(objectId, {
           ...zone,
           label: values.name,
           locked: Boolean(values.locked),
@@ -207,6 +210,7 @@ export const ZoneConfigModal = ({
           color: clearLegacyColor ? undefined : zone.color,
           trigger: nextTrigger,
         });
+        if (saved === false) return;
       }
       onCancel();
     } catch {

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneConfigModal.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneConfigModal.tsx
@@ -1,36 +1,58 @@
 /**
- * Modal for configuring zone settings (name, triggers, etc.)
+ * Modal for configuring zone identity, appearance, placement, and automation.
  */
 
 import type { AgenticToolName, BoardObject, ZoneTriggerBehavior } from '@agor-live/client';
 import { isAgenticToolName } from '@agor-live/client';
-import { Alert, Form, Input, Modal, Select } from 'antd';
-import { useEffect, useRef, useState } from 'react';
+import {
+  Alert,
+  Button,
+  ColorPicker,
+  Flex,
+  Form,
+  Input,
+  InputNumber,
+  Modal,
+  Select,
+  Space,
+  Switch,
+  Tabs,
+  Typography,
+  theme,
+} from 'antd';
+import type { Color } from 'antd/es/color-picker';
+import { AggregationColor } from 'antd/es/color-picker/color';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useMutationGate } from '../../../contexts/ConnectionContext';
 import { AgentSelectionGrid, AVAILABLE_AGENTS } from '../../AgentSelectionGrid';
 import { ExpandableAlert } from '../../ExpandableAlert';
+import { ZONE_CONTENT_OPACITY } from './zoneAppearance';
+import {
+  sanitizeZoneFontSize,
+  ZONE_FONT_SIZE_MAX,
+  ZONE_FONT_SIZE_MIN,
+  ZONE_FONT_SIZE_STEP,
+} from './zoneFontSize';
 
 interface ZoneConfigModalProps {
   open: boolean;
   onCancel: () => void;
   zoneName: string;
   objectId: string;
-  onUpdate: (objectId: string, objectData: BoardObject) => void;
+  onUpdate: (objectId: string, objectData: BoardObject) => void | Promise<void>;
   zoneData: BoardObject;
+  canEdit?: boolean;
 }
 
 interface ZoneFormValues {
   name: string;
+  locked: boolean;
   triggerBehavior: ZoneTriggerBehavior;
   triggerTemplate: string;
 }
 
-// Sensible default so that a freshly-created zone always has a behavior
-// selected — previously the field came up blank, the Select allowed clearing,
-// and any template the user typed got silently discarded on save unless they
-// also remembered to pick a behavior. With a default of 'show_picker', the
-// template is preserved by default and users only need to opt OUT (by leaving
-// the template empty) for an organizational-only zone.
+// A newly configured trigger defaults to the picker. An empty template still
+// means an organizational-only zone and persists no trigger.
 const DEFAULT_TRIGGER_BEHAVIOR: ZoneTriggerBehavior = 'show_picker';
 
 export const ZoneConfigModal = ({
@@ -40,15 +62,21 @@ export const ZoneConfigModal = ({
   objectId,
   onUpdate,
   zoneData,
+  canEdit = true,
 }: ZoneConfigModalProps) => {
+  const { token } = theme.useToken();
   const [form] = Form.useForm<ZoneFormValues>();
   const [triggerAgent, setTriggerAgent] = useState<AgenticToolName | null>('claude-code');
+  const [borderColor, setBorderColor] = useState<string | undefined>();
+  const [backgroundColor, setBackgroundColor] = useState<string | undefined>();
+  const [fontSize, setFontSize] = useState<number | undefined>();
+  const [clearLegacyColor, setClearLegacyColor] = useState(false);
   const isInitializingRef = useRef(false);
   const mutationGate = useMutationGate();
 
   const triggerBehavior = Form.useWatch('triggerBehavior', form);
-
-  const zoneTrigger = zoneData.type === 'zone' ? zoneData.trigger : undefined;
+  const zone = zoneData.type === 'zone' ? zoneData : undefined;
+  const zoneTrigger = zone?.trigger;
   const hasZoneTrigger = Boolean(zoneTrigger);
   const zoneTriggerBehavior = zoneTrigger?.behavior;
   const zoneTriggerTemplate = zoneTrigger?.template;
@@ -57,40 +85,73 @@ export const ZoneConfigModal = ({
     zoneTriggerAgent && !isAgenticToolName(zoneTriggerAgent) && triggerAgent === null
   );
 
-  // Reset form when modal opens (prevent WebSocket updates from erasing user input).
-  // Keep dependencies to stable primitive fields: ZoneNode re-renders often, and
-  // passing a freshly-created zone object through this effect used to make AntD's
-  // Form/Modal tree re-run initialization work unnecessarily while open.
+  const palette = useMemo(
+    () => [
+      token.colorBorder,
+      token.red6 || token.red,
+      token.orange6 || token.orange,
+      token.green6 || token.green,
+      token.blue6 || token.blue,
+      token.purple6 || token.purple,
+      token.magenta6 || token.magenta,
+    ],
+    [token]
+  );
+
+  const colorToRgba = (value: string, alpha: number): string => {
+    try {
+      const rgb = new AggregationColor(value).toRgb();
+      // biome-ignore lint/plugin/noHardcodedColorLiteral: user color resolver emits CSS syntax from parsed channels
+      return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${rgb.a * alpha})`;
+    } catch {
+      return `${token.colorBgContainer}40`;
+    }
+  };
+
+  const legacyColor = clearLegacyColor ? undefined : zone?.color;
+  const effectiveBorderColor = borderColor ?? legacyColor ?? token.colorBorder;
+  const effectiveBackgroundColor =
+    backgroundColor ??
+    (borderColor
+      ? borderColor
+      : legacyColor
+        ? colorToRgba(legacyColor, ZONE_CONTENT_OPACITY)
+        : `${token.colorBgContainer}40`);
+
+  // Reset only when the modal opens. Live board patches must not erase edits in
+  // progress, but reopening should always reflect the freshest zone object.
   useEffect(() => {
     if (open && !isInitializingRef.current) {
       isInitializingRef.current = true;
-      if (hasZoneTrigger) {
-        form.setFieldsValue({
-          name: zoneName,
-          triggerBehavior: zoneTriggerBehavior,
-          triggerTemplate: zoneTriggerTemplate,
-        });
-        setTriggerAgent(
-          zoneTriggerAgent === undefined
+      form.setFieldsValue({
+        name: zoneName,
+        locked: Boolean(zone?.locked),
+        triggerBehavior: hasZoneTrigger ? zoneTriggerBehavior : DEFAULT_TRIGGER_BEHAVIOR,
+        triggerTemplate: hasZoneTrigger ? zoneTriggerTemplate : '',
+      });
+      setBorderColor(zone?.borderColor);
+      setBackgroundColor(zone?.backgroundColor);
+      setFontSize(sanitizeZoneFontSize(zone?.fontSize));
+      setClearLegacyColor(false);
+      setTriggerAgent(
+        hasZoneTrigger
+          ? zoneTriggerAgent === undefined
             ? 'claude-code'
             : isAgenticToolName(zoneTriggerAgent)
               ? zoneTriggerAgent
               : null
-        );
-      } else {
-        form.setFieldsValue({
-          name: zoneName,
-          triggerBehavior: DEFAULT_TRIGGER_BEHAVIOR,
-          triggerTemplate: '',
-        });
-        setTriggerAgent('claude-code');
-      }
+          : 'claude-code'
+      );
     } else if (!open) {
       isInitializingRef.current = false;
     }
   }, [
     open,
     zoneName,
+    zone?.locked,
+    zone?.borderColor,
+    zone?.backgroundColor,
+    zone?.fontSize,
     hasZoneTrigger,
     zoneTriggerBehavior,
     zoneTriggerTemplate,
@@ -98,160 +159,303 @@ export const ZoneConfigModal = ({
     form,
   ]);
 
+  const handleBorderColorChange = (color: Color) => setBorderColor(color.toHexString());
+  const handleBackgroundColorChange = (color: Color) => setBackgroundColor(color.toHexString());
+
   const handleSave = async () => {
-    if (!mutationGate.canMutate) return;
-    if (requiresSupportedToolSelection || triggerAgent === null) return;
+    if (
+      !mutationGate.canMutate ||
+      !canEdit ||
+      requiresSupportedToolSelection ||
+      triggerAgent === null
+    )
+      return;
     try {
       const values = await form.validateFields();
+      if (!zone) {
+        onCancel();
+        return;
+      }
 
-      if (zoneData.type === 'zone') {
-        const template = values.triggerTemplate?.trim() || '';
-        const hasChanges =
-          values.name !== zoneName ||
-          template !== (zoneData.trigger?.template || '') ||
-          values.triggerBehavior !== (zoneData.trigger?.behavior || undefined) ||
-          triggerAgent !== (zoneData.trigger?.agent || 'claude-code');
+      const template = values.triggerTemplate?.trim() || '';
+      const nextTrigger =
+        template && values.triggerBehavior
+          ? { behavior: values.triggerBehavior, template, agent: triggerAgent }
+          : undefined;
+      const hasChanges =
+        values.name !== zoneName ||
+        Boolean(values.locked) !== Boolean(zone.locked) ||
+        borderColor !== zone.borderColor ||
+        backgroundColor !== zone.backgroundColor ||
+        fontSize !== sanitizeZoneFontSize(zone.fontSize) ||
+        (clearLegacyColor && zone.color !== undefined) ||
+        template !== (zone.trigger?.template || '') ||
+        values.triggerBehavior !== (zone.trigger?.behavior || undefined) ||
+        triggerAgent !== (zone.trigger?.agent || 'claude-code');
 
-        if (hasChanges) {
-          onUpdate(objectId, {
-            ...zoneData,
-            label: values.name,
-            trigger:
-              template && values.triggerBehavior
-                ? {
-                    behavior: values.triggerBehavior,
-                    template,
-                    agent: triggerAgent,
-                  }
-                : undefined,
-          });
-        }
+      if (hasChanges) {
+        await onUpdate(objectId, {
+          ...zone,
+          label: values.name,
+          locked: Boolean(values.locked),
+          borderColor,
+          backgroundColor,
+          fontSize,
+          color: clearLegacyColor ? undefined : zone.color,
+          trigger: nextTrigger,
+        });
       }
       onCancel();
     } catch {
-      // Validation failed — form will show inline errors
+      // Validation or persistence failed. Validation renders inline feedback;
+      // persistence keeps the modal open so the operator can retry.
     }
   };
 
+  const generalContent = (
+    <>
+      <Form.Item name="name" label="Name">
+        <Input placeholder="Enter zone name..." autoComplete="off" />
+      </Form.Item>
+
+      <Typography.Title level={5}>Appearance</Typography.Title>
+      <Space orientation="vertical" size="middle" style={{ display: 'flex' }}>
+        <Flex justify="space-between" align="center" gap="middle" wrap>
+          <div>
+            <Typography.Text>Border color</Typography.Text>
+            <Typography.Text type="secondary" style={{ display: 'block' }}>
+              The zone outline and resize handles.
+            </Typography.Text>
+          </div>
+          <Space>
+            <ColorPicker
+              value={effectiveBorderColor}
+              onChange={handleBorderColorChange}
+              showText
+              format="hex"
+              presets={[{ label: 'Presets', colors: palette }]}
+            >
+              <Button aria-label="Zone border color">{effectiveBorderColor.toUpperCase()}</Button>
+            </ColorPicker>
+            <Button
+              size="small"
+              disabled={borderColor === undefined && legacyColor === undefined}
+              onClick={() => {
+                if (legacyColor && backgroundColor === undefined) {
+                  setBackgroundColor(colorToRgba(legacyColor, ZONE_CONTENT_OPACITY));
+                }
+                setBorderColor(undefined);
+                setClearLegacyColor(true);
+              }}
+            >
+              Use default
+            </Button>
+          </Space>
+        </Flex>
+
+        <Flex justify="space-between" align="center" gap="middle" wrap>
+          <div>
+            <Typography.Text>Fill color</Typography.Text>
+            <Typography.Text type="secondary" style={{ display: 'block' }}>
+              Supports transparency so cards remain readable.
+            </Typography.Text>
+          </div>
+          <Space>
+            <ColorPicker
+              value={effectiveBackgroundColor}
+              onChange={handleBackgroundColorChange}
+              showText
+              format="hex"
+              presets={[
+                {
+                  label: 'Presets',
+                  colors: palette.map(
+                    (color) =>
+                      `${color}${Math.round(ZONE_CONTENT_OPACITY * 255)
+                        .toString(16)
+                        .padStart(2, '0')}`
+                  ),
+                },
+              ]}
+            >
+              <Button aria-label="Zone fill color">{effectiveBackgroundColor.toUpperCase()}</Button>
+            </ColorPicker>
+            <Button
+              size="small"
+              disabled={backgroundColor === undefined && legacyColor === undefined}
+              onClick={() => {
+                if (legacyColor && borderColor === undefined) setBorderColor(legacyColor);
+                setBackgroundColor(undefined);
+                setClearLegacyColor(true);
+              }}
+            >
+              Use default
+            </Button>
+          </Space>
+        </Flex>
+
+        <Flex justify="space-between" align="center" gap="middle" wrap>
+          <div>
+            <Typography.Text>Label size</Typography.Text>
+            <Typography.Text type="secondary" style={{ display: 'block' }}>
+              Uses the theme default when no custom size is set.
+            </Typography.Text>
+          </div>
+          <Space.Compact>
+            <InputNumber
+              aria-label="Zone label size"
+              min={ZONE_FONT_SIZE_MIN}
+              max={ZONE_FONT_SIZE_MAX}
+              step={ZONE_FONT_SIZE_STEP}
+              value={fontSize ?? token.fontSize}
+              onChange={(value) => setFontSize(sanitizeZoneFontSize(value))}
+              style={{ width: 112 }}
+            />
+            <Button disabled={fontSize === undefined} onClick={() => setFontSize(undefined)}>
+              Use default
+            </Button>
+          </Space.Compact>
+        </Flex>
+      </Space>
+
+      <Typography.Title level={5} style={{ marginTop: token.marginLG }}>
+        Placement
+      </Typography.Title>
+      <Form.Item
+        name="locked"
+        label="Lock position and size"
+        valuePropName="checked"
+        extra="Prevents accidental moving and resizing. Other zone settings remain editable."
+      >
+        <Switch />
+      </Form.Item>
+    </>
+  );
+
+  const automationContent = (
+    <>
+      <Form.Item name="triggerBehavior" label="Trigger behavior">
+        <Select
+          style={{ width: '100%' }}
+          options={[
+            {
+              value: 'show_picker',
+              label: 'Show picker — choose session and action when dropped',
+            },
+            { value: 'always_new', label: 'Always new — auto-create a new root session' },
+          ]}
+        />
+      </Form.Item>
+
+      {requiresSupportedToolSelection && (
+        <Alert
+          type="warning"
+          showIcon
+          title="This zone uses a removed agentic tool"
+          description="Its saved trigger is preserved, but it cannot create a session. Choose a supported tool to migrate the zone explicitly."
+          style={{ marginBottom: token.margin }}
+        />
+      )}
+
+      {(triggerBehavior === 'always_new' || requiresSupportedToolSelection) && (
+        <Form.Item
+          label="Agent"
+          help="New sessions will use the dropping user's default configuration for this agent."
+        >
+          <AgentSelectionGrid
+            agents={AVAILABLE_AGENTS}
+            selectedAgentId={triggerAgent}
+            onSelect={(id) => setTriggerAgent(id as AgenticToolName)}
+            columns={2}
+            showHelperText={false}
+            showComparisonLink={false}
+          />
+        </Form.Item>
+      )}
+
+      <Form.Item
+        name="triggerTemplate"
+        label="Trigger template"
+        help="Leave empty for an organizational-only zone (no trigger fires on drop)."
+        extra={
+          <ExpandableAlert
+            key={`${objectId}:${open}`}
+            title="Handlebars template support"
+            summary="Reference branch, session, and board data with {{ ... }} syntax."
+          >
+            <p style={{ marginBottom: token.marginXS }}>
+              Use Handlebars syntax to reference session and board data in your trigger:
+            </p>
+            <ul style={{ marginLeft: token.margin, marginBottom: token.marginXS }}>
+              <li>
+                <code>{'{{ branch.issue_url }}'}</code> — GitHub issue URL
+              </li>
+              <li>
+                <code>{'{{ branch.pull_request_url }}'}</code> — Pull request URL
+              </li>
+              <li>
+                <code>{'{{ branch.notes }}'}</code> — Branch notes
+              </li>
+              <li>
+                <code>{'{{ session.description }}'}</code> — Session description
+              </li>
+              <li>
+                <code>{'{{ session.context.* }}'}</code> — Custom session context
+              </li>
+              <li>
+                <code>{'{{ board.name }}'}</code> — Board name
+              </li>
+              <li>
+                <code>{'{{ board.description }}'}</code> — Board description
+              </li>
+              <li>
+                <code>{'{{ board.context.* }}'}</code> — Custom board context
+              </li>
+            </ul>
+            <p style={{ marginTop: token.marginXS, marginBottom: 0 }}>
+              Example:{' '}
+              <code>
+                {
+                  'Review {{ branch.issue_url }} for {{ board.context.team }} sprint {{ board.context.sprint }}'
+                }
+              </code>
+            </p>
+          </ExpandableAlert>
+        }
+      >
+        <Input.TextArea
+          placeholder="Enter the prompt template that runs when a branch is dropped here..."
+          rows={6}
+        />
+      </Form.Item>
+    </>
+  );
+
   return (
     <Modal
-      title="Configure Zone"
+      title="Zone settings"
       open={open}
       onCancel={onCancel}
       onOk={handleSave}
       okText="Save"
       okButtonProps={{
-        disabled: !mutationGate.canMutate || requiresSupportedToolSelection,
+        disabled: !mutationGate.canMutate || !canEdit || requiresSupportedToolSelection,
       }}
       cancelText="Cancel"
-      width={600}
+      width={640}
     >
       <Form form={form} layout="vertical">
-        <Form.Item name="name" label="Zone Name">
-          <Input placeholder="Enter zone name..." size="large" />
-        </Form.Item>
-
-        <Form.Item name="triggerBehavior" label="Trigger Behavior">
-          {/* No allowClear / no placeholder: the field always has a value
-              (DEFAULT_TRIGGER_BEHAVIOR for new zones), so there is no
-              "unset" state to represent. To make a zone organizational
-              only, leave the template empty. */}
-          <Select
-            style={{ width: '100%' }}
-            options={[
-              {
-                value: 'show_picker',
-                label: 'Show Picker - Choose session and action when dropped',
-              },
-              { value: 'always_new', label: 'Always New - Auto-create new root session' },
-            ]}
-          />
-        </Form.Item>
-
-        {requiresSupportedToolSelection && (
-          <Alert
-            type="warning"
-            showIcon
-            title="This zone uses a removed agentic tool"
-            description="Its saved trigger is preserved, but it cannot create a session. Choose a supported tool to migrate the zone explicitly."
-            style={{ marginBottom: 16 }}
-          />
-        )}
-
-        {(triggerBehavior === 'always_new' || requiresSupportedToolSelection) && (
-          <Form.Item
-            label="Agent"
-            help="New sessions will use the dropping user's default configuration for this agent."
-          >
-            <AgentSelectionGrid
-              agents={AVAILABLE_AGENTS}
-              selectedAgentId={triggerAgent}
-              onSelect={(id) => setTriggerAgent(id as AgenticToolName)}
-              columns={2}
-              showHelperText={false}
-              showComparisonLink={false}
-            />
-          </Form.Item>
-        )}
-
-        <Form.Item
-          name="triggerTemplate"
-          label="Trigger Template"
-          help="Leave empty for an organizational-only zone (no trigger fires on drop)."
-          extra={
-            <ExpandableAlert
-              // Re-mount when the modal opens or the zone changes so the
-              // details collapse back to default; otherwise the AntD Modal
-              // keeps children mounted and stale `expanded` state persists.
-              key={`${objectId}:${open}`}
-              title="Handlebars template support"
-              summary="Reference branch, session, and board data with {{ ... }} syntax."
-            >
-              <p style={{ marginBottom: 8 }}>
-                Use Handlebars syntax to reference session and board data in your trigger:
-              </p>
-              <ul style={{ marginLeft: 16, marginBottom: 8 }}>
-                <li>
-                  <code>{'{{ branch.issue_url }}'}</code> - GitHub issue URL
-                </li>
-                <li>
-                  <code>{'{{ branch.pull_request_url }}'}</code> - Pull request URL
-                </li>
-                <li>
-                  <code>{'{{ branch.notes }}'}</code> - Branch notes
-                </li>
-                <li>
-                  <code>{'{{ session.description }}'}</code> - Session description
-                </li>
-                <li>
-                  <code>{'{{ session.context.* }}'}</code> - Custom context from session settings
-                </li>
-                <li>
-                  <code>{'{{ board.name }}'}</code> - Board name
-                </li>
-                <li>
-                  <code>{'{{ board.description }}'}</code> - Board description
-                </li>
-                <li>
-                  <code>{'{{ board.context.* }}'}</code> - Custom context from board settings
-                </li>
-              </ul>
-              <p style={{ marginTop: 8, marginBottom: 0 }}>
-                Example:{' '}
-                <code>
-                  {
-                    'Review {{ branch.issue_url }} for {{ board.context.team }} sprint {{ board.context.sprint }}'
-                  }
-                </code>
-              </p>
-            </ExpandableAlert>
-          }
-        >
-          <Input.TextArea
-            placeholder="Enter the prompt template that will be triggered when a branch is dropped here..."
-            rows={6}
-          />
-        </Form.Item>
+        <Tabs
+          defaultActiveKey="general"
+          items={[
+            { key: 'general', label: 'General', children: generalContent },
+            {
+              key: 'automation',
+              label: requiresSupportedToolSelection ? 'Automation (action required)' : 'Automation',
+              children: automationContent,
+            },
+          ]}
+        />
       </Form>
     </Modal>
   );

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneConfigModal.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/ZoneConfigModal.tsx
@@ -21,12 +21,11 @@ import {
   theme,
 } from 'antd';
 import type { Color } from 'antd/es/color-picker';
-import { AggregationColor } from 'antd/es/color-picker/color';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useMutationGate } from '../../../contexts/ConnectionContext';
 import { AgentSelectionGrid, AVAILABLE_AGENTS } from '../../AgentSelectionGrid';
 import { ExpandableAlert } from '../../ExpandableAlert';
-import { ZONE_CONTENT_OPACITY } from './zoneAppearance';
+import { toTranslucentZoneFill, ZONE_CONTENT_OPACITY } from './zoneAppearance';
 import {
   sanitizeZoneFontSize,
   ZONE_FONT_SIZE_MAX,
@@ -100,16 +99,6 @@ export const ZoneConfigModal = ({
     [token]
   );
 
-  const colorToRgba = (value: string, alpha: number): string => {
-    try {
-      const rgb = new AggregationColor(value).toRgb();
-      // biome-ignore lint/plugin/noHardcodedColorLiteral: user color resolver emits CSS syntax from parsed channels
-      return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${rgb.a * alpha})`;
-    } catch {
-      return `${token.colorBgContainer}40`;
-    }
-  };
-
   const legacyColor = clearLegacyColor ? undefined : zone?.color;
   const effectiveBorderColor = borderColor ?? legacyColor ?? token.colorBorder;
   const effectiveBackgroundColor =
@@ -117,7 +106,7 @@ export const ZoneConfigModal = ({
     (borderColor
       ? borderColor
       : legacyColor
-        ? colorToRgba(legacyColor, ZONE_CONTENT_OPACITY)
+        ? toTranslucentZoneFill(legacyColor, `${token.colorBgContainer}40`)
         : `${token.colorBgContainer}40`);
 
   // Reset only when the modal opens. Live board patches must not erase edits in
@@ -161,7 +150,19 @@ export const ZoneConfigModal = ({
     form,
   ]);
 
-  const handleBorderColorChange = (color: Color) => setBorderColor(color.toHexString());
+  const handleBorderColorChange = (color: Color) => {
+    // Introducing borderColor changes the renderer's fallback semantics. Keep
+    // the legacy `color` fill translucent by materializing it before saving.
+    if (
+      zone?.color &&
+      !zone.borderColor &&
+      !zone.backgroundColor &&
+      backgroundColor === undefined
+    ) {
+      setBackgroundColor(toTranslucentZoneFill(zone.color, `${token.colorBgContainer}40`));
+    }
+    setBorderColor(color.toHexString());
+  };
   const handleBackgroundColorChange = (color: Color) => setBackgroundColor(color.toHexString());
 
   const handleSave = async () => {
@@ -244,7 +245,9 @@ export const ZoneConfigModal = ({
               disabled={borderColor === undefined && legacyColor === undefined}
               onClick={() => {
                 if (legacyColor && backgroundColor === undefined) {
-                  setBackgroundColor(colorToRgba(legacyColor, ZONE_CONTENT_OPACITY));
+                  setBackgroundColor(
+                    toTranslucentZoneFill(legacyColor, `${token.colorBgContainer}40`)
+                  );
                 }
                 setBorderColor(undefined);
                 setClearLegacyColor(true);

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.test.tsx
@@ -1,4 +1,4 @@
-import type { Board } from '@agor-live/client';
+import type { Board, BoardObject } from '@agor-live/client';
 import { renderHook } from '@testing-library/react';
 import { App as AntApp } from 'antd';
 import type { ReactNode } from 'react';
@@ -84,6 +84,32 @@ describe('zone toolbar metadata', () => {
       overlappingZoneCount: 0,
       layerAvailability: { front: false, forward: false, backward: true, back: true },
     });
+  });
+});
+
+describe('updateObject', () => {
+  it('returns false when the board patch rejects so modal callers stay open', async () => {
+    const { client, patch } = makeRejectingClient();
+    const zone = {
+      type: 'zone',
+      x: 0,
+      y: 0,
+      width: 200,
+      height: 200,
+      label: 'Review',
+    } as BoardObject;
+    const board = makeBoard({ a: zone });
+    const { result } = renderReorder(board, client);
+    const node = result.current.getBoardObjectNodes().find(({ id }) => id === 'a');
+    const onUpdate = node?.data.onUpdate as (
+      objectId: string,
+      objectData: BoardObject
+    ) => Promise<boolean>;
+
+    await expect(onUpdate('a', { ...zone, label: 'Updated' })).resolves.toBe(false);
+
+    expect(patch).toHaveBeenCalledTimes(1);
+    expect(showError).toHaveBeenCalledWith('Failed to save board object');
   });
 });
 

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.test.tsx
@@ -3,6 +3,7 @@ import { renderHook } from '@testing-library/react';
 import { App as AntApp } from 'antd';
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ConnectionProvider } from '../../../contexts/ConnectionContext';
 import { useBoardObjects } from './useBoardObjects';
 
 // Spy the themed error toast so the failure path of reorderObject is observable.
@@ -18,8 +19,20 @@ vi.mock('../../../utils/message', () => ({
   }),
 }));
 
+const connectionState = {
+  connected: true,
+  connecting: false,
+  authGeneration: 1,
+  outOfSync: false,
+  capturedSha: null,
+  currentSha: null,
+};
+
 beforeEach(() => {
   showError.mockClear();
+  connectionState.connected = true;
+  connectionState.connecting = false;
+  connectionState.outOfSync = false;
 });
 
 /**
@@ -28,8 +41,9 @@ beforeEach(() => {
  */
 function makeClient() {
   const patch = vi.fn().mockResolvedValue({});
-  const client = { service: vi.fn().mockReturnValue({ patch }) };
-  return { client: client as never, patch };
+  const service = vi.fn().mockReturnValue({ patch });
+  const client = { service };
+  return { client: client as never, patch, service };
 }
 
 /** Like makeClient but `patch` rejects, to exercise the error path. */
@@ -43,7 +57,11 @@ function makeBoard(objects: Record<string, unknown>): Board {
   return { board_id: 'board-1', objects } as unknown as Board;
 }
 
-const wrapper = ({ children }: { children: ReactNode }) => <AntApp>{children}</AntApp>;
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <ConnectionProvider value={connectionState}>
+    <AntApp>{children}</AntApp>
+  </ConnectionProvider>
+);
 
 function renderReorder(board: Board, client: unknown, canEdit = true) {
   return renderHook(
@@ -178,6 +196,33 @@ describe('updateObject', () => {
 
     expect(patch).not.toHaveBeenCalled();
     expect(setNodes).not.toHaveBeenCalled();
+  });
+});
+
+describe('deleteArtifact', () => {
+  it('blocks a stale lifecycle-delete callback after the connection gate closes', async () => {
+    const { client, service } = makeClient();
+    const board = makeBoard({
+      artifact: {
+        type: 'artifact',
+        x: 0,
+        y: 0,
+        width: 300,
+        height: 200,
+        artifact_id: 'artifact-1',
+      },
+    });
+    const { result, rerender } = renderReorder(board, client);
+    const onDeleteArtifact = result.current.getBoardObjectNodes()[0]?.data.onDeleteArtifact as (
+      objectId: string,
+      artifactId: string
+    ) => Promise<void>;
+
+    connectionState.connecting = true;
+    rerender({ effectiveCanEdit: true });
+    await onDeleteArtifact('artifact', 'artifact-1');
+
+    expect(service).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.test.tsx
@@ -79,6 +79,7 @@ describe('zone toolbar metadata', () => {
       overlappingZoneCount: 1,
       layerAvailability: { front: true, forward: true, backward: false, back: false },
     });
+    expect(a?.draggable).toBe(false);
     expect(c?.data).toMatchObject({
       overlappingZoneCount: 0,
       layerAvailability: { front: false, forward: false, backward: true, back: true },

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.test.tsx
@@ -47,16 +47,16 @@ const wrapper = ({ children }: { children: ReactNode }) => <AntApp>{children}</A
 
 function renderReorder(board: Board, client: unknown, canEdit = true) {
   return renderHook(
-    () =>
+    ({ effectiveCanEdit }) =>
       useBoardObjects({
         board,
         client: client as never,
         boardObjectsForBoard: [],
         setNodes: vi.fn(),
         deletedObjectsRef: { current: new Set<string>() },
-        canEdit,
+        canEdit: effectiveCanEdit,
       }),
-    { wrapper }
+    { wrapper, initialProps: { effectiveCanEdit: canEdit } }
   );
 }
 
@@ -85,20 +85,50 @@ describe('zone toolbar metadata', () => {
       layerAvailability: { front: false, forward: false, backward: true, back: true },
     });
   });
+
+  it('passes effective edit permission to every structural object component', () => {
+    const { client } = makeClient();
+    const board = makeBoard({
+      app: {
+        type: 'app',
+        x: 0,
+        y: 0,
+        width: 300,
+        height: 200,
+        title: 'App',
+        template: 'react',
+        files: {},
+      },
+      artifact: {
+        type: 'artifact',
+        x: 0,
+        y: 0,
+        width: 300,
+        height: 200,
+        artifact_id: 'artifact-1',
+      },
+      note: { type: 'markdown', x: 0, y: 0, width: 300, content: 'Note' },
+    });
+    const { result } = renderReorder(board, client, false);
+
+    for (const node of result.current.getBoardObjectNodes()) {
+      expect(node.data.canEdit).toBe(false);
+      expect(node.draggable).toBe(false);
+    }
+  });
 });
 
 describe('updateObject', () => {
   it('returns false when the board patch rejects so modal callers stay open', async () => {
     const { client, patch } = makeRejectingClient();
-    const zone = {
-      type: 'zone',
+    const note = {
+      type: 'markdown',
       x: 0,
       y: 0,
-      width: 200,
-      height: 200,
-      label: 'Review',
+      width: 300,
+      content: 'Review',
     } as BoardObject;
-    const board = makeBoard({ a: zone });
+    const board = makeBoard({ a: note });
     const { result } = renderReorder(board, client);
     const node = result.current.getBoardObjectNodes().find(({ id }) => id === 'a');
     const onUpdate = node?.data.onUpdate as (
@@ -106,10 +136,48 @@ describe('updateObject', () => {
       objectData: BoardObject
     ) => Promise<boolean>;
 
-    await expect(onUpdate('a', { ...zone, label: 'Updated' })).resolves.toBe(false);
+    await expect(onUpdate('a', { ...note, content: 'Updated' })).resolves.toBe(false);
 
     expect(patch).toHaveBeenCalledTimes(1);
     expect(showError).toHaveBeenCalledWith('Failed to save board object');
+  });
+
+  it('blocks stale update and delete callbacks after permission revocation', async () => {
+    const { client, patch } = makeClient();
+    const setNodes = vi.fn();
+    const note = {
+      type: 'markdown',
+      x: 0,
+      y: 0,
+      width: 300,
+      content: 'Review',
+    } as BoardObject;
+    const board = makeBoard({ a: note });
+    const { result, rerender } = renderHook(
+      ({ canEdit }) =>
+        useBoardObjects({
+          board,
+          client,
+          boardObjectsForBoard: [],
+          setNodes,
+          deletedObjectsRef: { current: new Set<string>() },
+          canEdit,
+        }),
+      { wrapper, initialProps: { canEdit: true } }
+    );
+    const data = result.current.getBoardObjectNodes()[0]?.data;
+    const onUpdate = data.onUpdate as (
+      objectId: string,
+      objectData: BoardObject
+    ) => Promise<boolean>;
+    const onDelete = data.onDelete as (objectId: string) => Promise<void>;
+
+    rerender({ canEdit: false });
+    await expect(onUpdate('a', { ...note, content: 'Updated' })).resolves.toBe(false);
+    await onDelete('a');
+
+    expect(patch).not.toHaveBeenCalled();
+    expect(setNodes).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.test.tsx
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.test.tsx
@@ -45,7 +45,7 @@ function makeBoard(objects: Record<string, unknown>): Board {
 
 const wrapper = ({ children }: { children: ReactNode }) => <AntApp>{children}</AntApp>;
 
-function renderReorder(board: Board, client: unknown) {
+function renderReorder(board: Board, client: unknown, canEdit = true) {
   return renderHook(
     () =>
       useBoardObjects({
@@ -54,10 +54,37 @@ function renderReorder(board: Board, client: unknown) {
         boardObjectsForBoard: [],
         setNodes: vi.fn(),
         deletedObjectsRef: { current: new Set<string>() },
+        canEdit,
       }),
     { wrapper }
   );
 }
+
+describe('zone toolbar metadata', () => {
+  it('reports geometric overlaps, layer no-ops, and effective edit permission', () => {
+    const { client } = makeClient();
+    const board = makeBoard({
+      a: { type: 'zone', x: 0, y: 0, width: 200, height: 200, label: 'A', zIndex: 100 },
+      b: { type: 'zone', x: 100, y: 100, width: 200, height: 200, label: 'B', zIndex: 110 },
+      c: { type: 'zone', x: 500, y: 500, width: 200, height: 200, label: 'C', zIndex: 120 },
+    });
+    const { result } = renderReorder(board, client, false);
+
+    const nodes = result.current.getBoardObjectNodes();
+    const a = nodes.find((node) => node.id === 'a');
+    const c = nodes.find((node) => node.id === 'c');
+
+    expect(a?.data).toMatchObject({
+      canEdit: false,
+      overlappingZoneCount: 1,
+      layerAvailability: { front: true, forward: true, backward: false, back: false },
+    });
+    expect(c?.data).toMatchObject({
+      overlappingZoneCount: 0,
+      layerAvailability: { front: false, forward: false, backward: true, back: true },
+    });
+  });
+});
 
 describe('reorderObject', () => {
   it('"front" sends a single mergeObjectFields patch with the clamped zIndex', async () => {

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.ts
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.ts
@@ -5,6 +5,7 @@
 import type { AgorClient, Board, BoardEntityObject, BoardObject } from '@agor-live/client';
 import { useCallback, useRef } from 'react';
 import type { Node } from 'reactflow';
+import { useMutationGate } from '../../../contexts/ConnectionContext';
 import { useThemedMessage } from '../../../utils/message';
 import {
   computeLayerChanges,
@@ -52,6 +53,9 @@ export const useBoardObjects = ({
   boardRef.current = board;
   const canEditRef = useRef(canEdit);
   canEditRef.current = canEdit;
+  const mutationGate = useMutationGate();
+  const canMutateRef = useRef(mutationGate.canMutate);
+  canMutateRef.current = mutationGate.canMutate;
 
   const { showError } = useThemedMessage();
 
@@ -220,7 +224,10 @@ export const useBoardObjects = ({
    */
   const deleteArtifact = useCallback(
     async (objectId: string, artifactId: string) => {
-      if (!client) return;
+      // Artifact lifecycle authorization is creator/admin based rather than
+      // board.edit based, but it still obeys the global connection/version
+      // mutation gate. The ref protects callbacks captured before reconnect.
+      if (!canMutateRef.current || !client) return;
 
       // Mark as deleted to prevent re-appearance during WebSocket updates
       deletedObjectsRef.current.add(objectId);

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.ts
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.ts
@@ -25,6 +25,15 @@ interface UseBoardObjectsProps {
    *  "selected" outline. */
   activeUrlTargetArtifactId?: string | null;
   onEditMarkdown?: (objectId: string, content: string, width: number) => void;
+  /** Effective board.edit permission, resolved by the canvas. */
+  canEdit?: boolean;
+}
+
+function zonesOverlap(
+  a: Extract<BoardObject, { type: 'zone' }>,
+  b: Extract<BoardObject, { type: 'zone' }>
+): boolean {
+  return a.x < b.x + b.width && a.x + a.width > b.x && a.y < b.y + b.height && a.y + a.height > b.y;
 }
 
 export const useBoardObjects = ({
@@ -36,6 +45,7 @@ export const useBoardObjects = ({
   eraserMode = false,
   activeUrlTargetArtifactId,
   onEditMarkdown,
+  canEdit = true,
 }: UseBoardObjectsProps) => {
   // Use ref to avoid recreating callbacks when board changes
   const boardRef = useRef(board);
@@ -234,6 +244,14 @@ export const useBoardObjects = ({
   const getBoardObjectNodes = useCallback((): Node[] => {
     if (!boardObjects) return [];
 
+    const zoneEntries = Object.entries(boardObjects).filter(
+      (entry): entry is [string, Extract<BoardObject, { type: 'zone' }>] => entry[1].type === 'zone'
+    );
+    const zonePeers = zoneEntries.map(([id, zone]) => ({
+      id,
+      zIndex: sanitizeZIndex(zone.zIndex, DEFAULT_BOARD_OBJECT_Z_INDEX.zone),
+    }));
+
     return Object.entries(boardObjects)
       .filter(([, objectData]) => {
         // Filter out objects with invalid positions (prevents NaN errors in React Flow)
@@ -381,6 +399,23 @@ export const useBoardObjects = ({
             y: objectData.y,
             trigger: objectData.type === 'zone' ? objectData.trigger : undefined,
             pinnedItemCount,
+            canEdit,
+            overlappingZoneCount:
+              objectData.type === 'zone'
+                ? zoneEntries.filter(
+                    ([peerId, peer]) => peerId !== objectId && zonesOverlap(objectData, peer)
+                  ).length
+                : 0,
+            layerAvailability:
+              objectData.type === 'zone'
+                ? (['front', 'forward', 'backward', 'back'] as const).reduce(
+                    (availability, op) => {
+                      availability[op] = computeLayerChanges(op, objectId, zonePeers).length > 0;
+                      return availability;
+                    },
+                    {} as Record<LayerOp, boolean>
+                  )
+                : undefined,
             onUpdate: handleUpdateObject,
             onDelete: deleteZone,
             onReorder: reorderObject,
@@ -398,6 +433,7 @@ export const useBoardObjects = ({
     eraserMode,
     activeUrlTargetArtifactId,
     onEditMarkdown,
+    canEdit,
   ]);
 
   /**

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.ts
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.ts
@@ -274,7 +274,7 @@ export const useBoardObjects = ({
             id: objectId,
             type: 'appNode',
             position: { x: objectData.x, y: objectData.y },
-            // draggable inherits from canvas-level nodesDraggable (mutationGate.canMutate)
+            draggable: canEdit,
             selectable: true,
             // Above markdown (300), below branches (500) by default.
             zIndex: sanitizeZIndex(objectData.zIndex, DEFAULT_BOARD_OBJECT_Z_INDEX.app),
@@ -304,9 +304,7 @@ export const useBoardObjects = ({
             id: objectId,
             type: 'artifactNode',
             position: { x: objectData.x, y: objectData.y },
-            // Locked artifacts are never draggable. Unlocked artifacts inherit
-            // from canvas-level nodesDraggable (mutationGate.canMutate).
-            ...(isLocked ? { draggable: false } : {}),
+            draggable: canEdit && !isLocked,
             selectable: true,
             zIndex: sanitizeZIndex(objectData.zIndex, DEFAULT_BOARD_OBJECT_Z_INDEX.artifact),
             className: eraserMode ? 'eraser-mode' : undefined,
@@ -331,7 +329,7 @@ export const useBoardObjects = ({
             id: objectId,
             type: 'markdown',
             position: { x: objectData.x, y: objectData.y },
-            // draggable inherits from canvas-level nodesDraggable (mutationGate.canMutate)
+            draggable: canEdit,
             selectable: true,
             // Above zones (100), below branches (500) by default.
             zIndex: sanitizeZIndex(objectData.zIndex, DEFAULT_BOARD_OBJECT_Z_INDEX.markdown),
@@ -367,9 +365,7 @@ export const useBoardObjects = ({
           id: objectId,
           type: 'zone',
           position: { x: objectData.x, y: objectData.y },
-          // Locked zones are never draggable. Unlocked zones inherit from
-          // canvas-level nodesDraggable (mutationGate.canMutate).
-          ...(isLocked ? { draggable: false } : {}),
+          draggable: canEdit && !isLocked,
           // Zones behind branches and comments by default; honor explicit order.
           zIndex: sanitizeZIndex(objectData.zIndex, DEFAULT_BOARD_OBJECT_Z_INDEX.zone),
           className: eraserMode ? 'eraser-mode' : undefined,
@@ -455,7 +451,7 @@ export const useBoardObjects = ({
           id: objectId,
           type: 'zone',
           position: { x, y },
-          // draggable inherits from canvas-level nodesDraggable (mutationGate.canMutate)
+          draggable: canEdit,
           zIndex: DEFAULT_BOARD_OBJECT_Z_INDEX.zone, // Zones behind branches and comments
           style: {
             width,
@@ -493,7 +489,7 @@ export const useBoardObjects = ({
         setNodes((nodes) => nodes.filter((n) => n.id !== objectId));
       }
     },
-    [client, setNodes, handleUpdateObject] // Removed board dependency
+    [canEdit, client, setNodes, handleUpdateObject] // Removed board dependency
   );
 
   /**

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.ts
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.ts
@@ -50,6 +50,8 @@ export const useBoardObjects = ({
   // Use ref to avoid recreating callbacks when board changes
   const boardRef = useRef(board);
   boardRef.current = board;
+  const canEditRef = useRef(canEdit);
+  canEditRef.current = canEdit;
 
   const { showError } = useThemedMessage();
 
@@ -64,7 +66,7 @@ export const useBoardObjects = ({
   const handleUpdateObject = useCallback(
     async (objectId: string, objectData: BoardObject) => {
       const currentBoard = boardRef.current;
-      if (!currentBoard || !client) return false;
+      if (!canEditRef.current || !currentBoard || !client) return false;
 
       try {
         await client.service('boards').patch(currentBoard.board_id, {
@@ -107,7 +109,7 @@ export const useBoardObjects = ({
   const reorderObject = useCallback(
     async (objectId: string, op: LayerOp) => {
       const currentBoard = boardRef.current;
-      if (!currentBoard || !client) return;
+      if (!canEditRef.current || !currentBoard || !client) return;
 
       const objects = currentBoard.objects ?? {};
       const target = objects[objectId];
@@ -148,7 +150,7 @@ export const useBoardObjects = ({
    */
   const deleteZone = useCallback(
     async (objectId: string, _deleteAssociatedSessions: boolean) => {
-      if (!board || !client) return;
+      if (!canEditRef.current || !board || !client) return;
 
       // Mark as deleted to prevent re-appearance during WebSocket updates
       deletedObjectsRef.current.add(objectId);
@@ -184,7 +186,7 @@ export const useBoardObjects = ({
   const deleteObject = useCallback(
     async (objectId: string) => {
       const currentBoard = boardRef.current;
-      if (!currentBoard || !client) return;
+      if (!canEditRef.current || !currentBoard || !client) return;
 
       // Mark as deleted to prevent re-appearance during WebSocket updates
       deletedObjectsRef.current.add(objectId);
@@ -294,6 +296,7 @@ export const useBoardObjects = ({
               showConsole: objectData.showConsole,
               width: objectData.width,
               height: objectData.height,
+              canEdit,
               onUpdate: handleUpdateObject,
               onDelete: deleteObject,
             },
@@ -319,6 +322,7 @@ export const useBoardObjects = ({
               locked: isLocked,
               x: objectData.x,
               y: objectData.y,
+              canEdit,
               isActiveUrlTarget: objectData.artifact_id === activeUrlTargetArtifactId,
               onUpdate: handleUpdateObject,
               onDeleteArtifact: deleteArtifact,
@@ -341,6 +345,7 @@ export const useBoardObjects = ({
               objectId,
               content: objectData.content,
               width: objectData.width,
+              canEdit,
               onUpdate: handleUpdateObject,
               onEdit: onEditMarkdown,
               onDelete: deleteObject,
@@ -441,7 +446,7 @@ export const useBoardObjects = ({
   const addZoneNode = useCallback(
     async (x: number, y: number) => {
       const currentBoard = boardRef.current;
-      if (!currentBoard || !client) return;
+      if (!canEditRef.current || !currentBoard || !client) return;
 
       const objectId = `zone-${Date.now()}`;
       const width = 400;
@@ -466,6 +471,7 @@ export const useBoardObjects = ({
             width,
             height,
             color: undefined, // Will use theme default (colorBorder)
+            canEdit,
             onUpdate: handleUpdateObject,
           },
         },
@@ -501,7 +507,8 @@ export const useBoardObjects = ({
   const batchUpdateObjectPositions = useCallback(
     async (updates: Record<string, { x: number; y: number }>) => {
       const currentBoard = boardRef.current;
-      if (!currentBoard || !client || Object.keys(updates).length === 0) return;
+      if (!canEditRef.current || !currentBoard || !client || Object.keys(updates).length === 0)
+        return;
 
       try {
         // Build objects payload with full object data + new positions

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.ts
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/useBoardObjects.ts
@@ -64,7 +64,7 @@ export const useBoardObjects = ({
   const handleUpdateObject = useCallback(
     async (objectId: string, objectData: BoardObject) => {
       const currentBoard = boardRef.current;
-      if (!currentBoard || !client) return;
+      if (!currentBoard || !client) return false;
 
       try {
         await client.service('boards').patch(currentBoard.board_id, {
@@ -72,11 +72,14 @@ export const useBoardObjects = ({
           objectId,
           objectData,
         } as unknown as Partial<Board>);
+        return true;
       } catch (error) {
         console.error('Failed to update object:', error);
+        showError('Failed to save board object');
+        return false;
       }
     },
-    [client] // Only depend on client, not board
+    [client, showError] // Only depend on stable services, not board
   );
 
   /**

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/utils/collisionDetection.test.ts
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/utils/collisionDetection.test.ts
@@ -1,0 +1,82 @@
+import type { BoardObject } from '@agor-live/client';
+import type { Node } from 'reactflow';
+import { describe, expect, it } from 'vitest';
+import { findIntersectingObjects, findZoneAtPosition, findZoneForNode } from './collisionDetection';
+
+function zone(label: string, zIndex?: number): Extract<BoardObject, { type: 'zone' }> {
+  return {
+    type: 'zone',
+    x: 0,
+    y: 0,
+    width: 300,
+    height: 300,
+    label,
+    zIndex,
+  };
+}
+
+describe('zone collision layering', () => {
+  it('targets the visually topmost overlapping zone', () => {
+    const objects: Record<string, BoardObject> = {
+      'zone-front': zone('Front', 120),
+      'zone-back': zone('Back', 80),
+    };
+
+    expect(findZoneAtPosition({ x: 100, y: 100 }, objects)?.zoneId).toBe('zone-front');
+  });
+
+  it('uses later paint order as the deterministic equal-z tie breaker', () => {
+    const objects: Record<string, BoardObject> = {
+      'zone-first': zone('First', 100),
+      'zone-later': zone('Later', 100),
+    };
+
+    expect(findZoneAtPosition({ x: 100, y: 100 }, objects)?.zoneId).toBe('zone-later');
+  });
+
+  it('uses the same topmost rule for a dragged node center', () => {
+    const dragged: Node = { id: 'card', position: { x: 50, y: 50 }, data: {} };
+    const objects: Record<string, BoardObject> = {
+      'zone-back': zone('Back', 99),
+      'zone-front': zone('Front', 101),
+    };
+
+    expect(findZoneForNode(dragged, [dragged], objects, 100, 100)?.zoneId).toBe('zone-front');
+  });
+
+  it('chooses the topmost intersecting node while preserving branch priority', () => {
+    const nodes: Node[] = [
+      {
+        id: 'zone-back',
+        type: 'zone',
+        position: { x: 0, y: 0 },
+        width: 300,
+        height: 300,
+        zIndex: 80,
+        data: {},
+      },
+      {
+        id: 'zone-front',
+        type: 'zone',
+        position: { x: 0, y: 0 },
+        width: 300,
+        height: 300,
+        zIndex: 120,
+        data: {},
+      },
+      {
+        id: 'branch',
+        type: 'branchNode',
+        position: { x: 0, y: 0 },
+        width: 300,
+        height: 300,
+        zIndex: 500,
+        data: {},
+      },
+    ];
+
+    const result = findIntersectingObjects({ x: 100, y: 100 }, nodes);
+    expect(result.branchNode?.id).toBe('branch');
+    expect(result.zoneNode?.id).toBe('zone-front');
+  });
+});

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/utils/collisionDetection.ts
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/utils/collisionDetection.ts
@@ -7,6 +7,7 @@
 
 import type { BoardObject } from '@agor-live/client';
 import type { Node } from 'reactflow';
+import { DEFAULT_BOARD_OBJECT_Z_INDEX, sanitizeZIndex } from '../zOrder';
 import { getNodeAbsolutePosition, getNodeCenter, type Position } from './coordinateTransforms';
 import { getAbsoluteNodePosition } from './nodePositionUtils';
 import type { ReactFlowNode } from './reactFlowTypes';
@@ -14,6 +15,16 @@ import type { ReactFlowNode } from './reactFlowTypes';
 export interface CollisionResult {
   branchNode?: Node;
   zoneNode?: Node;
+}
+
+/** Pick the visually topmost node. Later nodes win equal-z ties, matching DOM paint order. */
+function topmostNode(nodes: Node[]): Node | undefined {
+  return nodes.reduce<Node | undefined>((top, node) => {
+    if (!top) return node;
+    const topZ = typeof top.zIndex === 'number' ? top.zIndex : 0;
+    const nodeZ = typeof node.zIndex === 'number' ? node.zIndex : 0;
+    return nodeZ >= topZ ? node : top;
+  }, undefined);
 }
 
 /**
@@ -70,8 +81,8 @@ export function findIntersectingObjects(
 
   // Priority: branch > zone (branches are rendered on top)
   return {
-    branchNode: intersectingNodes.find((n) => n.type === 'branchNode'),
-    zoneNode: intersectingNodes.find((n) => n.type === 'zone'),
+    branchNode: topmostNode(intersectingNodes.filter((node) => node.type === 'branchNode')),
+    zoneNode: topmostNode(intersectingNodes.filter((node) => node.type === 'zone')),
   };
 }
 
@@ -81,6 +92,34 @@ export function findIntersectingObjects(
 export interface ZoneCollision {
   zoneId: string;
   zoneData: BoardObject & { type: 'zone' };
+}
+
+function topmostZoneAtPoint(
+  point: Position,
+  boardObjects: Record<string, BoardObject>
+): ZoneCollision | null {
+  let result: ZoneCollision | null = null;
+  let resultZ = Number.NEGATIVE_INFINITY;
+
+  // Later entries win equal-z ties, matching the order used to build React
+  // Flow nodes. This keeps the visible top zone and the drop target aligned.
+  for (const [zoneId, zoneData] of Object.entries(boardObjects)) {
+    if (zoneData.type !== 'zone') continue;
+    const isInZone =
+      point.x >= zoneData.x &&
+      point.x <= zoneData.x + zoneData.width &&
+      point.y >= zoneData.y &&
+      point.y <= zoneData.y + zoneData.height;
+    if (!isInZone) continue;
+
+    const zIndex = sanitizeZIndex(zoneData.zIndex, DEFAULT_BOARD_OBJECT_Z_INDEX.zone);
+    if (zIndex >= resultZ) {
+      result = { zoneId, zoneData };
+      resultZ = zIndex;
+    }
+  }
+
+  return result;
 }
 
 /**
@@ -118,26 +157,7 @@ export function findZoneForNode(
   // Calculate center point for collision detection
   const center = getNodeCenter(absolutePos, nodeWidth, nodeHeight);
 
-  // Check each zone
-  for (const [zoneId, zoneData] of Object.entries(boardObjects)) {
-    if (zoneData.type !== 'zone') continue;
-
-    // Check if center is within zone bounds
-    const isInZone =
-      center.x >= zoneData.x &&
-      center.x <= zoneData.x + zoneData.width &&
-      center.y >= zoneData.y &&
-      center.y <= zoneData.y + zoneData.height;
-
-    if (isInZone) {
-      return {
-        zoneId,
-        zoneData: zoneData as BoardObject & { type: 'zone' },
-      };
-    }
-  }
-
-  return null;
+  return topmostZoneAtPoint(center, boardObjects);
 }
 
 /**
@@ -153,22 +173,5 @@ export function findZoneAtPosition(
 ): ZoneCollision | null {
   if (!boardObjects) return null;
 
-  for (const [zoneId, zoneData] of Object.entries(boardObjects)) {
-    if (zoneData.type !== 'zone') continue;
-
-    const isInZone =
-      absolutePosition.x >= zoneData.x &&
-      absolutePosition.x <= zoneData.x + zoneData.width &&
-      absolutePosition.y >= zoneData.y &&
-      absolutePosition.y <= zoneData.y + zoneData.height;
-
-    if (isInZone) {
-      return {
-        zoneId,
-        zoneData: zoneData as BoardObject & { type: 'zone' },
-      };
-    }
-  }
-
-  return null;
+  return topmostZoneAtPoint(absolutePosition, boardObjects);
 }

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/utils/commentUtils.test.ts
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/utils/commentUtils.test.ts
@@ -1,6 +1,6 @@
-import type { BoardComment } from '@agor-live/client';
+import type { BoardComment, User } from '@agor-live/client';
 import { describe, expect, it } from 'vitest';
-import { planBoardCommentReposition } from './commentUtils';
+import { canRepositionBoardComment, planBoardCommentReposition } from './commentUtils';
 
 const BASE_COMMENT = {
   comment_id: 'comment-1',
@@ -75,5 +75,19 @@ describe('planBoardCommentReposition', () => {
     expect(planBoardCommentReposition(BASE_COMMENT, { x: 70, y: 80 }, branch('branch-a'))).toEqual({
       data: { branch_id: null, position: { absolute: { x: 70, y: 80 } } },
     });
+  });
+});
+
+describe('canRepositionBoardComment', () => {
+  it('matches the server author-or-admin authorization boundary', () => {
+    expect(
+      canRepositionBoardComment(BASE_COMMENT, { user_id: 'user-1', role: 'member' } as User)
+    ).toBe(true);
+    expect(
+      canRepositionBoardComment(BASE_COMMENT, { user_id: 'user-2', role: 'member' } as User)
+    ).toBe(false);
+    expect(
+      canRepositionBoardComment(BASE_COMMENT, { user_id: 'admin-1', role: 'admin' } as User)
+    ).toBe(true);
   });
 });

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/utils/commentUtils.ts
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/utils/commentUtils.ts
@@ -11,6 +11,9 @@ import {
   type BoardCommentReposition,
   type Branch,
   boardCommentZoneParentObjectKey,
+  hasMinimumRole,
+  ROLES,
+  type User,
 } from '@agor-live/client';
 
 export interface ParentInfo {
@@ -29,6 +32,16 @@ export interface CommentSpatialParent {
 export interface BoardCommentRepositionPlan {
   data: BoardCommentReposition;
   reactFlowParentId?: string;
+}
+
+/** Mirror the route's author-or-admin gate for spatial comment movement. */
+export function canRepositionBoardComment(
+  comment: BoardComment,
+  user: User | null | undefined
+): boolean {
+  return Boolean(
+    user && (comment.created_by === user.user_id || hasMinimumRole(user.role, ROLES.ADMIN))
+  );
 }
 
 /**

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/zoneAppearance.test.ts
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/zoneAppearance.test.ts
@@ -1,0 +1,9 @@
+// biome-ignore-all lint/plugin/noHardcodedColorLiteral: persisted color fixtures verify zone color conversion
+import { describe, expect, it } from 'vitest';
+import { toTranslucentZoneFill } from './zoneAppearance';
+
+describe('toTranslucentZoneFill', () => {
+  it('preserves source alpha while applying the shared zone opacity', () => {
+    expect(toTranslucentZoneFill('rgba(255, 0, 0, 0.5)', 'fallback')).toBe('rgba(255, 0, 0, 0.05)');
+  });
+});

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/zoneAppearance.ts
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/zoneAppearance.ts
@@ -1,2 +1,20 @@
+import { AggregationColor } from 'antd/es/color-picker/color';
+
 /** Opacity used by the default translucent zone fill palette. */
 export const ZONE_CONTENT_OPACITY = 0.1;
+
+/**
+ * Apply the historical zone-fill opacity to a user-selected color.
+ *
+ * Kept here so the compact appearance popover, full settings modal, and zone
+ * renderer cannot drift when migrating the legacy single `color` field.
+ */
+export function toTranslucentZoneFill(color: string, fallback: string): string {
+  try {
+    const rgb = new AggregationColor(color).toRgb();
+    // biome-ignore lint/plugin/noHardcodedColorLiteral: user color resolver emits CSS syntax from parsed channels
+    return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${rgb.a * ZONE_CONTENT_OPACITY})`;
+  } catch {
+    return fallback;
+  }
+}

--- a/apps/agor-ui/src/components/SessionCanvas/canvas/zoneAppearance.ts
+++ b/apps/agor-ui/src/components/SessionCanvas/canvas/zoneAppearance.ts
@@ -1,0 +1,2 @@
+/** Opacity used by the default translucent zone fill palette. */
+export const ZONE_CONTENT_OPACITY = 0.1;

--- a/apps/agor-ui/src/hooks/useCanManageBoard.test.tsx
+++ b/apps/agor-ui/src/hooks/useCanManageBoard.test.tsx
@@ -1,0 +1,73 @@
+import type { AgorClient, Board, User } from '@agor-live/client';
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { __resetAuthConfigForTests, __setAuthConfigForTests } from './useAuthConfig';
+import { useCanManageBoard } from './useCanManageBoard';
+
+const member = {
+  user_id: 'user-2',
+  role: 'member',
+} as User;
+
+const board = {
+  board_id: 'board-1',
+  primary_owner_user_id: 'user-1',
+  archived: false,
+  objects: {},
+} as Board;
+
+afterEach(() => {
+  __resetAuthConfigForTests();
+});
+
+describe('useCanManageBoard', () => {
+  it('preserves member editing and skips policy requests when RBAC is disabled', async () => {
+    __setAuthConfigForTests({ requireAuth: true }, { branchRbac: false });
+    const service = vi.fn(() => {
+      throw new Error('permission service must not be called');
+    });
+    const client = { service } as unknown as AgorClient;
+
+    const { result } = renderHook(() => useCanManageBoard(client, board, member));
+
+    await waitFor(() => expect(result.current).toBe(true));
+    expect(service).not.toHaveBeenCalled();
+  });
+
+  it('uses effective access once and ignores ordinary board object patches', async () => {
+    __setAuthConfigForTests({ requireAuth: true }, { branchRbac: true });
+    const find = vi.fn().mockResolvedValue({ capabilities: ['board.view', 'board.edit'] });
+    const service = vi.fn((path: string) => {
+      expect(path).toBe('boards/:id/effective-access');
+      return { find };
+    });
+    const client = { service } as unknown as AgorClient;
+
+    const { result, rerender } = renderHook(
+      ({ currentBoard }) => useCanManageBoard(client, currentBoard, member),
+      { initialProps: { currentBoard: board } }
+    );
+
+    await waitFor(() => expect(result.current).toBe(true));
+    expect(find).toHaveBeenCalledTimes(1);
+
+    rerender({
+      currentBoard: {
+        ...board,
+        objects: {
+          'zone-1': {
+            type: 'zone',
+            x: 10,
+            y: 20,
+            width: 300,
+            height: 200,
+            label: 'Review',
+          },
+        },
+      } as Board,
+    });
+
+    expect(result.current).toBe(true);
+    expect(find).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/agor-ui/src/hooks/useCanManageBoard.test.tsx
+++ b/apps/agor-ui/src/hooks/useCanManageBoard.test.tsx
@@ -1,8 +1,13 @@
 import type { AgorClient, Board, User } from '@agor-live/client';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { __resetAuthConfigForTests, __setAuthConfigForTests } from './useAuthConfig';
 import { useCanManageBoard } from './useCanManageBoard';
+
+const connectionState = vi.hoisted(() => ({ authGeneration: 1 }));
+vi.mock('../contexts/ConnectionContext', () => ({
+  useConnectionState: () => connectionState,
+}));
 
 const member = {
   user_id: 'user-2',
@@ -17,6 +22,7 @@ const board = {
 } as Board;
 
 afterEach(() => {
+  connectionState.authGeneration = 1;
   __resetAuthConfigForTests();
 });
 
@@ -34,9 +40,16 @@ describe('useCanManageBoard', () => {
     expect(service).not.toHaveBeenCalled();
   });
 
-  it('uses effective access once and ignores ordinary board object patches', async () => {
+  it('ignores object patches but refetches effective access after authenticated reconnect', async () => {
     __setAuthConfigForTests({ requireAuth: true }, { branchRbac: true });
-    const find = vi.fn().mockResolvedValue({ capabilities: ['board.view', 'board.edit'] });
+    let resolveReconnect: ((access: { capabilities: string[] }) => void) | undefined;
+    const reconnectAccess = new Promise<{ capabilities: string[] }>((resolve) => {
+      resolveReconnect = resolve;
+    });
+    const find = vi
+      .fn()
+      .mockResolvedValueOnce({ capabilities: ['board.view', 'board.edit'] })
+      .mockReturnValueOnce(reconnectAccess);
     const service = vi.fn((path: string) => {
       expect(path).toBe('boards/:id/effective-access');
       return { find };
@@ -69,5 +82,16 @@ describe('useCanManageBoard', () => {
 
     expect(result.current).toBe(true);
     expect(find).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      connectionState.authGeneration += 1;
+      rerender({ currentBoard: board });
+    });
+
+    await waitFor(() => expect(find).toHaveBeenCalledTimes(2));
+    expect(result.current).toBe(false);
+
+    resolveReconnect?.({ capabilities: ['board.view'] });
+    await waitFor(() => expect(result.current).toBe(false));
   });
 });

--- a/apps/agor-ui/src/hooks/useCanManageBoard.ts
+++ b/apps/agor-ui/src/hooks/useCanManageBoard.ts
@@ -1,6 +1,7 @@
-import type { AgorClient, Board, GroupMembership, User } from '@agor-live/client';
-import { hasMinimumRole, ROLES, resolveCapabilityPolicyAccess } from '@agor-live/client';
+import type { AgorClient, Board, EffectiveCapabilityPolicyAccess, User } from '@agor-live/client';
+import { hasMinimumRole, ROLES } from '@agor-live/client';
 import { useEffect, useState } from 'react';
+import { useAuthConfig } from './useAuthConfig';
 
 /**
  * Resolve board-management capability from the same normalized policy used by
@@ -12,31 +13,43 @@ export function useCanManageBoard(
   user: User | null | undefined
 ) {
   const [canManage, setCanManage] = useState(false);
+  const { featuresConfig, loading: authConfigLoading } = useAuthConfig();
+  const branchRbacEnabled = featuresConfig?.branchRbac === true;
+  const boardId = board?.board_id;
+  const boardArchived = Boolean(board?.archived);
+  const primaryOwnerUserId = board?.primary_owner_user_id;
+  const userId = user?.user_id;
+  const userRole = user?.role;
 
   useEffect(() => {
     let cancelled = false;
     setCanManage(false);
-    if (!board || !user || !client || board.archived) return;
-    if (hasMinimumRole(user.role, ROLES.ADMIN) || board.primary_owner_user_id === user.user_id) {
+    if (authConfigLoading || !boardId || !userId || !userRole || !client || boardArchived) return;
+    if (!hasMinimumRole(userRole, ROLES.MEMBER)) return;
+
+    // Preserve the daemon's intentionally open member-level editing behavior
+    // while normalized board/branch RBAC is disabled.
+    if (!branchRbacEnabled) {
       setCanManage(true);
       return;
     }
-    if (!hasMinimumRole(user.role, ROLES.MEMBER)) return;
 
-    void Promise.all([
-      client.service('boards/:id/permissions').find({ route: { id: board.board_id } }),
-      client.service('group-memberships').findAll({ query: { user_id: user.user_id } }),
-    ])
-      .then(([permissions, memberships]) => {
+    if (hasMinimumRole(userRole, ROLES.ADMIN) || primaryOwnerUserId === userId) {
+      setCanManage(true);
+      return;
+    }
+
+    // The daemon owns policy, group-membership, and principal precedence. Use
+    // its effective-access projection instead of reimplementing that resolver
+    // in the browser.
+    void client
+      .service('boards/:id/effective-access')
+      .find({ route: { id: boardId } })
+      .then((access: unknown) => {
         if (cancelled) return;
-        const access = resolveCapabilityPolicyAccess({
-          policy: permissions.board_access,
-          primary_owner_user_id: permissions.primary_owner_user_id,
-          user_id: user.user_id,
-          user_status: 'active',
-          active_group_ids: (memberships as GroupMembership[]).map((item) => item.group_id),
-        });
-        setCanManage(access.capabilities.includes('board.edit'));
+        setCanManage(
+          (access as EffectiveCapabilityPolicyAccess).capabilities.includes('board.edit')
+        );
       })
       .catch(() => {
         if (!cancelled) setCanManage(false);
@@ -45,7 +58,16 @@ export function useCanManageBoard(
     return () => {
       cancelled = true;
     };
-  }, [board, client, user]);
+  }, [
+    boardArchived,
+    boardId,
+    branchRbacEnabled,
+    authConfigLoading,
+    client,
+    primaryOwnerUserId,
+    userId,
+    userRole,
+  ]);
 
   return canManage;
 }

--- a/apps/agor-ui/src/hooks/useCanManageBoard.ts
+++ b/apps/agor-ui/src/hooks/useCanManageBoard.ts
@@ -1,6 +1,7 @@
 import type { AgorClient, Board, EffectiveCapabilityPolicyAccess, User } from '@agor-live/client';
 import { hasMinimumRole, ROLES } from '@agor-live/client';
 import { useEffect, useState } from 'react';
+import { useConnectionState } from '../contexts/ConnectionContext';
 import { useAuthConfig } from './useAuthConfig';
 
 /**
@@ -12,30 +13,48 @@ export function useCanManageBoard(
   board: Board | undefined,
   user: User | null | undefined
 ) {
-  const [canManage, setCanManage] = useState(false);
+  const [permission, setPermission] = useState<{
+    client: AgorClient | null;
+    scopeKey: string | null;
+    canManage: boolean;
+  }>({ client: null, scopeKey: null, canManage: false });
   const { featuresConfig, loading: authConfigLoading } = useAuthConfig();
+  const { authGeneration } = useConnectionState();
   const branchRbacEnabled = featuresConfig?.branchRbac === true;
   const boardId = board?.board_id;
   const boardArchived = Boolean(board?.archived);
   const primaryOwnerUserId = board?.primary_owner_user_id;
   const userId = user?.user_id;
   const userRole = user?.role;
+  const scopeKey = [
+    authConfigLoading ? 'loading' : 'ready',
+    branchRbacEnabled ? 'rbac' : 'open',
+    boardId ?? '',
+    boardArchived ? 'archived' : 'active',
+    primaryOwnerUserId ?? '',
+    userId ?? '',
+    userRole ?? '',
+    authGeneration,
+  ].join(':');
 
   useEffect(() => {
     let cancelled = false;
-    setCanManage(false);
+    const publish = (canManage: boolean) => {
+      setPermission({ client, scopeKey, canManage });
+    };
+    publish(false);
     if (authConfigLoading || !boardId || !userId || !userRole || !client || boardArchived) return;
     if (!hasMinimumRole(userRole, ROLES.MEMBER)) return;
 
     // Preserve the daemon's intentionally open member-level editing behavior
     // while normalized board/branch RBAC is disabled.
     if (!branchRbacEnabled) {
-      setCanManage(true);
+      publish(true);
       return;
     }
 
     if (hasMinimumRole(userRole, ROLES.ADMIN) || primaryOwnerUserId === userId) {
-      setCanManage(true);
+      publish(true);
       return;
     }
 
@@ -47,12 +66,10 @@ export function useCanManageBoard(
       .find({ route: { id: boardId } })
       .then((access: unknown) => {
         if (cancelled) return;
-        setCanManage(
-          (access as EffectiveCapabilityPolicyAccess).capabilities.includes('board.edit')
-        );
+        publish((access as EffectiveCapabilityPolicyAccess).capabilities.includes('board.edit'));
       })
       .catch(() => {
-        if (!cancelled) setCanManage(false);
+        if (!cancelled) publish(false);
       });
 
     return () => {
@@ -65,9 +82,14 @@ export function useCanManageBoard(
     authConfigLoading,
     client,
     primaryOwnerUserId,
+    scopeKey,
     userId,
     userRole,
   ]);
 
-  return canManage;
+  // Never expose an answer from a previous authenticated generation, identity,
+  // board, or client during the render before the refetch effect runs.
+  return permission.client === client && permission.scopeKey === scopeKey
+    ? permission.canManage
+    : false;
 }


### PR DESCRIPTION
## Summary
<img width="563" height="364" alt="Screenshot 2026-09-03 at 3 18 05 PM" src="https://github.com/user-attachments/assets/b5dee74f-ea36-42c6-b823-e1660a39a48b" />
<img width="694" height="710" alt="Screenshot 2026-09-03 at 3 19 24 PM" src="https://github.com/user-attachments/assets/765deabe-0fd4-4a57-8008-39df9bd0e525" />
<img width="674" height="663" alt="Screenshot 2026-09-03 at 3 20 26 PM" src="https://github.com/user-attachments/assets/521565df-aded-4673-9659-21af889c6f48" />

- replace the wide always-visible zone toolbox with a compact, accessible action toolbar
- keep rename, appearance, placement lock, and settings at the top level; move layering and deletion into **More**
- make the appearance action recognizable with a paint-colors icon plus a live color swatch
- make **Automation** the first and default Zone settings section, leading with the prompt template and then its trigger behavior
- move name, colors, label size, and placement lock into the secondary **Appearance & placement** section
- expose structural editing controls only to users with effective `board.edit` permission and only while mutations are available
- preserve board-viewer collaboration: eligible members can still add comments, while comment movement follows the existing author/admin rule
- refresh effective board access after authenticated reconnects without permission flicker or refetches from ordinary board-object patches
- apply `board.edit` consistently to zone, Markdown, app, and artifact layout controls while retaining artifact lifecycle deletion's separate creator/admin authorization
- gate artifact deletion during reconnect/out-of-sync states, including confirmations already open when the connection gate closes
- make overlapping-zone layering discoverable, disable no-op layer actions, and align drop targeting with the visually topmost zone
- simplify deletion confirmation around the supported non-destructive behavior: remove the zone, unpin its content, and keep branches, cards, comments, notes, sessions, and history
- preserve zone-pinned spatial comments at their absolute board positions instead of leaving them attached to a deleted parent
- keep Zone Settings open—with the operator's automation edits intact—when persistence fails
- document the updated editing, automation, and deletion workflows

## Compatibility and risk

- preserves existing zone fields, trigger defaults, z-index values, colors, font sizes, and lock behavior
- keeps the existing delete-zone API shape and ignores the legacy `deleteAssociatedSessions` argument as before
- converts zone-relative branch/card positions and spatial-comment positions to absolute coordinates before removing the zone
- performs zone deletion and all related coordinate updates in one tenant-scoped database transaction, with realtime events emitted only after commit
- materializes a legacy translucent fill whenever a legacy single-color zone receives a separate border color, including through Zone Settings
- respects the `execution.branch_rbac` feature flag and uses the canonical effective-access endpoint when RBAC is enabled
- requires no public API, database schema, or migration changes

## Testing

- `pnpm check`
- focused zone/permission/structural-control UI run (8 files, 49 tests)
- earlier focused permission/appearance/comment run (8 files, 36 tests)
- `pnpm --filter @agor/daemon exec vitest run src/services/boards.test.ts` (1 file, 24 tests)
- earlier canvas regression run: `pnpm --filter agor-ui exec vitest run src/components/SessionCanvas/canvas src/components/SessionCanvas/SessionCanvas.zoom.test.tsx src/components/SessionCanvas/SessionCanvas.rerender.test.tsx` (13 files, 103 tests)
