### PR TITLE
chore: upgrade Claude and Codex SDKs for 0.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@ Every release-version bump PR must include its finalized changelog section; a ve
 
 ## Unreleased
 
+## 0.26.1 (2026-09-03)
+
+### Fixes
+
+- **Claude and Codex integrations track current SDK contracts** — upgrades the managed runtimes to Claude Agent SDK 0.3.259 and Codex SDK 0.153.0, including cumulative Claude result accounting, background-task snapshots, prompt provenance, and Codex cache-write usage. Adds the verified `claude-fable-5-1` alias with native 1M context while deliberately retaining OpenCode 1.14.33 pending a dedicated event/API migration. ([#2667](https://github.com/preset-io/agor/pull/2667))
+
+### Chores
+
+- **Align the 0.26.1 release train** — `agor-live`, the CLI, client, and version-aligned agentic-tool packages now share the release version. ([#2667](https://github.com/preset-io/agor/pull/2667))
+
 ## 0.26.0 (2026-08-30)
 
 ### Breaking

--- a/apps/agor-cli/package.json
+++ b/apps/agor-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor/cli",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "private": true,
   "type": "module",
   "bin": {

--- a/apps/agor-daemon/package.json
+++ b/apps/agor-daemon/package.json
@@ -49,7 +49,7 @@
     "socket.io": "^4.8.3"
   },
   "devDependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.197",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.259",
     "@anthropic-ai/sdk": "^0.109.0",
     "@aws-sdk/client-s3": "^3.1106.0",
     "@aws-sdk/lib-storage": "^3.1106.0",

--- a/apps/agor-daemon/package.json
+++ b/apps/agor-daemon/package.json
@@ -49,7 +49,7 @@
     "socket.io": "^4.8.3"
   },
   "devDependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.259",
+    "@anthropic-ai/claude-agent-sdk": "0.3.259",
     "@anthropic-ai/sdk": "^0.109.0",
     "@aws-sdk/client-s3": "^3.1106.0",
     "@aws-sdk/lib-storage": "^3.1106.0",

--- a/apps/agor-daemon/src/mcp/tools/branches.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.test.ts
@@ -1424,8 +1424,12 @@ describe('agor_branches_set_zone', () => {
       baseServiceParams
     );
     expect(promptCreate).toHaveBeenCalledWith(
-      { prompt: 'Run Branch 1 in Evidence/QA', stream: true },
-      { ...baseServiceParams, route: { id: 'session-1' } }
+      {
+        prompt: 'Run Branch 1 in Evidence/QA',
+        stream: true,
+        metadata: { system_authored: true },
+      },
+      { ...baseServiceParams, provider: undefined, route: { id: 'session-1' } }
     );
     expect(parsed.trigger.sessionId).toBe('session-1');
   });

--- a/apps/agor-daemon/src/mcp/tools/branches.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.ts
@@ -1448,12 +1448,14 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
         const renderedPrompt = renderTemplate(zone.trigger!.template, templateContext);
 
         if (renderedPrompt) {
-          const task = await ctx.app
-            .service('/sessions/:id/prompt')
-            .create(
-              { prompt: renderedPrompt, stream: true },
-              { ...ctx.baseServiceParams, route: { id: targetSessionId } }
-            );
+          const task = await ctx.app.service('/sessions/:id/prompt').create(
+            {
+              prompt: renderedPrompt,
+              stream: true,
+              metadata: { system_authored: true },
+            },
+            { ...ctx.baseServiceParams, provider: undefined, route: { id: targetSessionId } }
+          );
 
           if (task.status === 'queued') {
             promptResult = {

--- a/apps/agor-daemon/src/mcp/tools/sessions.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.test.ts
@@ -1498,7 +1498,9 @@ describe('agor_sessions_prompt task callback', () => {
       callback: true,
     });
 
+    expect(promptCalls[0][0]).toMatchObject({ metadata: { system_authored: true } });
     expect(promptCalls[0][1]).toMatchObject({
+      provider: undefined,
       route: { id: 'sess-target' },
       _taskCompletionCallback: {
         target_session_id: 'sess-caller',

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -702,9 +702,11 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
           prompt: args.prompt,
           permissionMode: childSession.permission_config?.mode || 'acceptEdits',
           stream: true,
+          metadata: { system_authored: true },
         },
         {
           ...ctx.baseServiceParams,
+          provider: undefined,
           route: { id: childSession.session_id },
         }
       );
@@ -791,8 +793,8 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         const task = await ctx.app
           .service('/sessions/:id/prompt')
           .create(
-            { prompt: args.prompt, stream: true },
-            { ...callbackParams, route: { id: sessionId } }
+            { prompt: args.prompt, stream: true, metadata: { system_authored: true } },
+            { ...callbackParams, provider: undefined, route: { id: sessionId } }
           );
 
         if (task.status === 'queued') {
@@ -865,8 +867,9 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
             prompt: args.prompt,
             permissionMode: updatedSession.permission_config?.mode,
             stream: true,
+            metadata: { system_authored: true },
           },
-          { ...callbackParams, route: { id: forkedSession.session_id } }
+          { ...callbackParams, provider: undefined, route: { id: forkedSession.session_id } }
         );
 
         const note =
@@ -899,8 +902,9 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
             prompt: args.prompt,
             permissionMode: childSession.permission_config?.mode,
             stream: true,
+            metadata: { system_authored: true },
           },
-          { ...callbackParams, route: { id: childSession.session_id } }
+          { ...callbackParams, provider: undefined, route: { id: childSession.session_id } }
         );
 
         return textResult({
@@ -1330,8 +1334,9 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
             prompt: args.initialPrompt,
             permissionMode: session.permission_config?.mode,
             stream: true,
+            metadata: { system_authored: true },
           },
-          { ...ctx.baseServiceParams, route: { id: session.session_id } }
+          { ...ctx.baseServiceParams, provider: undefined, route: { id: session.session_id } }
         );
       }
 

--- a/apps/agor-daemon/src/mcp/tools/widgets.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/widgets.test.ts
@@ -535,6 +535,7 @@ describe('agor_widgets_request_env_vars', () => {
     expect(promptData.metadata.widget_id).toBe(widgetId);
     expect(promptData.idempotencyTaskId).toBe(widgetAutoResumeTaskId(widgetId as MessageID));
     expect(promptData.idempotencyTaskId).not.toBe(widgetId);
+    expect((promptCall!.args[1] as { provider?: string }).provider).toBeUndefined();
   });
 
   it('reads the prompt actor env vars rather than the shared Session owner', async () => {

--- a/apps/agor-daemon/src/mcp/tools/widgets.ts
+++ b/apps/agor-daemon/src/mcp/tools/widgets.ts
@@ -210,7 +210,7 @@ export function registerWidgetTools(server: McpServer, ctx: McpContext): void {
                 widget_id: widgetId,
               },
             },
-            { ...ctx.baseServiceParams, route: { id: currentSessionId } }
+            { ...ctx.baseServiceParams, provider: undefined, route: { id: currentSessionId } }
           );
         }
         return textResult({ widget_id: widgetId, status: 'already_present' });

--- a/apps/agor-daemon/src/register-hooks.test.ts
+++ b/apps/agor-daemon/src/register-hooks.test.ts
@@ -25,7 +25,7 @@ import {
   getCurrentTenantId,
   runWithTenantContext,
 } from '@agor/core/db';
-import { type Branch, type HookContext, TaskStatus } from '@agor/core/types';
+import { type Branch, type HookContext, type Task, TaskStatus } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -53,6 +53,7 @@ import {
   validateBranchEnvPolicyHook,
 } from './register-hooks';
 import { canReceiveMcpTokenForSession } from './utils/mcp-token-authorization';
+import { resolvePromptOrigin } from './utils/prompt-origin';
 
 const makeSession = (sessionId: string): import('@agor/core/types').Session =>
   ({
@@ -327,7 +328,11 @@ describe('protectExternalTaskCreate', () => {
       session_id: 'session-1',
       full_prompt: 'hello',
       status: TaskStatus.CREATED,
+      metadata: { source: 'agor' },
     });
+    expect(
+      resolvePromptOrigin(hook.data as Pick<Task, 'metadata'>, { custom_context: undefined })
+    ).toEqual({ kind: 'human' });
   });
 
   it.each(['running', 'queued', 'completed'])('rejects externally forged status %s', (status) => {

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -157,6 +157,7 @@ import {
   loadScheduleAndBranch,
   loadSession,
   loadSessionBranch,
+  protectGatewaySourceMetadata,
   resolveSessionContext,
   scopeFindToAccessibleBoardsSql,
   scopeFindToAccessibleBranchesSql,
@@ -691,6 +692,7 @@ export function protectExternalTaskCreate(context: HookContext): HookContext {
   }
 
   data.status = TaskStatus.CREATED;
+  data.metadata = { source: 'agor' };
   return context;
 }
 
@@ -2996,6 +2998,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   // SessionsService.update delegates straight to patch, so both verbs mutate a
   // session the same way and must clear the same authorization chain.
   const sessionWriteGuards = [
+    protectGatewaySourceMetadata,
     // created_by and unix_username remain immutable identity/history stamps.
     // unix_username is load-bearing for delegated execution-home Sessions;
     // branch-home Sessions deliberately use the current prompt actor instead.
@@ -3066,6 +3069,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       ],
       create: [
         requireMinimumRole(ROLES.MEMBER, 'create sessions'),
+        protectGatewaySourceMetadata,
         // Stamp session with creator's unix_username (MUST run first). Also
         // registered without RBAC when delegated mode makes
         // unix_username load-bearing — otherwise sessions would be stamped

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -2815,7 +2815,9 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
             authentication: params.authentication,
             tenant: params.tenant,
           };
-          await promptService.create({ prompt: promptText }, promptParams);
+          // This provider-less nested service call represents text submitted
+          // by the authenticated uploader, not daemon-authored automation.
+          await promptService.create({ prompt: promptText, messageSource: 'agor' }, promptParams);
         } catch (_error) {
           console.error('❌ [Upload Handler] Failed to notify agent');
           notificationError = 'Failed to send notification to agent';

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -224,6 +224,7 @@ import {
 } from './utils/mcp-header-secrets.js';
 import { canConfigureMcpServers } from './utils/mcp-server-authorization.js';
 import { patchUnlessRemoved } from './utils/patch-unless-removed.js';
+import { resolvePromptOrigin } from './utils/prompt-origin.js';
 import {
   buildPromptTaskMetadata,
   type InternalPromptTaskMetadataInput,
@@ -1823,6 +1824,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     const useStreaming = options.stream !== false;
     const sessionId = task.session_id;
     const taskId = task.task_id;
+    const promptOrigin = resolvePromptOrigin(updatedTask, session);
 
     // Background spawn + failure handling. Returning the patched Task to the
     // caller before this resolves matches the previous behavior — the HTTP
@@ -1843,6 +1845,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
             permissionMode: options.permissionMode,
             stream: useStreaming,
             messageSource: runtimeMessageSource,
+            promptOrigin,
           },
           params
         );
@@ -2433,8 +2436,13 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
 
         const promptService = app.service('/sessions/:id/prompt');
         return promptService.create(
-          { prompt: metaPrompt, permissionMode: parentPermissionMode, messageSource: 'agor' },
-          { ...params, route: { id } }
+          {
+            prompt: metaPrompt,
+            permissionMode: parentPermissionMode,
+            messageSource: 'agor',
+            metadata: { system_authored: true },
+          },
+          { ...params, provider: undefined, route: { id } }
         );
       },
     },

--- a/apps/agor-daemon/src/register-routes.upload-boundary.test.ts
+++ b/apps/agor-daemon/src/register-routes.upload-boundary.test.ts
@@ -28,6 +28,14 @@ describe('browser upload route boundary ordering', () => {
     expect(handler).toContain('ref: staged.ref');
   });
 
+  it('classifies an authenticated upload notification as a direct human prompt', () => {
+    const handler = source.slice(
+      source.indexOf('const uploadHandler'),
+      source.indexOf('const uploadLogger')
+    );
+    expect(handler).toContain("{ prompt: promptText, messageSource: 'agor' }");
+  });
+
   it('propagates the tenant verified by authentication on the same params object', async () => {
     const verifiedTenant = { tenant_id: 'verified-tenant', source: 'explicit' } as TenantContext;
     const rawDb = { run: vi.fn(), select: vi.fn(() => ({ user_id: 'user-1' })) };

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -94,6 +94,7 @@ import type {
   MCPServerID,
   MessageSource,
   Params,
+  PromptOrigin,
   SessionID,
   UserID,
   UUID,
@@ -1131,6 +1132,7 @@ function createExecuteHandler(
       permissionMode?: import('@agor/core/types').PermissionMode;
       stream?: boolean;
       messageSource?: MessageSource;
+      promptOrigin?: PromptOrigin;
     },
     // biome-ignore lint/suspicious/noExplicitAny: FeathersJS params type varies by context
     params: any
@@ -1558,6 +1560,7 @@ function createExecuteHandler(
         permissionMode: permissionModeForPayload as 'ask' | 'auto' | 'allow-all' | undefined,
         cwd,
         messageSource: data.messageSource,
+        promptOrigin: data.promptOrigin,
         // Authoritative sandbox mount inputs (consumed in spawn-executor →
         // buildSandboxWrap). Undefined when the sandbox / per_user home is off.
         sandboxBaseRepoPath,

--- a/apps/agor-daemon/src/services/claude-models.test.ts
+++ b/apps/agor-daemon/src/services/claude-models.test.ts
@@ -37,4 +37,15 @@ describe('Claude model discovery materialization', () => {
       },
     ]);
   });
+
+  it('materializes the verified Claude Fable 5.1 alias as native 1M', () => {
+    expect(toModelOptions([model('claude-fable-5-1', 'Claude Fable 5.1')])).toEqual([
+      {
+        id: 'claude-fable-5-1',
+        displayName: 'Claude Fable 5.1 · 1M',
+        description: 'Most capable model for demanding reasoning and long-horizon agentic work',
+        source: 'dynamic',
+      },
+    ]);
+  });
 });

--- a/apps/agor-daemon/src/services/claude-oauth.test.ts
+++ b/apps/agor-daemon/src/services/claude-oauth.test.ts
@@ -172,6 +172,9 @@ describe('PKCE + pure helpers', () => {
     expect(url.searchParams.get('code_challenge')).toBe(challenge);
     expect(url.searchParams.get('code')).toBe('true');
     expect(url.searchParams.get('state')).toBe('STATE123');
+    expect(url.searchParams.get('scope')).toBe(
+      'user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload'
+    );
     // The PKCE verifier is the secret half — it must never appear in the URL.
     expect(url.toString()).not.toContain(verifier);
   });

--- a/apps/agor-daemon/src/services/claude-oauth.ts
+++ b/apps/agor-daemon/src/services/claude-oauth.ts
@@ -73,14 +73,13 @@ import {
 } from './codex-auth-shared.js';
 import { markTrustedUserMutation } from './user-mutation-trust.js';
 
-// Constants are the PROD OAuth config (`yol`) read out of the native `claude`
-// binary bundled by the pinned SDK: package.json pins
-// @anthropic-ai/claude-agent-sdk@0.3.197, whose manifest.json bundles claude
-// CLI v2.1.197 (commit c8fd8048). The prod config is identical in the installed
-// CLI v2.1.211, which was byte-inspected: config object at file offset
-// ~237512852 (`yol={...}`), login authorize builder at ~101457400, token
-// exchange at ~101464300. The `-local-oauth` config (client id
-// 22422756-…, localhost:8205) is dev-only and deliberately not used here.
+// Constants are the PROD OAuth config read out of the native `claude` binary
+// bundled by the pinned SDK: package.json pins
+// @anthropic-ai/claude-agent-sdk@0.3.259, whose manifest.json bundles claude
+// CLI v2.1.259 (commit 9b549c8d). The URLs, client id, redirect, scope set, and
+// JSON authorization-code exchange were re-checked in that native binary for
+// this upgrade. The `-local-oauth` config (client id 22422756-…,
+// localhost:8205) is dev-only and deliberately not used here.
 /** PROD OAuth client id (`yol.CLIENT_ID`). Fixed and public across installs. */
 const CLAUDE_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
 // Subscription (Claude Pro/Max) authorize endpoint = `yol.CLAUDE_AI_AUTHORIZE_URL`.
@@ -95,13 +94,15 @@ const CLAUDE_TOKEN_URL = 'https://platform.claude.com/v1/oauth/token';
 // runs no loopback server, so it uses the manual redirect, and the token is
 // issued for exactly this redirect + client id, so both must match byte-for-byte.
 const CLAUDE_REDIRECT_URI = 'https://platform.claude.com/oauth/code/callback';
-// Scope string the CLI's claude.ai login sends (login builder at offset
-// ~101458000: "user:profile user:inference user:sessions:claude_code user:mcp_servers").
+// Scope string the CLI's claude.ai login sends. `user:file_upload` was added by
+// the CLI bundled with Agent SDK 0.3.259; omitting it would leave a successful
+// Agor sign-in less capable than `/login` in the same CLI.
 const CLAUDE_SCOPES = [
   'user:profile',
   'user:inference',
   'user:sessions:claude_code',
   'user:mcp_servers',
+  'user:file_upload',
 ];
 
 const FETCH_TIMEOUT_MS = 15_000;
@@ -152,7 +153,8 @@ export function buildAuthorizeUrl(challenge: string, state: string): string {
   url.searchParams.set('state', state);
   // `code=true` selects the code-display (paste-back) page instead of a silent
   // loopback redirect — the CLI sets it for its manual flow (authorize builder
-  // offset ~101457400). Required here since the daemon has no loopback server.
+  // originally audited in v2.1.211). Required here since the daemon has no
+  // loopback server.
   url.searchParams.set('code', 'true');
   return url.toString();
 }
@@ -232,8 +234,7 @@ export async function exchangeCodeForTokens(
   verifier: string,
   state: string
 ): Promise<ExchangedTokens> {
-  // The CLI posts the exchange as JSON (no oauth beta header on this call);
-  // token exchange at binary offset ~101464300 uses application/json.
+  // The CLI posts the exchange as JSON (no oauth beta header on this call).
   let res: Response;
   try {
     res = await fetchWithTimeout(CLAUDE_TOKEN_URL, {

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -81,6 +81,7 @@ import type {
   GatewayOutboundMessage,
   GatewayOutboundMessageID,
   GatewayOutboundReplyAdmission,
+  GatewaySource,
   MCPServerID,
   Message,
   MessageSource,
@@ -2790,7 +2791,7 @@ export class GatewayService {
       );
 
       // Build custom_context with gateway metadata + platform-specific fields
-      const gatewaySource: Record<string, unknown> = {
+      const gatewaySource: GatewaySource & Record<string, unknown> = {
         channel_id: channel.id,
         channel_name: channel.name,
         channel_type: channel.channel_type,
@@ -2931,7 +2932,7 @@ export class GatewayService {
           typeof priorGatewaySourceValue === 'object' &&
           priorGatewaySourceValue !== null &&
           !Array.isArray(priorGatewaySourceValue)
-            ? (priorGatewaySourceValue as Record<string, unknown>)
+            ? (priorGatewaySourceValue as unknown as GatewaySource & Record<string, unknown>)
             : null;
         const currentTenantId = getCurrentTenantId();
         const priorSeedId = priorGatewaySource?.outbound_seed_id;

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -257,6 +257,7 @@ export type ExecuteTaskData = {
   permissionMode?: import('@agor/core/types').PermissionMode;
   stream?: boolean;
   messageSource?: import('@agor/core/types').MessageSource;
+  promptOrigin?: import('@agor/core/types').PromptOrigin;
 };
 
 export type SessionArchiveOptions = {

--- a/apps/agor-daemon/src/services/zone-trigger.ts
+++ b/apps/agor-daemon/src/services/zone-trigger.ts
@@ -135,12 +135,14 @@ export async function fireAlwaysNewZoneTrigger(
     }
   }
 
-  const task: Task = await app
-    .service('/sessions/:id/prompt')
-    .create(
-      { prompt: renderedPrompt, messageSource: 'agor' },
-      { ...params, route: { id: newSession.session_id } }
-    );
+  const task: Task = await app.service('/sessions/:id/prompt').create(
+    {
+      prompt: renderedPrompt,
+      messageSource: 'agor',
+      metadata: { system_authored: true },
+    },
+    { ...params, provider: undefined, route: { id: newSession.session_id } }
+  );
 
   return { session: newSession, task };
 }

--- a/apps/agor-daemon/src/utils/branch-authorization.test.ts
+++ b/apps/agor-daemon/src/utils/branch-authorization.test.ts
@@ -17,11 +17,60 @@ import {
   loadSession,
   loadSessionBranch,
   paginateClientSide,
+  protectGatewaySourceMetadata,
   resolveBranchPermission,
   resolveSessionContext,
   scopeSessionQuery,
   setSessionUnixUsername,
 } from './branch-authorization';
+
+describe('protectGatewaySourceMetadata', () => {
+  const context = (
+    data: unknown,
+    provider: string | null = 'rest',
+    method: 'create' | 'patch' = 'patch'
+  ) => ({ data, method, params: { provider } }) as HookContext;
+
+  it.each(['create', 'patch'] as const)(
+    'rejects external %s writes of gateway provenance',
+    (method) => {
+      expect(() =>
+        protectGatewaySourceMetadata(
+          context(
+            {
+              custom_context: {
+                gateway_source: {
+                  channel_id: 'channel-1',
+                  channel_name: 'general',
+                  channel_type: 'slack',
+                  thread_id: 'thread-1',
+                },
+              },
+            },
+            'rest',
+            method
+          )
+        )
+      ).toThrow('gateway_source is server-managed');
+    }
+  );
+
+  it('allows external user context that omits the reserved key', () => {
+    const hook = context({ custom_context: { project: 'agor' } });
+    expect(protectGatewaySourceMetadata(hook)).toBe(hook);
+  });
+
+  it('rejects clearing the context through a non-object patch', () => {
+    expect(() => protectGatewaySourceMetadata(context({ custom_context: null }))).toThrow(
+      'custom_context must be an object'
+    );
+  });
+
+  it('allows trusted gateway service writes', () => {
+    const hook = context({ custom_context: { gateway_source: { channel_type: 'slack' } } }, null);
+    expect(protectGatewaySourceMetadata(hook)).toBe(hook);
+  });
+});
 
 /** Minimal branch fixture for permission tests */
 function makeBranch(overrides: Partial<Branch> = {}): Branch {

--- a/apps/agor-daemon/src/utils/branch-authorization.ts
+++ b/apps/agor-daemon/src/utils/branch-authorization.ts
@@ -17,7 +17,7 @@ import type {
   SessionRepository,
 } from '@agor/core/db';
 import { shortId } from '@agor/core/db';
-import { Forbidden, NotAuthenticated, NotFound } from '@agor/core/feathers';
+import { BadRequest, Forbidden, NotAuthenticated, NotFound } from '@agor/core/feathers';
 import type {
   AuthenticatedParams,
   Branch,
@@ -1135,6 +1135,34 @@ export function ensureSessionImmutability() {
 
     return context;
   };
+}
+
+/**
+ * Keep gateway provenance under daemon ownership.
+ *
+ * Gateway integrations create sessions through provider-less service calls.
+ * Browser, REST, Socket.IO, and MCP callers may still use the rest of
+ * `custom_context`, but cannot create, replace, or clear `gateway_source`.
+ * Session repository patches deep-merge nested context, so omitting this key
+ * preserves an existing gateway stamp.
+ */
+export function protectGatewaySourceMetadata(context: HookContext): HookContext {
+  if (!context.params.provider) return context;
+
+  const writes = Array.isArray(context.data) ? context.data : [context.data];
+  for (const write of writes) {
+    if (!write || typeof write !== 'object') continue;
+    const customContext = (write as { custom_context?: unknown }).custom_context;
+    if (customContext === undefined) continue;
+    if (!customContext || typeof customContext !== 'object' || Array.isArray(customContext)) {
+      throw new BadRequest('session.custom_context must be an object');
+    }
+    if (Object.hasOwn(customContext, 'gateway_source')) {
+      throw new Forbidden('session.custom_context.gateway_source is server-managed');
+    }
+  }
+
+  return context;
 }
 
 /**

--- a/apps/agor-daemon/src/utils/prompt-origin.test.ts
+++ b/apps/agor-daemon/src/utils/prompt-origin.test.ts
@@ -1,0 +1,42 @@
+import type { Session, Task } from '@agor/core/types';
+import { describe, expect, it } from 'vitest';
+import { resolvePromptOrigin } from './prompt-origin.js';
+
+const task = (metadata: Task['metadata']): Pick<Task, 'metadata'> => ({ metadata });
+const session = (channelType?: string): Pick<Session, 'custom_context'> => ({
+  custom_context: channelType
+    ? {
+        gateway_source: {
+          channel_id: 'channel-1',
+          channel_name: 'agents',
+          channel_type: channelType,
+          thread_id: 'thread-1',
+        },
+      }
+    : undefined,
+});
+
+describe('resolvePromptOrigin', () => {
+  it('trusts a direct Agor prompt as human', () => {
+    expect(resolvePromptOrigin(task({ source: 'agor' }), session())).toEqual({ kind: 'human' });
+  });
+
+  it('maps gateway provenance through the trusted Session channel type', () => {
+    expect(resolvePromptOrigin(task({ source: 'gateway' }), session('slack'))).toEqual({
+      kind: 'channel',
+      server: 'slack',
+    });
+  });
+
+  it('fails closed when gateway Session metadata is missing', () => {
+    expect(resolvePromptOrigin(task({ source: 'gateway' }), session())).toBeUndefined();
+  });
+
+  it.each([
+    { source: 'agor' as const, is_agor_callback: true },
+    { source: 'agor' as const, system_authored: true },
+    undefined,
+  ])('leaves synthesized or unattributed prompts unattributed (%j)', (metadata) => {
+    expect(resolvePromptOrigin(task(metadata), session())).toBeUndefined();
+  });
+});

--- a/apps/agor-daemon/src/utils/prompt-origin.ts
+++ b/apps/agor-daemon/src/utils/prompt-origin.ts
@@ -1,0 +1,22 @@
+import { getGatewaySource, type PromptOrigin, type Session, type Task } from '@agor/core/types';
+
+/**
+ * Derive provider prompt trust from daemon-owned durable state.
+ *
+ * An omitted result is intentional: callbacks, system-authored prompts, and
+ * unattributed internal producers must not acquire human authority merely
+ * because they ultimately enter an SDK as a user-role message.
+ */
+export function resolvePromptOrigin(
+  task: Pick<Task, 'metadata'>,
+  session: Pick<Session, 'custom_context'>
+): PromptOrigin | undefined {
+  if (task.metadata?.is_agor_callback || task.metadata?.system_authored) return undefined;
+
+  if (task.metadata?.source === 'gateway') {
+    const gatewaySource = getGatewaySource(session);
+    return gatewaySource ? { kind: 'channel', server: gatewaySource.channel_type } : undefined;
+  }
+
+  return task.metadata?.source === 'agor' ? { kind: 'human' } : undefined;
+}

--- a/apps/agor-docs/content/guide/typescript-client.mdx
+++ b/apps/agor-docs/content/guide/typescript-client.mdx
@@ -66,6 +66,8 @@ await client.tasks.run(task.task_id, { stream: true });
 ```
 
 `client.tasks.run()` calls `POST /tasks/:id/run`, the explicit "fire this task now" trigger. It accepts `created` tasks on idle sessions; `queued` tasks drain automatically in order, and busy sessions should be prompted via `client.sessions.prompt()` (which queues atomically).
+Both authenticated forms are classified server-side as direct human prompts;
+clients cannot select provider trust metadata themselves.
 
 ## Quickstart (Real-time)
 

--- a/apps/agor-ui/src/components/ModelSelector/ModelSelector.test.tsx
+++ b/apps/agor-ui/src/components/ModelSelector/ModelSelector.test.tsx
@@ -481,7 +481,7 @@ describe('ModelSelector (Claude)', () => {
     );
     fireEvent.mouseDown(screen.getByRole('combobox'));
     // A long model description renders in full and is allowed to wrap.
-    expect(screen.getByText(/Frontier model for complex reasoning/)).toHaveStyle({
+    expect(screen.getByText(/Most capable model for demanding reasoning/)).toHaveStyle({
       whiteSpace: 'normal',
     });
   });

--- a/context/explorations/claude-code-oauth-signin.md
+++ b/context/explorations/claude-code-oauth-signin.md
@@ -23,19 +23,19 @@ what remains unconfirmed.
 
 ### VERIFIED
 
-Sources: the pinned SDK is **`@anthropic-ai/claude-agent-sdk@0.3.197`** (in
+Sources: the pinned SDK is **`@anthropic-ai/claude-agent-sdk@0.3.259`** (in
 every workspace `package.json`; loaded via `loadManagedAgenticToolSdk`). That
 SDK no longer ships a `cli.js` — its `manifest.json` bundles the **native
-`claude` CLI v2.1.197** (commit `c8fd8048`) which it extracts and spawns. The
-OAuth constants below were read by **byte-inspecting the native binary** (the
-installed v2.1.211, whose prod OAuth config is identical to 2.1.197's) at the
-file offsets cited, and cross-checked against Anthropic's official docs
+`claude` CLI v2.1.259** (commit `9b549c8d`) which it extracts and spawns. The
+OAuth constants and flow below were **re-checked in the installed v2.1.259
+native binary** for this upgrade (the original audit used v2.1.211), and
+cross-checked against Anthropic's official docs
 (<https://code.claude.com/docs/en/authentication>).
 
 1. **There is NO device-authorization (RFC 8628) endpoint for Claude Code.**
    The claim "no device endpoint" was treated as something to disprove, not
    assume. The native binary's login flow uses only a loopback-or-manual
-   authorization-code redirect (login builder ~101457400); its Anthropic OAuth
+   authorization-code redirect (original v2.1.211 login-builder audit); its Anthropic OAuth
    config exposes no device-grant endpoint, and the official auth doc describes
    only the browser + paste-back flow. The one `device_code` string in the binary
    lives in the bundled `@azure/msal-common` generic OAuth param enum (the
@@ -43,9 +43,8 @@ file offsets cited, and cross-checked against Anthropic's official docs
    device endpoint. This is the **one structural difference from Codex** — see
    below.
 2. **Claude Code uses OAuth 2.0 authorization-code + PKCE (S256) with a
-   paste-back code.** These are the PROD OAuth config object (`yol`) at binary
-   offset ~237512852, plus the login authorize builder (~101457400) and token
-   exchange (~101464300). The values the service uses:
+   paste-back code.** These are the production OAuth config plus the login
+   authorize builder and token exchange. The values the service uses:
    - authorize URL (subscription / Claude Pro-Max):
      **`https://claude.com/cai/oauth/authorize`** (`yol.CLAUDE_AI_AUTHORIZE_URL`).
      The Console/API-billing login instead uses `yol.CONSOLE_AUTHORIZE_URL` =
@@ -61,12 +60,14 @@ file offsets cited, and cross-checked against Anthropic's official docs
      single fixed public id. (The other id in the binary,
      `22422756-60c9-4084-8eb7-27705fd5cf9a`, is the **local-dev** config
      `-local-oauth`/`localhost:8205`, not prod.)
-   - authorize query params (login builder ~101457400): `code=true`, `client_id`,
+   - authorize query params (re-checked in v2.1.259): `code=true`, `client_id`,
      `response_type=code`, `redirect_uri`, `scope`, `code_challenge`,
      `code_challenge_method=S256`, `state`. `code=true` selects the code-display
      (paste-back) page — required since we have no loopback server.
-   - scope string: **`user:profile user:inference user:sessions:claude_code user:mcp_servers`**.
-   - token exchange (~101464300): **`POST` with `Content-Type: application/json`**,
+   - scope string: **`user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload`**.
+     `user:file_upload` is present in the v2.1.259 subscription-login scope set
+     and was added to Agor's URL as part of this SDK upgrade.
+   - token exchange: **`POST` with `Content-Type: application/json`**,
      `grant_type=authorization_code`; **no** `oauth-2025-04-20` beta header on the
      exchange call. `refresh_token` grant also present (renewal).
    - the authorize page returns the code as **`CODE#STATE`** which the user

--- a/packages/agentic-tool-opencode/src/shared/known-models.test.ts
+++ b/packages/agentic-tool-opencode/src/shared/known-models.test.ts
@@ -86,6 +86,7 @@ describe('OpenCode known model catalog', () => {
       availableForSelection: true,
       suggestedModel: 'claude-sonnet-5',
       models: expect.arrayContaining([
+        expect.objectContaining({ id: 'claude-fable-5-1' }),
         expect.objectContaining({ id: 'claude-opus-5' }),
         expect.objectContaining({ id: 'claude-sonnet-5' }),
         expect.objectContaining({ id: 'claude-haiku-4-5' }),

--- a/packages/agentic-tool-opencode/src/shared/known-models.ts
+++ b/packages/agentic-tool-opencode/src/shared/known-models.ts
@@ -67,6 +67,7 @@ const KNOWN_PROVIDERS = [
     availableWithoutCredentials: false,
     suggestedModel: 'claude-sonnet-5',
     models: activeModels([
+      ['claude-fable-5-1', 'Claude Fable 5.1'],
       ['claude-opus-5', 'Claude Opus 5'],
       ['claude-sonnet-5', 'Claude Sonnet 5'],
       ['claude-fable-5', 'Claude Fable 5'],

--- a/packages/agor-claude/package.json
+++ b/packages/agor-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/claude",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "description": "Version-aligned claude agentic tool integration for Agor",
   "type": "module",
   "main": "./dist/index.js",
@@ -22,7 +22,7 @@
     "check:pack": "npm pack --dry-run"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.3.197"
+    "@anthropic-ai/claude-agent-sdk": "0.3.259"
   },
   "devDependencies": {
     "@types/node": "^24.6.0",

--- a/packages/agor-claude/src/index.ts
+++ b/packages/agor-claude/src/index.ts
@@ -1,4 +1,4 @@
 /** Agor-managed, release-aligned claude integration. */
-export const AGOR_INTEGRATION_VERSION = '0.26.0';
+export const AGOR_INTEGRATION_VERSION = '0.26.1';
 export const VENDOR_PACKAGE = '@anthropic-ai/claude-agent-sdk';
 export * as sdk from '@anthropic-ai/claude-agent-sdk';

--- a/packages/agor-codex/package.json
+++ b/packages/agor-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/codex",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "description": "Version-aligned codex agentic tool integration for Agor",
   "type": "module",
   "main": "./dist/index.js",
@@ -22,7 +22,7 @@
     "check:pack": "npm pack --dry-run"
   },
   "dependencies": {
-    "@openai/codex-sdk": "0.144.0"
+    "@openai/codex-sdk": "0.153.0"
   },
   "devDependencies": {
     "@types/node": "^24.6.0",

--- a/packages/agor-codex/src/index.ts
+++ b/packages/agor-codex/src/index.ts
@@ -1,4 +1,4 @@
 /** Agor-managed, release-aligned codex integration. */
-export const AGOR_INTEGRATION_VERSION = '0.26.0';
+export const AGOR_INTEGRATION_VERSION = '0.26.1';
 export const VENDOR_PACKAGE = '@openai/codex-sdk';
 export * as sdk from '@openai/codex-sdk';

--- a/packages/agor-copilot/package.json
+++ b/packages/agor-copilot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/copilot",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "description": "Version-aligned copilot agentic tool integration for Agor",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agor-copilot/src/index.ts
+++ b/packages/agor-copilot/src/index.ts
@@ -1,4 +1,4 @@
 /** Agor-managed, release-aligned copilot integration. */
-export const AGOR_INTEGRATION_VERSION = '0.26.0';
+export const AGOR_INTEGRATION_VERSION = '0.26.1';
 export const VENDOR_PACKAGE = '@github/copilot-sdk';
 export * as sdk from '@github/copilot-sdk';

--- a/packages/agor-cursor/package.json
+++ b/packages/agor-cursor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/cursor",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "description": "Version-aligned cursor agentic tool integration for Agor",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agor-cursor/src/index.ts
+++ b/packages/agor-cursor/src/index.ts
@@ -1,4 +1,4 @@
 /** Agor-managed, release-aligned cursor integration. */
-export const AGOR_INTEGRATION_VERSION = '0.26.0';
+export const AGOR_INTEGRATION_VERSION = '0.26.1';
 export const VENDOR_PACKAGE = '@cursor/sdk';
 export * as sdk from '@cursor/sdk';

--- a/packages/agor-gemini/package.json
+++ b/packages/agor-gemini/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/gemini",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "description": "Version-aligned gemini agentic tool integration for Agor",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agor-gemini/src/index.ts
+++ b/packages/agor-gemini/src/index.ts
@@ -1,4 +1,4 @@
 /** Agor-managed, release-aligned gemini integration. */
-export const AGOR_INTEGRATION_VERSION = '0.26.0';
+export const AGOR_INTEGRATION_VERSION = '0.26.1';
 export const VENDOR_PACKAGE = '@google/gemini-cli-core';
 export * as sdk from '@google/gemini-cli-core';

--- a/packages/agor-live/package.json
+++ b/packages/agor-live/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agor-live",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "description": "Team command center for all things agentic — shared canvas for coding agents and assistants on isolated git branches, with real-time multiplayer and an MCP surface agents drive themselves.",
   "type": "module",
   "bin": {

--- a/packages/agor-opencode/package.json
+++ b/packages/agor-opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/opencode",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "description": "Version-aligned opencode agentic tool integration for Agor",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agor-opencode/src/index.ts
+++ b/packages/agor-opencode/src/index.ts
@@ -1,5 +1,5 @@
 /** Agor-managed, release-aligned opencode integration. */
-export const AGOR_INTEGRATION_VERSION = '0.26.0';
+export const AGOR_INTEGRATION_VERSION = '0.26.1';
 export const VENDOR_PACKAGE = '@opencode-ai/sdk';
 export * as sdk from '@opencode-ai/sdk';
 export * as sdkV2 from '@opencode-ai/sdk/v2';

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/client",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "description": "TypeScript client for connecting to the Agor daemon",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -532,12 +532,12 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.259",
+    "@anthropic-ai/claude-agent-sdk": "0.3.259",
     "@google/gemini-cli-core": "^0.40.0",
     "@google/genai": "^1.43.0",
     "@octokit/auth-app": "^8.3.0",
     "@octokit/rest": "^22.0.1",
-    "@openai/codex-sdk": "^0.153.0",
+    "@openai/codex-sdk": "0.153.0",
     "@types/bcryptjs": "^2.4.6",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^24.6.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -532,12 +532,12 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.3.197",
+    "@anthropic-ai/claude-agent-sdk": "^0.3.259",
     "@google/gemini-cli-core": "^0.40.0",
     "@google/genai": "^1.43.0",
     "@octokit/auth-app": "^8.3.0",
     "@octokit/rest": "^22.0.1",
-    "@openai/codex-sdk": "^0.144.0",
+    "@openai/codex-sdk": "^0.153.0",
     "@types/bcryptjs": "^2.4.6",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^24.6.0",

--- a/packages/core/src/client/claude-system-suppression.test.ts
+++ b/packages/core/src/client/claude-system-suppression.test.ts
@@ -5,6 +5,22 @@ import {
 } from './claude-system-suppression';
 
 describe('shouldHidePersistedClaudeSdkEvent', () => {
+  it('suppresses background task snapshots before and after persistence', () => {
+    const event = {
+      subtype: 'background_tasks_changed',
+      tasks: [{ task_id: 'task-1', description: 'private implementation detail' }],
+    };
+    expect(shouldSuppressClaudeSystemEvent(event)).toBe(true);
+    expect(
+      shouldHidePersistedClaudeSdkEvent({
+        type: 'sdk_event',
+        sdkType: 'system',
+        sdkSubtype: 'background_tasks_changed',
+        metadata: event,
+      })
+    ).toBe(true);
+  });
+
   it('hides task_updated rows (including ones with patch.error)', () => {
     expect(
       shouldHidePersistedClaudeSdkEvent({

--- a/packages/core/src/client/claude-system-suppression.ts
+++ b/packages/core/src/client/claude-system-suppression.ts
@@ -55,6 +55,7 @@ export type ClaudeSystemStatus = Extract<
  * have a diagnostic surface.
  */
 export const SUPPRESSED_CLAUDE_SYSTEM_SUBTYPES: ReadonlySet<ClaudeSystemSubtype> = new Set([
+  'background_tasks_changed',
   'files_persisted',
   'hook_started',
   'hook_progress',

--- a/packages/core/src/models/claude.test.ts
+++ b/packages/core/src/models/claude.test.ts
@@ -16,6 +16,7 @@ describe('AVAILABLE_CLAUDE_MODEL_ALIASES', () => {
     expect(ids).toContain('claude-opus-4-7');
     expect(ids).toContain('claude-sonnet-4-6');
     expect(ids).toContain('claude-haiku-4-5');
+    expect(ids).toContain('claude-fable-5-1');
     expect(ids).toContain('claude-fable-5');
   });
 
@@ -33,9 +34,12 @@ describe('AVAILABLE_CLAUDE_MODEL_ALIASES', () => {
 });
 
 describe('hasNativeMillionContext', () => {
-  it.each(['claude-fable-5', 'claude-sonnet-5'])('recognizes %s as native 1M', (modelId) => {
-    expect(hasNativeMillionContext(modelId)).toBe(true);
-  });
+  it.each(['claude-fable-5-1', 'claude-fable-5', 'claude-sonnet-5'])(
+    'recognizes %s as native 1M',
+    (modelId) => {
+      expect(hasNativeMillionContext(modelId)).toBe(true);
+    }
+  );
 
   it.each(['claude-opus-5', 'claude-opus-4-8', 'claude-opus-4-7', 'claude-opus-4-6'])(
     'keeps %s on the opt-in context path',
@@ -58,6 +62,7 @@ describe('Claude context-window accounting fallback', () => {
     expect(getClaudeContextWindowLimit('claude-opus-5')).toBe(200_000);
     expect(getClaudeContextWindowLimit('claude-opus-5[1m]')).toBe(1_000_000);
     expect(getClaudeContextWindowLimit('claude-sonnet-5')).toBe(1_000_000);
+    expect(getClaudeContextWindowLimit('claude-fable-5-1')).toBe(1_000_000);
   });
 
   it('does not guess for unknown exact models or unsupported suffixes', () => {

--- a/packages/core/src/models/claude.ts
+++ b/packages/core/src/models/claude.ts
@@ -54,10 +54,17 @@ export function getClaudeContextWindowLimit(modelId?: string): number | undefine
  */
 export const AVAILABLE_CLAUDE_MODEL_ALIASES: ClaudeModel[] = [
   {
+    id: 'claude-fable-5-1',
+    displayName: 'Claude Fable 5.1 · 1M',
+    family: 'claude-5',
+    description: 'Most capable model for demanding reasoning and long-horizon agentic work',
+    contextWindow: CLAUDE_EXTENDED_CONTEXT_WINDOW,
+  },
+  {
     id: 'claude-fable-5',
     displayName: 'Claude Fable 5 · 1M',
     family: 'claude-5',
-    description: 'Frontier model for complex reasoning, creative work, and agentic coding',
+    description: 'Previous Fable model for complex reasoning and long-horizon agentic work',
     contextWindow: CLAUDE_EXTENDED_CONTEXT_WINDOW,
   },
   {

--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -26,6 +26,16 @@ export enum MessageRole {
 export type MessageSource = 'gateway' | 'agor';
 
 /**
+ * Trusted prompt provenance sent over the daemon-to-executor boundary.
+ *
+ * This is deliberately narrower than persisted message source metadata. The
+ * daemon derives it from the admitted Task and Session; public prompt callers
+ * cannot select it. Omission means the prompt is synthesized or otherwise
+ * unattributed and must fail closed at provider human-trust gates.
+ */
+export type PromptOrigin = { kind: 'human' } | { kind: 'channel'; server: string };
+
+/**
  * Read-only provenance left on messages written by removed integrations.
  * Runtime request types intentionally exclude these values.
  */

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -19,6 +19,7 @@ import type {
 } from './agentic-tool';
 import type { AgenticToolConfigurationReference } from './agentic-tool-preset';
 import type { ContextFilePath } from './context';
+import type { ChannelType } from './gateway';
 import type { BoardID, BranchID, SessionID, SessionRelationshipID, TaskID, UserID } from './id';
 import type { ScheduleID } from './schedule';
 import type { TaskStatus, TerminationCoordinationPendingCode } from './task';
@@ -399,6 +400,8 @@ export interface Session {
    * Access in templates: {{ session.context.teamName }}
    */
   custom_context?: Record<string, unknown> & {
+    /** Server-owned provenance for sessions admitted by a gateway channel. */
+    gateway_source?: GatewaySource;
     /**
      * Scheduled run metadata (populated by scheduler)
      *
@@ -710,7 +713,7 @@ export interface SessionRelationship {
 export interface GatewaySource {
   channel_id: string;
   channel_name: string;
-  channel_type: string;
+  channel_type: ChannelType;
   thread_id: string;
   /** GitHub-specific: "owner/repo" format */
   github_repo?: string;

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -367,8 +367,8 @@ export interface Task {
       inputTokens: number;
       outputTokens: number;
       totalTokens: number;
-      cacheReadTokens?: number; // Claude-specific: prompt caching reads
-      cacheCreationTokens?: number; // Claude-specific: prompt caching writes
+      cacheReadTokens?: number; // Provider-reported prompt cache reads
+      cacheCreationTokens?: number; // Provider-reported prompt cache writes
     };
     contextWindowLimit?: number; // Model's max context window (e.g., 200k for Claude)
     costUsd?: number; // Estimated cost in USD (if pricing available)

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -175,8 +175,10 @@ export interface TaskMetadata {
   }>;
   /**
    * Marks a task whose prompt was authored by the daemon (not typed by a
-   * human). Used by widget auto-resume so the UI can label the queued
-   * prompt appropriately.
+   * human). This is a security-relevant provenance marker: MCP, widget,
+   * zone, spawn, and other synthesized prompt paths set it so provider SDKs
+   * do not grant the prompt human authority. The UI may also use it to label
+   * the queued prompt appropriately.
    */
   system_authored?: boolean;
   /**

--- a/packages/executor/package.json
+++ b/packages/executor/package.json
@@ -40,8 +40,8 @@
     "typescript": "^6.0.3",
     "vitest": "^4.1.10",
     "@github/copilot-sdk": "^0.2.2",
-    "@anthropic-ai/claude-agent-sdk": "^0.3.259",
-    "@openai/codex-sdk": "^0.153.0"
+    "@anthropic-ai/claude-agent-sdk": "0.3.259",
+    "@openai/codex-sdk": "0.153.0"
   },
   "files": [
     "dist",

--- a/packages/executor/package.json
+++ b/packages/executor/package.json
@@ -40,8 +40,8 @@
     "typescript": "^6.0.3",
     "vitest": "^4.1.10",
     "@github/copilot-sdk": "^0.2.2",
-    "@anthropic-ai/claude-agent-sdk": "^0.3.197",
-    "@openai/codex-sdk": "^0.144.0"
+    "@anthropic-ai/claude-agent-sdk": "^0.3.259",
+    "@openai/codex-sdk": "^0.153.0"
   },
   "files": [
     "dist",

--- a/packages/executor/src/cli.ts
+++ b/packages/executor/src/cli.ts
@@ -275,6 +275,7 @@ async function handlePromptPayload(
     permissionMode: payload.params.permissionMode,
     daemonUrl: resolvedDaemonUrl,
     messageSource: payload.params.messageSource,
+    promptOrigin: payload.params.promptOrigin,
     agenticToolContext: payload.agenticToolContext,
     resolvedConfig: payload.resolvedConfig,
   });

--- a/packages/executor/src/handlers/sdk/base-executor.ts
+++ b/packages/executor/src/handlers/sdk/base-executor.ts
@@ -18,6 +18,7 @@ import type {
   MessageID,
   MessageSource,
   PermissionMode,
+  PromptOrigin,
   SessionID,
   StreamingEventType,
   Task,
@@ -116,7 +117,8 @@ export interface BaseTool {
     permissionMode?: PermissionMode,
     callbacks?: StreamingCallbacks,
     abortController?: AbortController,
-    messageSource?: MessageSource
+    messageSource?: MessageSource,
+    promptOrigin?: PromptOrigin
   ): Promise<{
     userMessageId: MessageID;
     assistantMessageIds: MessageID[];
@@ -480,6 +482,7 @@ export async function executeToolTask(params: {
   toolName: AgenticToolName;
   onPulse?: StreamingCallbacks['onPulse'];
   messageSource?: MessageSource;
+  promptOrigin?: PromptOrigin;
   createTool: (
     repos: ReturnType<typeof createFeathersBackedRepositories>,
     apiKey: string,
@@ -588,7 +591,8 @@ export async function executeToolTask(params: {
       permissionMode,
       ctx.callbacks,
       params.abortController,
-      params.messageSource
+      params.messageSource,
+      params.promptOrigin
     );
 
     if (daemonOwnsTerminality()) return;

--- a/packages/executor/src/handlers/sdk/claude.ts
+++ b/packages/executor/src/handlers/sdk/claude.ts
@@ -9,6 +9,7 @@ import type {
   ExecutorPulseKind,
   MessageSource,
   PermissionMode,
+  PromptOrigin,
   SessionID,
   TaskID,
 } from '@agor/core/types';
@@ -31,6 +32,7 @@ export async function executeClaudeCodeTask(params: {
   permissionMode?: PermissionMode;
   abortController: AbortController;
   messageSource?: MessageSource;
+  promptOrigin?: PromptOrigin;
   resolvedConfig?: ResolvedConfigSlice;
   onPulse?: (kind: ExecutorPulseKind, detail?: string) => void;
 }): Promise<void> {

--- a/packages/executor/src/handlers/sdk/tool-registry.ts
+++ b/packages/executor/src/handlers/sdk/tool-registry.ts
@@ -10,6 +10,7 @@ import type {
   ExecutorPulseKind,
   MessageSource,
   PermissionMode,
+  PromptOrigin,
   SessionID,
   TaskID,
 } from '@agor/core/types';
@@ -32,6 +33,7 @@ export type ToolRunner = (params: {
   permissionMode?: PermissionMode;
   abortController: AbortController;
   messageSource?: MessageSource;
+  promptOrigin?: PromptOrigin;
   agenticToolContext?: Record<string, unknown>;
   /** Daemon-resolved config slice. Undefined in legacy CLI mode. */
   resolvedConfig?: ResolvedConfigSlice;
@@ -135,6 +137,7 @@ export class ToolRegistry {
       permissionMode?: PermissionMode;
       abortController: AbortController;
       messageSource?: MessageSource;
+      promptOrigin?: PromptOrigin;
       agenticToolContext?: Record<string, unknown>;
       resolvedConfig?: ResolvedConfigSlice;
       onPulse?: (kind: ExecutorPulseKind, detail?: string) => void;

--- a/packages/executor/src/index.ts
+++ b/packages/executor/src/index.ts
@@ -20,6 +20,7 @@ import type {
   MessageSource,
   PermissionMode,
   PermissionScope,
+  PromptOrigin,
   SessionID,
   Task,
   TaskID,
@@ -67,6 +68,7 @@ export interface ExecutorConfig {
   permissionMode?: PermissionMode;
   daemonUrl: string;
   messageSource?: MessageSource;
+  promptOrigin?: PromptOrigin;
   /** Opaque, daemon-authorized context interpreted by the selected integration. */
   agenticToolContext?: Record<string, unknown>;
   /** Daemon-resolved config slice. See payload-types.ResolvedConfigSliceSchema. */
@@ -373,6 +375,7 @@ export class AgorExecutor {
         permissionMode: this.config.permissionMode,
         abortController: this.abortController,
         messageSource: this.config.messageSource,
+        promptOrigin: this.config.promptOrigin,
         agenticToolContext: this.config.agenticToolContext,
         resolvedConfig: this.config.resolvedConfig,
         onPulse: (kind, detail) => this.recordPulse(kind, detail),

--- a/packages/executor/src/payload-types.test.ts
+++ b/packages/executor/src/payload-types.test.ts
@@ -59,6 +59,7 @@ describe('PromptPayloadSchema', () => {
         prompt: 'Hello!',
         tool: 'gemini',
         permissionMode: 'auto',
+        promptOrigin: { kind: 'channel', server: 'slack' },
         cwd: '/home/user/project',
       },
     };
@@ -68,6 +69,24 @@ describe('PromptPayloadSchema', () => {
     expect(result.env?.ANTHROPIC_API_KEY).toBe('key');
     expect(result.agenticToolContext).toEqual({ nativeHome: '/data/agor' });
     expect(result.params.permissionMode).toBe('auto');
+    expect(result.params.promptOrigin).toEqual({ kind: 'channel', server: 'slack' });
+  });
+
+  it('rejects malformed prompt provenance at the private executor boundary', () => {
+    expect(() =>
+      PromptPayloadSchema.parse({
+        command: 'prompt',
+        sessionToken: 'jwt-token-here',
+        params: {
+          sessionId: '550e8400-e29b-41d4-a716-446655440000',
+          taskId: '550e8400-e29b-41d4-a716-446655440001',
+          prompt: 'Hello!',
+          tool: 'claude-code',
+          cwd: '/home/user/project',
+          promptOrigin: { kind: 'channel', server: '' },
+        },
+      })
+    ).toThrow();
   });
 
   it('should reject invalid tool type', () => {

--- a/packages/executor/src/payload-types.ts
+++ b/packages/executor/src/payload-types.ts
@@ -166,6 +166,12 @@ export const PromptPayloadSchema = BasePayloadSchema.extend({
     permissionMode: PermissionModeSchema.optional(),
     cwd: z.string(),
     messageSource: z.enum(['gateway', 'agor']).optional(),
+    promptOrigin: z
+      .discriminatedUnion('kind', [
+        z.object({ kind: z.literal('human') }),
+        z.object({ kind: z.literal('channel'), server: z.string().min(1) }),
+      ])
+      .optional(),
   }),
 });
 

--- a/packages/executor/src/sdk-handlers/base/mcp-tool-permissions.test.ts
+++ b/packages/executor/src/sdk-handlers/base/mcp-tool-permissions.test.ts
@@ -145,7 +145,8 @@ describe('resolveMcpToolPermission', () => {
  *     let t = e.replace(/[^a-zA-Z0-9_-]/g, "_");
  *     if (e.startsWith("claude.ai ")) t = t.replace(/_+/g, "_").replace(/^_|_$/g, "");
  *
- * Transcribed from the shipped 0.3.197 CLI. It matters because those are
+ * Originally transcribed from the shipped 0.3.197 CLI and retained as a
+ * compatibility contract across SDK upgrades. It matters because those are
  * exactly the names claude.ai connectors carry, and a name that misses reads
  * as unconfigured -- which is `allow`.
  */

--- a/packages/executor/src/sdk-handlers/claude/background-task-lifecycle.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/background-task-lifecycle.test.ts
@@ -9,6 +9,19 @@ const settled = (taskId: string, status: 'completed' | 'failed' | 'stopped' = 'c
   message({ type: 'system', subtype: 'task_notification', task_id: taskId, status });
 const updated = (taskId: string, status: string) =>
   message({ type: 'system', subtype: 'task_updated', task_id: taskId, patch: { status } });
+const backgrounded = (taskId: string) =>
+  message({
+    type: 'system',
+    subtype: 'task_updated',
+    task_id: taskId,
+    patch: { is_backgrounded: true },
+  });
+const snapshot = (...tasks: Array<string | { task_id: string; ambient?: boolean }>) =>
+  message({
+    type: 'system',
+    subtype: 'background_tasks_changed',
+    tasks: tasks.map((task) => (typeof task === 'string' ? { task_id: task } : task)),
+  });
 const result = (subtype = 'success') => message({ type: 'result', subtype });
 
 describe('ClaudeBackgroundTaskLifecycle', () => {
@@ -48,7 +61,7 @@ describe('ClaudeBackgroundTaskLifecycle', () => {
     (status) => {
       const lifecycle = new ClaudeBackgroundTaskLifecycle();
       lifecycle.observe(started('bash-1'));
-      expect(lifecycle.observe(updated('bash-1', status)).taskTransition).toBe('settled');
+      expect(lifecycle.observe(updated('bash-1', status)).tasksSettled).toBe(1);
       expect(lifecycle.activeTaskCount).toBe(0);
       expect(lifecycle.observe(result()).resultDisposition).toBe('terminal');
     }
@@ -57,10 +70,10 @@ describe('ClaudeBackgroundTaskLifecycle', () => {
   it('deduplicates task_updated followed by task_notification and ignores non-terminal patches', () => {
     const lifecycle = new ClaudeBackgroundTaskLifecycle();
     lifecycle.observe(started('bash-1'));
-    expect(lifecycle.observe(updated('bash-1', 'running')).taskTransition).toBeUndefined();
+    expect(lifecycle.observe(updated('bash-1', 'running')).tasksSettled).toBeUndefined();
     expect(lifecycle.activeTaskCount).toBe(1);
-    expect(lifecycle.observe(updated('bash-1', 'completed')).taskTransition).toBe('settled');
-    expect(lifecycle.observe(settled('bash-1')).taskTransition).toBeUndefined();
+    expect(lifecycle.observe(updated('bash-1', 'completed')).tasksSettled).toBe(1);
+    expect(lifecycle.observe(settled('bash-1')).tasksSettled).toBeUndefined();
     expect(lifecycle.activeTaskCount).toBe(0);
   });
 
@@ -79,6 +92,60 @@ describe('ClaudeBackgroundTaskLifecycle', () => {
     expect(new ClaudeBackgroundTaskLifecycle().observe(result()).resultDisposition).toBe(
       'terminal'
     );
+  });
+
+  it('replaces edge state from the authoritative background task snapshot', () => {
+    const lifecycle = new ClaudeBackgroundTaskLifecycle();
+    lifecycle.observe(started('stale'));
+
+    expect(lifecycle.observe(snapshot('live-1', 'live-2'))).toMatchObject({
+      tasksStarted: 2,
+      tasksSettled: 1,
+    });
+    expect(lifecycle.activeTaskCount).toBe(2);
+    expect(lifecycle.observe(snapshot()).tasksSettled).toBe(2);
+    expect(lifecycle.observe(result()).resultDisposition).toBe('terminal');
+  });
+
+  it('ignores foreground task starts and tracks a later background transition', () => {
+    const lifecycle = new ClaudeBackgroundTaskLifecycle();
+    expect(
+      lifecycle.observe(
+        message({
+          type: 'system',
+          subtype: 'task_started',
+          task_id: 'foreground',
+          is_backgrounded: false,
+        })
+      ).tasksStarted
+    ).toBeUndefined();
+    expect(lifecycle.observe(result()).resultDisposition).toBe('terminal');
+    expect(lifecycle.observe(backgrounded('foreground')).tasksStarted).toBe(1);
+    expect(lifecycle.activeTaskCount).toBe(1);
+  });
+
+  it('does not let ambient housekeeping hold the Agor task open', () => {
+    const lifecycle = new ClaudeBackgroundTaskLifecycle();
+    expect(
+      lifecycle.observe(
+        message({
+          type: 'system',
+          subtype: 'task_started',
+          task_id: 'watcher',
+          is_backgrounded: true,
+          ambient: true,
+        })
+      ).tasksStarted
+    ).toBeUndefined();
+    expect(lifecycle.observe(backgrounded('watcher')).tasksStarted).toBeUndefined();
+    expect(lifecycle.observe(result()).resultDisposition).toBe('terminal');
+
+    expect(
+      lifecycle.observe(
+        snapshot({ task_id: 'watcher', ambient: true }, { task_id: 'user-agent', ambient: false })
+      ).tasksStarted
+    ).toBe(1);
+    expect(lifecycle.activeTaskCount).toBe(1);
   });
 
   it('ends error results even if a task never reports settlement', () => {
@@ -118,9 +185,9 @@ describe('ClaudeBackgroundTaskLifecycle', () => {
 
   it('reports only real task transitions and can clear orphaned activity', () => {
     const lifecycle = new ClaudeBackgroundTaskLifecycle();
-    expect(lifecycle.observe(started('agent-1')).taskTransition).toBe('started');
-    expect(lifecycle.observe(started('agent-1')).taskTransition).toBeUndefined();
-    expect(lifecycle.observe(settled('unknown')).taskTransition).toBeUndefined();
+    expect(lifecycle.observe(started('agent-1')).tasksStarted).toBe(1);
+    expect(lifecycle.observe(started('agent-1')).tasksStarted).toBeUndefined();
+    expect(lifecycle.observe(settled('unknown')).tasksSettled).toBeUndefined();
     expect(lifecycle.clearActiveTasks()).toBe(1);
     expect(lifecycle.clearActiveTasks()).toBe(0);
   });

--- a/packages/executor/src/sdk-handlers/claude/background-task-lifecycle.ts
+++ b/packages/executor/src/sdk-handlers/claude/background-task-lifecycle.ts
@@ -22,7 +22,8 @@ export const BACKGROUND_TASK_TIMEOUT_EVENT = 'background_task_timeout';
 
 export interface ClaudeQueryLifecycleTransition {
   resultDisposition: ResultDisposition;
-  taskTransition?: 'started' | 'settled';
+  tasksStarted?: number;
+  tasksSettled?: number;
 }
 
 /**
@@ -32,14 +33,61 @@ export interface ClaudeQueryLifecycleTransition {
  */
 export class ClaudeBackgroundTaskLifecycle {
   private readonly activeTaskIds = new Set<string>();
+  private readonly ambientTaskIds = new Set<string>();
 
   observe(message: SDKMessage): ClaudeQueryLifecycleTransition {
     if (message.type === 'system' && message.subtype === 'task_started') {
+      // Ambient housekeeping (including live-update watchers) can outlive a
+      // model turn indefinitely. The SDK explicitly excludes it from host
+      // activity indicators, so it must not hold Agor's task/watchdog open.
+      if (message.ambient === true || message.skip_transcript === true) {
+        this.activeTaskIds.delete(message.task_id);
+        this.ambientTaskIds.add(message.task_id);
+        return { resultDisposition: 'not-result' };
+      }
+      // Newer SDKs also emit task_started for foreground tasks. Only a task
+      // that is actually backgrounded should keep the query and watchdog open.
+      if (message.is_backgrounded === false) {
+        return { resultDisposition: 'not-result' };
+      }
       const wasActive = this.activeTaskIds.has(message.task_id);
       this.activeTaskIds.add(message.task_id);
       return {
         resultDisposition: 'not-result',
-        taskTransition: wasActive ? undefined : 'started',
+        tasksStarted: wasActive ? undefined : 1,
+      };
+    }
+
+    // Added in Agent SDK 0.3.203. This is the authoritative level signal for
+    // background work: replace our set instead of pairing potentially-missed
+    // task_started/task_notification edges. Those edges remain as a fallback
+    // for older CLI processes and are deduplicated whichever event arrives first.
+    if (message.type === 'system' && message.subtype === 'background_tasks_changed') {
+      const nextTaskIds = new Set(
+        message.tasks
+          .filter((task) => task.ambient !== true)
+          .map((task) => task.task_id)
+          .filter((taskId): taskId is string => typeof taskId === 'string' && taskId.length > 0)
+      );
+      const nextAmbientTaskIds = new Set(
+        message.tasks.filter((task) => task.ambient === true).map((task) => task.task_id)
+      );
+      let tasksStarted = 0;
+      let tasksSettled = 0;
+      for (const taskId of nextTaskIds) {
+        if (!this.activeTaskIds.has(taskId)) tasksStarted++;
+      }
+      for (const taskId of this.activeTaskIds) {
+        if (!nextTaskIds.has(taskId)) tasksSettled++;
+      }
+      this.activeTaskIds.clear();
+      for (const taskId of nextTaskIds) this.activeTaskIds.add(taskId);
+      this.ambientTaskIds.clear();
+      for (const taskId of nextAmbientTaskIds) this.ambientTaskIds.add(taskId);
+      return {
+        resultDisposition: 'not-result',
+        tasksStarted: tasksStarted || undefined,
+        tasksSettled: tasksSettled || undefined,
       };
     }
 
@@ -63,6 +111,22 @@ export class ClaudeBackgroundTaskLifecycle {
       return this.settleTask(message.task_id);
     }
 
+    if (
+      message.type === 'system' &&
+      message.subtype === 'task_updated' &&
+      message.patch.is_backgrounded === true
+    ) {
+      if (this.ambientTaskIds.has(message.task_id)) {
+        return { resultDisposition: 'not-result' };
+      }
+      const wasActive = this.activeTaskIds.has(message.task_id);
+      this.activeTaskIds.add(message.task_id);
+      return {
+        resultDisposition: 'not-result',
+        tasksStarted: wasActive ? undefined : 1,
+      };
+    }
+
     if (message.type !== 'result') return { resultDisposition: 'not-result' };
 
     // Error results cannot reliably produce later settlement notifications.
@@ -81,14 +145,16 @@ export class ClaudeBackgroundTaskLifecycle {
   clearActiveTasks(): number {
     const count = this.activeTaskIds.size;
     this.activeTaskIds.clear();
+    this.ambientTaskIds.clear();
     return count;
   }
 
   private settleTask(taskId: string): ClaudeQueryLifecycleTransition {
+    this.ambientTaskIds.delete(taskId);
     const settled = this.activeTaskIds.delete(taskId);
     return {
       resultDisposition: 'not-result',
-      taskTransition: settled ? 'settled' : undefined,
+      tasksSettled: settled ? 1 : undefined,
     };
   }
 }

--- a/packages/executor/src/sdk-handlers/claude/claude-tool.ts
+++ b/packages/executor/src/sdk-handlers/claude/claude-tool.ts
@@ -38,6 +38,7 @@ import {
   MessageRole,
   type MessageSource,
   type PermissionMode,
+  type PromptOrigin,
   type SessionID,
   type TaskID,
 } from '../../types.js';
@@ -256,7 +257,8 @@ export class ClaudeTool implements ITool {
     permissionMode?: PermissionMode,
     streamingCallbacks?: import('../base').StreamingCallbacks,
     abortController?: AbortController,
-    messageSource?: MessageSource
+    messageSource?: MessageSource,
+    promptOrigin?: PromptOrigin
   ): Promise<{
     userMessageId: MessageID;
     assistantMessageIds: MessageID[];
@@ -362,7 +364,8 @@ export class ClaudeTool implements ITool {
       mappedPermissionMode,
       undefined, // chunkCallback (unused)
       abortController,
-      streamingCallbacks?.onPulse
+      streamingCallbacks?.onPulse,
+      promptOrigin
     )) {
       // Detect if execution was stopped early
       if (event.type === 'stopped') {
@@ -945,7 +948,8 @@ export class ClaudeTool implements ITool {
     prompt: string,
     taskId?: TaskID,
     permissionMode?: PermissionMode,
-    messageSource?: MessageSource
+    messageSource?: MessageSource,
+    promptOrigin?: PromptOrigin
   ): Promise<{
     userMessageId: MessageID;
     assistantMessageIds: MessageID[];
@@ -1015,7 +1019,11 @@ export class ClaudeTool implements ITool {
       sessionId,
       prompt,
       taskId,
-      mappedPermissionMode
+      mappedPermissionMode,
+      undefined,
+      undefined,
+      undefined,
+      promptOrigin
     )) {
       // Detect if execution was stopped early
       if (event.type === 'stopped') {

--- a/packages/executor/src/sdk-handlers/claude/message-processor.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/message-processor.test.ts
@@ -200,6 +200,19 @@ describe('SDKMessageProcessor system event suppression', () => {
     expect(events.filter((e) => e.type === 'sdk_event')).toHaveLength(0);
   });
 
+  it('suppresses background task membership snapshots', async () => {
+    const processor = createProcessor();
+    const events = await processor.process(
+      systemMsg({
+        subtype: 'background_tasks_changed',
+        tasks: [{ task_id: 't1', description: 'implementation detail' }],
+        session_id: 's',
+        uuid: 'u',
+      })
+    );
+    expect(events.filter((event) => event.type === 'sdk_event')).toHaveLength(0);
+  });
+
   it('suppresses hook lifecycle telemetry', async () => {
     const processor = createProcessor();
 

--- a/packages/executor/src/sdk-handlers/claude/prompt-service.background-tasks.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/prompt-service.background-tasks.test.ts
@@ -198,7 +198,9 @@ describe('ClaudePromptService background task query lifetime', () => {
     expect(query.releaseInput).toHaveBeenCalledTimes(1);
     const terminalResult = events.filter((event) => event.type === 'result').at(-1);
     expect(terminalResult?.raw_sdk_message).toMatchObject({
-      total_cost_usd: 0.02,
+      // Newer Claude SDKs report this cumulatively on each result. Keep the
+      // terminal value instead of double-counting the parent result.
+      total_cost_usd: 0.01,
       num_turns: 2,
       usage: { input_tokens: 20, output_tokens: 10 },
     });

--- a/packages/executor/src/sdk-handlers/claude/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/claude/prompt-service.ts
@@ -390,12 +390,12 @@ If you continue to see authentication errors, please contact your Agor administr
         ) {
           clearBackgroundTaskActivity();
         }
-        if (lifecycleTransition.taskTransition === 'started') {
+        for (let index = 0; index < (lifecycleTransition.tasksStarted ?? 0); index++) {
           // Keep the SDK watchdog paused for the documented lifetime of the
           // background task, not merely the Agent/Workflow launch tool call.
           onActivity?.('progress', 'background_task.start');
         }
-        if (lifecycleTransition.taskTransition === 'settled') {
+        for (let index = 0; index < (lifecycleTransition.tasksSettled ?? 0); index++) {
           onActivity?.('progress', 'background_task.complete');
         }
         // Process message through processor

--- a/packages/executor/src/sdk-handlers/claude/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/claude/prompt-service.ts
@@ -9,6 +9,7 @@ import { projectClaudeResultResponse, projectContextUsageSnapshot } from '@agor/
 import { shortId } from '@agor/core/db';
 import { isMCPAbortError, sanitizeMCPExternalError } from '@agor/core/mcp';
 import type { PermissionMode, SDKResultMessage } from '@agor/core/sdk';
+import type { PromptOrigin } from '@agor/core/types';
 import type {
   BranchRepository,
   MCPOAuthAuthHeadersRepository,
@@ -176,7 +177,8 @@ If you continue to see authentication errors, please contact your Agor administr
     permissionMode?: PermissionMode,
     _chunkCallback?: (messageId: string, chunk: string) => void,
     abortController?: AbortController,
-    onActivity?: SdkActivityCallback
+    onActivity?: SdkActivityCallback,
+    promptOrigin?: PromptOrigin
   ): AsyncGenerator<ProcessedEvent> {
     // Intercept slash commands that don't work via the Claude Agent SDK.
     // Commands like /compact and /cost are handled natively by the SDK and pass through.
@@ -260,6 +262,7 @@ If you continue to see authentication errors, please contact your Agor administr
         permissionMode,
         resume: true,
         abortController,
+        promptOrigin,
       }
     );
 

--- a/packages/executor/src/sdk-handlers/claude/query-builder.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/query-builder.test.ts
@@ -99,6 +99,31 @@ describe('setupQuery - Local Settings Support', () => {
     );
   });
 
+  it.each([
+    [{ kind: 'human' as const }, { kind: 'human' }],
+    [
+      { kind: 'channel' as const, server: 'slack' },
+      { kind: 'channel', server: 'slack' },
+    ],
+    [undefined, undefined],
+  ])('passes only daemon-derived prompt origin to the SDK (%j)', async (promptOrigin, expected) => {
+    const setup = await setupQuery('test-session' as SessionID, 'test prompt', createMockDeps(), {
+      promptOrigin,
+    });
+    const prompt = vi.mocked(Claude.query).mock.calls[0][0].prompt;
+    expect(typeof prompt).not.toBe('string');
+
+    const first = await (prompt as AsyncIterable<Record<string, unknown>>)
+      [Symbol.asyncIterator]()
+      .next();
+    if (expected) {
+      expect(first.value).toMatchObject({ origin: expected });
+    } else {
+      expect(first.value).not.toHaveProperty('origin');
+    }
+    setup.query.releaseInput();
+  });
+
   it('logs only the generic prompt start and passes resume and prompt data to the SDK', async () => {
     const prompt = 'sk-ant-SECRET_QUERY_SENTINEL\r\nsecond line\nDATABASE_URL=do-not-log';
     const deps = createMockDeps();
@@ -122,7 +147,9 @@ describe('setupQuery - Local Settings Support', () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
     try {
-      await setupQuery('test-session' as SessionID, prompt, deps);
+      await setupQuery('test-session' as SessionID, prompt, deps, {
+        promptOrigin: { kind: 'human' },
+      });
 
       expect(logSpy.mock.calls).toEqual([['🤖 Prompting Claude for session test-session...']]);
 

--- a/packages/executor/src/sdk-handlers/claude/query-builder.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/query-builder.test.ts
@@ -132,6 +132,7 @@ describe('setupQuery - Local Settings Support', () => {
       const promptIterator = callArgs.prompt[Symbol.asyncIterator]();
       const firstMessage = await promptIterator.next();
       expect(firstMessage.value.message.content).toEqual([{ type: 'text', text: prompt }]);
+      expect(firstMessage.value.origin).toEqual({ kind: 'human' });
     } finally {
       logSpy.mockRestore();
     }

--- a/packages/executor/src/sdk-handlers/claude/query-builder.ts
+++ b/packages/executor/src/sdk-handlers/claude/query-builder.ts
@@ -11,7 +11,7 @@ import { shortId } from '@agor/core/db';
 import { validateDirectory } from '@agor/core/lib/validation';
 import { renderAgorSystemPrompt } from '@agor/core/templates/session-context';
 import { mergeMCPRemoteHeaders } from '@agor/core/tools/mcp/http-headers';
-import { isGatewaySession } from '@agor/core/types';
+import { isGatewaySession, type PromptOrigin } from '@agor/core/types';
 import type * as ClaudeSdk from '@anthropic-ai/claude-agent-sdk';
 import { McpAuthDiagnosticAccumulator } from '../../diagnostics/mcp-auth-diagnostic-accumulator.js';
 
@@ -127,13 +127,14 @@ export async function setupQuery(
     permissionMode?: PermissionMode;
     resume?: boolean;
     abortController?: AbortController;
+    promptOrigin?: PromptOrigin;
   } = {}
 ): Promise<{
   query: InterruptibleQuery;
   resolvedModel: string;
   getStderrMetadata: () => { hasStderr: boolean; byteLength: number };
 }> {
-  const { taskId, permissionMode, resume = true, abortController } = options;
+  const { taskId, permissionMode, resume = true, abortController, promptOrigin } = options;
 
   const session = await deps.sessionsRepo.findById(sessionId);
   if (!session) {
@@ -637,10 +638,9 @@ export async function setupQuery(
       message: { role: 'user' as const, content: [{ type: 'text' as const, text }] },
       parent_tool_use_id: null,
       // Agent SDK 0.3.259 treats an omitted origin as unattributed at strict
-      // human-trust gates. Every entry into this iterable is an authenticated
-      // Agor user prompt (including prompts relayed from a gateway), so retain
-      // that provenance explicitly instead of relying on the legacy default.
-      origin: { kind: 'human' as const },
+      // human-trust gates. The daemon derives this value from durable Task and
+      // Session state; synthesized prompts deliberately leave it undefined.
+      ...(promptOrigin ? { origin: promptOrigin } : {}),
     };
     // Hold the iterable open until releaseInput() is called, keeping stdin alive
     await inputHeldPromise;

--- a/packages/executor/src/sdk-handlers/claude/query-builder.ts
+++ b/packages/executor/src/sdk-handlers/claude/query-builder.ts
@@ -636,6 +636,11 @@ export async function setupQuery(
       type: 'user' as const,
       message: { role: 'user' as const, content: [{ type: 'text' as const, text }] },
       parent_tool_use_id: null,
+      // Agent SDK 0.3.259 treats an omitted origin as unattributed at strict
+      // human-trust gates. Every entry into this iterable is an authenticated
+      // Agor user prompt (including prompts relayed from a gateway), so retain
+      // that provenance explicitly instead of relying on the legacy default.
+      origin: { kind: 'human' as const },
     };
     // Hold the iterable open until releaseInput() is called, keeping stdin alive
     await inputHeldPromise;

--- a/packages/executor/src/sdk-handlers/claude/result-aggregation.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/result-aggregation.test.ts
@@ -2,7 +2,13 @@ import type { SDKResultMessage } from '@agor/core/sdk';
 import { describe, expect, it } from 'vitest';
 import { aggregateClaudeResults } from './result-aggregation.js';
 
-function result(uuid: string, inputTokens: number, cost: number): SDKResultMessage {
+function result(
+  uuid: string,
+  inputTokens: number,
+  cumulativeInputTokens: number,
+  cumulativeOutputTokens: number,
+  cumulativeCost: number
+): SDKResultMessage {
   return {
     type: 'result',
     subtype: 'success',
@@ -12,7 +18,7 @@ function result(uuid: string, inputTokens: number, cost: number): SDKResultMessa
     num_turns: 1,
     result: '',
     stop_reason: null,
-    total_cost_usd: cost,
+    total_cost_usd: cumulativeCost,
     usage: {
       input_tokens: inputTokens,
       output_tokens: 2,
@@ -23,12 +29,12 @@ function result(uuid: string, inputTokens: number, cost: number): SDKResultMessa
     },
     modelUsage: {
       sonnet: {
-        inputTokens,
-        outputTokens: 2,
+        inputTokens: cumulativeInputTokens,
+        outputTokens: cumulativeOutputTokens,
         cacheReadInputTokens: 4,
         cacheCreationInputTokens: 3,
         webSearchRequests: 0,
-        costUSD: cost,
+        costUSD: cumulativeCost,
         contextWindow: 200_000,
         maxOutputTokens: 32_000,
       },
@@ -40,10 +46,10 @@ function result(uuid: string, inputTokens: number, cost: number): SDKResultMessa
 }
 
 describe('aggregateClaudeResults', () => {
-  it('makes the terminal result an aggregate of every query turn', () => {
+  it('sums per-turn fields without double-counting cumulative accounting', () => {
     const aggregate = aggregateClaudeResults([
-      result('parent', 10, 0.01),
-      result('continuation', 20, 0.02),
+      result('parent', 10, 10, 2, 0.01),
+      result('continuation', 20, 30, 4, 0.03),
     ]);
 
     expect(aggregate.uuid).toBe('continuation');
@@ -65,6 +71,25 @@ describe('aggregateClaudeResults', () => {
       duration_api_ms: 16,
       num_turns: 2,
       total_cost_usd: 0.03,
+    });
+  });
+
+  it('preserves terminal model identity and pricing metadata', () => {
+    const parent = result('parent', 10, 10, 2, 0.01);
+    const continuation = result('continuation', 20, 30, 4, 0.03);
+    continuation.modelUsage.sonnet = {
+      ...continuation.modelUsage.sonnet,
+      thinkingTokens: 1,
+      canonicalModel: 'claude-sonnet-5',
+      provider: 'firstParty',
+      costBasis: 'list',
+    };
+
+    expect(aggregateClaudeResults([parent, continuation]).modelUsage.sonnet).toMatchObject({
+      thinkingTokens: 1,
+      canonicalModel: 'claude-sonnet-5',
+      provider: 'firstParty',
+      costBasis: 'list',
     });
   });
 });

--- a/packages/executor/src/sdk-handlers/claude/result-aggregation.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/result-aggregation.test.ts
@@ -92,4 +92,19 @@ describe('aggregateClaudeResults', () => {
       costBasis: 'list',
     });
   });
+
+  it('does not let a zeroed terminal error erase prior cumulative accounting', () => {
+    const success = result('parent', 10, 10, 2, 0.01);
+    const crash = result('crash', 0, 0, 0, 0);
+    crash.subtype = 'error_during_execution';
+    crash.is_error = true;
+    crash.modelUsage = {};
+
+    const aggregate = aggregateClaudeResults([success, crash]);
+
+    expect(aggregate.uuid).toBe('crash');
+    expect(aggregate.subtype).toBe('error_during_execution');
+    expect(aggregate.total_cost_usd).toBe(0.01);
+    expect(aggregate.modelUsage.sonnet).toMatchObject({ inputTokens: 10, outputTokens: 2 });
+  });
 });

--- a/packages/executor/src/sdk-handlers/claude/result-aggregation.ts
+++ b/packages/executor/src/sdk-handlers/claude/result-aggregation.ts
@@ -7,19 +7,13 @@ const TOP_LEVEL_USAGE_COUNTERS = [
   'cache_read_input_tokens',
 ] as const;
 
-const MODEL_USAGE_COUNTERS = [
-  'inputTokens',
-  'outputTokens',
-  'cacheReadInputTokens',
-  'cacheCreationInputTokens',
-  'webSearchRequests',
-  'costUSD',
-] as const;
-
 /**
  * Aggregate per-turn Agent SDK results into the terminal result consumed by
- * ClaudeTool's task-level accounting. The individual results are still yielded
- * upstream; this makes the last one an authoritative query-level summary.
+ * ClaudeTool's task-level accounting. `usage`, durations, turns, and permission
+ * denials are per-turn, so they are summed. `modelUsage` and `total_cost_usd`
+ * are cumulative across a streaming-input query as of Agent SDK 0.3.223, so
+ * the terminal result is already authoritative and must not be summed again.
+ * The individual results are still yielded upstream.
  */
 export function aggregateClaudeResults(results: SDKResultMessage[]): SDKResultMessage {
   const terminal = results.at(-1);
@@ -30,38 +24,12 @@ export function aggregateClaudeResults(results: SDKResultMessage[]): SDKResultMe
     usage[key] = results.reduce((sum, result) => sum + (result.usage[key] ?? 0), 0);
   }
 
-  const modelUsage: SDKResultMessage['modelUsage'] = {};
-  for (const result of results) {
-    for (const [modelId, current] of Object.entries(result.modelUsage)) {
-      const aggregate = modelUsage[modelId]
-        ? { ...modelUsage[modelId] }
-        : {
-            inputTokens: 0,
-            outputTokens: 0,
-            cacheReadInputTokens: 0,
-            cacheCreationInputTokens: 0,
-            webSearchRequests: 0,
-            costUSD: 0,
-            contextWindow: 0,
-            maxOutputTokens: 0,
-          };
-      for (const key of MODEL_USAGE_COUNTERS) {
-        aggregate[key] += current[key] ?? 0;
-      }
-      aggregate.contextWindow = Math.max(aggregate.contextWindow, current.contextWindow ?? 0);
-      aggregate.maxOutputTokens = Math.max(aggregate.maxOutputTokens, current.maxOutputTokens ?? 0);
-      modelUsage[modelId] = aggregate;
-    }
-  }
-
   return {
     ...terminal,
     duration_ms: results.reduce((sum, result) => sum + result.duration_ms, 0),
     duration_api_ms: results.reduce((sum, result) => sum + result.duration_api_ms, 0),
     num_turns: results.reduce((sum, result) => sum + result.num_turns, 0),
-    total_cost_usd: results.reduce((sum, result) => sum + result.total_cost_usd, 0),
     usage,
-    modelUsage,
     permission_denials: results.flatMap((result) => result.permission_denials),
   };
 }

--- a/packages/executor/src/sdk-handlers/claude/result-aggregation.ts
+++ b/packages/executor/src/sdk-handlers/claude/result-aggregation.ts
@@ -12,7 +12,9 @@ const TOP_LEVEL_USAGE_COUNTERS = [
  * ClaudeTool's task-level accounting. `usage`, durations, turns, and permission
  * denials are per-turn, so they are summed. `modelUsage` and `total_cost_usd`
  * are cumulative across a streaming-input query as of Agent SDK 0.3.223, so
- * the terminal result is already authoritative and must not be summed again.
+ * the latest meaningful cumulative snapshot is authoritative and must not be
+ * summed again. Crash/startup-error results may zero those cumulative fields,
+ * so a zeroed terminal result must not erase accounting already observed.
  * The individual results are still yielded upstream.
  */
 export function aggregateClaudeResults(results: SDKResultMessage[]): SDKResultMessage {
@@ -24,12 +26,34 @@ export function aggregateClaudeResults(results: SDKResultMessage[]): SDKResultMe
     usage[key] = results.reduce((sum, result) => sum + (result.usage[key] ?? 0), 0);
   }
 
+  let latestMeaningfulCumulative: SDKResultMessage | undefined;
+  for (let index = results.length - 1; index >= 0; index--) {
+    const result = results[index];
+    if (
+      result.total_cost_usd > 0 ||
+      Object.values(result.modelUsage).some(
+        (model) =>
+          model.inputTokens > 0 ||
+          model.outputTokens > 0 ||
+          model.cacheReadInputTokens > 0 ||
+          model.cacheCreationInputTokens > 0 ||
+          model.webSearchRequests > 0 ||
+          model.costUSD > 0
+      )
+    ) {
+      latestMeaningfulCumulative = result;
+      break;
+    }
+  }
+
   return {
     ...terminal,
     duration_ms: results.reduce((sum, result) => sum + result.duration_ms, 0),
     duration_api_ms: results.reduce((sum, result) => sum + result.duration_api_ms, 0),
     num_turns: results.reduce((sum, result) => sum + result.num_turns, 0),
     usage,
+    total_cost_usd: latestMeaningfulCumulative?.total_cost_usd ?? terminal.total_cost_usd,
+    modelUsage: latestMeaningfulCumulative?.modelUsage ?? terminal.modelUsage,
     permission_denials: results.flatMap((result) => result.permission_denials),
   };
 }

--- a/packages/executor/src/sdk-handlers/codex/normalizer.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/normalizer.test.ts
@@ -11,12 +11,13 @@ function buildTurnCompletedEvent(overrides: Partial<CodexSdkResponse> = {}): Cod
 }
 
 function buildUsage(overrides: Record<string, number | undefined> = {}): CodexSdkResponse['usage'] {
-  // Mirror the real @openai/codex-sdk Usage shape (input/cached_input/output/
-  // reasoning_output). The SDK does NOT include total_tokens — normalizer
-  // derives it as input + output.
+  // Mirror the real @openai/codex-sdk Usage shape (input/cached_input/
+  // cache_write_input/output/reasoning_output). The SDK does NOT include
+  // total_tokens — normalizer derives it as input + output.
   return {
     input_tokens: overrides.input_tokens,
     cached_input_tokens: overrides.cached_input_tokens,
+    cache_write_input_tokens: overrides.cache_write_input_tokens,
     output_tokens: overrides.output_tokens,
     reasoning_output_tokens: overrides.reasoning_output_tokens,
   } as CodexSdkResponse['usage'];
@@ -54,6 +55,7 @@ describe('CodexNormalizer', () => {
         input_tokens: 1_200,
         output_tokens: 800,
         cached_input_tokens: 300,
+        cache_write_input_tokens: 125,
       }),
     });
 
@@ -64,7 +66,7 @@ describe('CodexNormalizer', () => {
       outputTokens: 800,
       totalTokens: 2_000,
       cacheReadTokens: 300,
-      cacheCreationTokens: 0,
+      cacheCreationTokens: 125,
     });
     expect(result.primaryModel).toBeUndefined();
   });

--- a/packages/executor/src/sdk-handlers/codex/normalizer.ts
+++ b/packages/executor/src/sdk-handlers/codex/normalizer.ts
@@ -35,6 +35,7 @@ export class CodexNormalizer implements INormalizer<CodexSdkResponse> {
     const inputTokens = usage.input_tokens || 0;
     const outputTokens = usage.output_tokens || 0;
     const cacheReadTokens = usage.cached_input_tokens || 0;
+    const cacheCreationTokens = usage.cache_write_input_tokens || 0;
     const modelForPricing = options?.modelHint || DEFAULT_CODEX_MODEL;
     const estimatedCostUsd = estimateCodexCostUsd({
       modelId: modelForPricing,
@@ -49,7 +50,7 @@ export class CodexNormalizer implements INormalizer<CodexSdkResponse> {
         outputTokens,
         totalTokens: inputTokens + outputTokens,
         cacheReadTokens,
-        cacheCreationTokens: 0,
+        cacheCreationTokens,
       },
       contextWindowLimit,
       costUsd: estimatedCostUsd,

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
@@ -1615,6 +1615,7 @@ describe('CodexPromptService - event_msg terminal handling (issue #1749)', () =>
         usage: {
           input_tokens: 8,
           cached_input_tokens: 2,
+          cache_write_input_tokens: 1,
           output_tokens: 3,
           reasoning_output_tokens: 1,
         },
@@ -1629,6 +1630,7 @@ describe('CodexPromptService - event_msg terminal handling (issue #1749)', () =>
       usage: {
         input_tokens: 8,
         cached_input_tokens: 2,
+        cache_write_input_tokens: 1,
         output_tokens: 3,
         reasoning_output_tokens: 1,
       },

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -167,6 +167,7 @@ function projectCodexCompletedEvent(
     usage: {
       input_tokens: count('input_tokens'),
       cached_input_tokens: count('cached_input_tokens'),
+      cache_write_input_tokens: count('cache_write_input_tokens'),
       output_tokens: count('output_tokens'),
       reasoning_output_tokens: count('reasoning_output_tokens'),
     },

--- a/packages/executor/src/sdk-handlers/codex/usage.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/usage.test.ts
@@ -15,14 +15,16 @@ describe('extractCodexTokenUsage', () => {
   });
 
   it('maps the realistic @openai/codex-sdk Usage shape and derives total_tokens', () => {
-    // Matches the actual TurnCompletedEvent.usage shape in @openai/codex-sdk >= 0.133:
-    // input_tokens, cached_input_tokens, output_tokens, reasoning_output_tokens.
+    // Matches the actual TurnCompletedEvent.usage shape in @openai/codex-sdk 0.153:
+    // input_tokens, cached_input_tokens, cache_write_input_tokens, output_tokens,
+    // reasoning_output_tokens.
     // The SDK does NOT emit total_tokens — we derive it from input + output.
     // reasoning_output_tokens is a SUBSET of output_tokens (Responses API), so it
     // must NOT be added to the total.
     const result = extractCodexTokenUsage({
       input_tokens: 1200,
       cached_input_tokens: 300,
+      cache_write_input_tokens: 125,
       output_tokens: 800,
       reasoning_output_tokens: 200,
     });
@@ -31,6 +33,7 @@ describe('extractCodexTokenUsage', () => {
       input_tokens: 1200,
       output_tokens: 800,
       cache_read_tokens: 300,
+      cache_creation_tokens: 125,
       total_tokens: 2000, // input + output; reasoning_output_tokens is NOT added
     });
   });

--- a/packages/executor/src/sdk-handlers/codex/usage.ts
+++ b/packages/executor/src/sdk-handlers/codex/usage.ts
@@ -70,7 +70,8 @@ export function codexUsedPercentage(usedTokens: number, contextWindow: number): 
  * - We map cached_input_tokens → cache_read_tokens so downstream utilities
  *   (cost + context window) can treat Codex like Claude/Gemini.
  * - We map cache_write_input_tokens → cache_creation_tokens. This field was
- *   added in Codex SDK 0.153 and is independent from input_tokens.
+ *   added in Codex SDK 0.153 and is a breakdown already included in
+ *   input_tokens, so it must not be added to total token arithmetic.
  * - reasoning_output_tokens is intentionally NOT added to totals because
  *   per the OpenAI Responses API it is already included in output_tokens.
  *   It is preserved on the raw SDK response for debugging/UI surfacing.

--- a/packages/executor/src/sdk-handlers/codex/usage.ts
+++ b/packages/executor/src/sdk-handlers/codex/usage.ts
@@ -61,6 +61,7 @@ export function codexUsedPercentage(usedTokens: number, contextWindow: number): 
  * {
  *   input_tokens,
  *   cached_input_tokens,
+ *   cache_write_input_tokens,
  *   output_tokens,
  *   reasoning_output_tokens   // subset of output_tokens (Responses API convention)
  * }
@@ -68,6 +69,8 @@ export function codexUsedPercentage(usedTokens: number, contextWindow: number): 
  * Notes:
  * - We map cached_input_tokens → cache_read_tokens so downstream utilities
  *   (cost + context window) can treat Codex like Claude/Gemini.
+ * - We map cache_write_input_tokens → cache_creation_tokens. This field was
+ *   added in Codex SDK 0.153 and is independent from input_tokens.
  * - reasoning_output_tokens is intentionally NOT added to totals because
  *   per the OpenAI Responses API it is already included in output_tokens.
  *   It is preserved on the raw SDK response for debugging/UI surfacing.
@@ -84,6 +87,11 @@ export function extractCodexTokenUsage(raw: unknown): TokenUsage | undefined {
   const cacheReadTokens = normalizeNumber(
     payload.cached_input_tokens ?? payload.cachedInputTokens ?? payload.cache_read_tokens
   );
+  const cacheCreationTokens = normalizeNumber(
+    payload.cache_write_input_tokens ??
+      payload.cacheWriteInputTokens ??
+      payload.cache_creation_tokens
+  );
   const totalTokens = normalizeNumber(
     payload.total_tokens ??
       payload.totalTokens ??
@@ -96,6 +104,7 @@ export function extractCodexTokenUsage(raw: unknown): TokenUsage | undefined {
     input_tokens: inputTokens,
     output_tokens: outputTokens,
     cache_read_tokens: cacheReadTokens,
+    cache_creation_tokens: cacheCreationTokens,
     total_tokens: totalTokens,
   };
 
@@ -103,6 +112,7 @@ export function extractCodexTokenUsage(raw: unknown): TokenUsage | undefined {
     usage.input_tokens === undefined &&
     usage.output_tokens === undefined &&
     usage.cache_read_tokens === undefined &&
+    usage.cache_creation_tokens === undefined &&
     usage.total_tokens === undefined
   ) {
     return undefined;

--- a/packages/executor/src/sdk-watchdog.ts
+++ b/packages/executor/src/sdk-watchdog.ts
@@ -7,8 +7,8 @@ export type SdkActivityAdapter = 'claude-code' | 'codex' | 'gemini' | 'copilot';
 export type SdkActivityCallback = (kind: ExecutorPulseKind, detail?: string) => void;
 
 export const SDK_ACTIVITY_VERSION_MANIFEST: Record<SdkActivityAdapter, string> = {
-  'claude-code': '@anthropic-ai/claude-agent-sdk@0.3.197',
-  codex: '@openai/codex-sdk@0.144.0',
+  'claude-code': '@anthropic-ai/claude-agent-sdk@0.3.259',
+  codex: '@openai/codex-sdk@0.153.0',
   gemini: '@google/gemini-cli-core@0.40.1',
   copilot: '@github/copilot-sdk@0.2.2',
 };

--- a/packages/executor/src/types.ts
+++ b/packages/executor/src/types.ts
@@ -12,6 +12,7 @@ export type {
   MessageID,
   MessageSource,
   PermissionMode,
+  PromptOrigin,
   SessionID,
   TaskID,
   UserID,

--- a/packages/executor/src/types/sdk-response.ts
+++ b/packages/executor/src/types/sdk-response.ts
@@ -26,16 +26,11 @@ import type { TurnCompletedEvent } from '@openai/codex-sdk';
 export type ClaudeCodeSdkResponse = SDKResultMessage;
 
 /**
- * Internal structure of modelUsage from Claude Agent SDK
- * Maps model ID to usage statistics
+ * Per-model usage from the Claude Agent SDK. Derive it from the provider type
+ * so newly-added accounting metadata (for example thinkingTokens and
+ * costBasis) is retained without maintaining a second partial interface.
  */
-export interface ClaudeModelUsage {
-  inputTokens?: number;
-  outputTokens?: number;
-  cacheReadInputTokens?: number;
-  cacheCreationInputTokens?: number;
-  contextWindow?: number;
-}
+export type ClaudeModelUsage = SDKResultMessage['modelUsage'][string];
 
 /**
  * Internal structure of top-level usage from Claude Agent SDK (legacy/fallback)

--- a/packages/executor/src/user-runtime-paths.test.ts
+++ b/packages/executor/src/user-runtime-paths.test.ts
@@ -7,12 +7,16 @@ import {
 
 describe('effective executor user paths', () => {
   const originalHome = process.env.HOME;
+  const originalCodexHome = process.env.CODEX_HOME;
   afterEach(() => {
     if (originalHome === undefined) delete process.env.HOME;
     else process.env.HOME = originalHome;
+    if (originalCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = originalCodexHome;
   });
   it('ignores a misleading inherited HOME', () => {
     process.env.HOME = '/home/daemon';
+    delete process.env.CODEX_HOME;
     const lookup = () => ({ homedir: '/home/alice', shell: '/bin/zsh' });
     expect(resolveEffectiveUserInfo(lookup)).toEqual({
       homedir: '/home/alice',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -246,8 +246,8 @@ importers:
         version: 4.8.3(supports-color@8.1.1)
     devDependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.3.197
-        version: 0.3.197(@anthropic-ai/sdk@0.109.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(supports-color@8.1.1)(zod@4.4.3))(zod@4.4.3)
+        specifier: ^0.3.259
+        version: 0.3.259(@anthropic-ai/sdk@0.109.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(supports-color@8.1.1)(zod@4.4.3))(zod@4.4.3)
       '@anthropic-ai/sdk':
         specifier: ^0.109.0
         version: 0.109.0(zod@4.4.3)
@@ -676,8 +676,8 @@ importers:
   packages/agor-claude:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: 0.3.197
-        version: 0.3.197(@anthropic-ai/sdk@0.109.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(supports-color@8.1.1)(zod@4.4.3))(zod@4.4.3)
+        specifier: 0.3.259
+        version: 0.3.259(@anthropic-ai/sdk@0.109.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(supports-color@8.1.1)(zod@4.4.3))(zod@4.4.3)
     devDependencies:
       '@types/node':
         specifier: ^24.6.0
@@ -692,8 +692,8 @@ importers:
   packages/agor-codex:
     dependencies:
       '@openai/codex-sdk':
-        specifier: 0.144.0
-        version: 0.144.0
+        specifier: 0.153.0
+        version: 0.153.0
     devDependencies:
       '@types/node':
         specifier: ^24.6.0
@@ -1105,8 +1105,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.3.197
-        version: 0.3.197(@anthropic-ai/sdk@0.109.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(supports-color@8.1.1)(zod@4.4.3))(zod@4.4.3)
+        specifier: ^0.3.259
+        version: 0.3.259(@anthropic-ai/sdk@0.109.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(supports-color@8.1.1)(zod@4.4.3))(zod@4.4.3)
       '@google/gemini-cli-core':
         specifier: ^0.40.0
         version: 0.40.1(encoding@0.1.13)(express@5.2.1(supports-color@8.1.1))(supports-color@8.1.1)
@@ -1120,8 +1120,8 @@ importers:
         specifier: ^22.0.1
         version: 22.0.1
       '@openai/codex-sdk':
-        specifier: ^0.144.0
-        version: 0.144.0
+        specifier: ^0.153.0
+        version: 0.153.0
       '@types/bcryptjs':
         specifier: ^2.4.6
         version: 2.4.6
@@ -1187,8 +1187,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.3.197
-        version: 0.3.197(@anthropic-ai/sdk@0.109.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(supports-color@8.1.1)(zod@4.4.3))(zod@4.4.3)
+        specifier: ^0.3.259
+        version: 0.3.259(@anthropic-ai/sdk@0.109.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(supports-color@8.1.1)(zod@4.4.3))(zod@4.4.3)
       '@cursor/sdk':
         specifier: ^1.0.26
         version: 1.0.26
@@ -1205,8 +1205,8 @@ importers:
         specifier: '>=1.29.0 <2'
         version: 1.29.0(supports-color@8.1.1)(zod@4.4.3)
       '@openai/codex-sdk':
-        specifier: ^0.144.0
-        version: 0.144.0
+        specifier: ^0.153.0
+        version: 0.153.0
       '@types/diff':
         specifier: ^6.0.0
         version: 6.0.0
@@ -1357,52 +1357,52 @@ packages:
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.197':
-    resolution: {integrity: sha512-jC6WvH5Hr6APTfbMjo4nC6LlyMMqbpCMwiHXIw7/AsQXIHQhZ+cRRMesQlV6UFI1l3O53gLZHzsG9cXwfrPHKw==}
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.259':
+    resolution: {integrity: sha512-irMesPeaTll57VE+ZWw1+J9eSMtllbb1Mr9cKVW9igS0mu4nPtDFaNuycSSb0e/XJZlmUwEM+Q74XbilcfUBdA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.197':
-    resolution: {integrity: sha512-ZQNvGkMrTyatBlHTIQ4w2i2aLBuvq355UP/FDLnVXIH8l23RsL1x/0w9P+dqB7EmY9OZi/cPxSrpskpo+dZWLA==}
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.259':
+    resolution: {integrity: sha512-L8IESfv0vwoVFp+4icW3oSj1f0AT0jonnS5vVIF4RBr+52JogiPCTstG1AI9xSD5R82084Ov6G7ekjS/eZRREA==}
     cpu: [x64]
     os: [darwin]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.197':
-    resolution: {integrity: sha512-VuIGXsLGK/aqSQ0tTBqqPVNzjefWS5SWnK8mlYyQitT4s5UDzHXJm0UZBTGxRtlcS0e2+QAHKwbGBCq1ZKSXjg==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.259':
+    resolution: {integrity: sha512-6Mbet5P5LWwX1YexyzDkNP4vn1pmw8dlnNF/NU1+rXxEYmXiDVt2uf+p1hA/FbHCVottx8dc1CcVNgFy+QbQTA==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.197':
-    resolution: {integrity: sha512-pWhQgCtAft4EGM4Zn24HRad1a/k2u6oA+2uM/KCdjehfKtooDiHfMNd1yzXY/n9AEBWP0RHB2Vz3mJ30X2pVAg==}
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.259':
+    resolution: {integrity: sha512-3AblD+jFXRkYssGQ/bfjIZ3kUmoqzgiVUO6G9UkVq8wClo6YNJTnYMUrkPvwX0ahR65Y3QsM2iPcLmao13vVCw==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.197':
-    resolution: {integrity: sha512-3Tuy7XhD4UIKE4A4RPmKJcbL7Q/3dcB1hEWQt2lKP7c/DlixeEv+tRzvpnFZKhFX2hy0tkBk3QjkozSAacMC/w==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.259':
+    resolution: {integrity: sha512-5lBXB6eXN90VKc+HT+PEKQp+/omhK88OK9caWohUp4ozCiyy2LoUz4s+l0S2HaNa2yiY7z+lhwcgpAkuOp8Olw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.197':
-    resolution: {integrity: sha512-AUccrbdcv4Hy/GteP/gYLjG/zDP+fe2BFtDMctEfRFVz40DazYDcOyW1+nIgSTQtxf5jSTAVVf3cNuXB2CZwlw==}
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.259':
+    resolution: {integrity: sha512-kpPgmCwNN+OA+q1suGvzKbUk9sfrYKz/gJmLne4ag91oqRHBP0wAEWex0c/0bmTb+wDa98WmpwpZYCmqKppCdg==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.197':
-    resolution: {integrity: sha512-Wx8uiAKBenDuL8lWQmrqnX5ppljaH5unQ9cKiCz2/9Kgf09dgnrwbX8n/FhndCZR8PmYw539eWwYVrSVc/bl6w==}
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.259':
+    resolution: {integrity: sha512-ryidK7vUU9CV4RStETCBwfQctMgFZ0nb/uP08GL85mpbnzPFnw+tD06rA7aIkQTXHuOv4BFvFxHRgYouBoZ0bg==}
     cpu: [arm64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.197':
-    resolution: {integrity: sha512-ZXJO/VvR3SI4G0gwthWeFXWdHB5RXPu3rtfGRcKZ/YgtDeW17rQ+LZIJTk2ywzbLb8EvlghR5JPgn293hC179Q==}
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.259':
+    resolution: {integrity: sha512-0zJUo/avBoyxzI/81/T7Yv3xBor4rjUJAQvUa8bJ2zmc0RL/fczGlJAKEfOql69kG8ap+Igo9nbNZ6TLyURjrw==}
     cpu: [x64]
     os: [win32]
 
-  '@anthropic-ai/claude-agent-sdk@0.3.197':
-    resolution: {integrity: sha512-XNIi8W1tb+QfMkcK+5kepOC6BsxG8wtupd72H+pIPzIJypVQhHy7FoX+KBMtTRYwtl+5dsjKyABhjWXebeUilw==}
+  '@anthropic-ai/claude-agent-sdk@0.3.259':
+    resolution: {integrity: sha512-5VJSzHQTAPFl2BytZSgyL0Xtdi3I7CeajEhO4KTvm6bx4nt1OIp+IHx78MuurA4Pp/t9UEPa3cWz8Q55Pi9MYw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       '@anthropic-ai/sdk': '>=0.93.0'
@@ -3315,47 +3315,47 @@ packages:
   '@open-draft/deferred-promise@2.2.0':
     resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
 
-  '@openai/codex-sdk@0.144.0':
-    resolution: {integrity: sha512-Avk4tZxfhNfwMhLoD9P+1aFlgaK2Mv11ouy+z9ImkgOKRHDMhDPFw1CbsNECfGNWJix7T0EG9TAU1XVkEKW3DQ==}
+  '@openai/codex-sdk@0.153.0':
+    resolution: {integrity: sha512-60D0LTPVczybWn4Db4Hk8uMRkBYex45MKax1PLrF/sqFRe/5oaZ+QykyGT9VCPnIbontMf5x7F7EqpEjRa6wug==}
     engines: {node: '>=18'}
 
-  '@openai/codex@0.144.0':
-    resolution: {integrity: sha512-QFh6f+v5QUx/Vg0HjIl9HB94p7aDLBDkZjc4IXX5RXUcXHPVCZNb6Hl2R49Og/fqW7orgZkeDcgWfRANUa1WoQ==}
+  '@openai/codex@0.153.0':
+    resolution: {integrity: sha512-k55kUZaclNi5ceUStSVuyW834ruA6AEdzTK7Xi3M1mOyXokUmq1sJLXm1RJ3XD2S7bRPeF1EXNsYB5Qxwus0mw==}
     engines: {node: '>=16'}
     hasBin: true
 
-  '@openai/codex@0.144.0-darwin-arm64':
-    resolution: {integrity: sha512-rqFAJdOa2I0VRgepVsSZeLxs96+Y+LXTjccOOvH6894FyaFAYPZ/o+6hgpB1iGHxxdoY/DsGa8jrJC8Leqn9Kg==}
+  '@openai/codex@0.153.0-darwin-arm64':
+    resolution: {integrity: sha512-C9F3HVEYekVJC3WhiGSztcxItWBwd7Y6hTWoDqa9Z9aLWsYywzqChABB59n7G5F5jCil9wxW3+u2L6uiVUydmw==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@openai/codex@0.144.0-darwin-x64':
-    resolution: {integrity: sha512-4p2jxRbN+Khg5UQzpkzT9upFj+qkEF/abmdvrtflkkWmVKP6Nt+yi8ospdqv9PDqvQ9SotPvX7iXaFaeUTrtmA==}
+  '@openai/codex@0.153.0-darwin-x64':
+    resolution: {integrity: sha512-DO5u+X/eL8pObrV0WDErOjS9DeuDvVuOL5oHR5y5Yklp0NGoGj3oOHsmaSXjGesiIiu3IX8l4pzS6dbeQXJAvQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@openai/codex@0.144.0-linux-arm64':
-    resolution: {integrity: sha512-k++xhZrn9P3laO00Q92APG6mdOFDD66nUBo+8ExCa1NXi2pjLEMLC4+UNJTUUtUT1PEflOZ5pDKxPXgzaiFFFg==}
+  '@openai/codex@0.153.0-linux-arm64':
+    resolution: {integrity: sha512-N2zLgmuslhMoC2RFC2aDkcCWk3iapZmBlSiESpjXFF+UMNxIpNxWJ5qQtQrCp5Md7kYbF4/EFy8RqJ8tL8UTeA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@openai/codex@0.144.0-linux-x64':
-    resolution: {integrity: sha512-GmKtQeX+cO9lN7mQD1FEVcXYEMLMgMByHwZdvlluH0bj/+c2ind3hwbRtE3eECFDekNhEiB80Ez0FfbkyFQqoA==}
+  '@openai/codex@0.153.0-linux-x64':
+    resolution: {integrity: sha512-sFF+g7p1o6sZVL6PHd9JTYrP2j3xao3Qeu5AngcrD5brWrCc+w9ifBJCJuRSM728WfgjXML9PQPdHPaZSeHAEA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@openai/codex@0.144.0-win32-arm64':
-    resolution: {integrity: sha512-e2yGSgwdzrT1SoJMoOzWD58WBEsIaAMZpEchuV2VGkE2T955SG7dn7EyVQTQcy7/rdpE8aEDktZ/1eQQfjkdtQ==}
+  '@openai/codex@0.153.0-win32-arm64':
+    resolution: {integrity: sha512-Ro+/2oAQnOObxuw3hpr+anv+j9hFmql/2iDxd7v0m46ctZy8x6ygW/Ud4f9CB1UXlRRsDhW+Tu9UAd5X9vTL1g==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [win32]
 
-  '@openai/codex@0.144.0-win32-x64':
-    resolution: {integrity: sha512-QiholLCYqNeYvNM77HOmPtrOFrY0rQc/N9nXt+sQGXO3rEGmcWjpLzujY4Oegl3CLRHoieWqlep3EqEvFBjoIA==}
+  '@openai/codex@0.153.0-win32-x64':
+    resolution: {integrity: sha512-eXvmitT1Hmr6d8n9r5HVjTuSgdHtxFSyXh0c3rRnaTcJA0ef8JnI5LY0TJci/QHYLNJGaEMBZ5R4dEdB2d87Lw==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -10836,44 +10836,44 @@ snapshots:
       package-manager-detector: 1.5.0
       tinyexec: 1.2.4
 
-  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.197':
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.259':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.197':
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.259':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.197':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.259':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.197':
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.259':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.197':
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.259':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.197':
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.259':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.197':
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.259':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.197':
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.259':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk@0.3.197(@anthropic-ai/sdk@0.109.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(supports-color@8.1.1)(zod@4.4.3))(zod@4.4.3)':
+  '@anthropic-ai/claude-agent-sdk@0.3.259(@anthropic-ai/sdk@0.109.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(supports-color@8.1.1)(zod@4.4.3))(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.109.0(zod@4.4.3)
       '@modelcontextprotocol/sdk': 1.29.0(supports-color@8.1.1)(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
-      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.197
-      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.197
-      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.197
-      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.197
-      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.197
-      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.197
-      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.197
-      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.197
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.3.259
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.3.259
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.3.259
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.3.259
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.3.259
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.3.259
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.3.259
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.3.259
 
   '@anthropic-ai/sdk@0.109.0(zod@4.4.3)':
     dependencies:
@@ -13200,35 +13200,35 @@ snapshots:
 
   '@open-draft/deferred-promise@2.2.0': {}
 
-  '@openai/codex-sdk@0.144.0':
+  '@openai/codex-sdk@0.153.0':
     dependencies:
-      '@openai/codex': 0.144.0
+      '@openai/codex': 0.153.0
 
-  '@openai/codex@0.144.0':
+  '@openai/codex@0.153.0':
     optionalDependencies:
-      '@openai/codex-darwin-arm64': '@openai/codex@0.144.0-darwin-arm64'
-      '@openai/codex-darwin-x64': '@openai/codex@0.144.0-darwin-x64'
-      '@openai/codex-linux-arm64': '@openai/codex@0.144.0-linux-arm64'
-      '@openai/codex-linux-x64': '@openai/codex@0.144.0-linux-x64'
-      '@openai/codex-win32-arm64': '@openai/codex@0.144.0-win32-arm64'
-      '@openai/codex-win32-x64': '@openai/codex@0.144.0-win32-x64'
+      '@openai/codex-darwin-arm64': '@openai/codex@0.153.0-darwin-arm64'
+      '@openai/codex-darwin-x64': '@openai/codex@0.153.0-darwin-x64'
+      '@openai/codex-linux-arm64': '@openai/codex@0.153.0-linux-arm64'
+      '@openai/codex-linux-x64': '@openai/codex@0.153.0-linux-x64'
+      '@openai/codex-win32-arm64': '@openai/codex@0.153.0-win32-arm64'
+      '@openai/codex-win32-x64': '@openai/codex@0.153.0-win32-x64'
 
-  '@openai/codex@0.144.0-darwin-arm64':
+  '@openai/codex@0.153.0-darwin-arm64':
     optional: true
 
-  '@openai/codex@0.144.0-darwin-x64':
+  '@openai/codex@0.153.0-darwin-x64':
     optional: true
 
-  '@openai/codex@0.144.0-linux-arm64':
+  '@openai/codex@0.153.0-linux-arm64':
     optional: true
 
-  '@openai/codex@0.144.0-linux-x64':
+  '@openai/codex@0.153.0-linux-x64':
     optional: true
 
-  '@openai/codex@0.144.0-win32-arm64':
+  '@openai/codex@0.153.0-win32-arm64':
     optional: true
 
-  '@openai/codex@0.144.0-win32-x64':
+  '@openai/codex@0.153.0-win32-x64':
     optional: true
 
   '@opencode-ai/sdk@1.14.33':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -246,7 +246,7 @@ importers:
         version: 4.8.3(supports-color@8.1.1)
     devDependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.3.259
+        specifier: 0.3.259
         version: 0.3.259(@anthropic-ai/sdk@0.109.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(supports-color@8.1.1)(zod@4.4.3))(zod@4.4.3)
       '@anthropic-ai/sdk':
         specifier: ^0.109.0
@@ -1105,7 +1105,7 @@ importers:
         version: 4.4.3
     devDependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.3.259
+        specifier: 0.3.259
         version: 0.3.259(@anthropic-ai/sdk@0.109.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(supports-color@8.1.1)(zod@4.4.3))(zod@4.4.3)
       '@google/gemini-cli-core':
         specifier: ^0.40.0
@@ -1120,7 +1120,7 @@ importers:
         specifier: ^22.0.1
         version: 22.0.1
       '@openai/codex-sdk':
-        specifier: ^0.153.0
+        specifier: 0.153.0
         version: 0.153.0
       '@types/bcryptjs':
         specifier: ^2.4.6
@@ -1187,7 +1187,7 @@ importers:
         version: 4.4.3
     devDependencies:
       '@anthropic-ai/claude-agent-sdk':
-        specifier: ^0.3.259
+        specifier: 0.3.259
         version: 0.3.259(@anthropic-ai/sdk@0.109.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(supports-color@8.1.1)(zod@4.4.3))(zod@4.4.3)
       '@cursor/sdk':
         specifier: ^1.0.26
@@ -1205,7 +1205,7 @@ importers:
         specifier: '>=1.29.0 <2'
         version: 1.29.0(supports-color@8.1.1)(zod@4.4.3)
       '@openai/codex-sdk':
-        specifier: ^0.153.0
+        specifier: 0.153.0
         version: 0.153.0
       '@types/diff':
         specifier: ^6.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -96,6 +96,8 @@ allowBuilds:
   'unix-dgram@2.0.7': false
 patchedDependencies:
   streamdown@2.5.0: patches/streamdown@2.5.0.patch
+# These reviewed versions must remain installable when CI or an operator's
+# global pnpm config enforces minimumReleaseAge; this repo sets no age itself.
 minimumReleaseAgeExclude:
   - '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.259'
   - '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.259'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -96,3 +96,15 @@ allowBuilds:
   'unix-dgram@2.0.7': false
 patchedDependencies:
   streamdown@2.5.0: patches/streamdown@2.5.0.patch
+minimumReleaseAgeExclude:
+  - '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.259'
+  - '@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.259'
+  - '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.259'
+  - '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.259'
+  - '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.259'
+  - '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.259'
+  - '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.259'
+  - '@anthropic-ai/claude-agent-sdk-win32-x64@0.3.259'
+  - '@anthropic-ai/claude-agent-sdk@0.3.259'
+  - '@openai/codex-sdk@0.153.0'
+  - '@openai/codex@0.153.0-darwin-arm64 || 0.153.0-darwin-x64 || 0.153.0-linux-arm64 || 0.153.0-linux-x64 || 0.153.0-win32-arm64 || 0.153.0-win32-x64 || 0.153.0'


### PR DESCRIPTION
## Summary

- upgrade `@openai/codex-sdk` from 0.144.0 to 0.153.0 and `@anthropic-ai/claude-agent-sdk` from 0.3.197 to 0.3.259
- adapt Codex cache-write accounting and Claude streaming result/background-task contracts
- derive Claude prompt trust at the daemon Task/Session boundary: direct Agor prompts are human, gateway prompts are channels, and synthesized prompts remain unattributed
- re-verify Claude subscription OAuth constants against the SDK-bundled CLI and add its current `user:file_upload` scope
- add the verified `claude-fable-5-1` alias with native 1M context metadata, including the pinned OpenCode fallback catalog
- align the release train at 0.26.1 using `packages/agor-live/build.sh --bump patch`
- keep OpenCode at 1.14.33 after auditing the current 1.18.27 release line; its multi-minor event/API migration is not safe to include incidentally

## Upgrade matrix

| Component | Before | After | Notes |
| --- | ---: | ---: | --- |
| Agor release train | 0.26.0 | 0.26.1 | CLI, client, agor-live, and managed wrappers aligned |
| OpenAI Codex SDK | 0.144.0 | 0.153.0 | Stable release; API diff is additive for Agor's surface; contract consumers exact-pinned |
| Anthropic Claude Agent SDK | 0.3.197 | 0.3.259 | Peer requirements remain satisfied; contract consumers exact-pinned to the managed wrapper version |
| Claude native CLI bundled by SDK | — | 2.1.259 | OAuth flow/constants re-audited in the installed native binary |
| OpenCode SDK | 1.14.33 | unchanged | 1.18.27 audited and deliberately deferred |
| Claude model registries | — | + `claude-fable-5-1` | Exact documented alias; native 1M context in Claude and safe fallback discovery in pinned OpenCode |

## Changelog evidence

- Codex stable releases 0.145.0–0.153.0: https://github.com/openai/codex/releases/tag/rust-v0.153.0
- Claude Agent SDK changelog 0.3.198–0.3.259: https://github.com/anthropics/claude-agent-sdk-typescript/blob/main/CHANGELOG.md
- Claude Fable 5.1 model documentation: https://platform.claude.com/docs/en/models/fable-5-1/overview
- OpenCode 1.18.27 audit point: https://github.com/anomalyco/opencode/releases/tag/v1.18.27

## Compatibility notes

### Codex

The 0.153.0 TypeScript declaration diff is additive on Agor's used surface. Agor now projects `cache_write_input_tokens` through safe result logging and maps it to canonical cache-creation accounting. Cache writes remain a breakdown of input tokens rather than an additional total. Existing event/result discriminants remain supported.

### Claude

- `usage`, durations, turn counts, and denials remain per-turn and are summed.
- `modelUsage` and `total_cost_usd` are cumulative for a streaming-input query as documented since 0.3.223, so Agor retains the latest meaningful snapshot rather than double-counting continuation results or letting a zeroed terminal crash result erase prior accounting.
- `background_tasks_changed` is handled as authoritative lifecycle state and suppressed from user-facing/persisted SDK-event rows; foreground and ambient housekeeping tasks no longer hold an Agor task open, while later background transitions remain tracked.
- prompt origin is a closed daemon-to-executor value derived from durable Task/Session provenance: direct authenticated Agor prompts (including two-step Task execution and upload notifications) map to `human`; gateway prompts map to `channel` using immutable, server-owned gateway metadata; callbacks, widgets, MCP/agent-authored prompts, zone/spawn prompts, and otherwise unattributed prompts omit origin and fail closed at strict human-trust gates.
- per-model usage types derive from the SDK, preserving new metadata such as thinking tokens and cost basis.

There is **no database schema or migration change**, so SQLite/Postgres rollout behavior is unchanged. Persisted Task JSON gains backward-compatible additive accounting fields (for example Codex cache-write usage); old readers continue to tolerate them.

## Validation

- `pnpm install --frozen-lockfile --offline` (including supply-chain policy check)
- `pnpm check` — typecheck, lint, architecture/boundary checks, and all 15 non-doc builds
- `packages/agor-live/build.sh --bump patch` — 15/15 release builds plus pack/content checks
- executor full suite — 66 files / 719 tests, plus runtime and Claude auth precedence smoke tests
- focused review-fix suites — prompt provenance (including direct/two-step/upload/gateway and MCP sessions/branches/widgets), gateway-source immutability, payload validation, background snapshots/suppression, result aggregation, Codex usage, core models, and daemon task metadata
- final provenance-focused daemon validation — 5 files / 246 tests
- focused core model tests — 25 tests
- focused daemon Claude model/OAuth tests — 49 tests
- focused UI model and previously timed-out board tests — 3 files / 24 tests
- CLI full suite — 29 files / 180 tests
- serial broad workspace run completed 15 packages; the UI run found the updated model-copy assertion plus two unrelated timeout flakes. The assertion was corrected, and all three files passed together afterward.

## Rollout

1. Drain in-flight agent tasks before upgrading managed wrappers and daemon/UI artifacts.
2. Canary API-key and subscription-auth sessions for both providers.
3. Exercise direct, gateway, callback, and widget-originated prompts; new and resumed/forked sessions; MCP permission prompts; Claude background continuations; and token/cache accounting.
4. Confirm `claude-fable-5-1` entitlement through provider discovery, then expand by cohort.
5. Keep OpenCode on 1.14.33 until its event/v2 API changes receive a dedicated compatibility pass.

## Rollback

Drain work and redeploy the prior 0.26.0 artifacts, then reinstall the 0.26.0 managed wrappers. No database restore or down-migration is required because this PR changes no DB schema. The additive Task JSON accounting fields are rollback-compatible and may be ignored by prior readers. Preserve session state/configuration and verify resumed provider sessions after rollback.

## Safety

This PR does **not** publish, merge, or deploy anything.

