### PR TITLE
feat(ui): animated Agor logo spinner on the initial loading screen

### DIFF
--- a/apps/agor-ui/src/components/AgorLogoSpinner/AgorLogoSpinner.css
+++ b/apps/agor-ui/src/components/AgorLogoSpinner/AgorLogoSpinner.css
@@ -1,0 +1,90 @@
+/* biome-ignore-all lint/plugin/noFirstPartyCss: SVG stroke-dash keyframes and prefers-reduced-motion cannot be expressed inline */
+
+/* All dash animations use pathLength-normalized units: every animated path
+   declares pathLength="100", and dash/gap values sum to 101 (not 100) because
+   at dashoffset === dasharray exactly, some browsers paint a stray rounded-cap
+   stub at the path's start point. */
+
+.agor-logo-spinner-ring,
+.agor-logo-spinner-orbit {
+  transform-box: view-box;
+  transform-origin: 50% 50%;
+}
+
+/* Inner ring: a classic indeterminate spinner — the arc sweeps around while
+   growing and shrinking. Rotation and arc-length run on different periods so
+   the arc's start point drifts rather than repeating in place. */
+@keyframes agor-logo-spinner-turn {
+  to {
+    rotate: 360deg;
+  }
+}
+@keyframes agor-logo-spinner-arc {
+  0% {
+    stroke-dasharray: 8 93;
+    stroke-dashoffset: 0;
+  }
+  50% {
+    stroke-dasharray: 58 43;
+    stroke-dashoffset: -26;
+  }
+  100% {
+    stroke-dasharray: 8 93;
+    stroke-dashoffset: -101;
+  }
+}
+.agor-logo-spinner-ring {
+  animation:
+    agor-logo-spinner-turn 1.8s linear infinite,
+    agor-logo-spinner-arc 2.7s ease-in-out infinite;
+}
+
+/* Outer structure: dots and their connecting arcs rotate together as one rigid
+   group — the logo's silhouette stays intact, just in motion — in the same
+   direction as the inner spinner, at a much statelier pace. */
+.agor-logo-spinner-orbit {
+  animation: agor-logo-spinner-turn 6.4s linear infinite;
+}
+
+/* Connecting arcs: each tail retracts toward its leading dot, holds, then
+   re-extends until it reaches the trailing dot again. The two tails run a
+   half-cycle apart so one is always partially drawn. */
+@keyframes agor-logo-spinner-tail {
+  0%,
+  12% {
+    stroke-dashoffset: 0;
+    animation-timing-function: ease-in-out;
+  }
+  46%,
+  58% {
+    stroke-dashoffset: 101;
+    animation-timing-function: ease-in-out;
+  }
+  92%,
+  100% {
+    stroke-dashoffset: 0;
+  }
+}
+.agor-logo-spinner-tail {
+  stroke-dasharray: 101;
+  animation: agor-logo-spinner-tail 3.2s infinite;
+}
+.agor-logo-spinner-tail-alt {
+  animation-delay: -1.6s;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .agor-logo-spinner-ring,
+  .agor-logo-spinner-orbit,
+  .agor-logo-spinner-tail {
+    animation: none;
+  }
+  /* Rest state is the complete, static logo. */
+  .agor-logo-spinner-ring {
+    stroke-dasharray: none;
+    stroke-dashoffset: 0;
+  }
+  .agor-logo-spinner-tail {
+    stroke-dashoffset: 0;
+  }
+}

--- a/apps/agor-ui/src/components/AgorLogoSpinner/AgorLogoSpinner.test.tsx
+++ b/apps/agor-ui/src/components/AgorLogoSpinner/AgorLogoSpinner.test.tsx
@@ -1,0 +1,27 @@
+// biome-ignore-all lint/plugin/noHardcodedColorLiteral: distinctive literal verifies the color override prop propagates
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { AgorLogoSpinner } from './AgorLogoSpinner';
+
+describe('AgorLogoSpinner', () => {
+  it('renders the full logo geometry as an accessible loading image', () => {
+    const { container } = render(<AgorLogoSpinner />);
+
+    const svg = screen.getByRole('img', { name: 'Loading' });
+    expect(svg).toBeInTheDocument();
+    // Static A + crossbar, spinner ring, two orbit tails, four dots.
+    expect(container.querySelectorAll('path')).toHaveLength(4);
+    expect(container.querySelectorAll('circle')).toHaveLength(5);
+    expect(container.querySelector('.agor-logo-spinner-ring')).toBeInTheDocument();
+    expect(container.querySelectorAll('.agor-logo-spinner-tail')).toHaveLength(2);
+  });
+
+  it('honors size and color overrides', () => {
+    render(<AgorLogoSpinner size={48} color="#123456" aria-label="Loading boards" />);
+
+    const svg = screen.getByRole('img', { name: 'Loading boards' });
+    expect(svg).toHaveAttribute('width', '48');
+    expect(svg).toHaveAttribute('height', '48');
+    expect(svg).toHaveStyle({ color: '#123456' });
+  });
+});

--- a/apps/agor-ui/src/components/AgorLogoSpinner/AgorLogoSpinner.tsx
+++ b/apps/agor-ui/src/components/AgorLogoSpinner/AgorLogoSpinner.tsx
@@ -1,0 +1,71 @@
+import './AgorLogoSpinner.css';
+
+/* Agor logo brand teal — explicit brand asset color, overridable via `color`. */
+// biome-ignore lint/plugin/noHardcodedColorLiteral: the logo's brand color is an explicit brand asset, not a themeable surface
+const BRAND_TEAL = '#36B7AF';
+
+/* Geometry shared with the animated logo reveal
+   (apps/agor-docs/demo-videos/animated_agor_logo): 734×734 viewBox, 29px
+   strokes, dots r=40 on a 297 orbit, inner ring r=189, centered at 367,367. */
+const A_PATH =
+  'M188,607 C188,607 306.427,380.615 351.693,294.083 C355.033,287.698 361.66,283.713 368.865,283.756 C376.071,283.799 382.649,287.862 385.914,294.286 C420.058,361.482 494,507 494,507';
+const CROSSBAR_PATH =
+  'M293.84,404.67 C307.45,431.55 335.34,450 367.5,450 C400,450 428.13,431.17 441.58,403.83';
+const TAIL_PATHS = ['M367,70 A297,297 0 0,0 188,607', 'M367,664 A297,297 0 0,0 664,367'];
+const DOTS = [
+  { cx: 367, cy: 70 },
+  { cx: 367, cy: 664 },
+  { cx: 188, cy: 607 },
+  { cx: 664, cy: 367 },
+];
+
+interface Props {
+  /** Rendered width/height in px. */
+  size?: number;
+  /** Stroke/fill color; defaults to the logo's brand teal. */
+  color?: string;
+  'aria-label'?: string;
+}
+
+/**
+ * The Agor logo as an indeterminate loading spinner: the A holds still while
+ * the inner ring sweeps like a conventional spinner and the outer dots orbit
+ * with their connecting arcs collapsing and re-extending behind them. Pure
+ * CSS animation — no timers, no measurement. Honors prefers-reduced-motion by
+ * resting as the complete static logo.
+ */
+export function AgorLogoSpinner({ size = 96, color = BRAND_TEAL, ...rest }: Props) {
+  return (
+    <svg
+      className="agor-logo-spinner"
+      width={size}
+      height={size}
+      viewBox="0 0 734 734"
+      role="img"
+      aria-label={rest['aria-label'] ?? 'Loading'}
+      style={{ color, display: 'block' }}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={29}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d={CROSSBAR_PATH} />
+      <path d={A_PATH} />
+      <circle className="agor-logo-spinner-ring" cx={367} cy={367} r={189} pathLength={100} />
+      <g className="agor-logo-spinner-orbit">
+        {TAIL_PATHS.map((d, index) => (
+          <path
+            key={d}
+            className={`agor-logo-spinner-tail${index === 1 ? ' agor-logo-spinner-tail-alt' : ''}`}
+            d={d}
+            pathLength={100}
+          />
+        ))}
+        {DOTS.map(({ cx, cy }) => (
+          <circle key={`${cx},${cy}`} cx={cx} cy={cy} r={40} fill="currentColor" stroke="none" />
+        ))}
+      </g>
+    </svg>
+  );
+}

--- a/apps/agor-ui/src/components/InitialLoadingScreen.tsx
+++ b/apps/agor-ui/src/components/InitialLoadingScreen.tsx
@@ -7,6 +7,7 @@ import type {
   InitialLoadingStage,
   LoaderPhase,
 } from '../hooks';
+import { AgorLogoSpinner } from './AgorLogoSpinner/AgorLogoSpinner';
 import { Tag } from './Tag';
 
 const PRIMARY_INITIAL_LOAD_ITEMS = new Set<InitialLoadItemKey>([
@@ -87,7 +88,7 @@ export function InitialLoadingScreen({
         transition: 'opacity 280ms ease-out',
       }}
     >
-      <Spin size="large" />
+      <AgorLogoSpinner size={96} />
       <Typography.Text type="secondary" style={{ marginTop: token.marginMD }}>
         {statusMessage}
       </Typography.Text>


### PR DESCRIPTION
## What

Replaces the generic antd `Spin` on `InitialLoadingScreen` with the Agor logo animating as an indeterminate spinner:

- The **A** holds still so the mark stays legible.
- The **inner ring** sweeps like a conventional loading spinner (rotating arc that grows and shrinks).
- The **outer dots** orbit as a rigid group — the logo silhouette stays intact, just in motion — while their **connecting arcs procedurally collapse toward the leading dot and re-extend** to the trailing one, a half-cycle apart so one tail is always partially drawn.

Geometry is shared with the animated logo reveal built for the demo videos (`apps/agor-docs/demo-videos/animated_agor_logo`), so this is the same brand mark, looping instead of one-shot.

## How

- Pure CSS keyframes — no JS timers, no `getTotalLength()` measurement. All dash animation runs on `pathLength`-normalized strokes (dash/gap sums padded to 101 to avoid the rounded-cap phantom-dot stub at full offset).
- `prefers-reduced-motion` rests as the complete static logo.
- Component API: `size`, `color` (defaults to brand teal via `currentColor`), `aria-label`.
- The per-item checklist rows keep their small antd `Spin`s.

## Video

https://github.com/user-attachments/assets/e195af1a-3d40-4d0b-916a-65d9b1b79f3b



🤖 Generated with [Claude Code](https://claude.com/claude-code)