### PR TITLE
fix(sessions): route every archive path through one cascade engine

### DIFF
--- a/apps/agor-daemon/src/declarations.ts
+++ b/apps/agor-daemon/src/declarations.ts
@@ -47,6 +47,8 @@ import type {
   ExecuteTaskData,
   SessionArchiveOptions,
   SessionArchiveResult,
+  SessionBulkArchiveOptions,
+  SessionBulkArchivePreview,
 } from './services/sessions.js';
 
 // Re-export core types for convenience
@@ -110,6 +112,26 @@ export interface SessionsServiceImpl
     options?: SessionArchiveOptions,
     params?: FeathersParams
   ): Promise<SessionArchiveResult>;
+  archiveBtwSession(id: string, params?: FeathersParams): Promise<SessionArchiveResult>;
+  restorePromptedSession(id: string, params?: FeathersParams): Promise<SessionArchiveResult>;
+  archiveBranchSessions(
+    branchId: import('@agor/core/types').BranchID,
+    params?: FeathersParams
+  ): Promise<{ affectedSessions: import('@agor/core/types').Session[]; count: number }>;
+  unarchiveBranchSessions(
+    branchId: import('@agor/core/types').BranchID,
+    params?: FeathersParams
+  ): Promise<{ affectedSessions: import('@agor/core/types').Session[]; count: number }>;
+  previewBulkArchive(
+    roots: import('@agor/core/types').Session[],
+    options: SessionBulkArchiveOptions,
+    params?: FeathersParams
+  ): Promise<SessionBulkArchivePreview>;
+  bulkArchive(
+    roots: import('@agor/core/types').Session[],
+    options: SessionBulkArchiveOptions,
+    params?: FeathersParams
+  ): Promise<SessionArchiveResult & { preview: SessionBulkArchivePreview }>;
   enrichRemoteRelationships(
     sessionList: import('@agor/core/types').Session[]
   ): Promise<import('@agor/core/types').Session[]>;

--- a/apps/agor-daemon/src/mcp/tools/guard-regression.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/guard-regression.test.ts
@@ -17,17 +17,12 @@ import { SessionsService } from '../../services/sessions.js';
  * Both `agor_cards_get` and `agor_sessions_archive` used to call a custom
  * (non-transport) service method DIRECTLY from the MCP tool handler. The MCP
  * tool boundary (`tenantScopedToolProxy`) enters tenant *context* only — never a
- * DB scope — so the very first `this.db` touch in the custom method ran outside
- * any tenant/system database scope. Under HA that threw
- * `MissingTenantDatabaseScopeError`; in SQLite/tests the guard was disarmed, so
- * nothing failed and the bug reached production.
+ * DB scope. Cards still needs the transport wrapper; archive now establishes
+ * its own service-side scope before touching the database.
  *
  * These tests reproduce the exact boundary (tenant context, no DB scope) over a
- * real guarded proxy and assert:
- *   1. the pre-fix shape (unwrapped custom-method call) throws the guard error —
- *      i.e. it would now fail in the cheapest environment; and
- *   2. wrapping the same call in a tenant DB scope (the #2612 fix, and the
- *      Stage-B service-side self-scoping) satisfies the guard and reaches the DB.
+ * real guarded proxy and assert that cards fails until externally scoped while
+ * archive self-scopes and reaches the ordinary database result.
  *
  * No rows are seeded: even a lookup for a missing id issues a SELECT against the
  * guarded proxy, which is enough to trip the scope guard.
@@ -58,38 +53,18 @@ dbTest(
   }
 );
 
-dbTest(
-  'guarded harness would catch the pre-fix unscoped agor_sessions_archive (setArchiveStateForTree)',
-  async ({ db }) => {
-    const guardedDb = createTenantScopedDatabaseProxy(db, { label: 'guarded MCP test database' });
-    // setArchiveStateForTree touches the DB (this.get) before any app.service
-    // use, so a stub application suffices for this scope-presence proof.
-    const app = {
-      service: () => {
-        throw new Error('unexpected app.service use in scope-presence proof');
-      },
-    } as unknown as Application;
-    const sessionsService = new SessionsService(guardedDb, app);
+dbTest('agor_sessions_archive self-scopes when only tenant context is present', async ({ db }) => {
+  const guardedDb = createTenantScopedDatabaseProxy(db, { label: 'guarded MCP test database' });
+  // setArchiveStateForTree touches the DB (this.get) before any app.service
+  // use, so a stub application suffices for this scope-presence proof.
+  const app = {
+    service: () => {
+      throw new Error('unexpected app.service use in scope-presence proof');
+    },
+  } as unknown as Application;
+  const sessionsService = new SessionsService(guardedDb, app);
 
-    await runWithTenantContext('tenant-a', async () => {
-      // PRE-FIX agor_sessions_archive: archive → setArchiveStateForTree →
-      // this.get(id) ran unscoped.
-      await expect(sessionsService.archive('session-missing')).rejects.toThrow(
-        /Missing tenant database scope/
-      );
-
-      // POST-FIX / Stage-B: inside a tenant DB scope the read reaches the DB and
-      // fails with an ordinary not-found — NOT the scope guard.
-      let wrappedError: unknown;
-      try {
-        await runWithTenantDatabaseScope(guardedDb, 'tenant-a', () =>
-          sessionsService.archive('session-missing')
-        );
-      } catch (error) {
-        wrappedError = error;
-      }
-      expect(wrappedError).toBeDefined();
-      expect(String((wrappedError as Error)?.message)).not.toMatch(/Missing tenant database scope/);
-    });
-  }
-);
+  await runWithTenantContext('tenant-a', async () => {
+    await expect(sessionsService.archive('session-missing')).rejects.toThrow(/not found/i);
+  });
+});

--- a/apps/agor-daemon/src/mcp/tools/sessions.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.test.ts
@@ -1973,9 +1973,64 @@ describe('agor_sessions_archive tools', () => {
     vi.clearAllMocks();
   });
 
+  const archiveOutcome = (overrides: Record<string, unknown>) => ({
+    session: { session_id: 'sess-parent' },
+    dryRun: false,
+    wouldChangeCount: 0,
+    affectedSessions: [],
+    count: 0,
+    archivedCount: 0,
+    unarchivedCount: 0,
+    localCount: 0,
+    remoteCount: 0,
+    skippedCount: 0,
+    runningCount: 0,
+    units: [],
+    remainingArchived: [],
+    ...overrides,
+  });
+
   it('delegates archive and unarchive to the shared sessions service operations', async () => {
-    const archive = vi.fn(async () => ({ count: 3 }));
-    const unarchive = vi.fn(async () => ({ count: 2 }));
+    const archive = vi.fn(async () =>
+      archiveOutcome({
+        count: 3,
+        archivedCount: 3,
+        localCount: 2,
+        remoteCount: 1,
+        skippedCount: 1,
+        units: [
+          {
+            rootSessionId: 'sess-parent',
+            branchId: 'wt-1',
+            kind: 'local',
+            status: 'changed',
+            changedCount: 2,
+          },
+          {
+            rootSessionId: 'sess-remote',
+            branchId: 'wt-2',
+            kind: 'remote',
+            status: 'changed',
+            changedCount: 1,
+          },
+          {
+            rootSessionId: 'sess-remote-denied',
+            kind: 'remote',
+            status: 'skipped',
+            changedCount: 0,
+            reason: 'insufficient_permission',
+          },
+        ],
+      })
+    );
+    const unarchive = vi.fn(async () =>
+      archiveOutcome({
+        count: 2,
+        unarchivedCount: 2,
+        localCount: 2,
+        remainingArchived: [{ sessionId: 'sess-child', reason: 'independent_reason' }],
+      })
+    );
     const app = makeFakeApp({
       sessions: { archive, unarchive },
     });
@@ -1992,19 +2047,200 @@ describe('agor_sessions_archive tools', () => {
     const unarchiveResult = await tools.agor_sessions_unarchive({
       sessionId: 'sess-parent',
       includeChildren: false,
+      includeRemoteChildren: false,
     });
 
     expect(archive).toHaveBeenCalledWith(
       'sess-parent',
-      { includeChildren: true },
+      { includeChildren: true, includeRemoteChildren: true, dryRun: false },
       { provider: 'mcp' }
     );
     expect(unarchive).toHaveBeenCalledWith(
       'sess-parent',
-      { includeChildren: false },
+      { includeChildren: false, includeRemoteChildren: false, dryRun: false },
       { provider: 'mcp' }
     );
-    expect(JSON.parse(archiveResult.content[0].text)).toMatchObject({ archivedCount: 3 });
-    expect(JSON.parse(unarchiveResult.content[0].text)).toMatchObject({ unarchivedCount: 2 });
+    const archivePayload = JSON.parse(archiveResult.content[0].text);
+    expect(archivePayload).toMatchObject({
+      archivedCount: 3,
+      localCount: 2,
+      remoteCount: 1,
+      skippedCount: 1,
+    });
+    expect(archivePayload.message).toMatch(/1 remote unit\(s\) skipped/);
+    const unarchivePayload = JSON.parse(unarchiveResult.content[0].text);
+    expect(unarchivePayload).toMatchObject({
+      unarchivedCount: 2,
+      remainingArchived: [{ sessionId: 'sess-child', reason: 'independent_reason' }],
+    });
+    expect(unarchivePayload.message).toMatch(/1 child session\(s\) stay archived/);
+  });
+
+  it('agor_sessions_update rejects archive fields and names the dedicated tools', async () => {
+    const patch = vi.fn();
+    const app = makeFakeApp({ sessions: { patch } });
+    const tools = await registerAndCaptureHandlers(
+      { app, userId: 'user-1', sessionId: 'sess-current', baseServiceParams: { provider: 'mcp' } },
+      ['agor_sessions_update']
+    );
+
+    await expect(
+      tools.agor_sessions_update({ sessionId: 'sess-1', archived: true })
+    ).rejects.toThrow(/agor_sessions_archive/);
+    await expect(
+      tools.agor_sessions_update({ sessionId: 'sess-1', title: 'x', archived: false })
+    ).rejects.toThrow(/agor_sessions_unarchive/);
+    expect(patch).not.toHaveBeenCalled();
+  });
+});
+
+describe('agor_sessions_bulk_archive', () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  const root = {
+    session_id: 'sess-root',
+    title: 'Root',
+    status: 'idle',
+    branch_id: 'wt-1',
+    created_at: '2026-01-01T00:00:00.000Z',
+    last_updated: '2026-01-01T00:00:00.000Z',
+    archived: false,
+  };
+  const child = {
+    ...root,
+    session_id: 'sess-child',
+    title: 'Child',
+    status: 'running',
+    last_updated: new Date().toISOString(),
+  };
+
+  function makeBulkApp() {
+    const find = vi.fn(async () => ({ data: [root], total: 1, limit: 200, skip: 0 }));
+    const previewFor = (policy: 'none' | 'eligible' | 'all') => ({
+      policy,
+      directRoots: [root],
+      impliedDescendants: policy === 'all' ? [child] : [],
+      excludedDescendants: policy === 'eligible' ? [child] : [],
+      descendantsNewerThanCutoff: policy === 'all' ? [child] : [],
+      descendantsWithUnfinishedTasks: [],
+      activeDescendants: policy === 'all' ? [child] : [],
+      units: [
+        {
+          rootSessionId: 'sess-root',
+          kind: 'local',
+          status: 'changed',
+          changedCount: policy === 'all' ? 2 : 1,
+          branchId: 'wt-1',
+        },
+      ],
+      wouldArchive: policy === 'all' ? 2 : 1,
+    });
+    const previewBulkArchive = vi.fn(
+      async (_roots: unknown, options: { policy: 'none' | 'eligible' | 'all' }) =>
+        previewFor(options.policy)
+    );
+    const bulkArchive = vi.fn(
+      async (_roots: unknown, options: { policy: 'none' | 'eligible' | 'all' }) => ({
+        session: root,
+        dryRun: false,
+        wouldChangeCount: options.policy === 'all' ? 2 : 1,
+        affectedSessions: [],
+        count: options.policy === 'all' ? 2 : 1,
+        archivedCount: options.policy === 'all' ? 2 : 1,
+        unarchivedCount: 0,
+        localCount: options.policy === 'all' ? 2 : 1,
+        remoteCount: 0,
+        skippedCount: 0,
+        runningCount: 0,
+        units: [],
+        remainingArchived: [],
+        preview: previewFor(options.policy),
+      })
+    );
+    const app = makeFakeApp({ sessions: { find, previewBulkArchive, bulkArchive } });
+    return { app, find, previewBulkArchive, bulkArchive };
+  }
+
+  it('applies the legacy "none" policy with a deprecation warning when execution omits it', async () => {
+    const { app, bulkArchive } = makeBulkApp();
+    const tools = await registerAndCaptureHandlers(
+      { app, userId: 'user-1', sessionId: 'sess-current', baseServiceParams: { provider: 'mcp' } },
+      ['agor_sessions_bulk_archive']
+    );
+
+    const executed = JSON.parse(
+      (await tools.agor_sessions_bulk_archive({ dryRun: false })).content[0].text
+    );
+
+    expect(bulkArchive).toHaveBeenCalledWith(
+      [expect.objectContaining({ session_id: 'sess-root' })],
+      { policy: 'none', cutoffDate: null },
+      { provider: 'mcp' }
+    );
+    expect(executed).toMatchObject({
+      success: true,
+      descendantPolicy: 'none',
+      deprecatedDefaultApplied: true,
+      archivedCount: 1,
+    });
+    expect(executed.warning).toMatch(/descendantPolicy was omitted/);
+  });
+
+  it('previews all three policies on a dry-run and executes the chosen one through the same planner', async () => {
+    const { app, previewBulkArchive, bulkArchive } = makeBulkApp();
+    const tools = await registerAndCaptureHandlers(
+      { app, userId: 'user-1', sessionId: 'sess-current', baseServiceParams: { provider: 'mcp' } },
+      ['agor_sessions_bulk_archive']
+    );
+
+    const preview = JSON.parse(
+      (await tools.agor_sessions_bulk_archive({ olderThanDays: 30, sampleLimit: 1 })).content[0]
+        .text
+    );
+    expect(preview.dryRun).toBe(true);
+    expect(preview.matchedRootCount).toBe(1);
+    expect(Object.keys(preview.policies)).toEqual(['none', 'eligible', 'all']);
+    expect(preview.policies.none).toMatchObject({ wouldArchive: 1 });
+    expect(preview.policies.eligible).toMatchObject({
+      wouldArchive: 1,
+      excludedDescendants: { count: 1 },
+    });
+    expect(preview.policies.all).toMatchObject({
+      wouldArchive: 2,
+      impliedDescendants: { count: 1 },
+      descendantsNewerThanCutoff: { count: 1 },
+      descendantsStillRunning: { count: 1 },
+    });
+    expect(preview.policies.all.impliedDescendants.sample[0]).toMatchObject({
+      session_id: 'sess-child',
+    });
+    expect(previewBulkArchive).toHaveBeenCalledTimes(3);
+    expect(previewBulkArchive.mock.calls[1]?.[1]).toMatchObject({
+      policy: 'eligible',
+      cutoffDate: expect.any(Date),
+    });
+    expect(bulkArchive).not.toHaveBeenCalled();
+
+    const executed = JSON.parse(
+      (await tools.agor_sessions_bulk_archive({ dryRun: false, descendantPolicy: 'all' }))
+        .content[0].text
+    );
+    expect(bulkArchive).toHaveBeenCalledWith(
+      [expect.objectContaining({ session_id: 'sess-root' })],
+      { policy: 'all', cutoffDate: null },
+      { provider: 'mcp' }
+    );
+    expect(executed).toMatchObject({
+      success: true,
+      descendantPolicy: 'all',
+      archivedCount: 2,
+      directCount: 1,
+      descendantCount: 1,
+      failedCount: 0,
+    });
+    expect(executed.deprecatedDefaultApplied).toBeUndefined();
   });
 });

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -1372,7 +1372,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
     'agor_sessions_update',
     {
       description:
-        'Update session metadata (title, description, status, archived, callback config). Useful for agents to self-document their work or manage callback settings.',
+        'Update session metadata (title, description, status, callback config). Useful for agents to self-document their work or manage callback settings. Archive state is not accepted here: use agor_sessions_archive / agor_sessions_unarchive, which cascade to child sessions.',
       annotations: { idempotentHint: true },
       inputSchema: z.object({
         sessionId: mcpRequiredId(
@@ -1389,7 +1389,9 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         archived: z
           .boolean()
           .optional()
-          .describe('Set archive state. true to archive, false to unarchive (optional)'),
+          .describe(
+            'Deprecated and rejected. Use agor_sessions_archive or agor_sessions_unarchive instead.'
+          ),
         enableCallback: z
           .boolean()
           .optional()
@@ -1408,8 +1410,11 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
       if (args.description !== undefined) updates.description = args.description;
       if (args.status !== undefined) updates.status = args.status;
       if (args.archived !== undefined) {
-        updates.archived = args.archived;
-        updates.archived_reason = args.archived ? 'manual' : undefined;
+        throw new Error(
+          `agor_sessions_update no longer changes archive state. Use ${
+            args.archived ? 'agor_sessions_archive' : 'agor_sessions_unarchive'
+          } (cascades to child sessions; pass includeChildren: false to affect only this session).`
+        );
       }
 
       // Handle callback config updates
@@ -1428,7 +1433,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
 
       if (Object.keys(updates).length === 0) {
         throw new Error(
-          'At least one field (title, description, status, archived, enableCallback, callbackMode) must be provided'
+          'At least one field (title, description, status, enableCallback, callbackMode) must be provided'
         );
       }
 
@@ -1442,41 +1447,104 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
     }
   );
 
+  type ArchiveOutcome = Awaited<ReturnType<SessionsServiceImpl['archive']>>;
+
+  const describeArchiveOutcome = (
+    verb: 'Archived' | 'Unarchived',
+    result: ArchiveOutcome
+  ): string => {
+    const total = verb === 'Archived' ? result.archivedCount : result.unarchivedCount;
+    const lead = result.dryRun ? `Would ${verb === 'Archived' ? 'archive' : 'unarchive'}` : verb;
+    const parts = [
+      `${lead} ${total} session(s) (${result.localCount} in this branch, ${result.remoteCount} in other branches).`,
+    ];
+    if (result.limitExceeded) {
+      parts.push(
+        `Remote expansion exceeded the ${result.limitExceeded} bound, so execution would fail; pass includeRemoteChildren: false or archive the remote sessions separately.`
+      );
+    }
+    if (result.runningCount > 0) {
+      parts.push(
+        `${result.runningCount} of them are still running; archiving hides work, it does not stop it.`
+      );
+    }
+    if (result.skippedCount > 0) {
+      parts.push(
+        `${result.skippedCount} remote unit(s) skipped: insufficient permission in that branch; those sessions are unchanged.`
+      );
+    }
+    if (result.remainingArchived.length > 0) {
+      parts.push(
+        `${result.remainingArchived.length} child session(s) stay archived (independent reason, another archived parent, or archived branch).`
+      );
+    }
+    return parts.join(' ');
+  };
+
+  const archiveOutcomePayload = (verb: 'Archived' | 'Unarchived', result: ArchiveOutcome) => ({
+    success: true,
+    dryRun: result.dryRun,
+    wouldChangeCount: result.wouldChangeCount,
+    archivedCount: result.archivedCount,
+    unarchivedCount: result.unarchivedCount,
+    localCount: result.localCount,
+    remoteCount: result.remoteCount,
+    skippedCount: result.skippedCount,
+    runningCount: result.runningCount,
+    units: result.units,
+    remainingArchived: result.remainingArchived,
+    ...(result.limitExceeded && { limitExceeded: result.limitExceeded }),
+    message: describeArchiveOutcome(verb, result),
+  });
+
+  const dedicatedArchiveSchema = (verb: 'archive' | 'unarchive') =>
+    z.object({
+      sessionId: mcpRequiredId(
+        'sessionId',
+        'Session',
+        `Session ID to ${verb} (UUIDv7 or short ID)`
+      ),
+      includeChildren: z
+        .boolean()
+        .optional()
+        .describe(`Also ${verb} all child sessions (forks and subsessions). Default: true.`),
+      includeRemoteChildren: z
+        .boolean()
+        .optional()
+        .describe(
+          `Also ${verb} sessions this one created in other branches, with their children. Default: true.`
+        ),
+      dryRun: z
+        .boolean()
+        .optional()
+        .describe(
+          'Plan and authorize without changing anything; returns the counts and units execution would touch. Default: false.'
+        ),
+    });
+
   // Tool 8: agor_sessions_archive
   server.registerTool(
     'agor_sessions_archive',
     {
       description:
-        'Archive a session (soft delete). Archived sessions are hidden from listings by default but can be restored. By default, all child sessions (forks and subsessions) are also archived. Set includeChildren to false to archive only the target session.',
+        'Archive a session (soft delete). Archived sessions are hidden from listings by default but can be restored; archiving never stops running work. By default this also archives all child sessions (forks and subsessions) in the same branch AND the sessions this one created in other branches (with their children), within bounded depth/branch/session limits. Each other branch is authorized separately: branches you cannot modify are skipped and reported, not failed. Set includeChildren to false to leave local children active, includeRemoteChildren to false to leave remote work active, or dryRun to true to preview.',
       annotations: { destructiveHint: true },
-      inputSchema: z.object({
-        sessionId: mcpRequiredId(
-          'sessionId',
-          'Session',
-          'Session ID to archive (UUIDv7 or short ID)'
-        ),
-        includeChildren: z
-          .boolean()
-          .optional()
-          .describe('Also archive all child sessions (forks and subsessions). Default: true.'),
-      }),
+      inputSchema: dedicatedArchiveSchema('archive'),
     },
     async (args) => {
-      const includeChildren = args.includeChildren !== false;
+      const options = {
+        includeChildren: args.includeChildren !== false,
+        includeRemoteChildren: args.includeRemoteChildren !== false,
+        dryRun: args.dryRun === true,
+      };
       const sessionsService = ctx.app.service('sessions') as unknown as SessionsServiceImpl;
-      // archive() -> setArchiveStateForTree touches this.db (this.get,
-      // sessionRepo writes) directly and is not a Feathers transport method, so
-      // enter the tenant DB scope here (the HTTP archive route enters it via its
-      // around hook). The whole tree update is DB-only — no network held.
+      // archive() touches this.db directly and is not a Feathers transport
+      // method, so enter the tenant DB scope here (the HTTP archive route enters
+      // it via its around hook). The whole tree update is DB-only — no network held.
       const result = await runWithMcpTenantDatabaseWrite(ctx, () =>
-        sessionsService.archive(args.sessionId, { includeChildren }, ctx.baseServiceParams)
+        sessionsService.archive(args.sessionId, options, ctx.baseServiceParams)
       );
-
-      return textResult({
-        success: true,
-        archivedCount: result.count,
-        message: `Archived ${result.count} session(s).`,
-      });
+      return textResult(archiveOutcomePayload('Archived', result));
     }
   );
 
@@ -1485,32 +1553,21 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
     'agor_sessions_unarchive',
     {
       description:
-        'Restore a previously archived session. By default, all child sessions are also unarchived. Set includeChildren to false to unarchive only the target session.',
-      inputSchema: z.object({
-        sessionId: mcpRequiredId(
-          'sessionId',
-          'Session',
-          'Session ID to unarchive (UUIDv7 or short ID)'
-        ),
-        includeChildren: z
-          .boolean()
-          .optional()
-          .describe('Also unarchive all child sessions (forks and subsessions). Default: true.'),
-      }),
+        'Restore a previously archived session. By default, child sessions (local and remote-created) that were archived because of this session are restored too; children archived for their own reason, or still covered by another archived parent or an archived branch, stay archived and are reported in remainingArchived. Restoring a session inside an archived branch is rejected: restore the branch first. Set includeChildren or includeRemoteChildren to false to restore only the target session, or dryRun to true to preview.',
+      inputSchema: dedicatedArchiveSchema('unarchive'),
     },
     async (args) => {
-      const includeChildren = args.includeChildren !== false;
+      const options = {
+        includeChildren: args.includeChildren !== false,
+        includeRemoteChildren: args.includeRemoteChildren !== false,
+        dryRun: args.dryRun === true,
+      };
       const sessionsService = ctx.app.service('sessions') as unknown as SessionsServiceImpl;
       // Same as archive: enter the tenant DB scope around the (DB-only) tree walk.
       const result = await runWithMcpTenantDatabaseWrite(ctx, () =>
-        sessionsService.unarchive(args.sessionId, { includeChildren }, ctx.baseServiceParams)
+        sessionsService.unarchive(args.sessionId, options, ctx.baseServiceParams)
       );
-
-      return textResult({
-        success: true,
-        unarchivedCount: result.count,
-        message: `Unarchived ${result.count} session(s).`,
-      });
+      return textResult(archiveOutcomePayload('Unarchived', result));
     }
   );
 
@@ -1519,7 +1576,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
     'agor_sessions_bulk_archive',
     {
       description:
-        'Archive multiple sessions matching filter criteria. Supports filtering by session type (gateway/scheduled/agent), age, status, board, and branch. Returns a dry-run preview by default — set dryRun to false to actually archive. Respects RBAC: sessions the current user cannot modify are skipped and reported as errors.',
+        'Archive multiple sessions matching filter criteria. Supports filtering by session type (gateway/scheduled/agent), age, status, board, and branch; the filters select the matched (root) sessions. Returns a dry-run preview by default — set dryRun to false to actually archive. descendantPolicy decides which branch-local child sessions of each match are archived too: "none" leaves children active; "eligible" adds children that have no unfinished task and are not newer than olderThanDays; "all" adds every child, including newer ones and ones still running (archiving never stops work). A dry-run without descendantPolicy previews all three with exact counts and bounded samples. Omitting descendantPolicy on execution applies the legacy "none" behaviour with a deprecation warning; pass it explicitly. Sessions created in other branches are never followed. Respects RBAC: each matched session plus its children is one unit; units the current user cannot modify are skipped and reported.',
       annotations: { destructiveHint: true },
       inputSchema: z.object({
         sessionType: z
@@ -1540,6 +1597,19 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
           .describe('Only archive sessions with this status'),
         boardId: mcpOptionalId('boardId', 'Board', 'Only archive sessions on this board'),
         branchId: mcpOptionalId('branchId', 'Branch', 'Only archive sessions in this branch'),
+        descendantPolicy: z
+          .enum(['none', 'eligible', 'all'])
+          .optional()
+          .describe(
+            '"none" = only matched sessions; "eligible" = plus child sessions with no unfinished task that are not newer than olderThanDays; "all" = plus every child session. Omit on a dry-run to preview all three. Deprecated to omit on execution (applies "none").'
+          ),
+        sampleLimit: z
+          .number()
+          .int()
+          .min(1)
+          .max(100)
+          .optional()
+          .describe('Representative rows returned per preview category (default 20, max 100).'),
         dryRun: z
           .boolean()
           .optional()
@@ -1550,6 +1620,8 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
     },
     async (args) => {
       const dryRun = args.dryRun !== false;
+      const legacyDefaultApplied = !dryRun && args.descendantPolicy === undefined;
+      const sampleLimit = args.sampleLimit ?? 20;
 
       // Build service query for non-archived sessions
       const query: Record<string, unknown> = { archived: false };
@@ -1587,54 +1659,120 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         return true;
       });
 
+      const sessionsService = ctx.app.service('sessions') as unknown as SessionsServiceImpl;
+      const summarize = (s: Session) => ({
+        session_id: s.session_id,
+        title: s.title,
+        status: s.status,
+        session_type: getSessionType(s),
+        last_updated: s.last_updated,
+        created_at: s.created_at,
+        branch_id: s.branch_id,
+      });
+      // Exact counts always; bounded representative samples never the full set.
+      const sampled = (list: Session[]) => ({
+        count: list.length,
+        sample: list.slice(0, sampleLimit).map(summarize),
+        ...(list.length > sampleLimit && { sampleTruncated: true }),
+      });
+      const skippedRoots = (units: ArchiveOutcome['units']) => {
+        const ids = units
+          .filter((unit) => unit.status === 'skipped')
+          .map((unit) => unit.rootSessionId);
+        return {
+          count: ids.length,
+          sample: ids.slice(0, sampleLimit),
+          ...(ids.length > sampleLimit && { sampleTruncated: true }),
+        };
+      };
+      type BulkPolicy = 'none' | 'eligible' | 'all';
+
       if (dryRun) {
+        // Preview and execution share the planner, so the sets shown here are
+        // exactly what dryRun: false would attempt for the same policy.
+        const policies: BulkPolicy[] = args.descendantPolicy
+          ? [args.descendantPolicy]
+          : ['none', 'eligible', 'all'];
+        const previews: Record<string, { wouldArchive: number } & Record<string, unknown>> = {};
+        for (const policy of policies) {
+          if (toArchive.length === 0) {
+            previews[policy] = { wouldArchive: 0 };
+            continue;
+          }
+          const preview = await runWithMcpTenantDatabaseScope(ctx, () =>
+            sessionsService.previewBulkArchive(
+              toArchive,
+              { policy, cutoffDate },
+              ctx.baseServiceParams
+            )
+          );
+          previews[policy] = {
+            wouldArchive: preview.wouldArchive,
+            matchedRoots: sampled(preview.directRoots),
+            impliedDescendants: sampled(preview.impliedDescendants),
+            excludedDescendants: sampled(preview.excludedDescendants),
+            descendantsNewerThanCutoff: sampled(preview.descendantsNewerThanCutoff),
+            descendantsWithUnfinishedTasks: sampled(preview.descendantsWithUnfinishedTasks),
+            descendantsStillRunning: sampled(preview.activeDescendants),
+            skippedRoots: skippedRoots(preview.units),
+          };
+        }
+        const chosen = args.descendantPolicy ? previews[args.descendantPolicy] : undefined;
         return textResult({
           dryRun: true,
-          wouldArchive: toArchive.length,
           totalMatched: allSessions.length,
+          matchedRootCount: toArchive.length,
           ...(cutoffDate && { cutoffDate: cutoffDate.toISOString() }),
-          sessions: toArchive.map((s) => ({
-            session_id: s.session_id,
-            title: s.title,
-            status: s.status,
-            session_type: getSessionType(s),
-            last_updated: s.last_updated,
-            created_at: s.created_at,
-            branch_id: s.branch_id,
-          })),
-          message: `Would archive ${toArchive.length} session(s). Set dryRun=false to proceed.`,
+          policies: previews,
+          message: chosen
+            ? `Would archive ${chosen.wouldArchive} session(s) with descendantPolicy "${args.descendantPolicy}". Set dryRun=false to proceed.`
+            : `Matched ${toArchive.length} session(s). Choose descendantPolicy "none", "eligible", or "all" (see policies) and set dryRun=false to proceed.`,
         });
       }
 
-      // Archive each session (through service layer for RBAC)
-      let archivedCount = 0;
-      const errors: { session_id: string; error: string }[] = [];
-
-      for (const session of toArchive) {
-        try {
-          await ctx.app
-            .service('sessions')
-            .patch(
-              session.session_id,
-              { archived: true, archived_reason: 'manual' },
-              ctx.baseServiceParams
-            );
-          archivedCount++;
-        } catch (error) {
-          errors.push({
-            session_id: session.session_id,
-            error: error instanceof Error ? error.message : String(error),
-          });
-        }
+      const descendantPolicy: BulkPolicy = args.descendantPolicy ?? 'none';
+      const deprecation = legacyDefaultApplied
+        ? 'descendantPolicy was omitted, so the legacy "none" policy was applied and child sessions were left active. Pass descendantPolicy explicitly; omitting it will be rejected in a future release.'
+        : undefined;
+      if (toArchive.length === 0) {
+        return textResult({
+          success: true,
+          descendantPolicy,
+          ...(legacyDefaultApplied && { deprecatedDefaultApplied: true, warning: deprecation }),
+          archivedCount: 0,
+          failedCount: 0,
+          ...(cutoffDate && { cutoffDate: cutoffDate.toISOString() }),
+          message: 'No sessions matched the filters.',
+        });
       }
+
+      const result = await runWithMcpTenantDatabaseWrite(ctx, () =>
+        sessionsService.bulkArchive(
+          toArchive,
+          { policy: descendantPolicy, cutoffDate },
+          ctx.baseServiceParams
+        )
+      );
+      const errors = result.units
+        .filter((unit) => unit.status === 'skipped')
+        .map((unit) => ({
+          session_id: unit.rootSessionId,
+          error:
+            'Insufficient permission in this branch; the session and its children were not archived.',
+        }));
 
       return textResult({
         success: true,
-        archivedCount,
+        descendantPolicy,
+        ...(legacyDefaultApplied && { deprecatedDefaultApplied: true, warning: deprecation }),
+        archivedCount: result.archivedCount,
+        directCount: result.preview.directRoots.length,
+        descendantCount: result.preview.impliedDescendants.length,
+        excludedDescendantCount: result.preview.excludedDescendants.length,
         failedCount: errors.length,
         ...(cutoffDate && { cutoffDate: cutoffDate.toISOString() }),
         errors: errors.length > 0 ? errors : undefined,
-        message: `Archived ${archivedCount} session(s).${errors.length > 0 ? ` ${errors.length} failed (insufficient permissions or other errors).` : ''}`,
+        message: `Archived ${result.archivedCount} session(s) (${result.preview.directRoots.length} matched, ${result.preview.impliedDescendants.length} child sessions).${errors.length > 0 ? ` ${errors.length} unit(s) skipped (insufficient permissions).` : ''}${deprecation ? ` ${deprecation}` : ''}`,
       });
     }
   );

--- a/apps/agor-daemon/src/register-hooks.test.ts
+++ b/apps/agor-daemon/src/register-hooks.test.ts
@@ -1336,9 +1336,10 @@ describe('isPromptFlowPatchOnly', () => {
       expect(isPromptFlowPatchOnly({ tasks: ['task-1', 'task-2'] })).toBe(true);
     });
 
-    it('accepts the prompt-route auto-unarchive shape', () => {
-      // register-routes.ts: /sessions/:id/prompt auto-unarchives before sending
-      expect(isPromptFlowPatchOnly({ archived: false, archived_reason: undefined })).toBe(true);
+    it('no longer treats archive fields as prompt-flow bookkeeping', () => {
+      // register-routes.ts: /sessions/:id/prompt restores through the session
+      // archive engine; generic archive patches are rejected by the service.
+      expect(isPromptFlowPatchOnly({ archived: false, archived_reason: undefined })).toBe(false);
     });
 
     it('accepts the stop-route idle shape', () => {

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -336,7 +336,8 @@ export function validateBranchEnvPolicyHook(config: DeepReadonly<AgorConfig>) {
  * session metadata (name, model_config, permission_config, callback_config).
  *
  * Sources:
- *   - `/sessions/:id/prompt`  → `tasks`, `archived`, `archived_reason`
+ *   - `/sessions/:id/prompt`  → `tasks` (archive restoration goes through the
+ *     session archive engine, never a generic patch)
  *   - `/sessions/:id/stop`    → `status`, `ready_for_prompt`
  *   - executor status updates → `status`, `ready_for_prompt`
  *     (claude/copilot permission-hooks, see packages/executor)
@@ -360,8 +361,6 @@ export function validateBranchEnvPolicyHook(config: DeepReadonly<AgorConfig>) {
  */
 export const PROMPT_FLOW_PATCH_FIELDS: readonly string[] = [
   'tasks',
-  'archived',
-  'archived_reason',
   'status',
   'ready_for_prompt',
   'sdk_session_id',
@@ -3009,7 +3008,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
           loadSession(sessionsRepository),
           loadBranchFromSession(branchRepository),
           // Branch permission by patch type:
-          //   - Prompt-flow patches (tasks, archived, status, …) are bookkeeping
+          //   - Prompt-flow patches (tasks, status, …) are bookkeeping
           //     emitted by /sessions/:id/prompt and /sessions/:id/stop on behalf
           //     of the authenticated user. They need only the same tier as
           //     prompting the session (session-tier for own, prompt-tier for

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -2081,14 +2081,16 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
           throw error;
         }
 
-        // Auto-unarchive on prompt
+        // Auto-unarchive on prompt: restore only the prompted session.
+        // Ancestors, descendants, and remote work are deliberately untouched.
         if (session.archived) {
           console.log(
             `📦 [Prompt] Auto-unarchiving session ${shortId(id)} (was archived: ${session.archived_reason || 'unknown reason'})`
           );
-          session = (await runWithTenantDatabaseScope(db, promptTenantId, () =>
-            sessionsService.patch(id, { archived: false, archived_reason: undefined }, params)
-          )) as typeof session;
+          const restored = await runWithTenantDatabaseScope(db, promptTenantId, () =>
+            sessionsService.restorePromptedSession(id, params)
+          );
+          session = restored.session as typeof session;
         }
 
         if (session.status === SessionStatus.STOPPING) {

--- a/apps/agor-daemon/src/services/boards.test.ts
+++ b/apps/agor-daemon/src/services/boards.test.ts
@@ -13,10 +13,12 @@ import {
   type Database,
   generateId,
   RepoRepository,
+  SessionRepository,
   UsersRepository,
 } from '@agor/core/db';
 import { BadRequest } from '@agor/core/feathers';
 import type { Board, BoardID, BranchID, UUID } from '@agor/core/types';
+import { SessionStatus } from '@agor/core/types';
 import { describe, expect, vi } from 'vitest';
 import { ownedDbTest as dbTest } from '../../../../packages/core/src/db/test-helpers';
 import { type BoardParams, BoardsService } from './boards';
@@ -584,6 +586,60 @@ describe('BoardsService - Custom Methods', () => {
       id: board.board_id,
     });
   });
+
+  dbTest(
+    'board archive is container-only: it never archives its branches or sessions',
+    async ({ db }) => {
+      const service = new BoardsService(db, { emitBoardEvent: vi.fn() });
+      const board = (await service.create({
+        name: 'Archive exemption',
+        slug: 'archive-exemption',
+        created_by: TEST_USER,
+      })) as Board;
+      const repo = await new RepoRepository(db).create({
+        repo_id: generateId(),
+        slug: `repo-${generateId()}`,
+        name: 'Exemption Repo',
+        repo_type: 'remote' as const,
+        remote_url: 'https://github.com/test/repo.git',
+        local_path: `/tmp/test-repo-${generateId()}`,
+        default_branch: 'main',
+      });
+      const branch = await new BranchRepository(db).create({
+        branch_id: generateId(),
+        repo_id: repo.repo_id,
+        name: 'exemption',
+        ref: 'exemption',
+        branch_unique_id: 4242,
+        path: `/tmp/test-branch-${generateId()}`,
+        base_ref: 'main',
+        new_branch: false,
+        board_id: board.board_id,
+        created_by: TEST_USER,
+      });
+      const session = await new SessionRepository(db).create({
+        session_id: generateId(),
+        branch_id: branch.branch_id as UUID,
+        agentic_tool: 'claude-code',
+        status: SessionStatus.IDLE,
+        created_by: TEST_USER,
+        tasks: [],
+        contextFiles: [],
+        genealogy: { children: [] },
+      });
+
+      await service.archive(board.board_id, {
+        user: { user_id: TEST_USER },
+        tenant: { tenant_id: 'tenant-a', source: 'auth_claim' },
+      } as never);
+
+      const branchAfter = await new BranchRepository(db).findById(branch.branch_id);
+      const sessionAfter = await new SessionRepository(db).findById(session.session_id);
+      expect(branchAfter?.archived).toBeFalsy();
+      expect(sessionAfter?.archived).toBe(false);
+      expect(sessionAfter?.archived_reason).toBeUndefined();
+    }
+  );
 });
 
 describe('BoardsService.find SQL pushdown', () => {

--- a/apps/agor-daemon/src/services/branches.test.ts
+++ b/apps/agor-daemon/src/services/branches.test.ts
@@ -219,6 +219,8 @@ function createServiceHarness(appRbacEnabled = true) {
   const sessionsService = {
     find: vi.fn(async () => []),
     patch: vi.fn(async () => ({})),
+    archiveBranchSessions: vi.fn(async () => ({ affectedSessions: [], count: 0 })),
+    unarchiveBranchSessions: vi.fn(async () => ({ affectedSessions: [], count: 0 })),
   };
 
   const reposService = {
@@ -1414,7 +1416,7 @@ describe('BranchesService.unarchive', () => {
       position: { x: 111, y: 222 },
     });
 
-    expect(sessionsService.find).toHaveBeenCalledTimes(1);
+    expect(sessionsService.unarchiveBranchSessions).toHaveBeenCalledWith(branchId, userParams);
     expect(sessionsService.patch).not.toHaveBeenCalled();
   });
 
@@ -1528,10 +1530,8 @@ describe('BranchesService.archiveOrDelete', () => {
       params
     );
 
-    expect(sessionsService.find).toHaveBeenCalledWith({
-      query: { branch_id: branchId, $limit: 1000 },
-      paginate: false,
-    });
+    expect(sessionsService.archiveBranchSessions).toHaveBeenCalledWith(branchId, params);
+    expect(sessionsService.patch).not.toHaveBeenCalled();
     expect(boardObjectsService.findByBranchId).not.toHaveBeenCalled();
     expect(boardObjectsService.patch).not.toHaveBeenCalled();
     expect(branchesService.emit).toHaveBeenCalledTimes(1);

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -83,6 +83,7 @@ import {
 import { resolveHostIpAddress } from '@agor/core/utils/host-ip';
 import { isAllowedHealthCheckUrl } from '@agor/core/utils/url';
 import { DrizzleService, type Query } from '../adapters/drizzle';
+import type { SessionsServiceImpl } from '../declarations.js';
 import { buildBranchCreatedAnalyticsProperties } from '../utils/analytics-payloads.js';
 import { consumeBranchArchiveDeleteAuthorization } from '../utils/branch-archive-delete-authorization.js';
 import { ensureCanControlBranchEnvironment } from '../utils/branch-authorization.js';
@@ -1795,27 +1796,15 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
         id: archivedBranch.branch_id,
       });
 
-      // Archive all sessions in this branch
-      // Use internal call (no provider) to bypass RBAC hooks that would ignore branch_id filter
-      const sessionsService = this.app.service('sessions');
-      const sessionsResult = await sessionsService.find({
-        query: { branch_id: id, $limit: 1000 },
-        paginate: false,
-      });
-      const sessions = Array.isArray(sessionsResult) ? sessionsResult : sessionsResult.data;
+      // Archive every active session owned by this branch through the session
+      // archive engine: no pagination cap, prior archive reasons preserved, one
+      // atomic write, one event per changed row.
+      const sessionsService = this.app.service('sessions') as unknown as SessionsServiceImpl;
+      const archivedSessions = await this.withTenantDatabase(params, () =>
+        sessionsService.archiveBranchSessions(id, params)
+      );
 
-      for (const session of sessions) {
-        await sessionsService.patch(
-          session.session_id,
-          {
-            archived: true,
-            archived_reason: 'branch_archived',
-          },
-          { provider: undefined } // Bypass RBAC - this is an internal cascade operation
-        );
-      }
-
-      console.log(`✅ Archived branch ${branch.name} and ${sessions.length} session(s)`);
+      console.log(`✅ Archived branch ${branch.name} and ${archivedSessions.count} session(s)`);
 
       retireBranchTerminals();
       dispatchFilesystemAction();
@@ -2055,32 +2044,14 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
       }
     }
 
-    // Unarchive all sessions that were archived due to branch archival
-    // Use internal call (no provider) to bypass RBAC hooks that would ignore branch_id filter
-    const sessionsService = this.app.service('sessions');
-    const sessionsResult = await sessionsService.find({
-      query: {
-        branch_id: id,
-        archived: true,
-        archived_reason: 'branch_archived',
-        $limit: 1000,
-      },
-      paginate: false,
-    });
-    const sessions = Array.isArray(sessionsResult) ? sessionsResult : sessionsResult.data;
+    // Restore only the sessions this branch's archive caused. Sessions archived
+    // manually, by a parent, or by BTW completion stay archived.
+    const sessionsService = this.app.service('sessions') as unknown as SessionsServiceImpl;
+    const restoredSessions = await this.withTenantDatabase(params, () =>
+      sessionsService.unarchiveBranchSessions(id, params)
+    );
 
-    for (const session of sessions) {
-      await sessionsService.patch(
-        session.session_id,
-        {
-          archived: false,
-          archived_reason: undefined,
-        },
-        { provider: undefined } // Bypass RBAC - this is an internal cascade operation
-      );
-    }
-
-    console.log(`✅ Unarchived branch ${branch.name} and ${sessions.length} session(s)`);
+    console.log(`✅ Unarchived branch ${branch.name} and ${restoredSessions.count} session(s)`);
     return unarchivedBranch;
   }
 

--- a/apps/agor-daemon/src/services/sessions.archive.postgres.test.ts
+++ b/apps/agor-daemon/src/services/sessions.archive.postgres.test.ts
@@ -1,0 +1,238 @@
+import {
+  BranchRepository,
+  CapabilityPolicyRepository,
+  createDatabase,
+  createTenantScopedDatabaseProxy,
+  type Database,
+  generateId,
+  initializeDatabase,
+  RepoRepository,
+  runWithTenantDatabaseScope,
+  runWithTenantDatabaseTransaction,
+  SessionRepository,
+  type TenantScopeAwareDatabase,
+  UsersRepository,
+} from '@agor/core/db';
+import { type Application, feathers } from '@agor/core/feathers';
+import {
+  type BranchID,
+  capabilityPolicyPresetCapabilities,
+  type Session,
+  SessionStatus,
+  type TenantID,
+  type User,
+} from '@agor/core/types';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { setupCapabilityPolicyServices } from './capability-policies.js';
+import { type SessionParams, SessionsService } from './sessions.js';
+
+const postgresUrl = process.env.AGOR_TEST_POSTGRES_URL;
+const usesPostgresSchema = process.env.AGOR_DB_DIALECT === 'postgresql';
+let branchUnique = Date.now() % 1_000_000;
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function params(actor: User, tenantId: TenantID, branchId?: BranchID): SessionParams {
+  return {
+    provider: 'rest',
+    user: { user_id: actor.user_id, email: actor.email, role: actor.role },
+    tenant: { tenant_id: tenantId, source: 'auth_claim' },
+    ...(branchId && { route: { id: branchId } }),
+  } as SessionParams;
+}
+
+function archiveApp(events: Session[]): Application {
+  return {
+    get(key: string) {
+      return key === 'config'
+        ? { execution: { branch_rbac: true, allow_superadmin: false } }
+        : undefined;
+    },
+    service: () => ({
+      emit(event: string, session: Session) {
+        if (event === 'patched') events.push(session);
+      },
+    }),
+  } as unknown as Application;
+}
+
+describe.skipIf(!postgresUrl || !usesPostgresSchema)(
+  'Sessions archive authority and concurrency (PostgreSQL/RLS)',
+  () => {
+    let rawA: Database;
+    let rawB: Database;
+    let dbA: TenantScopeAwareDatabase;
+    let dbB: TenantScopeAwareDatabase;
+
+    beforeAll(async () => {
+      rawA = createDatabase({ dialect: 'postgresql', url: postgresUrl! });
+      rawB = createDatabase({ dialect: 'postgresql', url: postgresUrl! });
+      await initializeDatabase(rawA);
+      dbA = createTenantScopedDatabaseProxy(rawA, {
+        requireScope: true,
+        label: 'sessions-archive-postgres-a',
+      });
+      dbB = createTenantScopedDatabaseProxy(rawB, {
+        requireScope: true,
+        label: 'sessions-archive-postgres-b',
+      });
+    }, 60_000);
+
+    afterAll(async () => {
+      await Promise.all([
+        (rawA as Database & { $client: { end: () => Promise<void> } }).$client.end(),
+        (rawB as Database & { $client: { end: () => Promise<void> } }).$client.end(),
+      ]);
+    });
+
+    async function seed(tenantId: TenantID, label: string) {
+      return runWithTenantDatabaseScope(dbA, tenantId, async (scoped) => {
+        const users = new UsersRepository(scoped);
+        const owner = await users.create({
+          email: `${label}-owner-${generateId()}@example.invalid`,
+          role: 'member',
+        });
+        const actor = await users.create({
+          email: `${label}-actor-${generateId()}@example.invalid`,
+          role: 'member',
+        });
+        const repo = await new RepoRepository(scoped).create({
+          repo_id: generateId(),
+          slug: `${label}-${generateId()}`,
+          name: label,
+          repo_type: 'remote',
+          remote_url: `https://example.invalid/${label}.git`,
+          local_path: `/tmp/${generateId()}`,
+          default_branch: 'main',
+        });
+        const branch = await new BranchRepository(scoped).create({
+          branch_id: generateId(),
+          repo_id: repo.repo_id,
+          name: label,
+          ref: 'main',
+          branch_unique_id: branchUnique++,
+          path: `/tmp/${generateId()}`,
+          created_by: owner.user_id,
+          others_can: 'prompt',
+        });
+        const session = await new SessionRepository(scoped).create({
+          session_id: generateId(),
+          branch_id: branch.branch_id,
+          agentic_tool: 'claude-code',
+          status: SessionStatus.IDLE,
+          created_by: owner.user_id,
+        });
+        return { owner, actor, branch, session };
+      });
+    }
+
+    it('observes a branch permission revocation that wins the tenant authority fence', async () => {
+      const tenantId = `archive-authority-${generateId()}` as TenantID;
+      const { owner, actor, branch, session } = await seed(tenantId, 'archive-authority');
+      const policyApp = feathers();
+      setupCapabilityPolicyServices(policyApp, dbA);
+      const policyService = policyApp.service('branches/:id/permissions');
+      const current = await runWithTenantDatabaseScope(dbA, tenantId, (scoped) =>
+        new CapabilityPolicyRepository(scoped).getBranchPolicy(branch.branch_id)
+      );
+      const revoked = structuredClone(current);
+      revoked.override_config!.access.others = {
+        preset: 'viewer',
+        capabilities: capabilityPolicyPresetCapabilities('branch_access', 'viewer') ?? [],
+        fs_access: 'none',
+      };
+      const revokedBeforeCommit = deferred();
+      const releaseRevocation = deferred();
+
+      const revocation = runWithTenantDatabaseTransaction(dbA, tenantId, async () => {
+        const saved = await policyService.patch(
+          null,
+          revoked,
+          params(owner, tenantId, branch.branch_id) as never
+        );
+        revokedBeforeCommit.resolve();
+        await releaseRevocation.promise;
+        return saved;
+      });
+      await revokedBeforeCommit.promise;
+
+      let archiveSettled = false;
+      const archive = new SessionsService(dbB, archiveApp([]))
+        .archive(session.session_id, { includeChildren: false }, params(actor, tenantId))
+        .finally(() => {
+          archiveSettled = true;
+        });
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      expect(archiveSettled).toBe(false);
+      releaseRevocation.resolve();
+
+      await expect(revocation).resolves.toMatchObject({
+        override_config: { access: { others: { preset: 'viewer' } } },
+      });
+      await expect(archive).rejects.toMatchObject({ code: 403 });
+      await runWithTenantDatabaseScope(dbA, tenantId, async (scoped) => {
+        await expect(
+          new SessionRepository(scoped).findById(session.session_id)
+        ).resolves.toMatchObject({ archived: false });
+      });
+    }, 10_000);
+
+    it('serializes identical archive writes into one durable change and event', async () => {
+      const tenantId = `archive-row-lock-${generateId()}` as TenantID;
+      const { session } = await seed(tenantId, 'archive-row-lock');
+      const events: Session[] = [];
+      const serviceA = new SessionsService(dbA, archiveApp(events));
+      const serviceB = new SessionsService(dbB, archiveApp(events));
+      const firstChanged = deferred();
+      const releaseFirst = deferred();
+
+      const first = runWithTenantDatabaseTransaction(dbA, tenantId, async () => {
+        try {
+          const result = await serviceA.archive(
+            session.session_id,
+            { includeChildren: false, includeRemoteChildren: false },
+            { tenant: { tenant_id: tenantId, source: 'service' } } as SessionParams
+          );
+          firstChanged.resolve();
+          await releaseFirst.promise;
+          return result;
+        } finally {
+          firstChanged.resolve();
+        }
+      });
+      let second!: Promise<Awaited<ReturnType<SessionsService['archive']>>>;
+      try {
+        await firstChanged.promise;
+        expect(events).toEqual([]);
+
+        let secondSettled = false;
+        second = serviceB
+          .archive(session.session_id, { includeChildren: false, includeRemoteChildren: false }, {
+            tenant: { tenant_id: tenantId, source: 'service' },
+          } as SessionParams)
+          .finally(() => {
+            secondSettled = true;
+          });
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        expect(secondSettled).toBe(false);
+      } finally {
+        releaseFirst.resolve();
+      }
+
+      await expect(first).resolves.toMatchObject({ count: 1, archivedCount: 1 });
+      await expect(second).resolves.toMatchObject({ count: 0, archivedCount: 0 });
+      expect(events.map((event) => event.session_id)).toEqual([session.session_id]);
+      await runWithTenantDatabaseScope(dbA, tenantId, async (scoped) => {
+        await expect(
+          new SessionRepository(scoped).findById(session.session_id)
+        ).resolves.toMatchObject({ archived: true, archived_reason: 'manual' });
+      });
+    }, 10_000);
+  }
+);

--- a/apps/agor-daemon/src/services/sessions.archive.test.ts
+++ b/apps/agor-daemon/src/services/sessions.archive.test.ts
@@ -390,6 +390,7 @@ describe('SessionsService archive engine', () => {
         ...childOf(remoteChild),
       });
       await linkRemote(db, parent, remoteChild);
+      const findAll = vi.spyOn(SessionRepository.prototype, 'findAll');
 
       const result = await service.archive(
         parent.session_id,
@@ -416,6 +417,10 @@ describe('SessionsService archive engine', () => {
         },
       ]);
       expect(JSON.stringify(result.units)).not.toContain(targetBranchId);
+      expect(findAll.mock.calls.some(([filter]) => filter?.branchId === targetBranchId)).toBe(
+        false
+      );
+      findAll.mockRestore();
       await expect(getArchivedState(db, parent.session_id)).resolves.toEqual(ARCHIVED('manual'));
       await expect(getArchivedState(db, localChild.session_id)).resolves.toEqual(
         ARCHIVED('parent_archived')
@@ -491,6 +496,97 @@ describe('SessionsService archive engine', () => {
     await expect(getArchivedState(db, child.session_id)).resolves.toMatchObject({
       archived: true,
     });
+  });
+
+  dbTest(
+    'revalidates current branch permission immediately before archive mutation',
+    async ({ db }) => {
+      const service = new SessionsService(db, makeAppWithConfig({ branchRbac: true }));
+      const branchId = await createBranch(db, 'rbac-revalidation', {
+        primary_owner_user_id: OTHER_USER_ID,
+        others_can: 'prompt',
+      });
+      const session = await createSession(db, branchId, { created_by: OTHER_USER_ID });
+      const originalResolveUserAccess = BranchRepository.prototype.resolveUserAccess;
+      let checks = 0;
+      const resolveUserAccess = vi
+        .spyOn(BranchRepository.prototype, 'resolveUserAccess')
+        .mockImplementation(async function (branch, userId) {
+          if (branch.branch_id === branchId) {
+            checks += 1;
+            return {
+              can: checks === 1 ? 'prompt' : 'view',
+              is_owner: false,
+              source: 'others',
+            };
+          }
+          return originalResolveUserAccess.call(this, branch, userId);
+        });
+
+      await expect(
+        service.archive(session.session_id, undefined, externalParams(TEST_USER_ID))
+      ).rejects.toThrow(/prompt/);
+
+      expect(checks).toBe(2);
+      resolveUserAccess.mockRestore();
+      await expect(getArchivedState(db, session.session_id)).resolves.toEqual(ACTIVE);
+    }
+  );
+
+  dbTest('skips a remote unit whose permission is revoked before mutation', async ({ db }) => {
+    const service = new SessionsService(db, makeAppWithConfig({ branchRbac: true }));
+    const sourceBranchId = await createBranch(db, 'revoked-remote-source');
+    const targetBranchId = await createBranch(db, 'revoked-remote-target', {
+      primary_owner_user_id: OTHER_USER_ID,
+      others_can: 'prompt',
+    });
+    const source = await createSession(db, sourceBranchId);
+    const target = await createSession(db, targetBranchId, { created_by: OTHER_USER_ID });
+    await linkRemote(db, source, target);
+
+    const originalResolveUserAccess = BranchRepository.prototype.resolveUserAccess;
+    let targetChecks = 0;
+    const resolveUserAccess = vi
+      .spyOn(BranchRepository.prototype, 'resolveUserAccess')
+      .mockImplementation(async function (branch, userId) {
+        if (branch.branch_id === targetBranchId) {
+          targetChecks += 1;
+          return {
+            can: targetChecks < 3 ? 'prompt' : 'view',
+            is_owner: false,
+            source: 'others',
+          };
+        }
+        return originalResolveUserAccess.call(this, branch, userId);
+      });
+
+    const result = await service.archive(
+      source.session_id,
+      undefined,
+      externalParams(TEST_USER_ID)
+    );
+
+    resolveUserAccess.mockRestore();
+    expect(targetChecks).toBe(3);
+    expect(result.count).toBe(1);
+    expect(result.units).toEqual([
+      {
+        rootSessionId: target.session_id,
+        kind: 'remote',
+        status: 'skipped',
+        changedCount: 0,
+        reason: 'insufficient_permission',
+      },
+      {
+        rootSessionId: source.session_id,
+        kind: 'local',
+        status: 'changed',
+        changedCount: 1,
+        branchId: sourceBranchId,
+      },
+    ]);
+    await expect(getArchivedState(db, source.session_id)).resolves.toEqual(ARCHIVED('manual'));
+    await expect(getArchivedState(db, target.session_id)).resolves.toEqual(ACTIVE);
   });
 
   dbTest(
@@ -585,6 +681,42 @@ describe('SessionsService archive engine', () => {
       const creatorRestored = await service.unarchive(creator.session_id);
       expect(creatorRestored.count).toBe(2);
       await expect(getArchivedState(db, target.session_id)).resolves.toEqual(ACTIVE);
+    }
+  );
+
+  dbTest(
+    'keeps an implied restore archived when an incoming remote source is invisible',
+    async ({ db }) => {
+      const service = new SessionsService(db, STUB_APP);
+      const creatorBranchId = await createBranch(db, 'invisible-creator');
+      const targetBranchId = await createBranch(db, 'invisible-source-target');
+      const creator = await createSession(db, creatorBranchId);
+      const localParent = await createSession(db, targetBranchId);
+      const target = await createSession(db, targetBranchId, childOf(localParent));
+      await linkRemote(db, creator, target);
+      await service.archive(localParent.session_id, { includeRemoteChildren: false });
+
+      const originalFindByIds = SessionRepository.prototype.findByIds;
+      const findByIds = vi
+        .spyOn(SessionRepository.prototype, 'findByIds')
+        .mockImplementation(function (ids) {
+          if (ids.length === 1 && ids[0] === creator.session_id) return Promise.resolve([]);
+          return originalFindByIds.call(this, ids);
+        });
+
+      const restored = await service.unarchive(localParent.session_id, {
+        includeRemoteChildren: false,
+      });
+
+      findByIds.mockRestore();
+      expect(restored.count).toBe(1);
+      expect(restored.remainingArchived).toEqual([
+        { sessionId: target.session_id, reason: 'archived_ancestor' },
+      ]);
+      await expect(getArchivedState(db, localParent.session_id)).resolves.toEqual(ACTIVE);
+      await expect(getArchivedState(db, target.session_id)).resolves.toEqual(
+        ARCHIVED('parent_archived')
+      );
     }
   );
 
@@ -873,6 +1005,12 @@ describe('SessionsService archive engine', () => {
       expect(preview.excludedDescendants.map((session) => session.session_id).sort()).toEqual(
         [recentChild.session_id, oldBusyChild.session_id].sort()
       );
+      expect(preview.descendantsNewerThanCutoff.map((session) => session.session_id)).toEqual([
+        recentChild.session_id,
+      ]);
+      expect(preview.descendantsWithUnfinishedTasks.map((session) => session.session_id)).toEqual([
+        oldBusyChild.session_id,
+      ]);
 
       const all = await service.previewBulkArchive([parent], { policy: 'all', cutoffDate });
       expect(all.wouldArchive).toBe(4);
@@ -930,6 +1068,131 @@ describe('SessionsService archive engine', () => {
     await expect(getArchivedState(db, owned.session_id)).resolves.toEqual(ARCHIVED('manual'));
     await expect(getArchivedState(db, foreign.session_id)).resolves.toEqual(ACTIVE);
     await expect(getArchivedState(db, foreignChild.session_id)).resolves.toEqual(ACTIVE);
+  });
+
+  dbTest('bulk archive removes a newly denied unit from its execution preview', async ({ db }) => {
+    const service = new SessionsService(db, makeAppWithConfig({ branchRbac: true }));
+    const ownedBranchId = await createBranch(db, 'bulk-revalidation-owned');
+    const deniedBranchId = await createBranch(db, 'bulk-revalidation-denied', {
+      primary_owner_user_id: OTHER_USER_ID,
+      others_can: 'prompt',
+    });
+    const cutoffDate = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+    const old = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+    const owned = await createSession(db, ownedBranchId, { last_updated: old });
+    const ownedChild = await createSession(db, ownedBranchId, {
+      ...childOf(owned),
+      last_updated: old,
+    });
+    const ownedRecentChild = await createSession(db, ownedBranchId, childOf(owned));
+    const ownedBusyChild = await createSession(db, ownedBranchId, {
+      ...childOf(owned),
+      last_updated: old,
+    });
+    const denied = await createSession(db, deniedBranchId, {
+      created_by: OTHER_USER_ID,
+      last_updated: old,
+    });
+    const deniedChild = await createSession(db, deniedBranchId, {
+      created_by: OTHER_USER_ID,
+      ...childOf(denied),
+      last_updated: old,
+    });
+    const deniedRecentChild = await createSession(db, deniedBranchId, {
+      created_by: OTHER_USER_ID,
+      ...childOf(denied),
+    });
+    const deniedBusyChild = await createSession(db, deniedBranchId, {
+      created_by: OTHER_USER_ID,
+      ...childOf(denied),
+      last_updated: old,
+    });
+    const taskRepo = new TaskRepository(db);
+    await taskRepo.create({
+      session_id: ownedBusyChild.session_id,
+      full_prompt: 'owned still running',
+      created_by: TEST_USER_ID,
+      status: TaskStatus.RUNNING,
+    });
+    await taskRepo.create({
+      session_id: deniedBusyChild.session_id,
+      full_prompt: 'denied still running',
+      created_by: OTHER_USER_ID,
+      status: TaskStatus.RUNNING,
+    });
+
+    const originalResolveUserAccess = BranchRepository.prototype.resolveUserAccess;
+    let deniedChecks = 0;
+    const resolveUserAccess = vi
+      .spyOn(BranchRepository.prototype, 'resolveUserAccess')
+      .mockImplementation(async function (branch, userId) {
+        if (branch.branch_id === deniedBranchId) {
+          deniedChecks += 1;
+          return {
+            can: deniedChecks <= 2 ? 'prompt' : 'view',
+            is_owner: false,
+            source: 'others',
+          };
+        }
+        return originalResolveUserAccess.call(this, branch, userId);
+      });
+
+    const result = await service.bulkArchive(
+      [owned, denied],
+      { policy: 'eligible', cutoffDate },
+      externalParams(TEST_USER_ID)
+    );
+
+    resolveUserAccess.mockRestore();
+    expect(deniedChecks).toBe(3);
+    expect(result).toMatchObject({
+      count: 2,
+      wouldChangeCount: 2,
+      archivedCount: 2,
+      skippedCount: 1,
+      preview: { wouldArchive: 2 },
+    });
+    expect(result.preview.directRoots.map((session) => session.session_id)).toEqual([
+      owned.session_id,
+    ]);
+    expect(result.preview.impliedDescendants.map((session) => session.session_id)).toEqual([
+      ownedChild.session_id,
+    ]);
+    expect(result.preview.excludedDescendants.map((session) => session.session_id).sort()).toEqual(
+      [ownedRecentChild.session_id, ownedBusyChild.session_id].sort()
+    );
+    expect(result.preview.descendantsNewerThanCutoff.map((session) => session.session_id)).toEqual([
+      ownedRecentChild.session_id,
+    ]);
+    expect(
+      result.preview.descendantsWithUnfinishedTasks.map((session) => session.session_id)
+    ).toEqual([ownedBusyChild.session_id]);
+    expect(result.preview.units).toEqual(
+      expect.arrayContaining([
+        {
+          rootSessionId: denied.session_id,
+          kind: 'local',
+          status: 'skipped',
+          changedCount: 0,
+          reason: 'insufficient_permission',
+        },
+        {
+          rootSessionId: owned.session_id,
+          kind: 'local',
+          status: 'changed',
+          changedCount: 2,
+          branchId: ownedBranchId,
+        },
+      ])
+    );
+    await expect(getArchivedState(db, owned.session_id)).resolves.toEqual(ARCHIVED('manual'));
+    await expect(getArchivedState(db, ownedChild.session_id)).resolves.toEqual(
+      ARCHIVED('parent_archived')
+    );
+    await expect(getArchivedState(db, denied.session_id)).resolves.toEqual(ACTIVE);
+    await expect(getArchivedState(db, deniedChild.session_id)).resolves.toEqual(ACTIVE);
+    await expect(getArchivedState(db, deniedRecentChild.session_id)).resolves.toEqual(ACTIVE);
+    await expect(getArchivedState(db, deniedBusyChild.session_id)).resolves.toEqual(ACTIVE);
   });
 
   dbTest(

--- a/apps/agor-daemon/src/services/sessions.archive.test.ts
+++ b/apps/agor-daemon/src/services/sessions.archive.test.ts
@@ -135,6 +135,27 @@ async function linkRemote(db: any, source: Session, target: Session): Promise<vo
   });
 }
 
+function changeArchiveStateBeforeCurrentRead(
+  matchIds: SessionID[],
+  update: {
+    id: SessionID;
+    archived: boolean;
+    archivedReason: NonNullable<Session['archived_reason']> | null;
+  }
+) {
+  const originalFindByIds = SessionRepository.prototype.findByIds;
+  let injected = false;
+  return vi
+    .spyOn(SessionRepository.prototype, 'findByIds')
+    .mockImplementation(async function (ids) {
+      if (!injected && matchIds.every((id) => ids.includes(id))) {
+        injected = true;
+        await this.updateArchiveStateForTargets([update]);
+      }
+      return originalFindByIds.call(this, ids);
+    });
+}
+
 async function getArchivedState(
   db: any,
   sessionId: SessionID
@@ -281,6 +302,92 @@ describe('SessionsService archive engine', () => {
       ARCHIVED('btw_completed')
     );
     await expect(getArchivedState(db, manualChild.session_id)).resolves.toEqual(ARCHIVED('manual'));
+  });
+
+  dbTest(
+    'preserves an implied descendant manually archived after cascade planning',
+    async ({ db }) => {
+      const service = new SessionsService(db, STUB_APP);
+      const branchId = await createBranch(db, 'stale-archive-child');
+      const parent = await createSession(db, branchId);
+      const child = await createSession(db, branchId, childOf(parent));
+      const findByIds = changeArchiveStateBeforeCurrentRead([parent.session_id, child.session_id], {
+        id: child.session_id,
+        archived: true,
+        archivedReason: 'manual',
+      });
+
+      const result = await service.archive(parent.session_id, {
+        includeRemoteChildren: false,
+      });
+
+      findByIds.mockRestore();
+      expect(result).toMatchObject({
+        count: 1,
+        wouldChangeCount: 1,
+        archivedCount: 1,
+        localCount: 1,
+        remoteCount: 0,
+        runningCount: 0,
+      });
+      expect(result.affectedSessions.map((session) => session.session_id)).toEqual([
+        parent.session_id,
+      ]);
+      await expect(getArchivedState(db, parent.session_id)).resolves.toEqual(ARCHIVED('manual'));
+      await expect(getArchivedState(db, child.session_id)).resolves.toEqual(ARCHIVED('manual'));
+    }
+  );
+
+  dbTest('does not recount or re-emit a root archived after planning', async ({ db }) => {
+    const { app, emit } = makeEmittingApp();
+    const service = new SessionsService(db, app);
+    const branchId = await createBranch(db, 'concurrent-root-archive');
+    const root = await createSession(db, branchId);
+    const findByIds = changeArchiveStateBeforeCurrentRead([root.session_id], {
+      id: root.session_id,
+      archived: true,
+      archivedReason: 'manual',
+    });
+
+    const result = await service.archive(root.session_id, { includeRemoteChildren: false });
+
+    findByIds.mockRestore();
+    expect(result).toMatchObject({
+      count: 0,
+      wouldChangeCount: 0,
+      archivedCount: 0,
+      session: ARCHIVED('manual'),
+    });
+    expect(result.affectedSessions).toEqual([]);
+    expect(emit).not.toHaveBeenCalled();
+    await expect(getArchivedState(db, root.session_id)).resolves.toEqual(ARCHIVED('manual'));
+  });
+
+  dbTest('does not recount or re-emit a root restored after planning', async ({ db }) => {
+    const { app, emit } = makeEmittingApp();
+    const service = new SessionsService(db, app);
+    const branchId = await createBranch(db, 'concurrent-root-restore');
+    const root = await createSession(db, branchId);
+    await service.archive(root.session_id, { includeRemoteChildren: false });
+    emit.mockClear();
+    const findByIds = changeArchiveStateBeforeCurrentRead([root.session_id], {
+      id: root.session_id,
+      archived: false,
+      archivedReason: null,
+    });
+
+    const result = await service.unarchive(root.session_id, { includeRemoteChildren: false });
+
+    findByIds.mockRestore();
+    expect(result).toMatchObject({
+      count: 0,
+      wouldChangeCount: 0,
+      unarchivedCount: 0,
+      session: ACTIVE,
+    });
+    expect(result.affectedSessions).toEqual([]);
+    expect(emit).not.toHaveBeenCalled();
+    await expect(getArchivedState(db, root.session_id)).resolves.toEqual(ACTIVE);
   });
 
   dbTest('honors includeChildren false and rejects generic archive patches', async ({ db }) => {
@@ -753,35 +860,189 @@ describe('SessionsService archive engine', () => {
   );
 
   dbTest(
-    'rejects a restore when an implied descendant gains an independent archive reason after planning',
+    'replans a restore after an intermediate descendant gains an independent reason',
     async ({ db }) => {
       const service = new SessionsService(db, STUB_APP);
       const branchId = await createBranch(db, 'stale-restore-reason');
-      const parent = await createSession(db, branchId);
-      const child = await createSession(db, branchId, childOf(parent));
-      await service.archive(parent.session_id, { includeRemoteChildren: false });
+      const root = await createSession(db, branchId);
+      const intermediate = await createSession(db, branchId, childOf(root));
+      const leaf = await createSession(db, branchId, childOf(intermediate));
+      await service.archive(root.session_id, { includeRemoteChildren: false });
 
-      const originalFindByIds = SessionRepository.prototype.findByIds;
-      const findByIds = vi
-        .spyOn(SessionRepository.prototype, 'findByIds')
-        .mockImplementation(async function (ids) {
-          const rows = await originalFindByIds.call(this, ids);
-          if (ids.includes(parent.session_id) && ids.includes(child.session_id)) {
-            return rows.map((row) =>
-              row.session_id === child.session_id
-                ? { ...row, archived_reason: 'manual' as const }
-                : row
-            );
-          }
-          return rows;
-        });
+      const findByIds = changeArchiveStateBeforeCurrentRead(
+        [root.session_id, intermediate.session_id, leaf.session_id],
+        {
+          id: intermediate.session_id,
+          archived: true,
+          archivedReason: 'manual',
+        }
+      );
 
-      await expect(
-        service.unarchive(parent.session_id, { includeRemoteChildren: false })
-      ).rejects.toThrow(/restore eligibility changed/i);
+      const result = await service.unarchive(root.session_id, {
+        includeRemoteChildren: false,
+      });
       findByIds.mockRestore();
 
-      await expect(getArchivedState(db, parent.session_id)).resolves.toEqual(ARCHIVED('manual'));
+      expect(result).toMatchObject({ count: 1, wouldChangeCount: 1, unarchivedCount: 1 });
+      expect(result.remainingArchived).toEqual([
+        { sessionId: intermediate.session_id, reason: 'independent_reason' },
+        { sessionId: leaf.session_id, reason: 'archived_ancestor' },
+      ]);
+      await expect(getArchivedState(db, root.session_id)).resolves.toEqual(ACTIVE);
+      await expect(getArchivedState(db, intermediate.session_id)).resolves.toEqual(
+        ARCHIVED('manual')
+      );
+      await expect(getArchivedState(db, leaf.session_id)).resolves.toEqual(
+        ARCHIVED('parent_archived')
+      );
+    }
+  );
+
+  dbTest(
+    'does not restore beneath an implied descendant archived after restore planning',
+    async ({ db }) => {
+      const { app, emit } = makeEmittingApp();
+      const service = new SessionsService(db, app);
+      const branchId = await createBranch(db, 'stale-restore-implied-cascade');
+      const root = await createSession(db, branchId, ARCHIVED('manual'));
+      const intermediate = await createSession(db, branchId, childOf(root));
+      const leaf = await createSession(db, branchId, {
+        ...ARCHIVED('parent_archived'),
+        ...childOf(intermediate),
+      });
+      const findByIds = changeArchiveStateBeforeCurrentRead(
+        [root.session_id, intermediate.session_id, leaf.session_id],
+        {
+          id: intermediate.session_id,
+          archived: true,
+          archivedReason: 'parent_archived',
+        }
+      );
+
+      const result = await service.unarchive(root.session_id, {
+        includeRemoteChildren: false,
+      });
+      findByIds.mockRestore();
+
+      expect(result).toMatchObject({
+        count: 1,
+        wouldChangeCount: 1,
+        unarchivedCount: 1,
+        localCount: 1,
+        remoteCount: 0,
+      });
+      expect(result.affectedSessions.map((session) => session.session_id)).toEqual([
+        root.session_id,
+      ]);
+      expect(result.remainingArchived).toEqual([
+        { sessionId: intermediate.session_id, reason: 'archived_ancestor' },
+        { sessionId: leaf.session_id, reason: 'archived_ancestor' },
+      ]);
+      expect(emit).toHaveBeenCalledTimes(1);
+      expect(emit.mock.calls.map((call) => (call[1] as Session).session_id)).toEqual([
+        root.session_id,
+      ]);
+      await expect(getArchivedState(db, root.session_id)).resolves.toEqual(ACTIVE);
+      await expect(getArchivedState(db, intermediate.session_id)).resolves.toEqual(
+        ARCHIVED('parent_archived')
+      );
+      await expect(getArchivedState(db, leaf.session_id)).resolves.toEqual(
+        ARCHIVED('parent_archived')
+      );
+    }
+  );
+
+  dbTest(
+    'does not restore a remote unit beneath its target archived after restore planning',
+    async ({ db }) => {
+      const { app, emit } = makeEmittingApp();
+      const service = new SessionsService(db, app);
+      const sourceBranchId = await createBranch(db, 'stale-remote-restore-source');
+      const targetBranchId = await createBranch(db, 'stale-remote-restore-target');
+      const root = await createSession(db, sourceBranchId, ARCHIVED('manual'));
+      const remoteTarget = await createSession(db, targetBranchId);
+      const leaf = await createSession(db, targetBranchId, {
+        ...ARCHIVED('parent_archived'),
+        ...childOf(remoteTarget),
+      });
+      await linkRemote(db, root, remoteTarget);
+      const findByIds = changeArchiveStateBeforeCurrentRead(
+        [remoteTarget.session_id, leaf.session_id],
+        {
+          id: remoteTarget.session_id,
+          archived: true,
+          archivedReason: 'parent_archived',
+        }
+      );
+
+      const result = await service.unarchive(root.session_id);
+      findByIds.mockRestore();
+
+      expect(result).toMatchObject({
+        count: 1,
+        wouldChangeCount: 1,
+        unarchivedCount: 1,
+        localCount: 1,
+        remoteCount: 0,
+      });
+      expect(result.affectedSessions.map((session) => session.session_id)).toEqual([
+        root.session_id,
+      ]);
+      expect(result.remainingArchived).toEqual([
+        { sessionId: remoteTarget.session_id, reason: 'archived_ancestor' },
+        { sessionId: leaf.session_id, reason: 'archived_ancestor' },
+      ]);
+      expect(emit).toHaveBeenCalledTimes(1);
+      expect(emit.mock.calls.map((call) => (call[1] as Session).session_id)).toEqual([
+        root.session_id,
+      ]);
+      await expect(getArchivedState(db, root.session_id)).resolves.toEqual(ACTIVE);
+      await expect(getArchivedState(db, remoteTarget.session_id)).resolves.toEqual(
+        ARCHIVED('parent_archived')
+      );
+      await expect(getArchivedState(db, leaf.session_id)).resolves.toEqual(
+        ARCHIVED('parent_archived')
+      );
+    }
+  );
+
+  dbTest(
+    'keeps descendants archived when an explicit restore root gains an independent reason',
+    async ({ db }) => {
+      const { app, emit } = makeEmittingApp();
+      const service = new SessionsService(db, app);
+      const branchId = await createBranch(db, 'stale-restore-root-reason');
+      const root = await createSession(db, branchId);
+      const child = await createSession(db, branchId, childOf(root));
+      await service.archive(root.session_id, { includeRemoteChildren: false });
+      emit.mockClear();
+
+      const findByIds = changeArchiveStateBeforeCurrentRead([root.session_id, child.session_id], {
+        id: root.session_id,
+        archived: true,
+        archivedReason: 'btw_completed',
+      });
+
+      const result = await service.unarchive(root.session_id, {
+        includeRemoteChildren: false,
+      });
+      findByIds.mockRestore();
+
+      expect(result).toMatchObject({
+        count: 0,
+        wouldChangeCount: 0,
+        unarchivedCount: 0,
+        session: ARCHIVED('btw_completed'),
+      });
+      expect(result.affectedSessions).toEqual([]);
+      expect(result.remainingArchived).toEqual([
+        { sessionId: root.session_id, reason: 'independent_reason' },
+        { sessionId: child.session_id, reason: 'archived_ancestor' },
+      ]);
+      expect(emit).not.toHaveBeenCalled();
+      await expect(getArchivedState(db, root.session_id)).resolves.toEqual(
+        ARCHIVED('btw_completed')
+      );
       await expect(getArchivedState(db, child.session_id)).resolves.toEqual(
         ARCHIVED('parent_archived')
       );
@@ -818,7 +1079,7 @@ describe('SessionsService archive engine', () => {
   });
 
   dbTest(
-    'rejects a restore when an incoming remote source becomes archived after planning',
+    'replans a restore when an incoming remote source becomes archived after planning',
     async ({ db }) => {
       const service = new SessionsService(db, STUB_APP);
       const creatorBranchId = await createBranch(db, 'stale-restore-creator');
@@ -844,12 +1105,16 @@ describe('SessionsService archive engine', () => {
           return rows;
         });
 
-      await expect(
-        service.unarchive(parent.session_id, { includeRemoteChildren: false })
-      ).rejects.toThrow(/restore eligibility changed/i);
+      const result = await service.unarchive(parent.session_id, {
+        includeRemoteChildren: false,
+      });
       findByIds.mockRestore();
 
-      await expect(getArchivedState(db, parent.session_id)).resolves.toEqual(ARCHIVED('manual'));
+      expect(result).toMatchObject({ count: 1, wouldChangeCount: 1, unarchivedCount: 1 });
+      expect(result.remainingArchived).toEqual([
+        { sessionId: child.session_id, reason: 'archived_ancestor' },
+      ]);
+      await expect(getArchivedState(db, parent.session_id)).resolves.toEqual(ACTIVE);
       await expect(getArchivedState(db, child.session_id)).resolves.toEqual(
         ARCHIVED('parent_archived')
       );
@@ -993,6 +1258,25 @@ describe('SessionsService archive engine', () => {
     },
     120_000
   );
+
+  dbTest('preserves a branch session manually archived after restore selection', async ({ db }) => {
+    const service = new SessionsService(db, STUB_APP);
+    const branchId = await createBranch(db, 'stale-branch-restore');
+    const session = await createSession(db, branchId);
+    expect((await service.archiveBranchSessions(branchId as BranchID)).count).toBe(1);
+
+    const findByIds = changeArchiveStateBeforeCurrentRead([session.session_id], {
+      id: session.session_id,
+      archived: true,
+      archivedReason: 'manual',
+    });
+
+    const result = await service.unarchiveBranchSessions(branchId as BranchID);
+
+    findByIds.mockRestore();
+    expect(result).toEqual({ affectedSessions: [], count: 0 });
+    await expect(getArchivedState(db, session.session_id)).resolves.toEqual(ARCHIVED('manual'));
+  });
 
   dbTest(
     'ignores a stale reason on an active row and clears reasons on restore',

--- a/apps/agor-daemon/src/services/sessions.archive.test.ts
+++ b/apps/agor-daemon/src/services/sessions.archive.test.ts
@@ -1,17 +1,20 @@
 import {
   BranchRepository,
+  createTenantScopedDatabaseProxy,
   generateId,
   RepoRepository,
+  runWithTenantContext,
   SessionRelationshipRepository,
   SessionRepository,
+  TaskRepository,
   UsersRepository,
 } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
-import type { Branch, Session, SessionID, UUID } from '@agor/core/types';
-import { ROLES, SessionStatus } from '@agor/core/types';
-import { describe, expect } from 'vitest';
+import type { Branch, BranchID, Session, SessionID, UUID } from '@agor/core/types';
+import { ROLES, SessionStatus, TaskStatus } from '@agor/core/types';
+import { describe, expect, vi } from 'vitest';
 import { dbTest } from '../../../../packages/core/src/db/test-helpers';
-import { type SessionParams, SessionsService } from './sessions';
+import { ARCHIVE_PATCH_REJECTED_MESSAGE, type SessionParams, SessionsService } from './sessions';
 
 const STUB_APP = {
   service: () => ({
@@ -37,6 +40,12 @@ function makeAppWithConfig(config: {
     },
     service: STUB_APP.service,
   } as unknown as Application;
+}
+
+function makeEmittingApp(): { app: Application; emit: ReturnType<typeof vi.fn> } {
+  const emit = vi.fn();
+  const service = { emit };
+  return { app: { service: () => service } as unknown as Application, emit };
 }
 
 function externalParams(userId: UUID): SessionParams {
@@ -113,6 +122,19 @@ async function createSession(
   });
 }
 
+function childOf(parent: Session): Partial<Session> {
+  return { genealogy: { parent_session_id: parent.session_id, children: [] } };
+}
+
+async function linkRemote(db: any, source: Session, target: Session): Promise<void> {
+  await new SessionRelationshipRepository(db).create({
+    source_session_id: source.session_id,
+    target_session_id: target.session_id,
+    relationship_type: 'remote_create',
+    created_by: TEST_USER_ID,
+  });
+}
+
 async function getArchivedState(
   db: any,
   sessionId: SessionID
@@ -122,19 +144,21 @@ async function getArchivedState(
   return { archived: session.archived, archived_reason: session.archived_reason };
 }
 
-describe('SessionsService archive routes', () => {
+const ARCHIVED = (reason: NonNullable<Session['archived_reason']>) => ({
+  archived: true,
+  archived_reason: reason,
+});
+const ACTIVE = { archived: false, archived_reason: undefined };
+
+describe('SessionsService archive engine', () => {
   dbTest(
     'archives and unarchives branch-local spawned, forked, and nested descendants',
     async ({ db }) => {
       const service = new SessionsService(db, STUB_APP);
       const branchId = await createBranch(db);
       const parent = await createSession(db, branchId);
-      const spawnedChild = await createSession(db, branchId, {
-        genealogy: { parent_session_id: parent.session_id, children: [] },
-      });
-      const nestedChild = await createSession(db, branchId, {
-        genealogy: { parent_session_id: spawnedChild.session_id, children: [] },
-      });
+      const spawnedChild = await createSession(db, branchId, childOf(parent));
+      const nestedChild = await createSession(db, branchId, childOf(spawnedChild));
       const forkedChild = await createSession(db, branchId, {
         genealogy: { forked_from_session_id: parent.session_id, children: [] },
       });
@@ -142,160 +166,264 @@ describe('SessionsService archive routes', () => {
       const archiveResult = await service.archive(parent.session_id);
 
       expect(archiveResult.count).toBe(4);
-      await expect(getArchivedState(db, parent.session_id)).resolves.toEqual({
-        archived: true,
-        archived_reason: 'manual',
+      expect(archiveResult).toMatchObject({
+        dryRun: false,
+        wouldChangeCount: 4,
+        archivedCount: 4,
+        unarchivedCount: 0,
+        localCount: 4,
+        remoteCount: 0,
+        skippedCount: 0,
+        runningCount: 0,
+        remainingArchived: [],
       });
-      await expect(getArchivedState(db, spawnedChild.session_id)).resolves.toEqual({
-        archived: true,
-        archived_reason: 'parent_archived',
-      });
-      await expect(getArchivedState(db, nestedChild.session_id)).resolves.toEqual({
-        archived: true,
-        archived_reason: 'parent_archived',
-      });
-      await expect(getArchivedState(db, forkedChild.session_id)).resolves.toEqual({
-        archived: true,
-        archived_reason: 'parent_archived',
-      });
+      expect(archiveResult.units).toEqual([
+        {
+          rootSessionId: parent.session_id,
+          kind: 'local',
+          status: 'changed',
+          changedCount: 4,
+          branchId,
+        },
+      ]);
+      await expect(getArchivedState(db, parent.session_id)).resolves.toEqual(ARCHIVED('manual'));
+      for (const child of [spawnedChild, nestedChild, forkedChild]) {
+        await expect(getArchivedState(db, child.session_id)).resolves.toEqual(
+          ARCHIVED('parent_archived')
+        );
+      }
 
       const unarchiveResult = await service.unarchive(parent.session_id);
 
       expect(unarchiveResult.count).toBe(4);
-      await expect(getArchivedState(db, parent.session_id)).resolves.toEqual({
-        archived: false,
-        archived_reason: undefined,
-      });
-      await expect(getArchivedState(db, spawnedChild.session_id)).resolves.toEqual({
-        archived: false,
-        archived_reason: undefined,
-      });
-      await expect(getArchivedState(db, nestedChild.session_id)).resolves.toEqual({
-        archived: false,
-        archived_reason: undefined,
-      });
-      await expect(getArchivedState(db, forkedChild.session_id)).resolves.toEqual({
-        archived: false,
-        archived_reason: undefined,
-      });
+      expect(unarchiveResult.unarchivedCount).toBe(4);
+      for (const session of [parent, spawnedChild, nestedChild, forkedChild]) {
+        await expect(getArchivedState(db, session.session_id)).resolves.toEqual(ACTIVE);
+      }
     }
   );
+
+  dbTest('dry-run plans and authorizes without changing anything', async ({ db }) => {
+    const { app, emit } = makeEmittingApp();
+    const service = new SessionsService(db, app);
+    const branchId = await createBranch(db);
+    const parent = await createSession(db, branchId);
+    const runningChild = await createSession(db, branchId, {
+      ...childOf(parent),
+      status: SessionStatus.RUNNING,
+    });
+
+    const preview = await service.archive(parent.session_id, { dryRun: true });
+
+    expect(preview).toMatchObject({
+      dryRun: true,
+      wouldChangeCount: 2,
+      archivedCount: 2,
+      localCount: 2,
+      remoteCount: 0,
+      runningCount: 1,
+      count: 0,
+      affectedSessions: [],
+    });
+    expect(preview.units).toEqual([
+      {
+        rootSessionId: parent.session_id,
+        kind: 'local',
+        status: 'changed',
+        changedCount: 2,
+        branchId,
+      },
+    ]);
+    expect(emit).not.toHaveBeenCalled();
+    await expect(getArchivedState(db, parent.session_id)).resolves.toEqual(ACTIVE);
+    await expect(getArchivedState(db, runningChild.session_id)).resolves.toEqual(ACTIVE);
+  });
 
   dbTest('preserves descendants that were already archived for other reasons', async ({ db }) => {
     const service = new SessionsService(db, STUB_APP);
     const branchId = await createBranch(db);
     const parent = await createSession(db, branchId);
-    const activeChild = await createSession(db, branchId, {
-      genealogy: { parent_session_id: parent.session_id, children: [] },
-    });
+    const activeChild = await createSession(db, branchId, childOf(parent));
     const btwCompletedChild = await createSession(db, branchId, {
-      archived: true,
-      archived_reason: 'btw_completed',
+      ...ARCHIVED('btw_completed'),
       fork_origin: 'btw',
       genealogy: { forked_from_session_id: parent.session_id, children: [] },
     });
     const manualChild = await createSession(db, branchId, {
-      archived: true,
-      archived_reason: 'manual',
-      genealogy: { parent_session_id: parent.session_id, children: [] },
+      ...ARCHIVED('manual'),
+      ...childOf(parent),
     });
 
     const archiveResult = await service.archive(parent.session_id);
 
     expect(archiveResult.count).toBe(2);
-    await expect(getArchivedState(db, parent.session_id)).resolves.toEqual({
-      archived: true,
-      archived_reason: 'manual',
-    });
-    await expect(getArchivedState(db, activeChild.session_id)).resolves.toEqual({
-      archived: true,
-      archived_reason: 'parent_archived',
-    });
-    await expect(getArchivedState(db, btwCompletedChild.session_id)).resolves.toEqual({
-      archived: true,
-      archived_reason: 'btw_completed',
-    });
-    await expect(getArchivedState(db, manualChild.session_id)).resolves.toEqual({
-      archived: true,
-      archived_reason: 'manual',
-    });
+    await expect(getArchivedState(db, parent.session_id)).resolves.toEqual(ARCHIVED('manual'));
+    await expect(getArchivedState(db, activeChild.session_id)).resolves.toEqual(
+      ARCHIVED('parent_archived')
+    );
+    await expect(getArchivedState(db, btwCompletedChild.session_id)).resolves.toEqual(
+      ARCHIVED('btw_completed')
+    );
+    await expect(getArchivedState(db, manualChild.session_id)).resolves.toEqual(ARCHIVED('manual'));
 
     const unarchiveResult = await service.unarchive(parent.session_id);
 
     expect(unarchiveResult.count).toBe(2);
-    await expect(getArchivedState(db, parent.session_id)).resolves.toEqual({
-      archived: false,
-      archived_reason: undefined,
-    });
-    await expect(getArchivedState(db, activeChild.session_id)).resolves.toEqual({
-      archived: false,
-      archived_reason: undefined,
-    });
-    await expect(getArchivedState(db, btwCompletedChild.session_id)).resolves.toEqual({
-      archived: true,
-      archived_reason: 'btw_completed',
-    });
-    await expect(getArchivedState(db, manualChild.session_id)).resolves.toEqual({
-      archived: true,
-      archived_reason: 'manual',
-    });
+    expect(unarchiveResult.remainingArchived).toEqual(
+      expect.arrayContaining([
+        { sessionId: btwCompletedChild.session_id, reason: 'independent_reason' },
+        { sessionId: manualChild.session_id, reason: 'independent_reason' },
+      ])
+    );
+    await expect(getArchivedState(db, parent.session_id)).resolves.toEqual(ACTIVE);
+    await expect(getArchivedState(db, activeChild.session_id)).resolves.toEqual(ACTIVE);
+    await expect(getArchivedState(db, btwCompletedChild.session_id)).resolves.toEqual(
+      ARCHIVED('btw_completed')
+    );
+    await expect(getArchivedState(db, manualChild.session_id)).resolves.toEqual(ARCHIVED('manual'));
+  });
+
+  dbTest('honors includeChildren false and rejects generic archive patches', async ({ db }) => {
+    const service = new SessionsService(db, STUB_APP);
+    const branchId = await createBranch(db);
+    const parent = await createSession(db, branchId);
+    const child = await createSession(db, branchId, childOf(parent));
+
+    await expect(
+      service.patch(parent.session_id, { archived: true, archived_reason: 'manual' })
+    ).rejects.toThrow(ARCHIVE_PATCH_REJECTED_MESSAGE);
+    await expect(
+      service.patch(parent.session_id, { archived_reason: 'manual' } as never)
+    ).rejects.toThrow(ARCHIVE_PATCH_REJECTED_MESSAGE);
+    await expect(
+      service.patch(
+        null,
+        { archived: true } as never,
+        {
+          query: { branch_id: branchId },
+        } as SessionParams
+      )
+    ).rejects.toThrow(ARCHIVE_PATCH_REJECTED_MESSAGE);
+    await expect(getArchivedState(db, parent.session_id)).resolves.toEqual(ACTIVE);
+
+    const archiveResult = await service.archive(parent.session_id, { includeChildren: false });
+
+    expect(archiveResult.count).toBe(1);
+    await expect(getArchivedState(db, parent.session_id)).resolves.toEqual(ARCHIVED('manual'));
+    await expect(getArchivedState(db, child.session_id)).resolves.toEqual(ACTIVE);
+
+    await service.unarchive(parent.session_id, { includeChildren: false });
+    await expect(getArchivedState(db, parent.session_id)).resolves.toEqual(ACTIVE);
   });
 
   dbTest(
-    'honors includeChildren false while generic patch remains single-session',
+    'follows remote-created sessions by default and honors includeRemoteChildren false',
     async ({ db }) => {
       const service = new SessionsService(db, STUB_APP);
-      const branchId = await createBranch(db);
-      const parent = await createSession(db, branchId);
-      const child = await createSession(db, branchId, {
-        genealogy: { parent_session_id: parent.session_id, children: [] },
-      });
+      const sourceBranchId = await createBranch(db, 'source');
+      const targetBranchId = await createBranch(db, 'target');
+      const parent = await createSession(db, sourceBranchId);
+      const remoteChild = await createSession(db, targetBranchId);
+      const remoteGrandchild = await createSession(db, targetBranchId, childOf(remoteChild));
+      await linkRemote(db, parent, remoteChild);
 
-      await service.patch(parent.session_id, { archived: true, archived_reason: 'manual' });
-      await expect(getArchivedState(db, parent.session_id)).resolves.toMatchObject({
-        archived: true,
+      const localOnly = await service.archive(parent.session_id, {
+        includeRemoteChildren: false,
       });
-      await expect(getArchivedState(db, child.session_id)).resolves.toMatchObject({
-        archived: false,
-      });
+      expect(localOnly.count).toBe(1);
+      expect(localOnly.remoteCount).toBe(0);
+      await expect(getArchivedState(db, remoteChild.session_id)).resolves.toEqual(ACTIVE);
+      await service.unarchive(parent.session_id, { includeRemoteChildren: false });
 
-      await service.unarchive(parent.session_id, { includeChildren: false });
-      const archiveResult = await service.archive(parent.session_id, { includeChildren: false });
+      const result = await service.archive(parent.session_id);
 
-      expect(archiveResult.count).toBe(1);
-      await expect(getArchivedState(db, parent.session_id)).resolves.toMatchObject({
-        archived: true,
-      });
-      await expect(getArchivedState(db, child.session_id)).resolves.toMatchObject({
-        archived: false,
-      });
+      expect(result.count).toBe(3);
+      expect(result).toMatchObject({ localCount: 1, remoteCount: 2, skippedCount: 0 });
+      expect(result.units).toEqual([
+        {
+          rootSessionId: parent.session_id,
+          kind: 'local',
+          status: 'changed',
+          changedCount: 1,
+          branchId: sourceBranchId,
+        },
+        {
+          rootSessionId: remoteChild.session_id,
+          kind: 'remote',
+          status: 'changed',
+          changedCount: 2,
+          branchId: targetBranchId,
+        },
+      ]);
+      await expect(getArchivedState(db, parent.session_id)).resolves.toEqual(ARCHIVED('manual'));
+      await expect(getArchivedState(db, remoteChild.session_id)).resolves.toEqual(
+        ARCHIVED('parent_archived')
+      );
+      await expect(getArchivedState(db, remoteGrandchild.session_id)).resolves.toEqual(
+        ARCHIVED('parent_archived')
+      );
+
+      const restored = await service.unarchive(parent.session_id);
+
+      expect(restored.count).toBe(3);
+      for (const session of [parent, remoteChild, remoteGrandchild]) {
+        await expect(getArchivedState(db, session.session_id)).resolves.toEqual(ACTIVE);
+      }
     }
   );
 
-  dbTest('does not cascade through remote session relationships', async ({ db }) => {
-    const service = new SessionsService(db, STUB_APP);
-    const sourceBranchId = await createBranch(db, 'source');
-    const targetBranchId = await createBranch(db, 'target');
-    const parent = await createSession(db, sourceBranchId);
-    const remoteChild = await createSession(db, targetBranchId);
+  dbTest(
+    'skips an unauthorized remote branch without disclosing it and still commits the local unit',
+    async ({ db }) => {
+      const service = new SessionsService(db, makeAppWithConfig({ branchRbac: true }));
+      const sourceBranchId = await createBranch(db, 'source-owned');
+      const targetBranchId = await createBranch(db, 'target-view-only', {
+        created_by: OTHER_USER_ID,
+        primary_owner_user_id: OTHER_USER_ID,
+        others_can: 'view',
+      });
+      const parent = await createSession(db, sourceBranchId);
+      const localChild = await createSession(db, sourceBranchId, childOf(parent));
+      const remoteChild = await createSession(db, targetBranchId, { created_by: OTHER_USER_ID });
+      const remoteGrandchild = await createSession(db, targetBranchId, {
+        created_by: OTHER_USER_ID,
+        ...childOf(remoteChild),
+      });
+      await linkRemote(db, parent, remoteChild);
 
-    await new SessionRelationshipRepository(db).create({
-      source_session_id: parent.session_id,
-      target_session_id: remoteChild.session_id,
-      relationship_type: 'remote_create',
-      created_by: TEST_USER_ID,
-    });
+      const result = await service.archive(
+        parent.session_id,
+        undefined,
+        externalParams(TEST_USER_ID)
+      );
 
-    const archiveResult = await service.archive(parent.session_id);
-
-    expect(archiveResult.count).toBe(1);
-    await expect(getArchivedState(db, parent.session_id)).resolves.toMatchObject({
-      archived: true,
-    });
-    await expect(getArchivedState(db, remoteChild.session_id)).resolves.toMatchObject({
-      archived: false,
-    });
-  });
+      expect(result.count).toBe(2);
+      expect(result.skippedCount).toBe(1);
+      expect(result.units).toEqual([
+        {
+          rootSessionId: remoteChild.session_id,
+          kind: 'remote',
+          status: 'skipped',
+          changedCount: 0,
+          reason: 'insufficient_permission',
+        },
+        {
+          rootSessionId: parent.session_id,
+          kind: 'local',
+          status: 'changed',
+          changedCount: 2,
+          branchId: sourceBranchId,
+        },
+      ]);
+      expect(JSON.stringify(result.units)).not.toContain(targetBranchId);
+      await expect(getArchivedState(db, parent.session_id)).resolves.toEqual(ARCHIVED('manual'));
+      await expect(getArchivedState(db, localChild.session_id)).resolves.toEqual(
+        ARCHIVED('parent_archived')
+      );
+      await expect(getArchivedState(db, remoteChild.session_id)).resolves.toEqual(ACTIVE);
+      await expect(getArchivedState(db, remoteGrandchild.session_id)).resolves.toEqual(ACTIVE);
+    }
+  );
 
   dbTest(
     'rejects external archive and unarchive before mutating when RBAC prompt permission is missing',
@@ -308,33 +436,36 @@ describe('SessionsService archive routes', () => {
       const parent = await createSession(db, branchId, { created_by: TEST_USER_ID });
       const child = await createSession(db, branchId, {
         created_by: OTHER_USER_ID,
-        genealogy: { parent_session_id: parent.session_id, children: [] },
+        ...childOf(parent),
       });
 
       await expect(
         service.archive(parent.session_id, undefined, externalParams(TEST_USER_ID))
       ).rejects.toThrow(/prompt/);
 
-      await expect(getArchivedState(db, parent.session_id)).resolves.toMatchObject({
-        archived: false,
-      });
-      await expect(getArchivedState(db, child.session_id)).resolves.toMatchObject({
-        archived: false,
-      });
+      await expect(getArchivedState(db, parent.session_id)).resolves.toEqual(ACTIVE);
+      await expect(getArchivedState(db, child.session_id)).resolves.toEqual(ACTIVE);
 
-      await service.patch(parent.session_id, { archived: true, archived_reason: 'manual' });
-      await service.patch(child.session_id, { archived: true, archived_reason: 'parent_archived' });
+      // A session-tier caller can still archive only the root they own.
+      const ownRoot = await service.archive(
+        parent.session_id,
+        { includeChildren: false },
+        externalParams(TEST_USER_ID)
+      );
+      expect(ownRoot.count).toBe(1);
+      await expect(getArchivedState(db, child.session_id)).resolves.toEqual(ACTIVE);
 
+      await new SessionRepository(db).updateArchiveStateForTargets([
+        { id: child.session_id, archived: true, archivedReason: 'parent_archived' },
+      ]);
       await expect(
         service.unarchive(parent.session_id, undefined, externalParams(TEST_USER_ID))
       ).rejects.toThrow(/prompt/);
 
-      await expect(getArchivedState(db, parent.session_id)).resolves.toMatchObject({
-        archived: true,
-      });
-      await expect(getArchivedState(db, child.session_id)).resolves.toMatchObject({
-        archived: true,
-      });
+      await expect(getArchivedState(db, parent.session_id)).resolves.toEqual(ARCHIVED('manual'));
+      await expect(getArchivedState(db, child.session_id)).resolves.toEqual(
+        ARCHIVED('parent_archived')
+      );
     }
   );
 
@@ -344,7 +475,7 @@ describe('SessionsService archive routes', () => {
     const parent = await createSession(db, branchId, { created_by: OTHER_USER_ID });
     const child = await createSession(db, branchId, {
       created_by: OTHER_USER_ID,
-      genealogy: { parent_session_id: parent.session_id, children: [] },
+      ...childOf(parent),
     });
 
     const result = await service.archive(
@@ -361,4 +492,496 @@ describe('SessionsService archive routes', () => {
       archived: true,
     });
   });
+
+  dbTest(
+    'gives an explicitly archived descendant its own reason so a parent unarchive leaves it archived',
+    async ({ db }) => {
+      const service = new SessionsService(db, STUB_APP);
+      const branchId = await createBranch(db);
+      const parent = await createSession(db, branchId);
+      const child = await createSession(db, branchId, childOf(parent));
+
+      await service.archive(parent.session_id);
+      await expect(getArchivedState(db, child.session_id)).resolves.toEqual(
+        ARCHIVED('parent_archived')
+      );
+
+      const upgraded = await service.archive(child.session_id);
+      expect(upgraded.count).toBe(1);
+      await expect(getArchivedState(db, child.session_id)).resolves.toEqual(ARCHIVED('manual'));
+
+      const restored = await service.unarchive(parent.session_id);
+      expect(restored.count).toBe(1);
+      expect(restored.remainingArchived).toEqual([
+        { sessionId: child.session_id, reason: 'independent_reason' },
+      ]);
+      await expect(getArchivedState(db, parent.session_id)).resolves.toEqual(ACTIVE);
+      await expect(getArchivedState(db, child.session_id)).resolves.toEqual(ARCHIVED('manual'));
+    }
+  );
+
+  dbTest(
+    'keeps a descendant archived while another archived ancestor covers it',
+    async ({ db }) => {
+      const service = new SessionsService(db, STUB_APP);
+      const branchId = await createBranch(db);
+      const root = await createSession(db, branchId);
+      const middle = await createSession(db, branchId, childOf(root));
+      const leaf = await createSession(db, branchId, childOf(middle));
+
+      await service.archive(middle.session_id);
+      const rootArchive = await service.archive(root.session_id);
+      expect(rootArchive.count).toBe(1);
+
+      const restored = await service.unarchive(root.session_id);
+
+      expect(restored.count).toBe(1);
+      expect(restored.remainingArchived).toEqual(
+        expect.arrayContaining([
+          { sessionId: middle.session_id, reason: 'independent_reason' },
+          { sessionId: leaf.session_id, reason: 'archived_ancestor' },
+        ])
+      );
+      await expect(getArchivedState(db, root.session_id)).resolves.toEqual(ACTIVE);
+      await expect(getArchivedState(db, middle.session_id)).resolves.toEqual(ARCHIVED('manual'));
+      await expect(getArchivedState(db, leaf.session_id)).resolves.toEqual(
+        ARCHIVED('parent_archived')
+      );
+
+      const middleRestored = await service.unarchive(middle.session_id);
+      expect(middleRestored.count).toBe(2);
+      await expect(getArchivedState(db, leaf.session_id)).resolves.toEqual(ACTIVE);
+    }
+  );
+
+  dbTest(
+    'keeps a remote-created session archived while its creator is archived even after its local parent is restored',
+    async ({ db }) => {
+      const service = new SessionsService(db, STUB_APP);
+      const creatorBranchId = await createBranch(db, 'creator');
+      const targetBranchId = await createBranch(db, 'target');
+      const creator = await createSession(db, creatorBranchId);
+      const localParent = await createSession(db, targetBranchId);
+      const target = await createSession(db, targetBranchId, childOf(localParent));
+      await linkRemote(db, creator, target);
+
+      const creatorArchive = await service.archive(creator.session_id);
+      expect(creatorArchive.count).toBe(2);
+      await expect(getArchivedState(db, target.session_id)).resolves.toEqual(
+        ARCHIVED('parent_archived')
+      );
+
+      expect((await service.archive(localParent.session_id)).count).toBe(1);
+
+      const parentRestored = await service.unarchive(localParent.session_id);
+      expect(parentRestored.count).toBe(1);
+      expect(parentRestored.remainingArchived).toEqual([
+        { sessionId: target.session_id, reason: 'archived_ancestor' },
+      ]);
+      await expect(getArchivedState(db, target.session_id)).resolves.toEqual(
+        ARCHIVED('parent_archived')
+      );
+
+      const creatorRestored = await service.unarchive(creator.session_id);
+      expect(creatorRestored.count).toBe(2);
+      await expect(getArchivedState(db, target.session_id)).resolves.toEqual(ACTIVE);
+    }
+  );
+
+  dbTest(
+    'keeps implied descendants archived inside an archived branch and refuses explicit restores there',
+    async ({ db }) => {
+      const service = new SessionsService(db, STUB_APP);
+      const creatorBranchId = await createBranch(db, 'creator');
+      const targetBranchId = await createBranch(db, 'target');
+      const creator = await createSession(db, creatorBranchId);
+      const target = await createSession(db, targetBranchId);
+      await linkRemote(db, creator, target);
+
+      await service.archive(creator.session_id);
+      await new BranchRepository(db).update(targetBranchId, { archived: true });
+
+      const restored = await service.unarchive(creator.session_id);
+      expect(restored.count).toBe(1);
+      expect(restored.remainingArchived).toEqual([
+        { sessionId: target.session_id, reason: 'archived_branch' },
+      ]);
+      await expect(getArchivedState(db, creator.session_id)).resolves.toEqual(ACTIVE);
+      await expect(getArchivedState(db, target.session_id)).resolves.toEqual(
+        ARCHIVED('parent_archived')
+      );
+
+      await expect(service.unarchive(target.session_id)).rejects.toThrow(/archived branch/);
+      await expect(service.restorePromptedSession(target.session_id)).rejects.toThrow(
+        /archived branch/
+      );
+      await expect(getArchivedState(db, target.session_id)).resolves.toEqual(
+        ARCHIVED('parent_archived')
+      );
+    }
+  );
+
+  dbTest('archiveBtwSession archives the btw fork with local descendants only', async ({ db }) => {
+    const service = new SessionsService(db, STUB_APP);
+    const branchId = await createBranch(db);
+    const remoteBranchId = await createBranch(db, 'remote');
+    const parent = await createSession(db, branchId);
+    const btw = await createSession(db, branchId, {
+      fork_origin: 'btw',
+      genealogy: { forked_from_session_id: parent.session_id, children: [] },
+    });
+    const btwChild = await createSession(db, branchId, childOf(btw));
+    const remoteTarget = await createSession(db, remoteBranchId);
+    await linkRemote(db, btw, remoteTarget);
+
+    const result = await service.archiveBtwSession(btw.session_id);
+
+    expect(result.count).toBe(2);
+    await expect(getArchivedState(db, btw.session_id)).resolves.toEqual(ARCHIVED('btw_completed'));
+    await expect(getArchivedState(db, btwChild.session_id)).resolves.toEqual(
+      ARCHIVED('parent_archived')
+    );
+    await expect(getArchivedState(db, remoteTarget.session_id)).resolves.toEqual(ACTIVE);
+    await expect(getArchivedState(db, parent.session_id)).resolves.toEqual(ACTIVE);
+  });
+
+  dbTest('restorePromptedSession restores only the prompted session', async ({ db }) => {
+    const service = new SessionsService(db, STUB_APP);
+    const branchId = await createBranch(db);
+    const parent = await createSession(db, branchId);
+    const prompted = await createSession(db, branchId, childOf(parent));
+    const sibling = await createSession(db, branchId, childOf(parent));
+    const grandchild = await createSession(db, branchId, childOf(prompted));
+
+    await service.archive(parent.session_id);
+
+    const result = await service.restorePromptedSession(
+      prompted.session_id,
+      externalParams(TEST_USER_ID)
+    );
+
+    expect(result.count).toBe(1);
+    await expect(getArchivedState(db, prompted.session_id)).resolves.toEqual(ACTIVE);
+    await expect(getArchivedState(db, parent.session_id)).resolves.toEqual(ARCHIVED('manual'));
+    await expect(getArchivedState(db, sibling.session_id)).resolves.toEqual(
+      ARCHIVED('parent_archived')
+    );
+    await expect(getArchivedState(db, grandchild.session_id)).resolves.toEqual(
+      ARCHIVED('parent_archived')
+    );
+  });
+
+  dbTest(
+    'branch archive covers more than 1,000 sessions, preserves independent reasons, and branch unarchive restores only branch-caused rows',
+    async ({ db }) => {
+      const service = new SessionsService(db, STUB_APP);
+      const branchId = await createBranch(db);
+      const sessionRepo = new SessionRepository(db);
+      const activeCount = 1_002;
+      for (let index = 0; index < activeCount; index += 1) {
+        await createSession(db, branchId);
+      }
+      const manual = await createSession(db, branchId, ARCHIVED('manual'));
+      const btw = await createSession(db, branchId, {
+        ...ARCHIVED('btw_completed'),
+        fork_origin: 'btw',
+      });
+      const archivedParent = await createSession(db, branchId, ARCHIVED('manual'));
+      const parentArchivedChild = await createSession(db, branchId, {
+        ...ARCHIVED('parent_archived'),
+        ...childOf(archivedParent),
+      });
+
+      const archived = await service.archiveBranchSessions(branchId as BranchID);
+
+      expect(archived.count).toBe(activeCount);
+      const afterArchive = await sessionRepo.findAll({ branchId });
+      expect(afterArchive.filter((session) => !session.archived)).toHaveLength(0);
+      expect(
+        afterArchive.filter((session) => session.archived_reason === 'branch_archived')
+      ).toHaveLength(activeCount);
+      await expect(getArchivedState(db, manual.session_id)).resolves.toEqual(ARCHIVED('manual'));
+      await expect(getArchivedState(db, btw.session_id)).resolves.toEqual(
+        ARCHIVED('btw_completed')
+      );
+      await expect(getArchivedState(db, parentArchivedChild.session_id)).resolves.toEqual(
+        ARCHIVED('parent_archived')
+      );
+
+      const restored = await service.unarchiveBranchSessions(branchId as BranchID);
+
+      expect(restored.count).toBe(activeCount);
+      const afterRestore = await sessionRepo.findAll({ branchId });
+      expect(afterRestore.filter((session) => !session.archived)).toHaveLength(activeCount);
+      await expect(getArchivedState(db, manual.session_id)).resolves.toEqual(ARCHIVED('manual'));
+      await expect(getArchivedState(db, archivedParent.session_id)).resolves.toEqual(
+        ARCHIVED('manual')
+      );
+      await expect(getArchivedState(db, parentArchivedChild.session_id)).resolves.toEqual(
+        ARCHIVED('parent_archived')
+      );
+
+      expect((await service.unarchiveBranchSessions(branchId as BranchID)).count).toBe(0);
+    },
+    120_000
+  );
+
+  dbTest(
+    'ignores a stale reason on an active row and clears reasons on restore',
+    async ({ db }) => {
+      const service = new SessionsService(db, STUB_APP);
+      const sessionRepo = new SessionRepository(db);
+      const branchId = await createBranch(db);
+      const parent = await createSession(db, branchId);
+      const staleChild = await createSession(db, branchId, {
+        archived: false,
+        archived_reason: 'parent_archived',
+        ...childOf(parent),
+      });
+
+      // Nothing to restore: an active row with a legacy reason is not a blocker
+      // and is not counted.
+      expect((await service.unarchive(parent.session_id)).count).toBe(0);
+
+      const archived = await service.archive(parent.session_id);
+      expect(archived.count).toBe(2);
+      await expect(getArchivedState(db, staleChild.session_id)).resolves.toEqual(
+        ARCHIVED('parent_archived')
+      );
+
+      const restored = await service.unarchive(parent.session_id);
+      expect(restored.count).toBe(2);
+      await expect(getArchivedState(db, staleChild.session_id)).resolves.toEqual(ACTIVE);
+
+      // Generic repository restoration also normalizes the invariant.
+      const manual = await createSession(db, branchId, ARCHIVED('manual'));
+      await sessionRepo.update(manual.session_id, { archived: false });
+      await expect(getArchivedState(db, manual.session_id)).resolves.toEqual(ACTIVE);
+    }
+  );
+
+  dbTest(
+    'emits exactly one patched event per changed row and none on a no-op repeat',
+    async ({ db }) => {
+      const { app, emit } = makeEmittingApp();
+      const service = new SessionsService(db, app);
+      const branchId = await createBranch(db);
+      const parent = await createSession(db, branchId);
+      const child = await createSession(db, branchId, childOf(parent));
+
+      const first = await service.archive(parent.session_id);
+      expect(first.count).toBe(2);
+      expect(emit).toHaveBeenCalledTimes(2);
+      expect(emit.mock.calls.map((call) => call[0])).toEqual(['patched', 'patched']);
+      expect(new Set(emit.mock.calls.map((call) => (call[1] as Session).session_id))).toEqual(
+        new Set([parent.session_id, child.session_id])
+      );
+
+      emit.mockClear();
+      const repeat = await service.archive(parent.session_id);
+      expect(repeat.count).toBe(0);
+      expect(repeat.units).toEqual([
+        {
+          rootSessionId: parent.session_id,
+          kind: 'local',
+          status: 'unchanged',
+          changedCount: 0,
+          branchId,
+        },
+      ]);
+      expect(emit).not.toHaveBeenCalled();
+    }
+  );
+
+  dbTest(
+    'bulk archive merges overlapping root trees, lets direct roots win, and honors the descendant policy',
+    async ({ db }) => {
+      const service = new SessionsService(db, STUB_APP);
+      const branchId = await createBranch(db);
+      const parent = await createSession(db, branchId);
+      const child = await createSession(db, branchId, childOf(parent));
+      const grandchild = await createSession(db, branchId, childOf(child));
+      const other = await createSession(db, branchId);
+      const otherChild = await createSession(db, branchId, childOf(other));
+
+      const preview = await service.previewBulkArchive([parent, child, other], { policy: 'all' });
+      expect(preview.policy).toBe('all');
+      expect(preview.wouldArchive).toBe(5);
+      expect(preview.directRoots.map((session) => session.session_id).sort()).toEqual(
+        [parent.session_id, child.session_id, other.session_id].sort()
+      );
+      expect(preview.impliedDescendants.map((session) => session.session_id).sort()).toEqual(
+        [grandchild.session_id, otherChild.session_id].sort()
+      );
+      expect(preview.excludedDescendants).toEqual([]);
+      expect(preview.units.map((unit) => unit.changedCount).sort()).toEqual([2, 3]);
+
+      const noChildren = await service.previewBulkArchive([parent, child, other], {
+        policy: 'none',
+      });
+      expect(noChildren.wouldArchive).toBe(3);
+      expect(noChildren.impliedDescendants).toEqual([]);
+
+      const result = await service.bulkArchive([parent, child, other], { policy: 'all' });
+
+      expect(result.count).toBe(5);
+      expect(result.preview.wouldArchive).toBe(5);
+      await expect(getArchivedState(db, parent.session_id)).resolves.toEqual(ARCHIVED('manual'));
+      await expect(getArchivedState(db, child.session_id)).resolves.toEqual(ARCHIVED('manual'));
+      await expect(getArchivedState(db, grandchild.session_id)).resolves.toEqual(
+        ARCHIVED('parent_archived')
+      );
+      await expect(getArchivedState(db, other.session_id)).resolves.toEqual(ARCHIVED('manual'));
+      await expect(getArchivedState(db, otherChild.session_id)).resolves.toEqual(
+        ARCHIVED('parent_archived')
+      );
+    }
+  );
+
+  dbTest(
+    'bulk eligible policy keeps descendants that are old enough and have no unfinished task',
+    async ({ db }) => {
+      const service = new SessionsService(db, STUB_APP);
+      const branchId = await createBranch(db);
+      const cutoffDate = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+      const old = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+      const parent = await createSession(db, branchId, { last_updated: old });
+      const oldIdleChild = await createSession(db, branchId, {
+        ...childOf(parent),
+        last_updated: old,
+      });
+      const recentChild = await createSession(db, branchId, childOf(parent));
+      const oldBusyChild = await createSession(db, branchId, {
+        ...childOf(parent),
+        last_updated: old,
+      });
+      await new TaskRepository(db).create({
+        session_id: oldBusyChild.session_id,
+        full_prompt: 'still running',
+        created_by: TEST_USER_ID,
+        status: TaskStatus.RUNNING,
+      });
+
+      const preview = await service.previewBulkArchive([parent], {
+        policy: 'eligible',
+        cutoffDate,
+      });
+      expect(preview.wouldArchive).toBe(2);
+      expect(preview.impliedDescendants.map((session) => session.session_id)).toEqual([
+        oldIdleChild.session_id,
+      ]);
+      expect(preview.excludedDescendants.map((session) => session.session_id).sort()).toEqual(
+        [recentChild.session_id, oldBusyChild.session_id].sort()
+      );
+
+      const all = await service.previewBulkArchive([parent], { policy: 'all', cutoffDate });
+      expect(all.wouldArchive).toBe(4);
+      expect(all.descendantsNewerThanCutoff.map((session) => session.session_id)).toEqual([
+        recentChild.session_id,
+      ]);
+      expect(all.descendantsWithUnfinishedTasks.map((session) => session.session_id)).toEqual([
+        oldBusyChild.session_id,
+      ]);
+
+      const result = await service.bulkArchive([parent], { policy: 'eligible', cutoffDate });
+      expect(result.count).toBe(2);
+      await expect(getArchivedState(db, oldIdleChild.session_id)).resolves.toEqual(
+        ARCHIVED('parent_archived')
+      );
+      await expect(getArchivedState(db, recentChild.session_id)).resolves.toEqual(ACTIVE);
+      await expect(getArchivedState(db, oldBusyChild.session_id)).resolves.toEqual(ACTIVE);
+    }
+  );
+
+  dbTest('bulk archive skips unauthorized units and archives the rest', async ({ db }) => {
+    const service = new SessionsService(db, makeAppWithConfig({ branchRbac: true }));
+    const ownedBranchId = await createBranch(db, 'owned');
+    const foreignBranchId = await createBranch(db, 'foreign', {
+      created_by: OTHER_USER_ID,
+      primary_owner_user_id: OTHER_USER_ID,
+      others_can: 'view',
+    });
+    const owned = await createSession(db, ownedBranchId);
+    const foreign = await createSession(db, foreignBranchId, { created_by: OTHER_USER_ID });
+    const foreignChild = await createSession(db, foreignBranchId, {
+      created_by: OTHER_USER_ID,
+      ...childOf(foreign),
+    });
+
+    const result = await service.bulkArchive(
+      [owned, foreign],
+      { policy: 'all' },
+      externalParams(TEST_USER_ID)
+    );
+
+    expect(result.count).toBe(1);
+    expect(result.skippedCount).toBe(1);
+    expect(result.units).toEqual(
+      expect.arrayContaining([
+        {
+          rootSessionId: foreign.session_id,
+          kind: 'local',
+          status: 'skipped',
+          changedCount: 0,
+          reason: 'insufficient_permission',
+        },
+      ])
+    );
+    await expect(getArchivedState(db, owned.session_id)).resolves.toEqual(ARCHIVED('manual'));
+    await expect(getArchivedState(db, foreign.session_id)).resolves.toEqual(ACTIVE);
+    await expect(getArchivedState(db, foreignChild.session_id)).resolves.toEqual(ACTIVE);
+  });
+
+  dbTest(
+    'reports a bounded limit on dry-run and fails closed on execution when remote fan-out is too wide',
+    async ({ db }) => {
+      const service = new SessionsService(db, STUB_APP);
+      const sourceBranchId = await createBranch(db, 'fan-out-source');
+      const parent = await createSession(db, sourceBranchId);
+      for (let index = 0; index < 33; index += 1) {
+        const remoteBranchId = await createBranch(db, `fan-out-${index}`);
+        const remote = await createSession(db, remoteBranchId);
+        await linkRemote(db, parent, remote);
+      }
+
+      const preview = await service.archive(parent.session_id, { dryRun: true });
+      expect(preview.limitExceeded).toBe('remote_branch_units');
+      expect(preview.remoteCount).toBe(0);
+      expect(preview.wouldChangeCount).toBe(1);
+
+      await expect(service.archive(parent.session_id)).rejects.toThrow(
+        /more than 32 other branches/
+      );
+      await expect(getArchivedState(db, parent.session_id)).resolves.toEqual(ACTIVE);
+
+      const localOnly = await service.archive(parent.session_id, { includeRemoteChildren: false });
+      expect(localOnly.count).toBe(1);
+    },
+    60_000
+  );
+
+  dbTest(
+    'internal archive entry points satisfy the armed tenant database-scope guard on their own',
+    async ({ db }) => {
+      const guardedDb = createTenantScopedDatabaseProxy(db, { label: 'guarded archive test' });
+      const service = new SessionsService(guardedDb, STUB_APP);
+      const branchId = await createBranch(db);
+      const parent = await createSession(db, branchId);
+      const btw = await createSession(db, branchId, {
+        fork_origin: 'btw',
+        genealogy: { forked_from_session_id: parent.session_id, children: [] },
+      });
+
+      await runWithTenantContext('tenant-a', async () => {
+        expect((await service.archiveBtwSession(btw.session_id)).count).toBe(1);
+        expect((await service.restorePromptedSession(btw.session_id)).count).toBe(1);
+        expect((await service.archiveBranchSessions(branchId as BranchID)).count).toBe(2);
+        expect((await service.unarchiveBranchSessions(branchId as BranchID)).count).toBe(2);
+        expect((await service.previewBulkArchive([parent], { policy: 'all' })).wouldArchive).toBe(
+          2
+        );
+        expect((await service.bulkArchive([parent], { policy: 'none' })).count).toBe(1);
+      });
+    }
+  );
 });

--- a/apps/agor-daemon/src/services/sessions.archive.test.ts
+++ b/apps/agor-daemon/src/services/sessions.archive.test.ts
@@ -685,6 +685,38 @@ describe('SessionsService archive engine', () => {
   );
 
   dbTest(
+    'restores a remote parent before its child when repository rows are returned in reverse order',
+    async ({ db }) => {
+      const service = new SessionsService(db, STUB_APP);
+      const sourceBranchId = await createBranch(db, 'reverse-restore-source');
+      const targetBranchId = await createBranch(db, 'reverse-restore-target');
+      const source = await createSession(db, sourceBranchId);
+      const remoteParent = await createSession(db, targetBranchId);
+      const child = await createSession(db, targetBranchId, childOf(remoteParent));
+      await linkRemote(db, source, remoteParent);
+      expect((await service.archive(source.session_id)).count).toBe(3);
+
+      const originalFindByIds = SessionRepository.prototype.findByIds;
+      const findByIds = vi
+        .spyOn(SessionRepository.prototype, 'findByIds')
+        .mockImplementation(async function (ids) {
+          const rows = await originalFindByIds.call(this, ids);
+          return ids.includes(remoteParent.session_id) && ids.includes(child.session_id)
+            ? rows.reverse()
+            : rows;
+        });
+
+      const restored = await service.unarchive(source.session_id);
+
+      findByIds.mockRestore();
+      expect(restored.count).toBe(3);
+      for (const session of [source, remoteParent, child]) {
+        await expect(getArchivedState(db, session.session_id)).resolves.toEqual(ACTIVE);
+      }
+    }
+  );
+
+  dbTest(
     'keeps an implied restore archived when an incoming remote source is invisible',
     async ({ db }) => {
       const service = new SessionsService(db, STUB_APP);
@@ -715,6 +747,110 @@ describe('SessionsService archive engine', () => {
       ]);
       await expect(getArchivedState(db, localParent.session_id)).resolves.toEqual(ACTIVE);
       await expect(getArchivedState(db, target.session_id)).resolves.toEqual(
+        ARCHIVED('parent_archived')
+      );
+    }
+  );
+
+  dbTest(
+    'rejects a restore when an implied descendant gains an independent archive reason after planning',
+    async ({ db }) => {
+      const service = new SessionsService(db, STUB_APP);
+      const branchId = await createBranch(db, 'stale-restore-reason');
+      const parent = await createSession(db, branchId);
+      const child = await createSession(db, branchId, childOf(parent));
+      await service.archive(parent.session_id, { includeRemoteChildren: false });
+
+      const originalFindByIds = SessionRepository.prototype.findByIds;
+      const findByIds = vi
+        .spyOn(SessionRepository.prototype, 'findByIds')
+        .mockImplementation(async function (ids) {
+          const rows = await originalFindByIds.call(this, ids);
+          if (ids.includes(parent.session_id) && ids.includes(child.session_id)) {
+            return rows.map((row) =>
+              row.session_id === child.session_id
+                ? { ...row, archived_reason: 'manual' as const }
+                : row
+            );
+          }
+          return rows;
+        });
+
+      await expect(
+        service.unarchive(parent.session_id, { includeRemoteChildren: false })
+      ).rejects.toThrow(/restore eligibility changed/i);
+      findByIds.mockRestore();
+
+      await expect(getArchivedState(db, parent.session_id)).resolves.toEqual(ARCHIVED('manual'));
+      await expect(getArchivedState(db, child.session_id)).resolves.toEqual(
+        ARCHIVED('parent_archived')
+      );
+    }
+  );
+
+  dbTest('rejects a restore when its branch becomes archived after planning', async ({ db }) => {
+    const service = new SessionsService(db, STUB_APP);
+    const branchId = await createBranch(db, 'stale-restore-branch');
+    const parent = await createSession(db, branchId);
+    const child = await createSession(db, branchId, childOf(parent));
+    await service.archive(parent.session_id, { includeRemoteChildren: false });
+
+    const originalFindById = BranchRepository.prototype.findById;
+    let branchReads = 0;
+    const findById = vi
+      .spyOn(BranchRepository.prototype, 'findById')
+      .mockImplementation(async function (id) {
+        const branch = await originalFindById.call(this, id);
+        if (id !== branchId || !branch) return branch;
+        branchReads += 1;
+        return branchReads === 1 ? branch : { ...branch, archived: true };
+      });
+
+    await expect(
+      service.unarchive(parent.session_id, { includeRemoteChildren: false })
+    ).rejects.toThrow(/archived branch/i);
+    findById.mockRestore();
+
+    await expect(getArchivedState(db, parent.session_id)).resolves.toEqual(ARCHIVED('manual'));
+    await expect(getArchivedState(db, child.session_id)).resolves.toEqual(
+      ARCHIVED('parent_archived')
+    );
+  });
+
+  dbTest(
+    'rejects a restore when an incoming remote source becomes archived after planning',
+    async ({ db }) => {
+      const service = new SessionsService(db, STUB_APP);
+      const creatorBranchId = await createBranch(db, 'stale-restore-creator');
+      const targetBranchId = await createBranch(db, 'stale-restore-target');
+      const creator = await createSession(db, creatorBranchId);
+      const parent = await createSession(db, targetBranchId);
+      const child = await createSession(db, targetBranchId, childOf(parent));
+      await linkRemote(db, creator, child);
+      await service.archive(parent.session_id, { includeRemoteChildren: false });
+
+      const originalFindByIds = SessionRepository.prototype.findByIds;
+      let sourceReads = 0;
+      const findByIds = vi
+        .spyOn(SessionRepository.prototype, 'findByIds')
+        .mockImplementation(async function (ids) {
+          const rows = await originalFindByIds.call(this, ids);
+          if (ids.length === 1 && ids[0] === creator.session_id) {
+            sourceReads += 1;
+            return sourceReads === 1
+              ? rows
+              : rows.map((row) => ({ ...row, archived: true, archived_reason: 'manual' }));
+          }
+          return rows;
+        });
+
+      await expect(
+        service.unarchive(parent.session_id, { includeRemoteChildren: false })
+      ).rejects.toThrow(/restore eligibility changed/i);
+      findByIds.mockRestore();
+
+      await expect(getArchivedState(db, parent.session_id)).resolves.toEqual(ARCHIVED('manual'));
+      await expect(getArchivedState(db, child.session_id)).resolves.toEqual(
         ARCHIVED('parent_archived')
       );
     }
@@ -1224,7 +1360,83 @@ describe('SessionsService archive engine', () => {
   );
 
   dbTest(
-    'internal archive entry points satisfy the armed tenant database-scope guard on their own',
+    'rejects an authorized remote chain beyond the depth bound without changing any session',
+    async ({ db }) => {
+      const service = new SessionsService(db, makeAppWithConfig({ branchRbac: true }));
+      const sourceBranchId = await createBranch(db, 'authorized-depth-source');
+      const source = await createSession(db, sourceBranchId);
+      const chain = [source];
+      let previous = source;
+      for (let depth = 1; depth <= 9; depth += 1) {
+        const branchId = await createBranch(db, `authorized-depth-${depth}`);
+        const target = await createSession(db, branchId);
+        await linkRemote(db, previous, target);
+        chain.push(target);
+        previous = target;
+      }
+
+      await expect(
+        service.archive(source.session_id, { includeChildren: false }, externalParams(TEST_USER_ID))
+      ).rejects.toThrow(/deeper than 8 hops/);
+
+      for (const session of chain) {
+        await expect(getArchivedState(db, session.session_id)).resolves.toEqual(ACTIVE);
+      }
+    },
+    60_000
+  );
+
+  dbTest(
+    'skips a denied remote target beyond the depth bound without disclosing the bound',
+    async ({ db }) => {
+      const service = new SessionsService(db, makeAppWithConfig({ branchRbac: true }));
+      const sourceBranchId = await createBranch(db, 'depth-source');
+      const source = await createSession(db, sourceBranchId);
+      const authorized: Session[] = [];
+      let previous = source;
+      for (let depth = 1; depth <= 8; depth += 1) {
+        const branchId = await createBranch(db, `depth-${depth}`);
+        const target = await createSession(db, branchId);
+        await linkRemote(db, previous, target);
+        authorized.push(target);
+        previous = target;
+      }
+      const deniedBranchId = await createBranch(db, 'depth-denied', {
+        created_by: OTHER_USER_ID,
+        primary_owner_user_id: OTHER_USER_ID,
+        others_can: 'view',
+      });
+      const denied = await createSession(db, deniedBranchId, { created_by: OTHER_USER_ID });
+      await linkRemote(db, previous, denied);
+
+      const result = await service.archive(
+        source.session_id,
+        { includeChildren: false },
+        externalParams(TEST_USER_ID)
+      );
+
+      expect(result.count).toBe(9);
+      expect(result.limitExceeded).toBeUndefined();
+      expect(result.skippedCount).toBe(1);
+      expect(result.units).toContainEqual({
+        rootSessionId: denied.session_id,
+        kind: 'remote',
+        status: 'skipped',
+        changedCount: 0,
+        reason: 'insufficient_permission',
+      });
+      for (const session of [source, ...authorized]) {
+        await expect(getArchivedState(db, session.session_id)).resolves.toMatchObject({
+          archived: true,
+        });
+      }
+      await expect(getArchivedState(db, denied.session_id)).resolves.toEqual(ACTIVE);
+    },
+    60_000
+  );
+
+  dbTest(
+    'archive entry points satisfy the armed tenant database-scope guard on their own',
     async ({ db }) => {
       const guardedDb = createTenantScopedDatabaseProxy(db, { label: 'guarded archive test' });
       const service = new SessionsService(guardedDb, STUB_APP);
@@ -1236,6 +1448,12 @@ describe('SessionsService archive engine', () => {
       });
 
       await runWithTenantContext('tenant-a', async () => {
+        expect((await service.archive(parent.session_id, { includeChildren: false })).count).toBe(
+          1
+        );
+        expect((await service.unarchive(parent.session_id, { includeChildren: false })).count).toBe(
+          1
+        );
         expect((await service.archiveBtwSession(btw.session_id)).count).toBe(1);
         expect((await service.restorePromptedSession(btw.session_id)).count).toBe(1);
         expect((await service.archiveBranchSessions(branchId as BranchID)).count).toBe(2);

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -1826,23 +1826,29 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
     branchCache: Map<string, Branch | null>,
     sessionRepo = this.sessionRepo,
     relationshipRepo = this.sessionRelationshipRepo,
-    branchRepo = this.branchRepo
+    branchRepo = this.branchRepo,
+    applicableRestoreIds?: ReadonlySet<string>
   ): Promise<void> {
     const plannedActive = new Set<string>();
+    const blockedRestoreCandidates = new Set<string>();
     const impliedIds: SessionID[] = [];
     for (const unit of plan.units) {
       for (const [id, session] of unit.members) {
         const isExplicitRoot = unit.kind === 'local' && unit.rootIds.has(id);
-        if (!isExplicitRoot) {
-          impliedIds.push(id as SessionID);
+        if (!isExplicitRoot) impliedIds.push(id as SessionID);
+        if (isExplicitRoot) {
+          const branch = await this.loadArchiveBranch(branchCache, session.branch_id, branchRepo);
+          if (branch?.archived) {
+            throw new Conflict(
+              `Session ${shortId(session.session_id)} belongs to an archived branch. Restore the branch first.`
+            );
+          }
+        }
+        if (session.archived && applicableRestoreIds?.has(id) === false) {
+          blockedRestoreCandidates.add(id);
           continue;
         }
-        const branch = await this.loadArchiveBranch(branchCache, session.branch_id, branchRepo);
-        if (branch?.archived) {
-          throw new Conflict(
-            `Session ${shortId(session.session_id)} belongs to an archived branch. Restore the branch first.`
-          );
-        }
+        if (!isExplicitRoot) continue;
         plannedActive.add(id);
         if (session.archived) {
           plan.targets.push({
@@ -1885,6 +1891,16 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
     for (const unit of plan.units) {
       for (const [id, session] of unit.members) {
         if (plannedActive.has(id) || !session.archived) continue;
+        if (blockedRestoreCandidates.has(id)) {
+          plan.remainingArchived.push({
+            sessionId: id as SessionID,
+            reason:
+              session.archived_reason === PARENT_ARCHIVED_REASON
+                ? 'archived_ancestor'
+                : 'independent_reason',
+          });
+          continue;
+        }
         if (session.archived_reason !== PARENT_ARCHIVED_REASON) {
           plan.remainingArchived.push({ sessionId: id as SessionID, reason: 'independent_reason' });
           continue;
@@ -1932,7 +1948,7 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
     for (const unit of plan.units) {
       const unitTargets = plan.targets.filter((target) => target.unitKey === unit.key);
       if (unitTargets.length === 0) continue;
-      const unitChanged = await runWithTenantDatabaseTransaction(
+      const unitOutcome = await runWithTenantDatabaseTransaction(
         this.db,
         tenantId,
         async (operationDb) => {
@@ -1963,6 +1979,21 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
             branchRepo
           );
           if (denial) throw denial;
+          const applicableTargets: ArchivePlannedTarget[] = [];
+          for (const target of unitTargets) {
+            const current = currentMembersById.get(target.session.session_id);
+            if (!current) throw new NotFound('An archive target no longer exists');
+            const currentReason = current.archived ? (current.archived_reason ?? null) : null;
+            const observedReason = target.session.archived
+              ? (target.session.archived_reason ?? null)
+              : null;
+            const matchesObserved =
+              current.archived === target.session.archived && currentReason === observedReason;
+            if (matchesObserved) applicableTargets.push(target);
+          }
+
+          let writeTargets = applicableTargets;
+          let currentRemaining: SessionArchiveResult['remainingArchived'] | null = null;
           if (!plan.archived) {
             const currentGraphs = new Map<string, ArchiveBranchGraph>();
             for (const branchId of new Set(currentMembers.map((member) => member.branch_id))) {
@@ -1990,25 +2021,29 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
               new Map(),
               sessionRepo,
               new SessionRelationshipRepository(operationDb),
-              branchRepo
+              branchRepo,
+              new Set(applicableTargets.map((target) => target.session.session_id))
             );
             const currentlyRestorable = new Set(
               currentPlan.targets.map((target) => target.session.session_id)
             );
-            for (const target of unitTargets) {
-              const current = currentUnit.members.get(target.session.session_id);
-              if (current?.archived && !currentlyRestorable.has(current.session_id)) {
-                throw new Conflict('Archive restore eligibility changed. Retry the operation.');
-              }
-            }
+            writeTargets = applicableTargets.filter((target) =>
+              currentlyRestorable.has(target.session.session_id)
+            );
+            currentRemaining = currentPlan.remainingArchived;
           }
-          return sessionRepo.updateArchiveStateForTargets(
-            unitTargets.map((target) => ({
-              id: target.session.session_id,
-              archived: target.archived,
-              archivedReason: target.archivedReason,
-            }))
-          );
+          return {
+            changed: await sessionRepo.updateArchiveStateForTargets(
+              writeTargets.map((target) => ({
+                id: target.session.session_id,
+                archived: target.archived,
+                archivedReason: target.archivedReason,
+              }))
+            ),
+            currentMembers,
+            writeTargetIds: new Set(writeTargets.map((target) => target.session.session_id)),
+            currentRemaining,
+          };
         }
       ).catch((error) => {
         if (
@@ -2026,11 +2061,37 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
               reason: 'insufficient_permission',
             });
           }
-          return [];
+          return {
+            changed: [],
+            currentMembers: [],
+            writeTargetIds: new Set<string>(),
+            currentRemaining: null,
+          };
         }
         throw error;
       });
-      for (const session of unitChanged) {
+      if (unitOutcome.currentMembers.length > 0) {
+        for (const session of unitOutcome.currentMembers) {
+          unit.members.set(session.session_id, session);
+        }
+        plan.targets = plan.targets.filter(
+          (target) =>
+            target.unitKey !== unit.key || unitOutcome.writeTargetIds.has(target.session.session_id)
+        );
+      }
+      if (unitOutcome.currentRemaining) {
+        const memberIds = new Set(unit.members.keys());
+        const remainingById = new Map(
+          plan.remainingArchived
+            .filter(({ sessionId }) => !memberIds.has(sessionId))
+            .map((remaining) => [remaining.sessionId, remaining])
+        );
+        for (const remaining of unitOutcome.currentRemaining) {
+          remainingById.set(remaining.sessionId, remaining);
+        }
+        plan.remainingArchived = [...remainingById.values()];
+      }
+      for (const session of unitOutcome.changed) {
         emitServiceEvent(this.app, {
           path: 'sessions',
           event: 'patched',
@@ -2039,7 +2100,7 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
           id: session.session_id,
         });
       }
-      changed.push(...unitChanged);
+      changed.push(...unitOutcome.changed);
     }
     if (skippedUnitKeys.size > 0) {
       plan.units = plan.units.filter((unit) => !skippedUnitKeys.has(unit.key));
@@ -2107,8 +2168,11 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
       ? plan.targets.filter((target) => target.archived).length
       : (changed ?? []).filter((session) => session.archived).length;
     const total = dryRun ? plan.targets.length : (changed ?? []).length;
+    const currentRoot = plan.units
+      .map((unit) => unit.members.get(root.session_id))
+      .find((session): session is Session => session !== undefined);
     return {
-      session: changedById.get(root.session_id) ?? root,
+      session: changedById.get(root.session_id) ?? currentRoot ?? root,
       dryRun,
       wouldChangeCount: plan.targets.length,
       affectedSessions: changed ?? [],

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -27,6 +27,7 @@ import {
   SessionRelationshipRepository,
   SessionRepository,
   type SessionWithLastMessage,
+  shortId,
   TaskRepository,
   type TenantScopeAwareDatabase,
   UsersRepository,
@@ -67,6 +68,7 @@ import type {
 } from '@agor/core/types';
 import {
   isAgenticToolDefaultConfigurationReference,
+  isSessionExecuting,
   SessionStatus,
   USER_DEFAULT_AGENTIC_CONFIGURATION,
 } from '@agor/core/types';
@@ -96,14 +98,101 @@ type MaterializedAgenticToolConfiguration = Awaited<
 >;
 
 type SessionArchiveReason = NonNullable<Session['archived_reason']>;
-type SessionArchiveTarget = {
+
+const PARENT_ARCHIVED_REASON = 'parent_archived' satisfies SessionArchiveReason;
+
+export const ARCHIVE_PATCH_REJECTED_MESSAGE =
+  'Archive state cannot be changed through a generic session update. ' +
+  'Use POST /sessions/:id/archive, POST /sessions/:id/unarchive, or the ' +
+  'agor_sessions_archive / agor_sessions_unarchive MCP tools.';
+
+/** Named bounds for the remote expansion of one dedicated archive. */
+const MAX_ARCHIVE_REMOTE_DEPTH = 8;
+const MAX_ARCHIVE_REMOTE_BRANCH_UNITS = 32;
+const MAX_ARCHIVE_REMOTE_SESSION_TARGETS = 5_000;
+
+function describeArchiveLimit(limit: SessionArchiveLimit): string {
+  switch (limit) {
+    case 'remote_depth':
+      return `a chain of remote-created sessions deeper than ${MAX_ARCHIVE_REMOTE_DEPTH} hops`;
+    case 'remote_branch_units':
+      return `more than ${MAX_ARCHIVE_REMOTE_BRANCH_UNITS} other branches`;
+    case 'remote_session_targets':
+      return `more than ${MAX_ARCHIVE_REMOTE_SESSION_TARGETS} sessions in other branches`;
+  }
+}
+
+class ArchiveLimitExceededError extends Error {
+  constructor(readonly limit: SessionArchiveLimit) {
+    super(
+      `Archiving this session would reach ${describeArchiveLimit(limit)}. ` +
+        'Pass includeRemoteChildren: false or archive the remote sessions separately.'
+    );
+  }
+}
+
+type ArchiveBranchGraph = {
+  branchId: BranchID;
+  byId: Map<string, Session>;
+  childrenOf: Map<string, Session[]>;
+};
+
+/** One authorization + mutation unit: a local root tree or one remote branch. */
+type ArchiveUnit = {
+  key: string;
+  branchId: BranchID;
+  kind: 'local' | 'remote';
+  /** Explicit roots (local units) or relationship targets (remote units). */
+  rootIds: Set<string>;
+  members: Map<string, Session>;
+};
+
+type ArchivePlannedTarget = {
   session: Session;
   archived: boolean;
   archivedReason: SessionArchiveReason | null;
+  selection: 'direct' | 'implied';
+  unitKey: string;
 };
 
-const MANUAL_ARCHIVED_REASON = 'manual' satisfies SessionArchiveReason;
-const PARENT_ARCHIVED_REASON = 'parent_archived' satisfies SessionArchiveReason;
+type ArchiveTransitionPlan = {
+  archived: boolean;
+  units: ArchiveUnit[];
+  unitResults: SessionArchiveUnitResult[];
+  targets: ArchivePlannedTarget[];
+  remainingArchived: SessionArchiveResult['remainingArchived'];
+  /** Implied descendants a bulk eligibility policy left out. */
+  excludedImplied: Session[];
+  limitExceeded?: SessionArchiveLimit;
+};
+
+type ArchiveTransitionRequest = {
+  roots: Session[];
+  initiator: SessionArchiveInitiator;
+  archived: boolean;
+  includeChildren: boolean;
+  includeRemoteChildren: boolean;
+  /** `branch`: one local unit per branch. `root-tree`: one unit per (merged) root closure. */
+  grouping: 'branch' | 'root-tree';
+  /** What to do when a local unit is unauthorized. Remote units are always skipped. */
+  localFailure: 'throw' | 'skip';
+  /** Narrow implied descendants (never roots); returns the eligible session IDs. */
+  descendantEligibility?: (candidates: Session[]) => Promise<Set<string>>;
+  /** Dry-run: report a bound overflow on the plan instead of throwing. */
+  tolerateLimits?: boolean;
+  params?: SessionParams;
+};
+
+function localParentIds(session: Session): string[] {
+  return [session.genealogy?.parent_session_id, session.genealogy?.forked_from_session_id].filter(
+    (id): id is SessionID => typeof id === 'string' && id.length > 0
+  );
+}
+
+function internalArchiveParams(params: SessionParams | undefined): SessionParams | undefined {
+  // Trusted internal callers already authorized the user action that led here.
+  return params ? { ...params, provider: undefined } : undefined;
+}
 
 function sessionConfigurationSource(
   data: Pick<CreateSessionInput, 'model_config' | 'permission_config'>
@@ -261,13 +350,92 @@ export type ExecuteTaskData = {
 };
 
 export type SessionArchiveOptions = {
+  /** Include branch-local spawned/forked descendants. Default: true. */
   includeChildren?: boolean;
+  /** Follow outgoing `remote_create` relationships into other branches. Default: true. */
+  includeRemoteChildren?: boolean;
+  /** Plan and authorize only; change nothing. Default: false. */
+  dryRun?: boolean;
 };
+
+/** Trusted reason assigned to the explicit roots of an archive transition. */
+export type SessionArchiveInitiator = 'manual' | 'btw_completed' | 'branch_archived';
+
+export type SessionArchiveSkipReason = 'insufficient_permission' | 'not_found' | 'conflict';
+
+export type SessionArchiveUnitResult =
+  | {
+      /** The unit's anchor: an explicit root, or the relationship target of a remote unit. */
+      rootSessionId: SessionID;
+      kind: 'local' | 'remote';
+      status: 'changed' | 'unchanged';
+      changedCount: number;
+      /** Present only for units the caller is authorized for. */
+      branchId: BranchID;
+    }
+  | {
+      /** Already visible to the caller: a selected root or a relationship target. */
+      rootSessionId: SessionID;
+      kind: 'local' | 'remote';
+      status: 'skipped';
+      changedCount: 0;
+      reason: SessionArchiveSkipReason;
+    };
+
+export type SessionArchiveRemainingReason =
+  | 'independent_reason'
+  | 'archived_ancestor'
+  | 'archived_branch';
+
+export type SessionArchiveLimit = 'remote_depth' | 'remote_branch_units' | 'remote_session_targets';
 
 export type SessionArchiveResult = {
   session: Session;
+  dryRun: boolean;
+  /** Rows the plan would change. On execution this equals the attempted set. */
+  wouldChangeCount: number;
+  /** Sessions whose persisted state actually changed. Empty on a dry-run. */
   affectedSessions: Session[];
+  /** @deprecated alias of `affectedSessions.length`. */
   count: number;
+  /** On a dry-run these describe the plan; on execution, the committed rows. */
+  archivedCount: number;
+  unarchivedCount: number;
+  localCount: number;
+  remoteCount: number;
+  skippedCount: number;
+  /** Planned rows whose session is still executing (archive hides, never stops). */
+  runningCount: number;
+  units: SessionArchiveUnitResult[];
+  /** Descendants left archived by an unarchive, with the blocker. */
+  remainingArchived: Array<{ sessionId: SessionID; reason: SessionArchiveRemainingReason }>;
+  /** Set on a dry-run whose remote expansion exceeded a named bound. */
+  limitExceeded?: SessionArchiveLimit;
+};
+
+export type SessionBulkArchivePolicy = 'none' | 'eligible' | 'all';
+
+export type SessionBulkArchiveOptions = {
+  policy: SessionBulkArchivePolicy;
+  /** Age cutoff the caller's filter used; `eligible` reuses it for descendants. */
+  cutoffDate?: Date | null;
+};
+
+export type SessionBulkArchivePreview = {
+  policy: SessionBulkArchivePolicy;
+  directRoots: Session[];
+  /** Descendants the policy includes. */
+  impliedDescendants: Session[];
+  /** Descendants `eligible` left out: newer than the cutoff or with unfinished tasks. */
+  excludedDescendants: Session[];
+  /** Included descendants newer than the cutoff. */
+  descendantsNewerThanCutoff: Session[];
+  /** Included descendants with a nonterminal task. */
+  descendantsWithUnfinishedTasks: Session[];
+  /** Included descendants whose session status is executing. */
+  activeDescendants: Session[];
+  units: SessionArchiveUnitResult[];
+  wouldArchive: number;
 };
 
 /**
@@ -1226,10 +1394,570 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
     };
   }
 
-  private async collectBranchLocalDescendants(root: Session): Promise<Session[]> {
-    // Session archive cascades follow the branch-local genealogy tree only.
-    // Remote relationships are modeled separately and must not be affected.
-    return this.sessionRepo.findBranchLocalDescendants(root.session_id, root.branch_id);
+  // ===========================================================================
+  // Session archive engine
+  //
+  // One planner decides the affected set for every archive entry point
+  // (dedicated REST/MCP, bulk, BTW cleanup, prompt restore, branch archive),
+  // then one apply phase writes each unit atomically and emits one event per
+  // changed row. See context/explorations/session-archive-cascade.md.
+  // ===========================================================================
+
+  private async loadArchiveBranchGraph(
+    graphs: Map<string, ArchiveBranchGraph>,
+    branchId: BranchID
+  ): Promise<ArchiveBranchGraph> {
+    const cached = graphs.get(branchId);
+    if (cached) return cached;
+    const rows = await this.sessionRepo.findAll({ branchId });
+    const byId = new Map<string, Session>();
+    const childrenOf = new Map<string, Session[]>();
+    for (const session of rows) {
+      byId.set(session.session_id, session);
+      for (const parentId of localParentIds(session)) {
+        const siblings = childrenOf.get(parentId) ?? [];
+        siblings.push(session);
+        childrenOf.set(parentId, siblings);
+      }
+    }
+    const graph = { branchId, byId, childrenOf };
+    graphs.set(branchId, graph);
+    return graph;
+  }
+
+  /** Breadth-first branch-local descendants; parents always precede children. */
+  private collectLocalDescendants(graph: ArchiveBranchGraph, rootId: string): Session[] {
+    const descendants: Session[] = [];
+    const visited = new Set<string>([rootId]);
+    const queue = [...(graph.childrenOf.get(rootId) ?? [])];
+    for (let index = 0; index < queue.length; index += 1) {
+      const child = queue[index];
+      if (!child || visited.has(child.session_id)) continue;
+      visited.add(child.session_id);
+      descendants.push(child);
+      queue.push(...(graph.childrenOf.get(child.session_id) ?? []));
+    }
+    return descendants;
+  }
+
+  private async loadArchiveBranch(
+    cache: Map<string, Branch | null>,
+    branchId: BranchID
+  ): Promise<Branch | null> {
+    if (cache.has(branchId)) return cache.get(branchId) ?? null;
+    const branch = await this.branchRepo.findById(branchId);
+    cache.set(branchId, branch);
+    return branch;
+  }
+
+  private async archiveUnitDenial(
+    members: Session[],
+    archived: boolean,
+    params: SessionParams | undefined,
+    branchCache: Map<string, Branch | null>
+  ): Promise<Forbidden | null> {
+    try {
+      await this.assertCanArchiveSessions(members, archived, params, branchCache);
+      return null;
+    } catch (error) {
+      if (error instanceof Forbidden) return error;
+      throw error;
+    }
+  }
+
+  private async planArchiveTransition(
+    request: ArchiveTransitionRequest
+  ): Promise<ArchiveTransitionPlan> {
+    const graphs = new Map<string, ArchiveBranchGraph>();
+    const branchCache = new Map<string, Branch | null>();
+    const authorized: ArchiveUnit[] = [];
+    const unitResults: SessionArchiveUnitResult[] = [];
+    const excludedImplied: Session[] = [];
+
+    const skipUnit = (
+      unit: Pick<ArchiveUnit, 'kind'>,
+      anchorIds: Iterable<string>,
+      reason: SessionArchiveSkipReason
+    ) => {
+      for (const anchorId of anchorIds) {
+        unitResults.push({
+          rootSessionId: anchorId as SessionID,
+          kind: unit.kind,
+          status: 'skipped',
+          changedCount: 0,
+          reason,
+        });
+      }
+    };
+
+    // 1. Local closures: every root plus (optionally) its branch-local descendants.
+    const closures: Array<{ root: Session; members: Session[] }> = [];
+    for (const requested of request.roots) {
+      const graph = await this.loadArchiveBranchGraph(graphs, requested.branch_id);
+      const root = graph.byId.get(requested.session_id) ?? requested;
+      const descendants = request.includeChildren
+        ? this.collectLocalDescendants(graph, root.session_id)
+        : [];
+      closures.push({ root, members: [root, ...descendants] });
+    }
+
+    // 2. Optional eligibility narrows implied descendants only; roots always stay.
+    if (request.descendantEligibility) {
+      const rootIds = new Set(closures.map(({ root }) => root.session_id));
+      const candidates = new Map<string, Session>();
+      for (const { members } of closures) {
+        for (const member of members) {
+          if (!rootIds.has(member.session_id)) candidates.set(member.session_id, member);
+        }
+      }
+      const eligible = await request.descendantEligibility([...candidates.values()]);
+      for (const [id, session] of candidates) {
+        if (!eligible.has(id)) excludedImplied.push(session);
+      }
+      for (const closure of closures) {
+        closure.members = closure.members.filter(
+          (member) => rootIds.has(member.session_id) || eligible.has(member.session_id)
+        );
+      }
+    }
+
+    // 3. Group closures into local authorization units. Direct roots win over
+    //    implied membership when closures overlap.
+    const localUnits = new Map<string, ArchiveUnit>();
+    const closureUnitIndex = new Map<number, number>();
+    if (request.grouping === 'root-tree') {
+      // Union-find over closures that share a session so overlapping trees
+      // authorize and write as one unit.
+      const parent = closures.map((_, index) => index);
+      const find = (index: number): number => {
+        let current = index;
+        while (parent[current] !== current) current = parent[current] as number;
+        return current;
+      };
+      const owner = new Map<string, number>();
+      closures.forEach(({ members }, index) => {
+        for (const member of members) {
+          const existing = owner.get(member.session_id);
+          if (existing === undefined) {
+            owner.set(member.session_id, index);
+            continue;
+          }
+          const a = find(existing);
+          const b = find(index);
+          if (a !== b) parent[b] = a;
+        }
+      });
+      for (let index = 0; index < closures.length; index += 1) {
+        closureUnitIndex.set(index, find(index));
+      }
+    } else {
+      for (let index = 0; index < closures.length; index += 1) {
+        closureUnitIndex.set(index, index);
+      }
+    }
+    closures.forEach(({ root, members }, index) => {
+      const representative = closures[closureUnitIndex.get(index) ?? index]?.root ?? root;
+      const key =
+        request.grouping === 'branch'
+          ? `local:${root.branch_id}`
+          : `tree:${representative.session_id}`;
+      let unit = localUnits.get(key);
+      if (!unit) {
+        unit = {
+          key,
+          branchId: root.branch_id,
+          kind: 'local',
+          rootIds: new Set(),
+          members: new Map(),
+        };
+        localUnits.set(key, unit);
+      }
+      for (const member of members) {
+        if (!unit.members.has(member.session_id)) unit.members.set(member.session_id, member);
+      }
+      unit.rootIds.add(root.session_id);
+    });
+
+    // 4. Authorize local units before any traversal leaves them.
+    for (const unit of localUnits.values()) {
+      const denial = await this.archiveUnitDenial(
+        [...unit.members.values()],
+        request.archived,
+        request.params,
+        branchCache
+      );
+      if (!denial) {
+        authorized.push(unit);
+        continue;
+      }
+      if (request.localFailure === 'throw') throw denial;
+      skipUnit(unit, unit.rootIds, 'insufficient_permission');
+    }
+
+    // 5. Remote units: follow outgoing `remote_create` edges from authorized
+    //    members only, one authorization unit per canonical target branch,
+    //    within the named depth / branch / target bounds.
+    let limitExceeded: SessionArchiveLimit | undefined;
+    if (request.includeRemoteChildren) {
+      try {
+        await this.expandRemoteArchiveUnits(request, authorized, graphs, branchCache, skipUnit);
+      } catch (error) {
+        if (!(error instanceof ArchiveLimitExceededError)) throw error;
+        if (!request.tolerateLimits) throw new BadRequest(error.message);
+        limitExceeded = error.limit;
+        // Report the overflow instead of a partial plan: drop remote units.
+        for (let index = authorized.length - 1; index >= 0; index -= 1) {
+          if (authorized[index]?.kind === 'remote') authorized.splice(index, 1);
+        }
+      }
+    }
+
+    const plan: ArchiveTransitionPlan = {
+      archived: request.archived,
+      units: authorized,
+      unitResults,
+      targets: [],
+      remainingArchived: [],
+      excludedImplied,
+      ...(limitExceeded && { limitExceeded }),
+    };
+    if (request.archived) {
+      this.planArchiveTargets(plan, request.initiator);
+    } else {
+      await this.planRestoreTargets(plan, graphs, branchCache);
+    }
+    return plan;
+  }
+
+  private async expandRemoteArchiveUnits(
+    request: ArchiveTransitionRequest,
+    authorized: ArchiveUnit[],
+    graphs: Map<string, ArchiveBranchGraph>,
+    branchCache: Map<string, Branch | null>,
+    skipUnit: (
+      unit: Pick<ArchiveUnit, 'kind'>,
+      anchorIds: Iterable<string>,
+      reason: SessionArchiveSkipReason
+    ) => void
+  ): Promise<void> {
+    const visited = new Set<string>();
+    for (const unit of authorized) for (const id of unit.members.keys()) visited.add(id);
+    let frontier = [...visited];
+    let depth = 0;
+    let remoteUnitCount = 0;
+    let remoteTargetCount = 0;
+    while (frontier.length > 0) {
+      const edges = await this.sessionRelationshipRepo.findRemoteChildrenForSources(
+        frontier as SessionID[]
+      );
+      const targetIds = [...new Set(edges.map((edge) => edge.target_session_id))].filter(
+        (id) => !visited.has(id)
+      );
+      if (targetIds.length === 0) break;
+      depth += 1;
+      if (depth > MAX_ARCHIVE_REMOTE_DEPTH) throw new ArchiveLimitExceededError('remote_depth');
+      const targets = await this.sessionRepo.findByIds(targetIds);
+      const targetsByBranch = new Map<BranchID, Session[]>();
+      for (const target of targets) {
+        visited.add(target.session_id);
+        const bucket = targetsByBranch.get(target.branch_id) ?? [];
+        bucket.push(target);
+        targetsByBranch.set(target.branch_id, bucket);
+      }
+      const nextFrontier: string[] = [];
+      for (const [branchId, branchTargets] of targetsByBranch) {
+        const graph = await this.loadArchiveBranchGraph(graphs, branchId);
+        const members: Session[] = [];
+        for (const target of branchTargets) {
+          members.push(target);
+          if (!request.includeChildren) continue;
+          for (const descendant of this.collectLocalDescendants(graph, target.session_id)) {
+            if (visited.has(descendant.session_id)) continue;
+            visited.add(descendant.session_id);
+            members.push(descendant);
+          }
+        }
+        remoteTargetCount += members.length;
+        if (remoteTargetCount > MAX_ARCHIVE_REMOTE_SESSION_TARGETS) {
+          throw new ArchiveLimitExceededError('remote_session_targets');
+        }
+        const existing = authorized.find((unit) => unit.branchId === branchId);
+        const denial = await this.archiveUnitDenial(
+          members,
+          request.archived,
+          request.params,
+          branchCache
+        );
+        if (denial) {
+          skipUnit(
+            { kind: 'remote' },
+            branchTargets.map((target) => target.session_id),
+            'insufficient_permission'
+          );
+          continue;
+        }
+        let unit = existing;
+        if (!unit) {
+          remoteUnitCount += 1;
+          if (remoteUnitCount > MAX_ARCHIVE_REMOTE_BRANCH_UNITS) {
+            throw new ArchiveLimitExceededError('remote_branch_units');
+          }
+          unit = {
+            key: `remote:${branchId}`,
+            branchId,
+            kind: 'remote',
+            rootIds: new Set(),
+            members: new Map(),
+          };
+          authorized.push(unit);
+        }
+        for (const target of branchTargets) {
+          if (unit.kind === 'remote') unit.rootIds.add(target.session_id);
+        }
+        for (const member of members) {
+          unit.members.set(member.session_id, member);
+          nextFrontier.push(member.session_id);
+        }
+      }
+      frontier = nextFrontier;
+    }
+  }
+
+  private planArchiveTargets(plan: ArchiveTransitionPlan, initiator: SessionArchiveInitiator) {
+    for (const unit of plan.units) {
+      for (const [id, session] of unit.members) {
+        if (unit.kind === 'local' && unit.rootIds.has(id)) {
+          const reasonMatches = (session.archived_reason ?? null) === initiator;
+          if (session.archived !== true || !reasonMatches) {
+            plan.targets.push({
+              session,
+              archived: true,
+              archivedReason: initiator,
+              selection: 'direct',
+              unitKey: unit.key,
+            });
+          }
+          continue;
+        }
+        if (session.archived) continue;
+        plan.targets.push({
+          session,
+          archived: true,
+          archivedReason: PARENT_ARCHIVED_REASON,
+          selection: 'implied',
+          unitKey: unit.key,
+        });
+      }
+    }
+  }
+
+  /**
+   * Restoration is cause-aware. One activation predicate covers local and
+   * remote rows: a session may activate when its branch is active and it is
+   * either an explicit root or none of its incoming parent sources (local
+   * genealogy or remote creator) remains archived after the transition.
+   * An explicit root never overrides an archived branch; that is a conflict.
+   */
+  private async planRestoreTargets(
+    plan: ArchiveTransitionPlan,
+    graphs: Map<string, ArchiveBranchGraph>,
+    branchCache: Map<string, Branch | null>
+  ): Promise<void> {
+    const plannedActive = new Set<string>();
+    const impliedIds: SessionID[] = [];
+    for (const unit of plan.units) {
+      for (const [id, session] of unit.members) {
+        const isExplicitRoot = unit.kind === 'local' && unit.rootIds.has(id);
+        if (!isExplicitRoot) {
+          impliedIds.push(id as SessionID);
+          continue;
+        }
+        const branch = await this.loadArchiveBranch(branchCache, session.branch_id);
+        if (branch?.archived) {
+          throw new Conflict(
+            `Session ${shortId(session.session_id)} belongs to an archived branch. Restore the branch first.`
+          );
+        }
+        plannedActive.add(id);
+        if (session.archived) {
+          plan.targets.push({
+            session,
+            archived: false,
+            archivedReason: null,
+            selection: 'direct',
+            unitKey: unit.key,
+          });
+        }
+      }
+    }
+
+    const incoming = await this.sessionRelationshipRepo.findRemoteParentsForTargets(impliedIds);
+    const remoteSourcesOf = new Map<string, string[]>();
+    for (const edge of incoming) {
+      const sources = remoteSourcesOf.get(edge.target_session_id) ?? [];
+      sources.push(edge.source_session_id);
+      remoteSourcesOf.set(edge.target_session_id, sources);
+    }
+    const lookupSession = (id: string): Session | undefined => {
+      for (const graph of graphs.values()) {
+        const found = graph.byId.get(id);
+        if (found) return found;
+      }
+      return undefined;
+    };
+    const unknownSourceIds = [...new Set(incoming.map((edge) => edge.source_session_id))].filter(
+      (id) => !lookupSession(id)
+    );
+    const externalSources = new Map<string, Session>(
+      (await this.sessionRepo.findByIds(unknownSourceIds)).map((session) => [
+        session.session_id as string,
+        session,
+      ])
+    );
+
+    // Units and members are in discovery order, so every parent source is
+    // decided before the rows it covers.
+    for (const unit of plan.units) {
+      for (const [id, session] of unit.members) {
+        if (plannedActive.has(id) || !session.archived) continue;
+        if (session.archived_reason !== PARENT_ARCHIVED_REASON) {
+          plan.remainingArchived.push({ sessionId: id as SessionID, reason: 'independent_reason' });
+          continue;
+        }
+        const branch = await this.loadArchiveBranch(branchCache, session.branch_id);
+        if (branch?.archived) {
+          plan.remainingArchived.push({ sessionId: id as SessionID, reason: 'archived_branch' });
+          continue;
+        }
+        const parentIds = [...localParentIds(session), ...(remoteSourcesOf.get(id) ?? [])];
+        const blocked = parentIds.some((parentId) => {
+          if (plannedActive.has(parentId)) return false;
+          const parent = lookupSession(parentId) ?? externalSources.get(parentId);
+          return parent?.archived === true;
+        });
+        if (blocked) {
+          plan.remainingArchived.push({ sessionId: id as SessionID, reason: 'archived_ancestor' });
+          continue;
+        }
+        plan.targets.push({
+          session,
+          archived: false,
+          archivedReason: null,
+          selection: 'implied',
+          unitKey: unit.key,
+        });
+        plannedActive.add(id);
+      }
+    }
+  }
+
+  /**
+   * Apply one unit at a time. The repository re-reads current state inside its
+   * transaction and skips rows that already match, so a concurrent identical
+   * transition is a no-op and emits nothing.
+   */
+  private async applyArchiveTransitionPlan(
+    plan: ArchiveTransitionPlan,
+    params?: SessionParams
+  ): Promise<Session[]> {
+    const changed: Session[] = [];
+    for (const unit of plan.units) {
+      const unitTargets = plan.targets.filter((target) => target.unitKey === unit.key);
+      if (unitTargets.length === 0) continue;
+      const unitChanged = await this.sessionRepo.updateArchiveStateForTargets(
+        unitTargets.map((target) => ({
+          id: target.session.session_id,
+          archived: target.archived,
+          archivedReason: target.archivedReason,
+        }))
+      );
+      for (const session of unitChanged) {
+        emitServiceEvent(this.app, {
+          path: 'sessions',
+          event: 'patched',
+          data: session,
+          params,
+          id: session.session_id,
+        });
+      }
+      changed.push(...unitChanged);
+    }
+    return changed;
+  }
+
+  private buildArchiveResult(
+    root: Session,
+    plan: ArchiveTransitionPlan,
+    changed: Session[] | null
+  ): SessionArchiveResult {
+    const dryRun = changed === null;
+    const changedById = new Map<string, Session>(
+      (changed ?? []).map((session) => [session.session_id as string, session])
+    );
+    const countedById = dryRun
+      ? new Map<string, Session>(
+          plan.targets.map((target) => [target.session.session_id as string, target.session])
+        )
+      : changedById;
+    const units: SessionArchiveUnitResult[] = [...plan.unitResults];
+    let localCount = 0;
+    let remoteCount = 0;
+    for (const unit of plan.units) {
+      let changedCount = 0;
+      for (const id of unit.members.keys()) if (countedById.has(id)) changedCount += 1;
+      if (unit.kind === 'local') localCount += changedCount;
+      else remoteCount += changedCount;
+      const [anchor] = unit.rootIds;
+      units.push({
+        rootSessionId: (anchor ?? root.session_id) as SessionID,
+        kind: unit.kind,
+        status: changedCount > 0 ? 'changed' : 'unchanged',
+        changedCount,
+        branchId: unit.branchId,
+      });
+    }
+    const archivedCount = dryRun
+      ? plan.targets.filter((target) => target.archived).length
+      : (changed ?? []).filter((session) => session.archived).length;
+    const total = dryRun ? plan.targets.length : (changed ?? []).length;
+    return {
+      session: changedById.get(root.session_id) ?? root,
+      dryRun,
+      wouldChangeCount: plan.targets.length,
+      affectedSessions: changed ?? [],
+      count: (changed ?? []).length,
+      archivedCount,
+      unarchivedCount: total - archivedCount,
+      localCount,
+      remoteCount,
+      skippedCount: plan.unitResults.filter((unit) => unit.status === 'skipped').length,
+      runningCount: plan.targets.filter((target) => isSessionExecuting(target.session)).length,
+      units,
+      remainingArchived: plan.remainingArchived,
+      ...(plan.limitExceeded && { limitExceeded: plan.limitExceeded }),
+    };
+  }
+
+  private withArchiveScope<T>(
+    params: SessionParams | undefined,
+    work: () => Promise<T>
+  ): Promise<T> {
+    const tenantId = params?.tenant?.tenant_id ?? getCurrentTenantId();
+    return runWithTenantDatabaseScope(this.db, tenantId, work);
+  }
+
+  private async runArchiveTransition(
+    request: ArchiveTransitionRequest,
+    dryRun = false
+  ): Promise<SessionArchiveResult> {
+    const [root] = request.roots;
+    if (!root) throw new BadRequest('At least one session is required');
+    return this.withArchiveScope(request.params, async () => {
+      const plan = await this.planArchiveTransition({ ...request, tolerateLimits: dryRun });
+      if (dryRun) return this.buildArchiveResult(root, plan, null);
+      const changed = await this.applyArchiveTransitionPlan(plan, request.params);
+      return this.buildArchiveResult(root, plan, changed);
+    });
   }
 
   private getRuntimeExecutionConfig():
@@ -1269,7 +1997,8 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
   private async assertCanArchiveSessions(
     sessions: Session[],
     archived: boolean,
-    params?: SessionParams
+    params: SessionParams | undefined,
+    branchCache: Map<string, Branch | null>
   ): Promise<void> {
     if (!params?.provider || !this.shouldEnforceBranchRbac()) return;
 
@@ -1290,17 +2019,11 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
     const allowSuperadmin = this.shouldAllowSuperadminBypass();
     const userRole = user.role;
     const action = archived ? 'archive sessions' : 'unarchive sessions';
-    const branchCache = new Map<string, Branch>();
 
     for (const session of sessions) {
-      let branch = branchCache.get(session.branch_id);
+      const branch = await this.loadArchiveBranch(branchCache, session.branch_id);
       if (!branch) {
-        const loadedBranch = await this.branchRepo.findById(session.branch_id);
-        if (!loadedBranch) {
-          throw new Forbidden(`Branch not found for session: ${session.session_id}`);
-        }
-        branch = loadedBranch;
-        branchCache.set(session.branch_id, branch);
+        throw new Forbidden(`Branch not found for session: ${session.session_id}`);
       }
 
       const access = await this.branchRepo.resolveUserAccess(branch, userId);
@@ -1322,104 +2045,280 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
     }
   }
 
-  private async setArchiveStateForTree(
-    id: string,
-    archived: boolean,
-    options: SessionArchiveOptions | undefined,
-    params?: SessionParams
-  ): Promise<SessionArchiveResult> {
-    const root = await this.get(id, params);
-    const includeChildren = options?.includeChildren !== false;
-    const descendants = includeChildren ? await this.collectBranchLocalDescendants(root) : [];
-    const targets: SessionArchiveTarget[] = [
-      {
-        session: root,
-        archived,
-        archivedReason: archived ? MANUAL_ARCHIVED_REASON : null,
-      },
-    ];
-
-    for (const session of descendants) {
-      if (archived) {
-        if (!session.archived) {
-          targets.push({
-            session,
-            archived: true,
-            archivedReason: PARENT_ARCHIVED_REASON,
-          });
-        }
-        continue;
-      }
-
-      if (session.archived_reason === PARENT_ARCHIVED_REASON) {
-        targets.push({
-          session,
-          archived: false,
-          archivedReason: null,
-        });
-      }
-    }
-
-    await this.assertCanArchiveSessions(
-      targets.map((target) => target.session),
-      archived,
-      params
-    );
-
-    const affectedSessions = await this.sessionRepo.updateArchiveStateForTargets(
-      targets.map((target) => ({
-        id: target.session.session_id,
-        archived: target.archived,
-        archivedReason: target.archivedReason,
-      }))
-    );
-
-    for (const affectedSession of affectedSessions) {
-      emitServiceEvent(this.app, {
-        path: 'sessions',
-        event: 'patched',
-        data: affectedSession,
-        params,
-        id: affectedSession.session_id,
-      });
-    }
-
-    const [session] = affectedSessions;
-    if (!session) {
-      throw new Error(`Session ${id} not found`);
-    }
-
-    return {
-      session,
-      affectedSessions,
-      count: affectedSessions.length,
-    };
-  }
-
   /**
-   * Archive a session and, by default, its branch-local descendants.
-   *
-   * Generic `patch({ archived })` intentionally remains single-row so bulk
-   * archive, branch archive, and auto-cleanup paths keep their existing
-   * semantics.
+   * Archive a session with its branch-local descendants and, by default, the
+   * sessions it created in other branches (each remote branch is authorized and
+   * reported separately, within named bounds). `dryRun` plans and authorizes
+   * without changing anything. Generic `patch({ archived })` is rejected; this
+   * is the only archive entry point for callers.
    */
   async archive(
     id: string,
     options?: SessionArchiveOptions,
     params?: SessionParams
   ): Promise<SessionArchiveResult> {
-    return this.setArchiveStateForTree(id, true, options, params);
+    const root = await this.get(id, params);
+    return this.runArchiveTransition(
+      {
+        roots: [root],
+        initiator: 'manual',
+        archived: true,
+        includeChildren: options?.includeChildren !== false,
+        includeRemoteChildren: options?.includeRemoteChildren !== false,
+        grouping: 'branch',
+        localFailure: 'throw',
+        params,
+      },
+      options?.dryRun === true
+    );
   }
 
   /**
-   * Restore a session and, by default, its branch-local descendants.
+   * Restore a session and, cause-aware, the descendants its archive implied.
+   * Descendants archived for an independent reason, or still covered by another
+   * archived parent edge or an archived branch, stay archived and are reported.
+   * Restoring a session inside an archived branch is a conflict.
    */
   async unarchive(
     id: string,
     options?: SessionArchiveOptions,
     params?: SessionParams
   ): Promise<SessionArchiveResult> {
-    return this.setArchiveStateForTree(id, false, options, params);
+    const root = await this.get(id, params);
+    return this.runArchiveTransition(
+      {
+        roots: [root],
+        initiator: 'manual',
+        archived: false,
+        includeChildren: options?.includeChildren !== false,
+        includeRemoteChildren: options?.includeRemoteChildren !== false,
+        grouping: 'branch',
+        localFailure: 'throw',
+        params,
+      },
+      options?.dryRun === true
+    );
+  }
+
+  /**
+   * Internal: archive a completed ephemeral `btw` fork with its local
+   * descendants. Remote work it created stays active.
+   */
+  async archiveBtwSession(id: string, params?: SessionParams): Promise<SessionArchiveResult> {
+    const internal = internalArchiveParams(params);
+    return this.withArchiveScope(internal, async () => {
+      const root = await this.get(id, internal);
+      return this.runArchiveTransition({
+        roots: [root],
+        initiator: 'btw_completed',
+        archived: true,
+        includeChildren: true,
+        includeRemoteChildren: false,
+        grouping: 'branch',
+        localFailure: 'throw',
+        params: internal,
+      });
+    });
+  }
+
+  /**
+   * Internal: restore only the session a prompt was just sent to. Ancestors,
+   * descendants, and remote work are untouched; the prompt route already
+   * authorized the caller. Prompting into an archived branch is a conflict.
+   */
+  async restorePromptedSession(id: string, params?: SessionParams): Promise<SessionArchiveResult> {
+    const internal = internalArchiveParams(params);
+    return this.withArchiveScope(internal, async () => {
+      const root = await this.get(id, internal);
+      return this.runArchiveTransition({
+        roots: [root],
+        initiator: 'manual',
+        archived: false,
+        includeChildren: false,
+        includeRemoteChildren: false,
+        grouping: 'branch',
+        localFailure: 'throw',
+        params: internal,
+      });
+    });
+  }
+
+  /**
+   * Internal: archive every active session canonically owned by a branch as an
+   * explicit `branch_archived` root. Already-archived rows keep their reason.
+   */
+  async archiveBranchSessions(
+    branchId: BranchID,
+    params?: SessionParams
+  ): Promise<{ affectedSessions: Session[]; count: number }> {
+    const internal = internalArchiveParams(params);
+    return this.withArchiveScope(internal, async () => {
+      const roots = await this.sessionRepo.findAll({ branchId, archived: false });
+      if (roots.length === 0) return { affectedSessions: [], count: 0 };
+      const result = await this.runArchiveTransition({
+        roots,
+        initiator: 'branch_archived',
+        archived: true,
+        includeChildren: false,
+        includeRemoteChildren: false,
+        grouping: 'branch',
+        localFailure: 'throw',
+        params: internal,
+      });
+      return { affectedSessions: result.affectedSessions, count: result.count };
+    });
+  }
+
+  /**
+   * Internal: restore only the rows a branch archive caused. The branch row
+   * itself must already be active.
+   */
+  async unarchiveBranchSessions(
+    branchId: BranchID,
+    params?: SessionParams
+  ): Promise<{ affectedSessions: Session[]; count: number }> {
+    const internal = internalArchiveParams(params);
+    return this.withArchiveScope(internal, async () => {
+      const archivedRows = await this.sessionRepo.findAll({ branchId, archived: true });
+      const roots = archivedRows.filter((session) => session.archived_reason === 'branch_archived');
+      if (roots.length === 0) return { affectedSessions: [], count: 0 };
+      const result = await this.runArchiveTransition({
+        roots,
+        initiator: 'manual',
+        archived: false,
+        includeChildren: false,
+        includeRemoteChildren: false,
+        grouping: 'branch',
+        localFailure: 'throw',
+        params: internal,
+      });
+      return { affectedSessions: result.affectedSessions, count: result.count };
+    });
+  }
+
+  /**
+   * Bulk archive: the caller's filter selected the direct roots; the policy
+   * decides which branch-local descendants join them. `eligible` keeps only
+   * descendants with no unfinished task that are not newer than the caller's
+   * age cutoff. Each root tree is its own authorization unit (overlapping
+   * trees merge); unauthorized units are skipped and reported rather than
+   * failing the run. Remote work is never followed.
+   */
+  async previewBulkArchive(
+    roots: Session[],
+    options: SessionBulkArchiveOptions,
+    params?: SessionParams
+  ): Promise<SessionBulkArchivePreview> {
+    return this.withArchiveScope(params, async () => {
+      const { plan, unfinishedIds } = await this.planBulkArchive(roots, options, params);
+      return this.summarizeBulkPlan(plan, options, unfinishedIds);
+    });
+  }
+
+  async bulkArchive(
+    roots: Session[],
+    options: SessionBulkArchiveOptions,
+    params?: SessionParams
+  ): Promise<SessionArchiveResult & { preview: SessionBulkArchivePreview }> {
+    const [first] = roots;
+    if (!first) throw new BadRequest('At least one session is required');
+    return this.withArchiveScope(params, async () => {
+      const { plan, unfinishedIds } = await this.planBulkArchive(roots, options, params);
+      const preview = this.summarizeBulkPlan(plan, options, unfinishedIds);
+      const changed = await this.applyArchiveTransitionPlan(plan, params);
+      return { ...this.buildArchiveResult(first, plan, changed), preview };
+    });
+  }
+
+  private async planBulkArchive(
+    roots: Session[],
+    options: SessionBulkArchiveOptions,
+    params?: SessionParams
+  ): Promise<{ plan: ArchiveTransitionPlan; unfinishedIds: Set<string> }> {
+    const taskRepo = new TaskRepository(this.db);
+    let unfinishedIds = new Set<string>();
+    const cutoff = options.cutoffDate ?? null;
+    const isNewerThanCutoff = (session: Session) =>
+      cutoff !== null && new Date(session.last_updated || session.created_at) >= cutoff;
+    const plan = await this.planArchiveTransition({
+      roots,
+      initiator: 'manual',
+      archived: true,
+      includeChildren: options.policy !== 'none',
+      includeRemoteChildren: false,
+      grouping: 'root-tree',
+      localFailure: 'skip',
+      params,
+      ...(options.policy === 'eligible' && {
+        descendantEligibility: async (candidates: Session[]) => {
+          unfinishedIds = await taskRepo.findSessionIdsWithNonterminalTasks(
+            candidates.map((session) => session.session_id)
+          );
+          return new Set(
+            candidates
+              .filter(
+                (session) => !unfinishedIds.has(session.session_id) && !isNewerThanCutoff(session)
+              )
+              .map((session) => session.session_id as string)
+          );
+        },
+      }),
+    });
+    if (options.policy === 'all') {
+      unfinishedIds = await taskRepo.findSessionIdsWithNonterminalTasks(
+        plan.targets
+          .filter((target) => target.selection === 'implied')
+          .map((target) => target.session.session_id)
+      );
+    }
+    return { plan, unfinishedIds };
+  }
+
+  private summarizeBulkPlan(
+    plan: ArchiveTransitionPlan,
+    options: SessionBulkArchiveOptions,
+    unfinishedIds: Set<string>
+  ): SessionBulkArchivePreview {
+    const cutoff = options.cutoffDate ?? null;
+    const directRoots = plan.targets
+      .filter((target) => target.selection === 'direct')
+      .map((target) => target.session);
+    const impliedDescendants = plan.targets
+      .filter((target) => target.selection === 'implied')
+      .map((target) => target.session);
+    const plannedByUnit = new Map<string, number>();
+    for (const target of plan.targets) {
+      plannedByUnit.set(target.unitKey, (plannedByUnit.get(target.unitKey) ?? 0) + 1);
+    }
+    return {
+      policy: options.policy,
+      directRoots,
+      impliedDescendants,
+      excludedDescendants: plan.excludedImplied,
+      descendantsNewerThanCutoff: impliedDescendants.filter(
+        (session) =>
+          cutoff !== null && new Date(session.last_updated || session.created_at) >= cutoff
+      ),
+      descendantsWithUnfinishedTasks: impliedDescendants.filter((session) =>
+        unfinishedIds.has(session.session_id)
+      ),
+      activeDescendants: impliedDescendants.filter((session) => isSessionExecuting(session)),
+      units: [
+        ...plan.unitResults,
+        ...plan.units.map((unit) => {
+          const [anchor] = unit.rootIds;
+          const changedCount = plannedByUnit.get(unit.key) ?? 0;
+          return {
+            rootSessionId: (anchor ?? unit.key) as SessionID,
+            kind: unit.kind,
+            status: changedCount > 0 ? ('changed' as const) : ('unchanged' as const),
+            changedCount,
+            branchId: unit.branchId,
+          };
+        }),
+      ],
+      wouldArchive: plan.targets.length,
+    };
   }
 
   /**
@@ -1509,6 +2408,9 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
   ): Promise<Session | Session[]> {
     if (Object.hasOwn(data, 'sdk_home_scope')) {
       throw new BadRequest('sdk_home_scope is immutable and server-managed');
+    }
+    if (Object.hasOwn(data, 'archived') || Object.hasOwn(data, 'archived_reason')) {
+      throw new BadRequest(ARCHIVE_PATCH_REJECTED_MESSAGE);
     }
     let replaceAgenticConfig = false;
     if (

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -20,6 +20,8 @@ import {
   bindRepositoryToTenantUnitOfWork,
   EntityNotFoundError,
   getCurrentTenantId,
+  inArray,
+  lockRowForUpdate,
   runWithTenantDatabaseScope,
   runWithTenantDatabaseTransaction,
   SessionEnvSelectionRepository,
@@ -27,6 +29,7 @@ import {
   SessionRelationshipRepository,
   SessionRepository,
   type SessionWithLastMessage,
+  sessions,
   shortId,
   TaskRepository,
   type TenantScopeAwareDatabase,
@@ -1417,11 +1420,12 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
 
   private async loadArchiveBranchGraph(
     graphs: Map<string, ArchiveBranchGraph>,
-    branchId: BranchID
+    branchId: BranchID,
+    sessionRepo = this.sessionRepo
   ): Promise<ArchiveBranchGraph> {
     const cached = graphs.get(branchId);
     if (cached) return cached;
-    const rows = await this.sessionRepo.findAll({ branchId });
+    const rows = await sessionRepo.findAll({ branchId });
     const byId = new Map<string, Session>();
     const childrenOf = new Map<string, Session[]>();
     for (const session of rows) {
@@ -1690,8 +1694,6 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
         (id) => !visited.has(id)
       );
       if (targetIds.length === 0) break;
-      depth += 1;
-      if (depth > MAX_ARCHIVE_REMOTE_DEPTH) throw new ArchiveLimitExceededError('remote_depth');
       const targets = await this.sessionRepo.findByIds(targetIds);
       const targetsByBranch = new Map<BranchID, Session[]>();
       for (const target of targets) {
@@ -1701,6 +1703,7 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
         targetsByBranch.set(target.branch_id, bucket);
       }
       const nextFrontier: string[] = [];
+      const authorizedTargetsByBranch = new Map<BranchID, Session[]>();
       for (const [branchId, branchTargets] of targetsByBranch) {
         // Authorize the visible relationship targets before loading any other
         // sessions from their branch. Session-tier access is checked again for
@@ -1719,6 +1722,12 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
           );
           continue;
         }
+        authorizedTargetsByBranch.set(branchId, branchTargets);
+      }
+      if (authorizedTargetsByBranch.size === 0) break;
+      depth += 1;
+      if (depth > MAX_ARCHIVE_REMOTE_DEPTH) throw new ArchiveLimitExceededError('remote_depth');
+      for (const [branchId, branchTargets] of authorizedTargetsByBranch) {
         const members: Session[] = [...branchTargets];
         if (request.includeChildren) {
           const graph = await this.loadArchiveBranchGraph(graphs, branchId);
@@ -1814,7 +1823,10 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
   private async planRestoreTargets(
     plan: ArchiveTransitionPlan,
     graphs: Map<string, ArchiveBranchGraph>,
-    branchCache: Map<string, Branch | null>
+    branchCache: Map<string, Branch | null>,
+    sessionRepo = this.sessionRepo,
+    relationshipRepo = this.sessionRelationshipRepo,
+    branchRepo = this.branchRepo
   ): Promise<void> {
     const plannedActive = new Set<string>();
     const impliedIds: SessionID[] = [];
@@ -1825,7 +1837,7 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
           impliedIds.push(id as SessionID);
           continue;
         }
-        const branch = await this.loadArchiveBranch(branchCache, session.branch_id);
+        const branch = await this.loadArchiveBranch(branchCache, session.branch_id, branchRepo);
         if (branch?.archived) {
           throw new Conflict(
             `Session ${shortId(session.session_id)} belongs to an archived branch. Restore the branch first.`
@@ -1844,7 +1856,7 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
       }
     }
 
-    const incoming = await this.sessionRelationshipRepo.findRemoteParentsForTargets(impliedIds);
+    const incoming = await relationshipRepo.findRemoteParentsForTargets(impliedIds);
     const remoteSourcesOf = new Map<string, string[]>();
     for (const edge of incoming) {
       const sources = remoteSourcesOf.get(edge.target_session_id) ?? [];
@@ -1862,7 +1874,7 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
       (id) => !lookupSession(id)
     );
     const externalSources = new Map<string, Session>(
-      (await this.sessionRepo.findByIds(unknownSourceIds)).map((session) => [
+      (await sessionRepo.findByIds(unknownSourceIds)).map((session) => [
         session.session_id as string,
         session,
       ])
@@ -1877,7 +1889,7 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
           plan.remainingArchived.push({ sessionId: id as SessionID, reason: 'independent_reason' });
           continue;
         }
-        const branch = await this.loadArchiveBranch(branchCache, session.branch_id);
+        const branch = await this.loadArchiveBranch(branchCache, session.branch_id, branchRepo);
         if (branch?.archived) {
           plan.remainingArchived.push({ sessionId: id as SessionID, reason: 'archived_branch' });
           continue;
@@ -1926,19 +1938,70 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
         async (operationDb) => {
           const currentParams = await this.currentArchiveParams(operationDb, params);
           const sessionRepo = new SessionRepository(operationDb);
+          const branchRepo = new BranchRepository(operationDb);
           const memberIds = [...unit.members.keys()] as SessionID[];
-          const currentMembers = await sessionRepo.findByIds(memberIds);
-          if (currentMembers.length !== memberIds.length) {
-            throw new NotFound('An archive target no longer exists');
+          await lockRowForUpdate(
+            operationDb,
+            this.db,
+            sessions,
+            inArray(sessions.session_id, memberIds)
+          );
+          const currentMembersById = new Map(
+            (await sessionRepo.findByIds(memberIds)).map((member) => [member.session_id, member])
+          );
+          const currentMembers: Session[] = [];
+          for (const memberId of memberIds) {
+            const member = currentMembersById.get(memberId);
+            if (!member) throw new NotFound('An archive target no longer exists');
+            currentMembers.push(member);
           }
           const denial = await this.archiveUnitDenial(
             currentMembers,
             plan.archived,
             currentParams,
             new Map(),
-            new BranchRepository(operationDb)
+            branchRepo
           );
           if (denial) throw denial;
+          if (!plan.archived) {
+            const currentGraphs = new Map<string, ArchiveBranchGraph>();
+            for (const branchId of new Set(currentMembers.map((member) => member.branch_id))) {
+              const graph = await this.loadArchiveBranchGraph(currentGraphs, branchId, sessionRepo);
+              for (const member of currentMembers) {
+                if (member.branch_id === branchId) graph.byId.set(member.session_id, member);
+              }
+            }
+            const currentUnit: ArchiveUnit = {
+              ...unit,
+              members: new Map(currentMembers.map((member) => [member.session_id, member])),
+            };
+            const currentPlan: ArchiveTransitionPlan = {
+              archived: false,
+              localFailure: plan.localFailure,
+              units: [currentUnit],
+              unitResults: [],
+              targets: [],
+              remainingArchived: [],
+              excludedImplied: [],
+            };
+            await this.planRestoreTargets(
+              currentPlan,
+              currentGraphs,
+              new Map(),
+              sessionRepo,
+              new SessionRelationshipRepository(operationDb),
+              branchRepo
+            );
+            const currentlyRestorable = new Set(
+              currentPlan.targets.map((target) => target.session.session_id)
+            );
+            for (const target of unitTargets) {
+              const current = currentUnit.members.get(target.session.session_id);
+              if (current?.archived && !currentlyRestorable.has(current.session_id)) {
+                throw new Conflict('Archive restore eligibility changed. Retry the operation.');
+              }
+            }
+          }
           return sessionRepo.updateArchiveStateForTargets(
             unitTargets.map((target) => ({
               id: target.session.session_id,
@@ -2182,20 +2245,22 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
     options?: SessionArchiveOptions,
     params?: SessionParams
   ): Promise<SessionArchiveResult> {
-    const root = await this.get(id, params);
-    return this.runArchiveTransition(
-      {
-        roots: [root],
-        initiator: 'manual',
-        archived: true,
-        includeChildren: options?.includeChildren !== false,
-        includeRemoteChildren: options?.includeRemoteChildren !== false,
-        grouping: 'branch',
-        localFailure: 'throw',
-        params,
-      },
-      options?.dryRun === true
-    );
+    return this.withArchiveScope(params, async () => {
+      const root = await this.get(id, params);
+      return this.runArchiveTransition(
+        {
+          roots: [root],
+          initiator: 'manual',
+          archived: true,
+          includeChildren: options?.includeChildren !== false,
+          includeRemoteChildren: options?.includeRemoteChildren !== false,
+          grouping: 'branch',
+          localFailure: 'throw',
+          params,
+        },
+        options?.dryRun === true
+      );
+    });
   }
 
   /**
@@ -2209,20 +2274,22 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
     options?: SessionArchiveOptions,
     params?: SessionParams
   ): Promise<SessionArchiveResult> {
-    const root = await this.get(id, params);
-    return this.runArchiveTransition(
-      {
-        roots: [root],
-        initiator: 'manual',
-        archived: false,
-        includeChildren: options?.includeChildren !== false,
-        includeRemoteChildren: options?.includeRemoteChildren !== false,
-        grouping: 'branch',
-        localFailure: 'throw',
-        params,
-      },
-      options?.dryRun === true
-    );
+    return this.withArchiveScope(params, async () => {
+      const root = await this.get(id, params);
+      return this.runArchiveTransition(
+        {
+          roots: [root],
+          initiator: 'manual',
+          archived: false,
+          includeChildren: options?.includeChildren !== false,
+          includeRemoteChildren: options?.includeRemoteChildren !== false,
+          grouping: 'branch',
+          localFailure: 'throw',
+          params,
+        },
+        options?.dryRun === true
+      );
+    });
   }
 
   /**

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -30,6 +30,7 @@ import {
   shortId,
   TaskRepository,
   type TenantScopeAwareDatabase,
+  type TenantScopedDatabase,
   UsersRepository,
 } from '@agor/core/db';
 import {
@@ -92,6 +93,10 @@ import {
 import { emitServiceEvent } from '../utils/emit-service-event.js';
 import { parseLastMessageTruncationLength } from '../utils/query-params.js';
 import { deploymentAgenticToolUnavailableMessage } from './agentic-tool-deployment.js';
+import {
+  lockTenantAuthorizationFence,
+  resolveCurrentTenantAuthorityActor,
+} from './tenant-authorization-fence.js';
 
 type MaterializedAgenticToolConfiguration = Awaited<
   ReturnType<typeof materializeAgenticToolConfiguration>
@@ -155,14 +160,21 @@ type ArchivePlannedTarget = {
   unitKey: string;
 };
 
+type ArchiveExcludedImplied = {
+  session: Session;
+  /** Local authorization units whose root closures contain this descendant. */
+  unitKeys: Set<string>;
+};
+
 type ArchiveTransitionPlan = {
   archived: boolean;
+  localFailure: ArchiveTransitionRequest['localFailure'];
   units: ArchiveUnit[];
   unitResults: SessionArchiveUnitResult[];
   targets: ArchivePlannedTarget[];
   remainingArchived: SessionArchiveResult['remainingArchived'];
   /** Implied descendants a bulk eligibility policy left out. */
-  excludedImplied: Session[];
+  excludedImplied: ArchiveExcludedImplied[];
   limitExceeded?: SessionArchiveLimit;
 };
 
@@ -428,9 +440,9 @@ export type SessionBulkArchivePreview = {
   impliedDescendants: Session[];
   /** Descendants `eligible` left out: newer than the cutoff or with unfinished tasks. */
   excludedDescendants: Session[];
-  /** Included descendants newer than the cutoff. */
+  /** Descendants newer than the cutoff, whether included or excluded. */
   descendantsNewerThanCutoff: Session[];
-  /** Included descendants with a nonterminal task. */
+  /** Descendants with a nonterminal task, whether included or excluded. */
   descendantsWithUnfinishedTasks: Session[];
   /** Included descendants whose session status is executing. */
   activeDescendants: Session[];
@@ -1442,10 +1454,11 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
 
   private async loadArchiveBranch(
     cache: Map<string, Branch | null>,
-    branchId: BranchID
+    branchId: BranchID,
+    branchRepo = this.branchRepo
   ): Promise<Branch | null> {
     if (cache.has(branchId)) return cache.get(branchId) ?? null;
-    const branch = await this.branchRepo.findById(branchId);
+    const branch = await branchRepo.findById(branchId);
     cache.set(branchId, branch);
     return branch;
   }
@@ -1454,10 +1467,11 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
     members: Session[],
     archived: boolean,
     params: SessionParams | undefined,
-    branchCache: Map<string, Branch | null>
+    branchCache: Map<string, Branch | null>,
+    branchRepo = this.branchRepo
   ): Promise<Forbidden | null> {
     try {
-      await this.assertCanArchiveSessions(members, archived, params, branchCache);
+      await this.assertCanArchiveSessions(members, archived, params, branchCache, branchRepo);
       return null;
     } catch (error) {
       if (error instanceof Forbidden) return error;
@@ -1472,7 +1486,8 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
     const branchCache = new Map<string, Branch | null>();
     const authorized: ArchiveUnit[] = [];
     const unitResults: SessionArchiveUnitResult[] = [];
-    const excludedImplied: Session[] = [];
+    const excludedImplied: ArchiveExcludedImplied[] = [];
+    const excludedClosureIndexes = new Map<string, Set<number>>();
 
     const skipUnit = (
       unit: Pick<ArchiveUnit, 'kind'>,
@@ -1512,18 +1527,25 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
       }
       const eligible = await request.descendantEligibility([...candidates.values()]);
       for (const [id, session] of candidates) {
-        if (!eligible.has(id)) excludedImplied.push(session);
+        if (!eligible.has(id)) excludedImplied.push({ session, unitKeys: new Set() });
       }
-      for (const closure of closures) {
+      closures.forEach((closure, index) => {
+        for (const member of closure.members) {
+          if (rootIds.has(member.session_id) || eligible.has(member.session_id)) continue;
+          const indexes = excludedClosureIndexes.get(member.session_id) ?? new Set<number>();
+          indexes.add(index);
+          excludedClosureIndexes.set(member.session_id, indexes);
+        }
         closure.members = closure.members.filter(
           (member) => rootIds.has(member.session_id) || eligible.has(member.session_id)
         );
-      }
+      });
     }
 
     // 3. Group closures into local authorization units. Direct roots win over
     //    implied membership when closures overlap.
     const localUnits = new Map<string, ArchiveUnit>();
+    const unitKeyByClosure = new Map<number, string>();
     const closureUnitIndex = new Map<number, number>();
     if (request.grouping === 'root-tree') {
       // Union-find over closures that share a session so overlapping trees
@@ -1561,6 +1583,7 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
         request.grouping === 'branch'
           ? `local:${root.branch_id}`
           : `tree:${representative.session_id}`;
+      unitKeyByClosure.set(index, key);
       let unit = localUnits.get(key);
       if (!unit) {
         unit = {
@@ -1577,6 +1600,12 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
       }
       unit.rootIds.add(root.session_id);
     });
+    for (const excluded of excludedImplied) {
+      for (const index of excludedClosureIndexes.get(excluded.session.session_id) ?? []) {
+        const unitKey = unitKeyByClosure.get(index);
+        if (unitKey) excluded.unitKeys.add(unitKey);
+      }
+    }
 
     // 4. Authorize local units before any traversal leaves them.
     for (const unit of localUnits.values()) {
@@ -1612,13 +1641,20 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
       }
     }
 
+    const authorizedUnitKeys = new Set(authorized.map((unit) => unit.key));
     const plan: ArchiveTransitionPlan = {
       archived: request.archived,
+      localFailure: request.localFailure,
       units: authorized,
       unitResults,
       targets: [],
       remainingArchived: [],
-      excludedImplied,
+      excludedImplied: excludedImplied.flatMap((excluded) => {
+        const unitKeys = new Set(
+          [...excluded.unitKeys].filter((unitKey) => authorizedUnitKeys.has(unitKey))
+        );
+        return unitKeys.size > 0 ? [{ ...excluded, unitKeys }] : [];
+      }),
       ...(limitExceeded && { limitExceeded }),
     };
     if (request.archived) {
@@ -1666,29 +1702,16 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
       }
       const nextFrontier: string[] = [];
       for (const [branchId, branchTargets] of targetsByBranch) {
-        const graph = await this.loadArchiveBranchGraph(graphs, branchId);
-        const members: Session[] = [];
-        for (const target of branchTargets) {
-          members.push(target);
-          if (!request.includeChildren) continue;
-          for (const descendant of this.collectLocalDescendants(graph, target.session_id)) {
-            if (visited.has(descendant.session_id)) continue;
-            visited.add(descendant.session_id);
-            members.push(descendant);
-          }
-        }
-        remoteTargetCount += members.length;
-        if (remoteTargetCount > MAX_ARCHIVE_REMOTE_SESSION_TARGETS) {
-          throw new ArchiveLimitExceededError('remote_session_targets');
-        }
-        const existing = authorized.find((unit) => unit.branchId === branchId);
-        const denial = await this.archiveUnitDenial(
-          members,
+        // Authorize the visible relationship targets before loading any other
+        // sessions from their branch. Session-tier access is checked again for
+        // the complete unit after descendant discovery.
+        const rootDenial = await this.archiveUnitDenial(
+          branchTargets,
           request.archived,
           request.params,
           branchCache
         );
-        if (denial) {
+        if (rootDenial) {
           skipUnit(
             { kind: 'remote' },
             branchTargets.map((target) => target.session_id),
@@ -1696,6 +1719,36 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
           );
           continue;
         }
+        const members: Session[] = [...branchTargets];
+        if (request.includeChildren) {
+          const graph = await this.loadArchiveBranchGraph(graphs, branchId);
+          for (const target of branchTargets) {
+            for (const descendant of this.collectLocalDescendants(graph, target.session_id)) {
+              if (visited.has(descendant.session_id)) continue;
+              visited.add(descendant.session_id);
+              members.push(descendant);
+            }
+          }
+          const denial = await this.archiveUnitDenial(
+            members,
+            request.archived,
+            request.params,
+            branchCache
+          );
+          if (denial) {
+            skipUnit(
+              { kind: 'remote' },
+              branchTargets.map((target) => target.session_id),
+              'insufficient_permission'
+            );
+            continue;
+          }
+        }
+        remoteTargetCount += members.length;
+        if (remoteTargetCount > MAX_ARCHIVE_REMOTE_SESSION_TARGETS) {
+          throw new ArchiveLimitExceededError('remote_session_targets');
+        }
+        const existing = authorized.find((unit) => unit.branchId === branchId);
         let unit = existing;
         if (!unit) {
           remoteUnitCount += 1;
@@ -1833,7 +1886,7 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
         const blocked = parentIds.some((parentId) => {
           if (plannedActive.has(parentId)) return false;
           const parent = lookupSession(parentId) ?? externalSources.get(parentId);
-          return parent?.archived === true;
+          return parent === undefined || parent.archived === true;
         });
         if (blocked) {
           plan.remainingArchived.push({ sessionId: id as SessionID, reason: 'archived_ancestor' });
@@ -1861,16 +1914,59 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
     params?: SessionParams
   ): Promise<Session[]> {
     const changed: Session[] = [];
+    const skippedUnitKeys = new Set<string>();
+    const skippedMemberIds = new Set<string>();
+    const tenantId = params?.tenant?.tenant_id ?? getCurrentTenantId();
     for (const unit of plan.units) {
       const unitTargets = plan.targets.filter((target) => target.unitKey === unit.key);
       if (unitTargets.length === 0) continue;
-      const unitChanged = await this.sessionRepo.updateArchiveStateForTargets(
-        unitTargets.map((target) => ({
-          id: target.session.session_id,
-          archived: target.archived,
-          archivedReason: target.archivedReason,
-        }))
-      );
+      const unitChanged = await runWithTenantDatabaseTransaction(
+        this.db,
+        tenantId,
+        async (operationDb) => {
+          const currentParams = await this.currentArchiveParams(operationDb, params);
+          const sessionRepo = new SessionRepository(operationDb);
+          const memberIds = [...unit.members.keys()] as SessionID[];
+          const currentMembers = await sessionRepo.findByIds(memberIds);
+          if (currentMembers.length !== memberIds.length) {
+            throw new NotFound('An archive target no longer exists');
+          }
+          const denial = await this.archiveUnitDenial(
+            currentMembers,
+            plan.archived,
+            currentParams,
+            new Map(),
+            new BranchRepository(operationDb)
+          );
+          if (denial) throw denial;
+          return sessionRepo.updateArchiveStateForTargets(
+            unitTargets.map((target) => ({
+              id: target.session.session_id,
+              archived: target.archived,
+              archivedReason: target.archivedReason,
+            }))
+          );
+        }
+      ).catch((error) => {
+        if (
+          error instanceof Forbidden &&
+          (unit.kind === 'remote' || plan.localFailure === 'skip')
+        ) {
+          skippedUnitKeys.add(unit.key);
+          for (const memberId of unit.members.keys()) skippedMemberIds.add(memberId);
+          for (const rootSessionId of unit.rootIds) {
+            plan.unitResults.push({
+              rootSessionId: rootSessionId as SessionID,
+              kind: unit.kind,
+              status: 'skipped',
+              changedCount: 0,
+              reason: 'insufficient_permission',
+            });
+          }
+          return [];
+        }
+        throw error;
+      });
       for (const session of unitChanged) {
         emitServiceEvent(this.app, {
           path: 'sessions',
@@ -1882,7 +1978,35 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
       }
       changed.push(...unitChanged);
     }
+    if (skippedUnitKeys.size > 0) {
+      plan.units = plan.units.filter((unit) => !skippedUnitKeys.has(unit.key));
+      plan.targets = plan.targets.filter((target) => !skippedUnitKeys.has(target.unitKey));
+      plan.remainingArchived = plan.remainingArchived.filter(
+        ({ sessionId }) => !skippedMemberIds.has(sessionId)
+      );
+      plan.excludedImplied = plan.excludedImplied.filter((excluded) =>
+        [...excluded.unitKeys].some((unitKey) => !skippedUnitKeys.has(unitKey))
+      );
+    }
     return changed;
+  }
+
+  private async currentArchiveParams(
+    operationDb: TenantScopedDatabase,
+    params?: SessionParams
+  ): Promise<SessionParams | undefined> {
+    if (!params?.provider || !this.shouldEnforceBranchRbac()) return params;
+    await lockTenantAuthorizationFence(operationDb, params);
+    const actor = await resolveCurrentTenantAuthorityActor(operationDb, params);
+    return {
+      ...params,
+      user: {
+        ...params.user,
+        user_id: actor.user_id,
+        role: actor.role ?? params.user?.role,
+        _isServiceAccount: actor.service,
+      },
+    } as SessionParams;
   }
 
   private buildArchiveResult(
@@ -1998,7 +2122,8 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
     sessions: Session[],
     archived: boolean,
     params: SessionParams | undefined,
-    branchCache: Map<string, Branch | null>
+    branchCache: Map<string, Branch | null>,
+    branchRepo = this.branchRepo
   ): Promise<void> {
     if (!params?.provider || !this.shouldEnforceBranchRbac()) return;
 
@@ -2021,12 +2146,12 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
     const action = archived ? 'archive sessions' : 'unarchive sessions';
 
     for (const session of sessions) {
-      const branch = await this.loadArchiveBranch(branchCache, session.branch_id);
+      const branch = await this.loadArchiveBranch(branchCache, session.branch_id, branchRepo);
       if (!branch) {
         throw new Forbidden(`Branch not found for session: ${session.session_id}`);
       }
 
-      const access = await this.branchRepo.resolveUserAccess(branch, userId);
+      const access = await branchRepo.resolveUserAccess(branch, userId);
       const effectiveLevel: BranchPermissionLevel = isSuperAdmin(userRole, allowSuperadmin)
         ? 'all'
         : access.can;
@@ -2224,8 +2349,8 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
     if (!first) throw new BadRequest('At least one session is required');
     return this.withArchiveScope(params, async () => {
       const { plan, unfinishedIds } = await this.planBulkArchive(roots, options, params);
-      const preview = this.summarizeBulkPlan(plan, options, unfinishedIds);
       const changed = await this.applyArchiveTransitionPlan(plan, params);
+      const preview = this.summarizeBulkPlan(plan, options, unfinishedIds);
       return { ...this.buildArchiveResult(first, plan, changed), preview };
     });
   }
@@ -2286,6 +2411,8 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
     const impliedDescendants = plan.targets
       .filter((target) => target.selection === 'implied')
       .map((target) => target.session);
+    const excludedDescendants = plan.excludedImplied.map(({ session }) => session);
+    const classifiedDescendants = [...impliedDescendants, ...excludedDescendants];
     const plannedByUnit = new Map<string, number>();
     for (const target of plan.targets) {
       plannedByUnit.set(target.unitKey, (plannedByUnit.get(target.unitKey) ?? 0) + 1);
@@ -2294,12 +2421,12 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
       policy: options.policy,
       directRoots,
       impliedDescendants,
-      excludedDescendants: plan.excludedImplied,
-      descendantsNewerThanCutoff: impliedDescendants.filter(
+      excludedDescendants,
+      descendantsNewerThanCutoff: classifiedDescendants.filter(
         (session) =>
           cutoff !== null && new Date(session.last_updated || session.created_at) >= cutoff
       ),
-      descendantsWithUnfinishedTasks: impliedDescendants.filter((session) =>
+      descendantsWithUnfinishedTasks: classifiedDescendants.filter((session) =>
         unfinishedIds.has(session.session_id)
       ),
       activeDescendants: impliedDescendants.filter((session) => isSessionExecuting(session)),

--- a/apps/agor-daemon/src/services/tasks.ts
+++ b/apps/agor-daemon/src/services/tasks.ts
@@ -750,12 +750,13 @@ export class TasksService extends DrizzleService<Task, Partial<Task>, TaskParams
       if (session.fork_origin === 'btw') {
         if (!suppressBtwCleanup) {
           try {
-            await this.app.service('sessions').patch(session.session_id, {
-              archived: true,
-              archived_reason: 'btw_completed',
-            });
+            const sessionsService = this.app.service('sessions') as unknown as SessionsService;
+            const result = await sessionsService.archiveBtwSession(
+              session.session_id,
+              params as Parameters<SessionsService['archiveBtwSession']>[1]
+            );
             console.log(
-              `📦 [TasksService] Auto-archived btw fork session ${shortId(session.session_id)}`
+              `📦 [TasksService] Auto-archived btw fork session ${shortId(session.session_id)} (${result.count} row(s))`
             );
           } catch (error) {
             console.warn(`⚠️  [TasksService] Failed to auto-archive btw fork:`, error);

--- a/apps/agor-docs/content/guide/message-gateway.mdx
+++ b/apps/agor-docs/content/guide/message-gateway.mdx
@@ -231,11 +231,17 @@ Gateway conversations appear under **Gateway Sessions** on the target branch. Se
 
 Gateway Sessions are retained until someone archives them. Agor does not currently run an automatic gateway-retention worker or expose a per-channel retention setting.
 
-For branch-wide cleanup today, use a [scheduled prompt](/guide/scheduler) for an explicit, workspace-specific policy. Have the scheduled teammate call `agor_sessions_bulk_archive` with `sessionType: "gateway"`, its `branchId`, and the desired `olderThanDays`; test the filter with `dryRun: true` before changing the schedule to `dryRun: false`.
+For branch-wide cleanup today, use a [scheduled prompt](/guide/scheduler) for an explicit, workspace-specific policy. Have the scheduled teammate call `agor_sessions_bulk_archive` with `sessionType: "gateway"`, its `branchId`, the desired `olderThanDays`, and a `descendantPolicy`. A dry-run without a policy previews all three outcomes with exact counts and bounded samples (`sampleLimit`, default 20):
 
-This workaround is not the same as per-channel inactivity retention. It uses the Session's last-updated time, accepts whole days, scopes to a branch rather than a gateway channel, and archives only the matching gateway Session rows—not their spawned or remote-created children. Review those children separately before setting `dryRun: false`.
+- `"none"` archives only the matching gateway Session rows and leaves their spawned children active.
+- `"eligible"` also archives branch-local children that have no unfinished task and are not newer than `olderThanDays`. This is the recommended retention policy.
+- `"all"` archives every branch-local child of each match, including children newer than the cutoff and children that are still running.
 
-Archiving is reversible and preserves the Session transcript for search and audit. The tool applies the schedule owner's normal RBAC permissions and reports Sessions it cannot modify.
+Omitting `descendantPolicy` on execution still applies `"none"` for one compatibility release and returns `deprecatedDefaultApplied: true` with a warning; pass the policy explicitly, because a later release rejects the omission. No policy follows sessions created in other branches (`remote_create`); those keep their own lifecycle. This workaround is not the same as per-channel inactivity retention: it uses the Session's last-updated time, accepts whole days, and scopes to a branch rather than a gateway channel.
+
+Archiving is reversible, never stops running work, and preserves the Session transcript for search and audit. Each matched Session plus its children is authorized as one unit under the schedule owner's normal RBAC permissions; units it cannot modify are skipped and reported.
+
+Archiving a single Session from the UI, `POST /sessions/:id/archive`, or `agor_sessions_archive` behaves differently: by default it also archives the sessions that Session created in other branches (each other branch is authorized separately and skipped when you lack permission there), and `includeRemoteChildren: false` keeps that remote work active. Board archive is a container-only operation and never archives Branches or Sessions.
 
 ### Scope reference
 

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -34,10 +34,10 @@ import {
   theme,
 } from 'antd';
 import type React from 'react';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { useConnectionDisabled } from '../../contexts/ConnectionContext';
 import { useLocalStorage } from '../../hooks/useLocalStorage';
-import { useSessionActions } from '../../hooks/useSessionActions';
+import { type SessionArchiveOutcome, useSessionActions } from '../../hooks/useSessionActions';
 import {
   type BranchSectionKey,
   COLLAPSED_BRANCH_NODES_STORAGE_KEY,
@@ -62,6 +62,11 @@ import { ArchiveActionButton } from '../ArchiveButton';
 import { type ForkSpawnAction, ForkSpawnModal } from '../ForkSpawnModal';
 import { HighlightMatch } from '../HighlightMatch';
 import { ChannelPill } from '../Pill';
+import {
+  formatSessionArchiveOutcome,
+  isArchivePermissionDenial,
+  SessionArchiveConfirmContent,
+} from '../SessionArchiveConfirm';
 import { SessionRelationshipIcon } from '../SessionRelationshipIcon';
 import {
   SessionRelevanceLabel,
@@ -286,7 +291,8 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
 }) => {
   const { token } = theme.useToken();
   const { modal } = App.useApp();
-  const { showSuccess, showError } = useThemedMessage();
+  const { showSuccess, showError, showWarning } = useThemedMessage();
+  const includeRemoteChildrenRef = useRef(true);
   const connectionDisabled = useConnectionDisabled();
   const { archiveSession } = useSessionActions(client);
 
@@ -504,35 +510,99 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
   const unmountForkSpawnModal = () =>
     setForkSpawnModal({ open: false, action: 'fork', session: null });
 
-  const handleArchiveSession = useCallback(
-    (sessionId: string, e: React.MouseEvent) => {
-      e.stopPropagation();
+  const withArchiving = useCallback(async (sessionId: string, work: () => Promise<void>) => {
+    setArchivingSessionIds((prev) => new Set(prev).add(sessionId));
+    try {
+      await work();
+    } finally {
+      setArchivingSessionIds((prev) => {
+        const next = new Set(prev);
+        next.delete(sessionId);
+        return next;
+      });
+    }
+  }, []);
 
+  const archiveRootOnly = useCallback(
+    (sessionId: string) => {
       modal.confirm({
-        title: 'Archive session and child sessions?',
-        content: 'Are you sure you want to archive this session and its child sessions?',
-        okText: 'Archive',
+        title: 'Archive only this session?',
+        content:
+          'A child session in this branch belongs to someone you cannot archive for. You can archive just this session and leave its children active.',
+        okText: 'Archive only this session',
         cancelText: 'Cancel',
-        onOk: async () => {
-          setArchivingSessionIds((prev) => new Set(prev).add(sessionId));
-          try {
-            const result = await archiveSession(sessionId as SessionID);
-            if (result) {
-              showSuccess('Session and child sessions archived');
-            } else {
-              showError('Failed to archive session');
+        onOk: () =>
+          withArchiving(sessionId, async () => {
+            try {
+              const outcome = await archiveSession(sessionId as SessionID, {
+                includeChildren: false,
+                includeRemoteChildren: false,
+              });
+              showSuccess(formatSessionArchiveOutcome(outcome).success);
+            } catch (err) {
+              showError(err instanceof Error ? err.message : 'Failed to archive session');
             }
-          } finally {
-            setArchivingSessionIds((prev) => {
-              const next = new Set(prev);
-              next.delete(sessionId);
-              return next;
-            });
-          }
-        },
+          }),
       });
     },
-    [archiveSession, modal, showSuccess, showError]
+    [archiveSession, modal, showSuccess, showError, withArchiving]
+  );
+
+  const handleArchiveSession = useCallback(
+    async (sessionId: string, e: React.MouseEvent) => {
+      e.stopPropagation();
+
+      // Preview first so the confirmation shows exactly what will change.
+      let preview: SessionArchiveOutcome;
+      try {
+        preview = await archiveSession(sessionId as SessionID, {
+          includeChildren: true,
+          includeRemoteChildren: true,
+          dryRun: true,
+        });
+      } catch (err) {
+        if (isArchivePermissionDenial(err)) {
+          archiveRootOnly(sessionId);
+          return;
+        }
+        showError(err instanceof Error ? err.message : 'Failed to prepare archive');
+        return;
+      }
+
+      includeRemoteChildrenRef.current = true;
+      modal.confirm({
+        title: 'Archive session and child sessions?',
+        content: (
+          <SessionArchiveConfirmContent
+            preview={preview}
+            onIncludeRemoteChildrenChange={(value) => {
+              includeRemoteChildrenRef.current = value;
+            }}
+          />
+        ),
+        okText: 'Archive',
+        cancelText: 'Cancel',
+        onOk: () =>
+          withArchiving(sessionId, async () => {
+            try {
+              const outcome = await archiveSession(sessionId as SessionID, {
+                includeChildren: true,
+                includeRemoteChildren: includeRemoteChildrenRef.current,
+              });
+              const { success, warning } = formatSessionArchiveOutcome(outcome);
+              showSuccess(success);
+              if (warning) showWarning(warning);
+            } catch (err) {
+              if (isArchivePermissionDenial(err)) {
+                archiveRootOnly(sessionId);
+                return;
+              }
+              showError(err instanceof Error ? err.message : 'Failed to archive session');
+            }
+          }),
+      });
+    },
+    [archiveSession, archiveRootOnly, modal, showSuccess, showError, showWarning, withArchiving]
   );
 
   const getGatewaySource = useCallback(

--- a/apps/agor-ui/src/components/SessionArchiveConfirm/SessionArchiveConfirm.test.tsx
+++ b/apps/agor-ui/src/components/SessionArchiveConfirm/SessionArchiveConfirm.test.tsx
@@ -1,0 +1,109 @@
+import type { Session, SessionID } from '@agor-live/client';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { SessionArchiveOutcome } from '../../hooks/useSessionActions';
+import {
+  formatSessionArchiveOutcome,
+  isArchivePermissionDenial,
+  SessionArchiveConfirmContent,
+} from './SessionArchiveConfirm';
+
+function outcome(overrides: Partial<SessionArchiveOutcome> = {}): SessionArchiveOutcome {
+  return {
+    session: { session_id: 'root' as SessionID } as Session,
+    dryRun: true,
+    wouldChangeCount: 3,
+    archivedCount: 3,
+    unarchivedCount: 0,
+    localCount: 1,
+    remoteCount: 2,
+    skippedCount: 0,
+    runningCount: 0,
+    units: [
+      {
+        rootSessionId: 'root' as SessionID,
+        kind: 'local',
+        status: 'changed',
+        changedCount: 1,
+        branchId: 'wt-a',
+      },
+      {
+        rootSessionId: 'remote-1' as SessionID,
+        kind: 'remote',
+        status: 'changed',
+        changedCount: 2,
+        branchId: 'wt-b',
+      },
+    ],
+    remainingArchived: [],
+    ...overrides,
+  };
+}
+
+describe('SessionArchiveConfirmContent', () => {
+  it('shows the previewed local and remote counts with the remote choice checked by default', () => {
+    const onChange = vi.fn();
+    render(
+      <SessionArchiveConfirmContent preview={outcome()} onIncludeRemoteChildrenChange={onChange} />
+    );
+
+    expect(screen.getByText(/archives 1 session in this branch/i)).toBeTruthy();
+    const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+    expect(screen.getByText(/2 sessions this one created in 1 other branch/i)).toBeTruthy();
+  });
+
+  it('surfaces running work, skipped remote units, and bound overflow', () => {
+    render(
+      <SessionArchiveConfirmContent
+        preview={outcome({
+          runningCount: 2,
+          skippedCount: 1,
+          limitExceeded: 'remote_branch_units',
+        })}
+        onIncludeRemoteChildrenChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText(/2 sessions still running/i)).toBeTruthy();
+    expect(screen.getByText(/1 remote session in branches you cannot modify/i)).toBeTruthy();
+    expect(screen.getByText(/too many sessions in other branches/i)).toBeTruthy();
+  });
+});
+
+describe('formatSessionArchiveOutcome', () => {
+  it('reports local and remote counts and a permission warning', () => {
+    const { success, warning } = formatSessionArchiveOutcome(
+      outcome({ dryRun: false, skippedCount: 1 })
+    );
+    expect(success).toBe('Archived 3 sessions (1 in this branch, 2 in other branches)');
+    expect(warning).toMatch(/1 remote session skipped/);
+  });
+
+  it('reports children that stayed archived after a restore', () => {
+    const { success, warning } = formatSessionArchiveOutcome(
+      outcome({
+        dryRun: false,
+        archivedCount: 0,
+        unarchivedCount: 1,
+        localCount: 1,
+        remoteCount: 0,
+        remainingArchived: [{ sessionId: 'child' as SessionID, reason: 'independent_reason' }],
+      }),
+      'Restored'
+    );
+    expect(success).toBe('Restored 1 session');
+    expect(warning).toMatch(/1 child session stayed archived/);
+  });
+});
+
+describe('isArchivePermissionDenial', () => {
+  it('recognizes the branch prompt-permission refusal and nothing else', () => {
+    expect(
+      isArchivePermissionDenial(
+        new Error("You need 'prompt' permission to archive sessions in this branch.")
+      )
+    ).toBe(true);
+    expect(isArchivePermissionDenial(new Error('Session not found'))).toBe(false);
+  });
+});

--- a/apps/agor-ui/src/components/SessionArchiveConfirm/SessionArchiveConfirm.tsx
+++ b/apps/agor-ui/src/components/SessionArchiveConfirm/SessionArchiveConfirm.tsx
@@ -1,0 +1,101 @@
+import { Alert, Checkbox, Flex, Typography } from 'antd';
+import type { SessionArchiveOutcome } from '../../hooks/useSessionActions';
+
+function plural(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? '' : 's'}`;
+}
+
+interface SessionArchiveConfirmContentProps {
+  /** Dry-run result for the same request the confirmation will send. */
+  preview: SessionArchiveOutcome;
+  /** Initial state of the remote-children choice. Default: true. */
+  defaultIncludeRemoteChildren?: boolean;
+  onIncludeRemoteChildrenChange: (includeRemoteChildren: boolean) => void;
+}
+
+/**
+ * Body of the archive confirmation. The remote default is deliberate but must
+ * never be invisible: the user sees the counts a dry-run produced and can
+ * uncheck the remote choice before confirming.
+ */
+export function SessionArchiveConfirmContent({
+  preview,
+  defaultIncludeRemoteChildren = true,
+  onIncludeRemoteChildrenChange,
+}: SessionArchiveConfirmContentProps) {
+  const remoteBranches = new Set(
+    preview.units
+      .filter((unit) => unit.kind === 'remote' && unit.status !== 'skipped')
+      .map((unit) => unit.branchId)
+  ).size;
+  return (
+    <Flex vertical gap="small">
+      <Typography.Text>
+        This archives {plural(preview.localCount, 'session')} in this branch. Archiving hides
+        sessions from listings; it does not stop running work.
+      </Typography.Text>
+      <Checkbox
+        defaultChecked={defaultIncludeRemoteChildren}
+        onChange={(event) => onIncludeRemoteChildrenChange(event.target.checked)}
+      >
+        Also archive {plural(preview.remoteCount, 'session')} this one created in{' '}
+        {plural(remoteBranches, 'other branch')}
+      </Checkbox>
+      {preview.runningCount > 0 && (
+        <Alert
+          type="warning"
+          showIcon
+          message={`${plural(preview.runningCount, 'session')} still running will be hidden but keep working.`}
+        />
+      )}
+      {preview.skippedCount > 0 && (
+        <Alert
+          type="info"
+          showIcon
+          message={`${plural(preview.skippedCount, 'remote session')} in branches you cannot modify will be left unchanged.`}
+        />
+      )}
+      {preview.limitExceeded && (
+        <Alert
+          type="error"
+          showIcon
+          message="Too many sessions in other branches to archive at once. Uncheck the remote option or archive them separately."
+        />
+      )}
+    </Flex>
+  );
+}
+
+/** User-facing copy for a dedicated archive/unarchive outcome. */
+export function formatSessionArchiveOutcome(
+  outcome: SessionArchiveOutcome,
+  verb: 'Archived' | 'Restored' = 'Archived'
+): { success: string; warning?: string } {
+  const total = verb === 'Archived' ? outcome.archivedCount : outcome.unarchivedCount;
+  const success =
+    outcome.remoteCount > 0
+      ? `${verb} ${plural(total, 'session')} (${outcome.localCount} in this branch, ${outcome.remoteCount} in other branches)`
+      : `${verb} ${plural(total, 'session')}`;
+  const warnings: string[] = [];
+  if (outcome.skippedCount > 0) {
+    warnings.push(
+      `${plural(outcome.skippedCount, 'remote session')} skipped: you do not have permission in that branch, so they were left unchanged.`
+    );
+  }
+  if (verb === 'Restored' && outcome.remainingArchived.length > 0) {
+    warnings.push(
+      `${plural(outcome.remainingArchived.length, 'child session')} stayed archived because of an independent reason, another archived parent, or an archived branch.`
+    );
+  }
+  return { success, warning: warnings.length > 0 ? warnings.join(' ') : undefined };
+}
+
+/**
+ * True when the daemon refused the local unit because the caller lacks prompt
+ * permission for a child (session-tier callers on shared sessions). The
+ * caller can retry with `includeChildren: false` for its own root.
+ */
+export function isArchivePermissionDenial(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /need 'prompt' permission/i.test(message);
+}

--- a/apps/agor-ui/src/components/SessionArchiveConfirm/index.ts
+++ b/apps/agor-ui/src/components/SessionArchiveConfirm/index.ts
@@ -1,0 +1,5 @@
+export {
+  formatSessionArchiveOutcome,
+  isArchivePermissionDenial,
+  SessionArchiveConfirmContent,
+} from './SessionArchiveConfirm';

--- a/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
+++ b/apps/agor-ui/src/components/SessionPanel/SessionPanel.tsx
@@ -55,7 +55,7 @@ import { useAppActions } from '../../contexts/AppActionsContext';
 import { useRecenterMap } from '../../contexts/CanvasNavigationContext';
 import { useConnectionDisabled, useConnectionState } from '../../contexts/ConnectionContext';
 import { useAuthorityOperationGuard } from '../../hooks/useAuthorityOperationGuard';
-import { useSessionActions } from '../../hooks/useSessionActions';
+import { type SessionArchiveOutcome, useSessionActions } from '../../hooks/useSessionActions';
 import { useSessionSearch } from '../../hooks/useSessionSearch';
 import { useSharedReactiveSession } from '../../hooks/useSharedReactiveSession';
 import { useAgorStore } from '../../store/agorStore';
@@ -86,6 +86,11 @@ import { ForkSpawnModal } from '../ForkSpawnModal/ForkSpawnModal';
 import type { ModelConfig } from '../ModelSelector';
 import { CreatedByTag } from '../metadata';
 import { getUrlDisplayLabel } from '../Pill/url-helpers';
+import {
+  formatSessionArchiveOutcome,
+  isArchivePermissionDenial,
+  SessionArchiveConfirmContent,
+} from '../SessionArchiveConfirm';
 import { ToolIcon } from '../ToolIcon';
 import {
   buildPromptWithAttachments,
@@ -323,7 +328,8 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
 }) => {
   const { token } = theme.useToken();
   const { modal } = App.useApp();
-  const { showSuccess, showInfo, showError } = useThemedMessage();
+  const { showSuccess, showInfo, showError, showWarning } = useThemedMessage();
+  const includeRemoteChildrenRef = React.useRef(true);
   const connectionDisabled = useConnectionDisabled();
   const { connected, connecting, authGeneration } = useConnectionState();
   const recenterMap = useRecenterMap();
@@ -1119,24 +1125,80 @@ const SessionPanel: React.FC<SessionPanelProps> = ({
     ? (session as Session & { agentic_tool: AgenticToolName })
     : null;
 
-  const handleArchive = () => {
+  const archiveRootOnly = () => {
+    modal.confirm({
+      title: 'Archive only this session?',
+      content:
+        'A child session in this branch belongs to someone you cannot archive for. You can archive just this session and leave its children active.',
+      okText: 'Archive only this session',
+      cancelText: 'Cancel',
+      onOk: async () => {
+        try {
+          const outcome = await archiveSession(session.session_id, {
+            includeChildren: false,
+            includeRemoteChildren: false,
+          });
+          showSuccess(formatSessionArchiveOutcome(outcome).success);
+          onClose();
+        } catch (err) {
+          showError(err instanceof Error ? err.message : 'Failed to archive session');
+        }
+      },
+    });
+  };
+
+  const handleArchive = async () => {
     if (!client || connectionDisabled) {
       showError('Cannot archive while disconnected from the daemon.');
       return;
     }
 
+    // Preview first so the confirmation shows exactly what will change.
+    let preview: SessionArchiveOutcome;
+    try {
+      preview = await archiveSession(session.session_id, {
+        includeChildren: true,
+        includeRemoteChildren: true,
+        dryRun: true,
+      });
+    } catch (err) {
+      if (isArchivePermissionDenial(err)) {
+        archiveRootOnly();
+        return;
+      }
+      showError(err instanceof Error ? err.message : 'Failed to prepare archive');
+      return;
+    }
+
+    includeRemoteChildrenRef.current = true;
     modal.confirm({
       title: 'Archive session and child sessions?',
-      content: 'Are you sure you want to archive this session and its child sessions?',
+      content: (
+        <SessionArchiveConfirmContent
+          preview={preview}
+          onIncludeRemoteChildrenChange={(value) => {
+            includeRemoteChildrenRef.current = value;
+          }}
+        />
+      ),
       okText: 'Archive',
       cancelText: 'Cancel',
       onOk: async () => {
-        const archived = await archiveSession(session.session_id);
-        if (archived) {
-          showSuccess('Session and child sessions archived');
+        try {
+          const outcome = await archiveSession(session.session_id, {
+            includeChildren: true,
+            includeRemoteChildren: includeRemoteChildrenRef.current,
+          });
+          const { success, warning } = formatSessionArchiveOutcome(outcome);
+          showSuccess(success);
+          if (warning) showWarning(warning);
           onClose();
-        } else {
-          showError('Failed to archive session');
+        } catch (err) {
+          if (isArchivePermissionDenial(err)) {
+            archiveRootOnly();
+            return;
+          }
+          showError(err instanceof Error ? err.message : 'Failed to archive session');
         }
       },
     });

--- a/apps/agor-ui/src/hooks/useSessionActions.test.tsx
+++ b/apps/agor-ui/src/hooks/useSessionActions.test.tsx
@@ -1,7 +1,7 @@
 import type { AgorClient, Session } from '@agor-live/client';
 import { act, renderHook } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import { useSessionActions } from './useSessionActions';
+import { type SessionArchiveOutcome, useSessionActions } from './useSessionActions';
 
 function makeClient(services: Record<string, unknown>): AgorClient {
   return {
@@ -14,9 +14,24 @@ function makeClient(services: Record<string, unknown>): AgorClient {
 }
 
 describe('useSessionActions archive helpers', () => {
-  it('archives through the cascade archive route instead of generic sessions.patch', async () => {
+  const outcome = (session: Session) => ({
+    session,
+    dryRun: false,
+    wouldChangeCount: 1,
+    archivedCount: 1,
+    unarchivedCount: 0,
+    localCount: 1,
+    remoteCount: 0,
+    skippedCount: 0,
+    runningCount: 0,
+    units: [],
+    remainingArchived: [],
+  });
+
+  it('archives through the cascade archive route with explicit cascade options', async () => {
     const archivedSession = { session_id: 'session-1', archived: true } as Session;
-    const archiveCreate = vi.fn(async () => ({ session: archivedSession }));
+    const archiveOutcome = outcome(archivedSession);
+    const archiveCreate = vi.fn(async () => archiveOutcome);
     const sessionsPatch = vi.fn();
     const client = makeClient({
       'sessions/session-1/archive': { create: archiveCreate },
@@ -24,19 +39,34 @@ describe('useSessionActions archive helpers', () => {
     });
 
     const { result } = renderHook(() => useSessionActions(client));
-    let returned: Session | null = null;
+    let returned: SessionArchiveOutcome | null = null;
     await act(async () => {
       returned = await result.current.archiveSession('session-1' as Session['session_id']);
     });
+    await act(async () => {
+      await result.current.archiveSession('session-1' as Session['session_id'], {
+        includeRemoteChildren: false,
+      });
+    });
 
-    expect(returned).toBe(archivedSession);
-    expect(archiveCreate).toHaveBeenCalledWith({});
+    expect(returned).toBe(archiveOutcome);
+    expect(archiveCreate).toHaveBeenNthCalledWith(1, {
+      includeChildren: true,
+      includeRemoteChildren: true,
+      dryRun: false,
+    });
+    expect(archiveCreate).toHaveBeenNthCalledWith(2, {
+      includeChildren: true,
+      includeRemoteChildren: false,
+      dryRun: false,
+    });
     expect(sessionsPatch).not.toHaveBeenCalled();
   });
 
   it('unarchives through the cascade unarchive route instead of generic sessions.patch', async () => {
     const unarchivedSession = { session_id: 'session-1', archived: false } as Session;
-    const unarchiveCreate = vi.fn(async () => ({ session: unarchivedSession }));
+    const unarchiveOutcome = outcome(unarchivedSession);
+    const unarchiveCreate = vi.fn(async () => unarchiveOutcome);
     const sessionsPatch = vi.fn();
     const client = makeClient({
       'sessions/session-1/unarchive': { create: unarchiveCreate },
@@ -44,15 +74,34 @@ describe('useSessionActions archive helpers', () => {
     });
 
     const { result } = renderHook(() => useSessionActions(client));
-    let returned: Session | null = null;
+    let returned: SessionArchiveOutcome | null = null;
     await act(async () => {
       returned = await result.current.unarchiveSession('session-1' as Session['session_id']);
     });
 
-    expect(returned).toBe(unarchivedSession);
-    expect(unarchiveCreate).toHaveBeenCalledWith({});
+    expect(returned).toBe(unarchiveOutcome);
+    expect(unarchiveCreate).toHaveBeenCalledWith({
+      includeChildren: true,
+      includeRemoteChildren: true,
+      dryRun: false,
+    });
     expect(sessionsPatch).not.toHaveBeenCalled();
   });
+});
+
+it('propagates archive failures so callers can offer a targeted retry', async () => {
+  const failure = new Error("You need 'prompt' permission to archive sessions in this branch.");
+  const client = makeClient({
+    'sessions/session-1/archive': { create: vi.fn(async () => Promise.reject(failure)) },
+  });
+  const { result } = renderHook(() => useSessionActions(client));
+
+  await act(async () => {
+    await expect(
+      result.current.archiveSession('session-1' as Session['session_id'], { dryRun: true })
+    ).rejects.toBe(failure);
+  });
+  expect(result.current.error).toBe(failure.message);
 });
 
 it('preserves the session create failure for its caller', async () => {

--- a/apps/agor-ui/src/hooks/useSessionActions.ts
+++ b/apps/agor-ui/src/hooks/useSessionActions.ts
@@ -20,12 +20,59 @@ import {
 import { useState } from 'react';
 import type { NewSessionConfig } from '../domain/sessionCreation';
 
+/** Options accepted by `POST /sessions/:id/archive` and `/unarchive`. */
+export interface SessionArchiveOptions {
+  /** Include branch-local spawned/forked descendants. Default: true. */
+  includeChildren?: boolean;
+  /** Follow sessions this one created in other branches. Default: true. */
+  includeRemoteChildren?: boolean;
+  /** Plan and authorize only; nothing changes. Default: false. */
+  dryRun?: boolean;
+}
+
+/** Wire shape returned by the dedicated archive/unarchive routes. */
+export interface SessionArchiveOutcome {
+  session: Session;
+  dryRun: boolean;
+  /** Rows the plan would change (dry-run) or attempted (execution). */
+  wouldChangeCount: number;
+  archivedCount: number;
+  unarchivedCount: number;
+  localCount: number;
+  remoteCount: number;
+  skippedCount: number;
+  /** Planned rows whose session is still executing. */
+  runningCount: number;
+  units: Array<{
+    rootSessionId: SessionID;
+    kind: 'local' | 'remote';
+    status: 'changed' | 'unchanged' | 'skipped';
+    changedCount: number;
+    /** Only for units the caller is authorized for. */
+    branchId?: string;
+    reason?: 'insufficient_permission' | 'not_found' | 'conflict';
+  }>;
+  limitExceeded?: 'remote_depth' | 'remote_branch_units' | 'remote_session_targets';
+  remainingArchived: Array<{
+    sessionId: SessionID;
+    reason: 'independent_reason' | 'archived_ancestor' | 'archived_branch';
+  }>;
+}
+
 interface UseSessionActionsResult {
   createSession: (config: NewSessionConfig) => Promise<Session>;
   updateSession: (sessionId: SessionID, updates: Partial<Session>) => Promise<Session | null>;
   deleteSession: (sessionId: SessionID) => Promise<boolean>;
-  archiveSession: (sessionId: SessionID) => Promise<Session | null>;
-  unarchiveSession: (sessionId: SessionID) => Promise<Session | null>;
+  // Throw on failure so callers can offer a targeted retry (for example
+  // "archive only this session" after a shared-session child was denied).
+  archiveSession: (
+    sessionId: SessionID,
+    options?: SessionArchiveOptions
+  ) => Promise<SessionArchiveOutcome>;
+  unarchiveSession: (
+    sessionId: SessionID,
+    options?: SessionArchiveOptions
+  ) => Promise<SessionArchiveOutcome>;
   // Throw on failure (do NOT return null) so callers can preserve the user's
   // typed prompt in the compose box. See SessionPanel.handleFork / handleBtwSend
   // and ForkSpawnModal.handleOk for the preserved-on-failure invariants.
@@ -255,45 +302,43 @@ export function useSessionActions(client: AgorClient | null): UseSessionActionsR
     }
   };
 
-  const archiveSession = async (sessionId: SessionID): Promise<Session | null> => {
+  // The UI always states both cascade choices explicitly rather than relying on
+  // the transport default, so what the confirmation showed is what is sent.
+  const archiveRequestBody = (
+    options?: SessionArchiveOptions
+  ): Required<SessionArchiveOptions> => ({
+    includeChildren: options?.includeChildren ?? true,
+    includeRemoteChildren: options?.includeRemoteChildren ?? true,
+    dryRun: options?.dryRun ?? false,
+  });
+
+  const runArchiveRoute = async (
+    route: 'archive' | 'unarchive',
+    sessionId: SessionID,
+    options?: SessionArchiveOptions
+  ): Promise<SessionArchiveOutcome> => {
     if (!client) {
       setError('Client not connected');
-      return null;
+      throw new Error('Client not connected');
     }
-
     try {
       setError(null);
-      const result = (await client.service(`sessions/${sessionId}/archive`).create({})) as {
-        session: Session;
-      };
-      return result.session;
+      return (await client
+        .service(`sessions/${sessionId}/${route}`)
+        .create(archiveRequestBody(options))) as SessionArchiveOutcome;
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to archive session';
+      const message = err instanceof Error ? err.message : `Failed to ${route} session`;
       setError(message);
-      console.error('Failed to archive session:', err);
-      return null;
+      console.error(`Failed to ${route} session:`, err);
+      throw err instanceof Error ? err : new Error(message);
     }
   };
 
-  const unarchiveSession = async (sessionId: SessionID): Promise<Session | null> => {
-    if (!client) {
-      setError('Client not connected');
-      return null;
-    }
+  const archiveSession = (sessionId: SessionID, options?: SessionArchiveOptions) =>
+    runArchiveRoute('archive', sessionId, options);
 
-    try {
-      setError(null);
-      const result = (await client.service(`sessions/${sessionId}/unarchive`).create({})) as {
-        session: Session;
-      };
-      return result.session;
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to unarchive session';
-      setError(message);
-      console.error('Failed to unarchive session:', err);
-      return null;
-    }
-  };
+  const unarchiveSession = (sessionId: SessionID, options?: SessionArchiveOptions) =>
+    runArchiveRoute('unarchive', sessionId, options);
 
   return {
     createSession,

--- a/context/README.md
+++ b/context/README.md
@@ -64,6 +64,7 @@ Designs that are referenced from code or in flight. Anything here is either stil
 - [`teammate-kb-namespace-memory-plan.md`](explorations/teammate-kb-namespace-memory-plan.md) — implementation plan for teammate primary KB namespaces, memory append tools, and branch-scoped namespace grants.
 - [`kb-namespace-rbac-v1.md`](explorations/kb-namespace-rbac-v1.md) — directed V1 plan for Knowledge namespace RBAC and teammate home namespaces.
 - [`session-sharing.md`](explorations/session-sharing.md) — tenant/branch gates, immutable Session compatibility, and caller identity for shared prompts.
+- [`session-archive-cascade.md`](explorations/session-archive-cascade.md) — one archive engine for every Session archive entry point: local/remote cascade policy, explicit bulk policy, cause-aware restoration, reason invariant (referenced from `apps/agor-daemon/src/services/sessions.ts`).
 - [`parent-session-callbacks.md`](explorations/parent-session-callbacks.md) — child-session completion notifications (referenced from `docs/never-lose-prompt-design.md`).
 - [`frontend-hardcoded-colors.md`](explorations/frontend-hardcoded-colors.md) — Biome/GritQL color audit, classification, and enforcement rollout.
 - [`web-terminal-ownership-ha.md`](explorations/web-terminal-ownership-ha.md) — process-affine terminal ownership, HA support, and failure semantics.

--- a/context/concepts/mcp-session-tools.md
+++ b/context/concepts/mcp-session-tools.md
@@ -39,7 +39,7 @@ into SDK-private registration state.
 
 1. **`agor_sessions_prompt`** — continue, fork, or spawn from an existing session. `mode: 'continue' | 'fork' | 'subsession'`.
 2. **`agor_sessions_create`** — new session in a specified branch. Optional `initialPrompt`, agent override, permission mode.
-3. **`agor_sessions_update`** — rename, change status, refresh description.
+3. **`agor_sessions_update`** — rename, change status, refresh description. Archive state is rejected here; `agor_sessions_archive` / `agor_sessions_unarchive` own it and cascade to local and remote-created children (see `context/explorations/session-archive-cascade.md`).
 
 All enforce the branch-centric model (every session references a branch). Permission modes map to each agent's native settings.
 

--- a/context/explorations/session-archive-cascade.md
+++ b/context/explorations/session-archive-cascade.md
@@ -6,7 +6,7 @@ It is the contract the session archive engine implements; the code itself lives
 in the daemon (see "Implementation notes").
 
 **Status:** Implemented (revision 3); see "Implementation notes" for where the
-code lives and the few places the implementation refines this text.  
+code lives and the few places the implementation refines this text.
 **Research baseline:** upstream `main` at
 [`60e7a896`](https://github.com/preset-io/agor/commit/60e7a896d69ac14177c59f906da9e9e176253aa0).
 The archive domain logic is unchanged from the issue audit at

--- a/context/explorations/session-archive-cascade.md
+++ b/context/explorations/session-archive-cascade.md
@@ -1,0 +1,748 @@
+# Session archive cascade plan
+
+This document defines one explicit archive policy for Session lifecycle entry
+points tracked by [issue #2661](https://github.com/preset-io/agor/issues/2661).
+It is the contract the session archive engine implements; the code itself lives
+in the daemon (see "Implementation notes").
+
+**Status:** Implemented (revision 3); see "Implementation notes" for where the
+code lives and the few places the implementation refines this text.  
+**Research baseline:** upstream `main` at
+[`60e7a896`](https://github.com/preset-io/agor/commit/60e7a896d69ac14177c59f906da9e9e176253aa0).
+The archive domain logic is unchanged from the issue audit at
+[`cfc07997`](https://github.com/preset-io/agor/commit/cfc07997f366958fd90b6cc84208615cacc85c44),
+but [`8d43790c`](https://github.com/preset-io/agor/commit/8d43790c36880140598b2cb6012e6b94c5eccb30)
+materially changed the execution boundary by arming the tenant database-scope
+guard in every mode. The engine and every migrated caller must satisfy that
+newer boundary explicitly.
+
+## Outcome
+
+Session archive behavior must depend on an explicit descendant policy rather
+than on which route, tool, or internal caller initiated it. Preview,
+authorization, mutation, restoration, and realtime results must agree on the
+same affected set.
+
+Archive remains a reversible visibility/history operation. It does not stop a
+Task, terminate an executor, suppress callbacks, or hard-delete history.
+
+## Decisions
+
+1. `SessionsService` owns the canonical Session archive engine. Repository
+   methods perform scoped graph reads and atomic state writes; they do not own
+   product policy.
+2. The dedicated archive/unarchive operation includes branch-local spawned and
+   forked descendants by default, preserving the existing `includeChildren:
+false` opt-out introduced by
+   [PR #1842](https://github.com/preset-io/agor/pull/1842).
+3. The dedicated operation also follows outgoing `remote_create` relationships
+   by default. `includeRemoteChildren: false` keeps remote work active.
+4. The root branch-local tree is one all-or-nothing authorization and mutation
+   unit. Each additional canonical remote branch is a separate unit: authorized
+   units succeed; unauthorized units remain unchanged and are reported.
+5. Bulk archive never traverses `remote_create`. It supports
+   `descendantPolicy: 'none' | 'eligible' | 'all'`. For one compatibility
+   release, omission executes the legacy `none` policy with a prominent
+   deprecation warning; dry-run without a policy previews all three outcomes.
+6. Provider-facing generic Session patch/update may not change `archived` or
+   `archived_reason`. Archive-bearing multi-patch is also rejected. Callers use
+   the dedicated archive operations instead.
+7. BTW completion archives its root with `btw_completed`, includes local
+   descendants, and excludes remote descendants.
+8. Prompt auto-unarchive restores only the directly prompted Session when its
+   canonical Branch is active. Prompting into an archived Branch fails with a
+   conflict that directs the caller to restore the Branch first. It does not
+   restore ancestors, siblings, local descendants, or remote descendants.
+9. Branch archive affects every active Session canonically owned by that Branch
+   and never crosses `remote_create`.
+10. Board archive is a container-visibility operation. It does not archive its
+    Branches or Sessions and is explicitly exempt from Session cascade policy.
+11. This change does not repair historical archive inconsistencies
+    automatically and does not add a schema migration.
+12. Dedicated remote traversal is previewed and bounded. Exceeding any remote
+    depth, Branch-unit, or Session-target limit fails closed before mutation.
+
+## Current failure topology
+
+| Entry point                            | Current behavior                                  | Failure                                                                    |
+| -------------------------------------- | ------------------------------------------------- | -------------------------------------------------------------------------- |
+| Dedicated REST/MCP archive             | Cascades through branch-local genealogy           | Does not include visually nested remote-created Sessions                   |
+| Generic `sessions.patch({ archived })` | Mutates one row                                   | Leaves active local descendants and provides no descendant option          |
+| `agor_sessions_update({ archived })`   | Uses generic patch                                | Gives agents an easy non-cascading bypass                                  |
+| Generic multi-patch                    | Single-row updates over a selection where enabled | Forms a second undocumented bulk archive path                              |
+| MCP bulk archive                       | Filters and patches direct matches individually   | Preview omits descendants; tree behavior is implicit                       |
+| BTW completion cleanup                 | Archives one Session                              | Can leave active local descendants                                         |
+| Prompt auto-unarchive                  | Restores one Session                              | Re-roots the prompted Session while its parent remains archived            |
+| Branch archive/unarchive               | Reads at most 1,000 Sessions and patches each     | Omits large-Branch rows and overwrites independent archive reasons         |
+| Board archive                          | Archives only the Board                           | Intentional container-only behavior, currently undocumented in this policy |
+
+The dedicated operation already provides the strongest starting point: it
+walks branch-local genealogy, preflights its affected set, assigns causal
+reasons, updates atomically, and emits affected Session events. The plan deepens
+that owner rather than adding another archive service.
+
+Primary code evidence:
+
+- dedicated archive policy and RBAC preflight:
+  [`apps/agor-daemon/src/services/sessions.ts`](https://github.com/preset-io/agor/blob/cfc07997f366958fd90b6cc84208615cacc85c44/apps/agor-daemon/src/services/sessions.ts#L1228-L1395);
+- atomic archive-state repository update:
+  [`packages/core/src/db/repositories/sessions.ts`](https://github.com/preset-io/agor/blob/cfc07997f366958fd90b6cc84208615cacc85c44/packages/core/src/db/repositories/sessions.ts#L921-L995);
+- generic and bulk MCP paths:
+  [`apps/agor-daemon/src/mcp/tools/sessions.ts`](https://github.com/preset-io/agor/blob/cfc07997f366958fd90b6cc84208615cacc85c44/apps/agor-daemon/src/mcp/tools/sessions.ts#L1365-L1634);
+- Branch archive/unarchive:
+  [`apps/agor-daemon/src/services/branches.ts`](https://github.com/preset-io/agor/blob/cfc07997f366958fd90b6cc84208615cacc85c44/apps/agor-daemon/src/services/branches.ts#L1766-L2084);
+- remote relationship semantics:
+  [`packages/core/src/types/session.ts`](https://github.com/preset-io/agor/blob/cfc07997f366958fd90b6cc84208615cacc85c44/packages/core/src/types/session.ts#L683-L701);
+- documented root-only gateway cleanup:
+  [`apps/agor-docs/content/guide/message-gateway.mdx`](https://github.com/preset-io/agor/blob/cfc07997f366958fd90b6cc84208615cacc85c44/apps/agor-docs/content/guide/message-gateway.mdx#L228-L238).
+
+## Externally observable contract
+
+### Dedicated archive and unarchive
+
+Extend the existing options:
+
+```ts
+interface SessionArchiveOptions {
+  includeChildren?: boolean; // default true
+  includeRemoteChildren?: boolean; // default true
+  dryRun?: boolean; // default false
+}
+```
+
+The local unit contains the explicit root plus its active branch-local
+descendants. The remote frontier begins with outgoing `remote_create` edges from
+every Session included in that local unit. Every remote target starts a unit in
+its canonical Branch; that unit contains the target and its branch-local
+descendants. The frontier then follows outgoing remote edges from every Session
+in each authorized remote unit. It never follows callback targets, inbound
+relationship edges, excluded local descendants, or edges beyond an unauthorized
+unit.
+
+Dedicated preview and execution enforce these named bounds:
+
+```text
+MAX_ARCHIVE_REMOTE_DEPTH          = 8
+MAX_ARCHIVE_REMOTE_BRANCH_UNITS   = 32
+MAX_ARCHIVE_REMOTE_SESSION_TARGETS = 5_000
+```
+
+The limits apply to the remote expansion, not to the root's local closure or a
+Branch-wide archive. Preview returns a bounded limit-exceeded result; execution
+fails before changing the local or any remote unit. Both paths use a visited set
+for duplicate and cycle defense.
+
+If authorization for a remote unit fails, do not mutate or traverse through
+that unit. Continue with independent authorized units and return a bounded
+failure record. The local unit retains the existing all-or-nothing behavior.
+
+Archive results must distinguish what happened:
+
+```ts
+type SessionArchiveUnitResult =
+  | {
+      rootSessionId: SessionID;
+      kind: 'local' | 'remote';
+      status: 'changed' | 'unchanged';
+      changedCount: number;
+      branchId: BranchID; // caller is authorized for this unit
+    }
+  | {
+      rootSessionId: SessionID; // already visible through the relationship
+      kind: 'remote';
+      status: 'skipped';
+      changedCount: 0;
+      reason: 'insufficient_permission' | 'not_found' | 'conflict';
+      // Deliberately no branchId or target metadata.
+    };
+
+interface SessionArchiveResult {
+  session: Session;
+  dryRun: boolean;
+  wouldChangeCount: number;
+  archivedCount: number;
+  unarchivedCount: number;
+  localCount: number;
+  remoteCount: number;
+  skippedCount: number;
+  units: SessionArchiveUnitResult[];
+  remainingArchived: Array<{
+    sessionId: SessionID;
+    reason: 'independent_reason' | 'archived_ancestor' | 'archived_branch';
+  }>;
+}
+```
+
+Keep response detail bounded. A skipped remote unit is identified by the
+already-visible relationship target Session ID or an opaque count; it never
+returns the inaccessible target's Branch ID or additional metadata. Existing
+`count` may remain as a deprecated alias during the transport compatibility
+window.
+
+### Bulk archive
+
+Add:
+
+```ts
+descendantPolicy?: 'none' | 'eligible' | 'all';
+sampleLimit?: number; // default 20, maximum 100
+```
+
+Rules:
+
+- Filters select the direct roots exactly as they do today.
+- `none` archives only those roots.
+- `eligible` adds branch-local descendants that have no nonterminal Task and
+  are not newer than `olderThanDays` when an age cutoff is supplied. Session
+  type, status, Board, and Branch filters select roots only; they are not
+  reapplied to descendants. Without an age cutoff, Task terminality is the
+  descendant eligibility gate.
+- `all` adds every active branch-local spawned/forked descendant, even when it
+  does not satisfy the original age, status, or Session-type filters.
+- Neither policy follows remote relationships.
+- For one compatibility release, `dryRun: false` without `descendantPolicy`
+  executes `none` and returns `deprecatedDefaultApplied: true` plus an
+  actionable warning. The next contract version requires the field.
+- `dryRun: true` without a policy returns all three candidate outcomes.
+- Dry-run and execution call the same planning code. Execution re-reads and
+  reauthorizes current state; it may report intervening state/authority changes,
+  but may not use different selection semantics through a separate code path.
+
+The preview must report, for each policy:
+
+- directly matched roots;
+- unique implied descendants;
+- descendants newer than an age cutoff;
+- descendants included/excluded by age and nonterminal-Task eligibility;
+- descendants with an active Session status;
+- overlapping-tree deduplication;
+- unauthorized cascade units;
+- the exact total that execution would attempt.
+
+Return complete counts, not complete Session arrays. Each category includes at
+most `sampleLimit` representative rows plus `sampleTruncated: true` when more
+exist. Counts remain exact for large Branches.
+
+When `eligible` or `all` is selected, each direct root plus its selected local
+closure is an all-or-nothing authorization unit. Independent authorized units
+may succeed. Merge overlapping authorized closures before writing, with
+direct-root intent taking precedence over implied-child intent.
+
+### Generic patch and MCP update
+
+After migrating all internal archive callers:
+
+- reject `archived` or `archived_reason` in generic `patch`/`update` service
+  payloads;
+- reject those fields for `id === null` and array/multi-patch regardless of
+  whether Branch RBAC is enabled;
+- remove `archived` from `agor_sessions_update` input and description;
+- return an actionable error naming the dedicated archive/unarchive operation.
+
+The archive engine writes through repository archive-state methods, so it does
+not need a hidden generic-patch bypass.
+
+### Dedicated UI
+
+The remote default must not be invisible in the UI:
+
+- the UI first requests a dedicated dry-run and shows local, remote, Branch
+  unit, nonterminal-work, and authorization counts before confirmation;
+- the archive confirmation exposes an “also archive sessions created in other
+  branches” choice, checked by default;
+- the UI passes `includeChildren` and `includeRemoteChildren` explicitly instead
+  of relying on transport defaults;
+- success copy reports local and remote counts;
+- a partial result produces a warning that identifies skipped Branch units
+  without exposing inaccessible Session metadata;
+- unarchive exposes the symmetric option and reports Sessions that remain
+  archived because of an independent reason or archived ancestor.
+
+If a session-tier caller owns the root but the local preview fails because a
+shared-session descendant has another owner, preserve local all-or-nothing
+semantics. Explain the denial and offer an explicit “Archive only my Session”
+retry using `includeChildren: false`; never silently drop local descendants.
+
+## State and restoration rules
+
+### Required invariant
+
+```text
+archived = false  => archived_reason IS NULL
+archived = true   => archived_reason is a trusted known reason
+```
+
+All unarchive writes pass `null`, never `undefined`. Repository archive-state
+methods enforce the invariant. Generic repository update normalization also
+clears a reason whenever it persists `archived: false`, so an internal caller
+cannot create a stale active reason accidentally.
+
+Until historical data is repaired separately, planning and restoration ignore
+`archived_reason` on an active row.
+
+### Trusted initiating reasons
+
+The engine accepts an internal-only reason:
+
+```ts
+type ArchiveInitiator = 'manual' | 'btw_completed' | 'branch_archived';
+```
+
+- Explicit roots receive the initiating reason.
+- Newly archived implied descendants receive `parent_archived`.
+- A Session already archived for another reason keeps its existing state and
+  reason.
+- Public inputs cannot assign `parent_archived`, `branch_archived`, or
+  `btw_completed` directly.
+
+### Cause-aware unarchive
+
+Use one post-transition activation predicate for local and remote restoration:
+
+```text
+mayActivate(session, role) =
+  canonical Branch is active
+  AND (
+    role is explicit root
+    OR no direct incoming parent source remains archived
+  )
+```
+
+Incoming parent sources include `parent_session_id`,
+`forked_from_session_id`, and the source of every incoming `remote_create`
+relationship. Evaluate their state after applying the planned transition, not
+from the pre-operation snapshot alone.
+
+An explicit Session restore overrides archived local or remote parent edges and
+therefore deliberately re-roots that Session. It never overrides an archived
+canonical Branch: dedicated unarchive and prompt auto-unarchive return
+`409 Conflict` with guidance to restore the Branch first. An implied descendant
+remains archived whenever any incoming parent source remains archived. Return
+it in `remainingArchived` with the applicable blocker.
+
+Only rows carrying a parent-caused reason are candidates for implied
+restoration. Independently archived targets always remain archived. If a remote
+unit is unauthorized, leave it unchanged and report the already-visible target
+Session ID or an opaque count without its Branch metadata.
+
+The production fork and spawn paths currently create one incoming genealogy
+edge per Session, so the ordinary local case is a chain. A Session may also have
+incoming remote provenance, so the activation predicate must consider both
+edge classes from the first remote-cascade release. Traversal remains cycle-safe
+because the persistence schema does not enforce an acyclic shape for legacy,
+imported, or direct repository data.
+
+## Architecture
+
+### Policy owner
+
+Evolve `SessionsService.setArchiveStateForTree` into two private phases:
+
+1. `planArchiveTransition(...)`
+   - open a bounded tenant database read scope owned by the engine;
+   - resolve and validate explicit roots;
+   - load branch-local graphs once per involved Branch;
+   - traverse outgoing remote relationships only when enabled;
+   - classify direct/implied targets and warnings;
+   - compute cause-aware final state;
+   - partition targets into authorization/mutation units.
+2. `applyArchiveTransitionPlan(...)`
+   - open one fresh tenant write scope/transaction per unit;
+   - revalidate that unit inside the same scope;
+   - apply its final target states atomically;
+   - enqueue exactly one post-commit event per changed Session;
+   - return changed, skipped, and still-archived results.
+
+Dry-run stops after planning and authorization. Both dry-run and execution use
+the same immutable plan representation within one request. A later execution
+request creates a fresh plan and revalidates authority; previews are
+point-in-time evidence, not a lock on future state.
+
+### Repository work
+
+Add or generalize repository operations that:
+
+- load all Sessions for a specified Branch without service pagination;
+- batch-load outgoing `remote_create` relationships for a bounded frontier;
+- batch-identify candidate Sessions with nonterminal Tasks for Bulk eligibility
+  and preview warnings;
+- update distinct archive state/reason targets atomically;
+- return only rows whose persisted state actually changed;
+- accept a transaction-scoped repository/database supplied by the service.
+
+For multiple roots in one Branch, build adjacency once and use an indexed queue
+plus visited set. Do not call the current whole-Branch scan once per root.
+
+No new archive coordinator, table, relationship type, background worker, or
+repair job is introduced.
+
+### Change map
+
+| Area                                                    | Expected owner/files                                                                         |
+| ------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| Archive policy, planner, authorization, results         | `apps/agor-daemon/src/services/sessions.ts`, `apps/agor-daemon/src/declarations.ts`          |
+| Complete Branch reads and archive-state writes          | `packages/core/src/db/repositories/sessions.ts`                                              |
+| Batched outgoing remote traversal                       | `packages/core/src/db/repositories/session-relationships.ts`                                 |
+| REST request/response options and prompt auto-unarchive | `apps/agor-daemon/src/register-routes.ts`                                                    |
+| Dedicated, update, and bulk MCP contracts               | `apps/agor-daemon/src/mcp/tools/sessions.ts`                                                 |
+| BTW completion caller                                   | `apps/agor-daemon/src/services/tasks.ts`                                                     |
+| Branch archive/unarchive caller                         | `apps/agor-daemon/src/services/branches.ts`                                                  |
+| UI options and result messaging                         | `apps/agor-ui/src/hooks/useSessionActions.ts` and archive callers in Session/Branch surfaces |
+| Internal MCP contract note                              | `context/concepts/mcp-session-tools.md`                                                      |
+| Public behavior and generated API material              | gateway/session guide content and OpenAPI output                                             |
+
+### Events
+
+The engine, not Feathers automatic patch emission, owns archive transition
+events. Enqueue them after a successful unit commit. Emit one `sessions.patched`
+event for each changed row and none for unchanged, skipped, dry-run, or rolled
+back rows.
+
+## Entry-point migration
+
+| Caller                       | Engine request                                                               |
+| ---------------------------- | ---------------------------------------------------------------------------- |
+| REST/MCP dedicated archive   | `manual`, local `true` by default, remote `true` by default                  |
+| REST/MCP dedicated unarchive | Cause-aware inverse using the same requested edge policy                     |
+| MCP bulk `none`              | Each selected row is an explicit `manual` root; no descendants               |
+| MCP bulk `eligible`          | `manual` roots plus age/task-eligible local descendants; no remote traversal |
+| MCP bulk `all`               | `manual` roots plus local descendants; no remote traversal                   |
+| BTW natural completion       | `btw_completed`, local descendants on, remote off                            |
+| Prompt auto-unarchive        | Reject archived Branch; otherwise direct root only                           |
+| Branch archive               | Every active canonical Branch Session is an explicit `branch_archived` root  |
+| Branch unarchive             | Restore only canonical rows archived for `branch_archived`                   |
+
+Only after these callers have migrated should generic archive patching be
+rejected.
+
+## Branch archive delivery split
+
+### First: contained correctness fix
+
+In `BranchesService.archive/unarchive`:
+
+1. Replace the `$limit: 1000` service read with a complete tenant-scoped
+   repository read or explicit full pagination.
+2. Archive only `archived: false` Sessions.
+3. Unarchive only `archived: true AND archived_reason = 'branch_archived'`
+   Sessions.
+4. Clear the reason with `null` on restoration.
+5. Batch the Session state update and emit only changed rows.
+
+This prevents omissions and preserves independent manual, parent, and BTW
+archive intent.
+
+### Deferred branch-lifecycle hardening
+
+Coupling Branch metadata, terminal retirement, environment/filesystem work, and
+Session state into one recoverable workflow is distinct from Session cascade
+policy. Filesystem effects cannot join a database transaction. Keep that
+redesign outside #2661 unless implementing the contained fix exposes a new
+failure that cannot be made retry-safe locally.
+
+## Permission model
+
+Authorization never substitutes for tenant isolation.
+
+| Context                                        | Required behavior                                                                                                            |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Internal call with no provider                 | Supplies trusted tenant identity; engine opens its own scope/unit; no user Branch RBAC preflight                             |
+| Provider call, Branch RBAC disabled            | Authenticated tenant boundary and write gate apply; Branch permission preflight is intentionally skipped                     |
+| Provider call, RBAC enabled, `prompt` or `all` | May archive any Session in each authorized unit                                                                              |
+| Provider call, RBAC enabled, `session`         | May archive only Sessions created by that user; a shared-session child owned by another user rejects the complete local unit |
+| Service account                                | Preserve the existing deliberate service-account bypass inside the tenant boundary                                           |
+| Remote unit                                    | Resolve current access against that unit's canonical Branch; source-Branch access does not confer target-Branch access       |
+
+`includeChildren: false` remains the explicit way for a session-tier caller to
+archive only an owned root when a complete local cascade is unauthorized.
+
+An unauthorized remote unit is skipped and reported; it does not roll back the
+already authorized local unit. Do not continue relationship traversal through
+an unauthorized unit or reveal its additional Session metadata.
+
+## Tenant classification
+
+Multi-tenancy is implicated because this work changes persisted lifecycle data,
+HTTP/MCP service boundaries, relationship traversal, authorization, and
+realtime side effects.
+
+| Resource or effect             | Classification                   | Owner and enforcement                                                                           |
+| ------------------------------ | -------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Sessions and archive state     | Tenant-owned                     | Trusted tenant context plus scoped `SessionRepository`; PostgreSQL RLS remains defense in depth |
+| Branches and permission policy | Tenant-owned                     | Scoped `BranchRepository`; current Branch access resolved per mutation unit                     |
+| Session relationships          | Tenant-owned                     | Scoped `SessionRelationshipRepository`; both endpoints must resolve inside the same tenant      |
+| Tasks used for bulk warnings   | Derived through Session          | Scoped Task query using the selected tenant-owned Session IDs                                   |
+| Realtime archive events        | Derived through Session          | Existing tenant-aware realtime publisher after commit                                           |
+| Board archive exemption        | Tenant-owned container lifecycle | Existing Board authorization; no Session mutation side effect                                   |
+
+Trusted tenant identity comes from authenticated request/MCP context or the
+ambient internal operation context, never IDs in the archive payload. The
+default-on database proxy now raises `MissingTenantDatabaseScopeError` in every
+deployment mode when code touches `this.db` outside a scope.
+
+The archive engine, rather than each caller, owns its database scopes:
+
+1. Planning opens one bounded tenant read scope.
+2. Applying opens one fresh tenant write unit/transaction per local or remote
+   mutation unit.
+3. Each unit constructs `SessionRepository`, `BranchRepository`, Task, and
+   relationship repositories from that scoped database.
+4. Transport and internal callers supply trusted tenant identity and pass the
+   write gate, but do not hold an open database transaction across the engine
+   call.
+
+Adjust the current MCP wrapper accordingly. BTW completion runs after Task
+commit and must open a new engine-owned unit. Branch archive must pass trusted
+tenant identity rather than call the Session service with missing parameters.
+Add a guarded-SQLite regression for each migrated REST, MCP, BTW, prompt, Bulk,
+and Branch caller so missing scope fails in the same mode used by local
+development, not only under PostgreSQL/RLS.
+
+Required negative proof: tenant B cannot discover, count, archive, unarchive, or
+receive events for tenant A's Session by reusing a Session, Branch, or
+relationship ID. A cross-tenant/malformed relationship must fail closed rather
+than expanding the traversal.
+
+## Acceptance scenarios
+
+1. **Local dedicated archive:** a nested spawn/fork chain is archived by
+   default; `includeChildren: false` changes only the root.
+2. **Remote default and opt-out:** dedicated archive includes outgoing remote
+   units by default; `includeRemoteChildren: false` leaves them active and
+   reports no attempted remote units.
+3. **Remote preview and bounds:** dry-run reports bounded local/remote counts;
+   execution uses the same frontier semantics; depth, Branch-unit, or target
+   overflow fails before any mutation.
+4. **Remote authorization and disclosure:** the local unit commits, an
+   authorized remote Branch commits, and an unauthorized remote unit remains
+   unchanged, exposes no Branch metadata, and is not traversed further.
+5. **Unified restoration:** a local or remote implied child remains archived
+   when any direct incoming local/fork/remote parent source remains archived
+   after the transition.
+6. **Explicit root and Branch rule:** an explicit root may re-root beneath an
+   archived parent, but no Session is restored inside an archived canonical
+   Branch; prompt and dedicated unarchive return `409 Conflict` there.
+7. **Bulk compatibility:** omission executes legacy `none` with a deprecation
+   warning during the compatibility release; dry-run without a policy previews
+   exact `none`, `eligible`, and `all` counts with bounded samples.
+8. **Bulk eligibility:** `eligible` includes old-enough local descendants with
+   no nonterminal Task even when they do not match root-only type/status filters;
+   `all` also identifies newer and active/nonterminal descendants.
+9. **Generic bypass closure:** provider archive patch, update-tool archive, and
+   archive-bearing multi-patch are rejected with dedicated-operation guidance.
+10. **Trusted reasons:** manual, BTW, and Branch roots receive their initiating
+    reasons; implied children receive `parent_archived`; independent reasons are
+    preserved.
+11. **Chain restoration:** for `R -> A -> B`, where `A` remains manually
+    archived, unarchiving `R` does not revive `B` and reports the archived
+    ancestor blocker.
+12. **Prompt restoration:** in an active Branch, prompting an archived child
+    restores only that child and it remains re-rooted until its parent is
+    restored; prompting inside an archived Branch is rejected.
+13. **Session-tier fallback:** a shared-session descendant can reject the local
+    unit; the UI explains why and offers an explicit root-only retry.
+14. **Branch completeness:** archive/unarchive handles more than 1,000 Sessions
+    and never revives a previously manual or BTW archive.
+15. **Reason invariant:** every path persists `archived_reason = NULL` for an
+    active row; a stale legacy reason cannot block or cause restoration.
+16. **Events:** each changed Session emits once after commit; skipped, unchanged,
+    dry-run, and rolled-back rows emit nothing.
+17. **Scope guard:** every migrated caller passes a guarded-SQLite test proving
+    that the engine, not the caller, opens the required database scope.
+18. **Tenant isolation:** same-tenant behavior succeeds and a cross-tenant ID or
+    relationship attempt fails without observable target information.
+19. **Board exemption:** Board archive does not mutate Branch or Session archive
+    state.
+
+## Implementation sequence
+
+### Slice 1 — Branch correctness and invariant
+
+- Add complete Branch Session selection.
+- Add active/reason predicates.
+- Persist `null` on restoration and normalize the active-row invariant.
+- Add greater-than-1,000 and reason-preservation regression tests.
+
+This slice is independently shippable and reduces existing data-integrity risk.
+
+### Slice 2 — Canonical local planner
+
+- Extract the current dedicated local cascade into plan/apply phases.
+- Add multi-root deduplication, trusted root reasons, cause-aware unarchive, and
+  actual-change event emission.
+- Migrate dedicated local archive, BTW cleanup, prompt restoration, and Branch
+  Session transitions.
+
+### Slice 3 — Bulk policy
+
+- Add `none | eligible | all` and the one-release legacy-default warning.
+- Make dry-run preview all three policies when omitted using exact counts and
+  bounded samples.
+- Reuse the canonical planner for preview and execution.
+- Add warning classifications, authorization-unit results, and count parity.
+
+### Slice 4 — Close generic paths and document exemptions
+
+- Remove archive from `agor_sessions_update`.
+- Reject archive-bearing generic and multi-patch.
+- Update gateway/archive documentation and generated API material.
+- Update `context/concepts/mcp-session-tools.md` so agent guidance no longer
+  presents generic Session update as an archive path.
+- Document prompt and Board exemptions.
+
+Do not close the generic paths before all trusted internal callers have moved.
+
+### Slice 5 — Dedicated remote units (separate PR)
+
+- Add the dedicated dry-run, exact frontier, named bounds, and cycle defense.
+- Add `includeRemoteChildren` to REST/MCP/UI contracts and documentation.
+- Add independent per-Branch authorization, opaque skipped-unit reporting, and
+  unified local/remote restoration coverage.
+- Include only sanitized aggregate orphan evidence in the PR rationale; never
+  include Session titles, prompts, IDs, Branch names, or other local data.
+
+Remote lifecycle semantics intentionally ship in their own PR. Debate over
+reversing the historical provenance-only contract must not block Slices 1–4.
+
+## Verification
+
+Add or extend focused tests in:
+
+- `apps/agor-daemon/src/services/sessions.archive.test.ts`
+- `apps/agor-daemon/src/mcp/tools/sessions.test.ts`
+- `apps/agor-daemon/src/services/branches.test.ts`
+- `apps/agor-daemon/src/services/boards.test.ts`
+- `apps/agor-daemon/src/register-hooks.test.ts`
+- `apps/agor-ui/src/hooks/useSessionActions.test.tsx`
+- the Session/Branch archive confirmation component tests covering preview,
+  explicit opt-outs, partial remote results, and session-tier root-only retry
+- PostgreSQL/RLS repository or service integration coverage at the changed
+  tenant boundary
+
+Run focused checks first:
+
+```bash
+pnpm --filter @agor/daemon test -- \
+  src/services/sessions.archive.test.ts \
+  src/mcp/tools/sessions.test.ts \
+  src/services/branches.test.ts \
+  src/services/boards.test.ts \
+  src/register-hooks.test.ts
+
+pnpm --filter @agor/daemon typecheck
+pnpm check:multitenancy-boundaries
+pnpm exec biome check <touched-files>
+git diff --check
+```
+
+Run the new repository/service cases against both SQLite and PostgreSQL/RLS.
+Then perform real-boundary QA in an isolated Agor environment:
+
+1. Build a nested local tree and remote-created targets across two Branches.
+2. Exercise dedicated defaults, both opt-outs, and a denied remote Branch.
+3. Compare bulk dry-run `none`/`eligible`/`all` previews with actual execution.
+4. Verify age/nonterminal eligibility and bounded preview samples.
+5. Verify session-tier local denial offers and executes the root-only retry.
+6. Verify prompt auto-unarchive restores only the prompted Session in an active
+   Branch and rejects an archived Branch.
+7. Verify Branch archive completeness and independent-reason preservation.
+8. Confirm API, MCP, UI active listings, and realtime updates converge.
+9. Confirm archived running work remains running, preserving archive-versus-Stop
+   semantics.
+
+## Rollout and compatibility
+
+- This is an API behavior change. Update MCP descriptions, REST/OpenAPI output,
+  and the gateway guide in the same delivery.
+- For one compatibility release, Bulk omission retains root-only behavior but
+  returns a prominent deprecation warning. Documentation and examples pass
+  `descendantPolicy` explicitly. The next contract version rejects omission.
+- Removing archive from generic update is intentionally breaking. Error text
+  must name the dedicated replacement.
+- Dedicated archive expands to remote children by default. Surface the opt-out
+  in both UI and MCP before enabling the new default.
+- No historical repair runs automatically. If production inventory shows a
+  material need, design a separate dry-run-first reconciliation tool.
+- Retry is safe: already-correct rows remain unchanged and emit no duplicate
+  transition events.
+
+## Deferred hardening
+
+- A coordinated Branch metadata/filesystem/terminal recovery workflow.
+- Create-time inheritance or stronger serialization for a child created after
+  archive discovery but before commit. The engine guarantees its discovered
+  transaction snapshot; closing the creation race changes Session creation and
+  needs separate acceptance criteria.
+- A durable multi-cause archive table. Recompute from current ancestry and
+  Branch state first; add schema only if relationship removal or production
+  overlap proves the scalar reason insufficient.
+- A historical orphan-repair operation.
+- Realtime coalescing or a bounded Branch-level invalidation event for very
+  large transitions. This plan preserves the current one-event-per-changed-row
+  contract and records fanout as a scalability concern rather than changing the
+  client protocol inside #2661.
+
+## Delivery map
+
+```text
+Plan review
+  -> Slice 1: Branch completeness + reason invariant
+  -> Slice 2: canonical local archive planner
+  -> Slice 3: explicit bulk policy
+  -> Slice 4: reject generic bypasses + docs
+  -> focused SQLite/PostgreSQL proof
+  -> fresh review and remediation
+  -> real-boundary QA
+  -> Slice 5 (separate PR): bounded dedicated remote units
+  -> remote-policy review + focused proof + QA
+  -> final issue evidence
+```
+
+## Implementation notes
+
+The engine lives in `apps/agor-daemon/src/services/sessions.ts`
+(`planArchiveTransition`, `expandRemoteArchiveUnits`, `planArchiveTargets`,
+`planRestoreTargets`, `applyArchiveTransitionPlan`, `buildArchiveResult`) with
+the public entry points `archive`, `unarchive`, `archiveBtwSession`,
+`restorePromptedSession`, `archiveBranchSessions`, `unarchiveBranchSessions`,
+`previewBulkArchive`, and `bulkArchive`. Repository support is
+`SessionRepository.findByIds` / `updateArchiveStateForTargets` (no-op aware,
+invariant-enforcing), `SessionRelationshipRepository.findRemoteChildrenForSources`
+/ `findRemoteParentsForTargets`, and
+`TaskRepository.findSessionIdsWithNonterminalTasks`. Proof is in
+`apps/agor-daemon/src/services/sessions.archive.test.ts`.
+
+Where the code refines the text above:
+
+- **Scopes.** The engine opens one tenant read scope for planning and applies
+  each unit through the repository's native transaction. When a transport hook
+  already holds a tenant transaction (PostgreSQL), that write nests as a
+  savepoint instead of opening a second unit; the invariant kept is "one
+  atomic write per unit, revalidated against current row state".
+- **Skipped units.** A skipped remote unit is reported once per relationship
+  target (`rootSessionId`), never with the denied branch's ID. A skipped bulk
+  unit is reported once per selected root.
+- **Dry-run overflow.** A remote bound overflow on a dry-run drops the remote
+  units from the reported plan and sets `limitExceeded`; execution fails with
+  `400 Bad Request` before any mutation.
+- **Prompt restore.** `restorePromptedSession` reuses the explicit-root rule,
+  so prompting into an archived branch surfaces the same `409 Conflict` as
+  dedicated unarchive.
+- **UI.** Both archive confirmations request a dry-run first and render the
+  local/remote/running/skipped counts with the remote checkbox
+  (`SessionArchiveConfirmContent`). A session-tier denial offers the explicit
+  root-only retry. There is no UI unarchive surface today; REST and MCP expose
+  the symmetric option.
+- **Bulk preview payload.** Every category returns an exact `count` plus at
+  most `sampleLimit` rows; the legacy omission path returns
+  `deprecatedDefaultApplied: true` and a warning.
+- **Delivery shape.** Slices 1–5 shipped in one pull request at the
+  requester's instruction rather than the two PRs sketched above. The remote
+  policy is isolated in `expandRemoteArchiveUnits`, `planRestoreTargets`'
+  incoming-remote-source check, and the `includeRemoteChildren` option, so it
+  can be reviewed, split, or defaulted off independently of the local engine.
+- **Not in this delivery.** PostgreSQL/RLS integration coverage at the changed
+  boundary, the OpenAPI snapshot refresh (the archive routes' request bodies are
+  not modeled in the checked-in document), and the one-time maintenance script
+  `scripts/archive-old-gateway-sessions.ts`, which still writes through the
+  repository and bypasses the engine.

--- a/packages/core/src/db/repositories/session-relationships.ts
+++ b/packages/core/src/db/repositories/session-relationships.ts
@@ -155,6 +155,58 @@ export class SessionRelationshipRepository {
     }
   }
 
+  /**
+   * Batch-load outgoing `remote_create` edges for a frontier of source sessions.
+   */
+  async findRemoteChildrenForSources(
+    sourceSessionIds: SessionID[]
+  ): Promise<SessionRelationship[]> {
+    const uniqueIds = [...new Set(sourceSessionIds)];
+    if (uniqueIds.length === 0) return [];
+    try {
+      const rows = await select(this.db)
+        .from(sessionRelationships)
+        .where(
+          and(
+            inArray(sessionRelationships.source_session_id, uniqueIds),
+            eq(sessionRelationships.relationship_type, 'remote_create')
+          )
+        )
+        .all();
+      return rows.map((row: SessionRelationshipRow) => this.rowToRelationship(row));
+    } catch (error) {
+      throw new RepositoryError(
+        `Failed to list remote child relationships: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
+  /**
+   * Batch-load incoming `remote_create` edges for a set of target sessions.
+   */
+  async findRemoteParentsForTargets(targetSessionIds: SessionID[]): Promise<SessionRelationship[]> {
+    const uniqueIds = [...new Set(targetSessionIds)];
+    if (uniqueIds.length === 0) return [];
+    try {
+      const rows = await select(this.db)
+        .from(sessionRelationships)
+        .where(
+          and(
+            inArray(sessionRelationships.target_session_id, uniqueIds),
+            eq(sessionRelationships.relationship_type, 'remote_create')
+          )
+        )
+        .all();
+      return rows.map((row: SessionRelationshipRow) => this.rowToRelationship(row));
+    } catch (error) {
+      throw new RepositoryError(
+        `Failed to list remote parent relationships: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
   async findRemoteParents(targetSessionId: SessionID): Promise<SessionRelationship[]> {
     try {
       const rows = await select(this.db)

--- a/packages/core/src/db/repositories/sessions.ts
+++ b/packages/core/src/db/repositories/sessions.ts
@@ -968,6 +968,12 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
       const baseUrl = await getBaseUrl();
       const now = new Date();
       const result = await this.db.transaction(async (tx) => {
+        await lockRowForUpdate(
+          txAsDb(tx),
+          this.db,
+          sessions,
+          inArray(sessions.session_id, fullIds)
+        );
         const currentRows = await select(txAsDb(tx))
           .from(sessions)
           .where(inArray(sessions.session_id, fullIds))

--- a/packages/core/src/db/repositories/sessions.ts
+++ b/packages/core/src/db/repositories/sessions.ts
@@ -366,6 +366,33 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
   }
 
   /**
+   * Load several sessions by full ID in one read. Missing IDs are omitted.
+   */
+  async findByIds(ids: string[]): Promise<Session[]> {
+    const uniqueIds = [...new Set(ids)];
+    if (uniqueIds.length === 0) return [];
+    try {
+      const baseUrl = await getBaseUrl();
+      const results = await select(this.db)
+        .from(sessions)
+        .leftJoin(branches, eq(sessions.branch_id, branches.branch_id))
+        .where(inArray(sessions.session_id, uniqueIds))
+        .all();
+      return results.map(
+        (result: { sessions: SessionRow; branches?: { board_id?: string } | null }) => {
+          const boardId = (result.branches?.board_id ?? null) as UUID | null;
+          return this.rowToSession(result.sessions, boardId, baseUrl);
+        }
+      );
+    } catch (error) {
+      throw new RepositoryError(
+        `Failed to find sessions by id: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
+  /**
    * Find only the branch ID for a session. Used by realtime routing hot paths
    * to avoid loading/enriching the full session row.
    */
@@ -836,6 +863,10 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
         } else if (sdkSessionIdUpdate !== undefined) {
           merged.sdk_session_id = sdkSessionIdUpdate;
         }
+        // Archive invariant: an active row never carries a stale reason.
+        if (genericUpdates.archived === false) {
+          merged.archived_reason = undefined;
+        }
         if (options.replaceAgenticConfig) {
           if (Object.hasOwn(updates, 'model_config')) {
             merged.model_config = updates.model_config;
@@ -917,6 +948,11 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
   /**
    * Atomically update archive state for known sessions that may need distinct
    * archive reasons.
+   *
+   * Rows whose persisted state already matches their target are left untouched
+   * and omitted from the result, so callers can emit exactly one event per
+   * changed session. Restoring a row always clears its reason (archive
+   * invariant: `archived = false` implies `archived_reason IS NULL`).
    */
   async updateArchiveStateForTargets(targets: SessionArchiveStateUpdate[]): Promise<Session[]> {
     if (targets.length === 0) return [];
@@ -927,12 +963,42 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
       const updates = targets.map((target, index) => ({
         ...target,
         id: fullIds[index],
+        archivedReason: target.archived ? target.archivedReason : null,
       }));
       const baseUrl = await getBaseUrl();
       const now = new Date();
       const result = await this.db.transaction(async (tx) => {
+        const currentRows = await select(txAsDb(tx))
+          .from(sessions)
+          .where(inArray(sessions.session_id, fullIds))
+          .all();
+        const currentById = new Map<
+          string,
+          { archived: boolean; archived_reason: string | null }
+        >();
+        for (const row of currentRows as SessionRow[]) {
+          currentById.set(row.session_id, {
+            archived: Boolean(row.archived),
+            archived_reason: row.archived_reason ?? null,
+          });
+        }
+        if (currentById.size !== fullIds.length) {
+          const missing = fullIds.find((id) => !currentById.has(id));
+          throw new EntityNotFoundError('Session', missing ?? ids[0]);
+        }
+
+        const changed = updates.filter((updateTarget) => {
+          const current = currentById.get(updateTarget.id);
+          return (
+            !current ||
+            current.archived !== updateTarget.archived ||
+            current.archived_reason !== (updateTarget.archivedReason ?? null)
+          );
+        });
+        if (changed.length === 0) return [];
+
         const groups = new Map<string, SessionArchiveStateUpdate[]>();
-        for (const updateTarget of updates) {
+        for (const updateTarget of changed) {
           const key = `${updateTarget.archived}:${updateTarget.archivedReason ?? ''}`;
           const group = groups.get(key) ?? [];
           group.push(updateTarget);
@@ -957,15 +1023,12 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
             .run();
         }
 
+        const changedIds = changed.map((target) => target.id);
         const rows = await select(txAsDb(tx))
           .from(sessions)
           .leftJoin(branches, eq(sessions.branch_id, branches.branch_id))
-          .where(inArray(sessions.session_id, fullIds))
+          .where(inArray(sessions.session_id, changedIds))
           .all();
-
-        if (rows.length !== fullIds.length) {
-          throw new EntityNotFoundError('Session', ids[0]);
-        }
 
         const byId = new Map<string, Session>();
         for (const row of rows as Array<{
@@ -976,7 +1039,7 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
           byId.set(row.sessions.session_id, this.rowToSession(row.sessions, boardId, baseUrl));
         }
 
-        return fullIds.map((id) => {
+        return changedIds.map((id) => {
           const session = byId.get(id);
           if (!session) throw new EntityNotFoundError('Session', id);
           return session;

--- a/packages/core/src/db/repositories/tasks.ts
+++ b/packages/core/src/db/repositories/tasks.ts
@@ -725,6 +725,29 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
     }
   }
 
+  /** Which of the given Sessions still have at least one unfinished Task. */
+  async findSessionIdsWithNonterminalTasks(sessionIds: string[]): Promise<Set<string>> {
+    const uniqueIds = [...new Set(sessionIds)];
+    if (uniqueIds.length === 0) return new Set();
+    try {
+      const rows = await select(this.db, { session_id: tasks.session_id })
+        .from(tasks)
+        .where(
+          and(
+            inArray(tasks.session_id, uniqueIds),
+            inArray(tasks.status, [...NONTERMINAL_TASK_STATUSES])
+          )
+        )
+        .all();
+      return new Set(rows.map((row: { session_id: string }) => row.session_id));
+    } catch (error) {
+      throw new RepositoryError(
+        `Failed to inspect unfinished session tasks: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
   /** Whether deleting this Session would cascade any unfinished Task. */
   async hasNonterminalForSession(sessionId: string): Promise<boolean> {
     try {


### PR DESCRIPTION
## Linked issue

Closes #2661

## Summary

- Add one plan/apply **session archive engine** in `SessionsService` and route every archive entry point through it: dedicated REST/MCP archive and unarchive, bulk archive, BTW completion cleanup, prompt auto-unarchive, and branch archive/unarchive.
- Dedicated archive cascades through branch-local descendants and, by default, the sessions the root created in other branches (`remote_create`). Each remote branch is a separate authorization unit that is skipped and reported when the caller lacks permission there. Expansion is bounded (8 hops, 32 branches, 5,000 sessions) and fails closed before mutation. `includeRemoteChildren: false` and `dryRun: true` are supported on the routes and MCP tools.
- Bulk archive takes `descendantPolicy: none | eligible | all` (`eligible` = children with no unfinished task and not newer than `olderThanDays`). A dry-run without a policy previews all three with exact counts and bounded samples (`sampleLimit`). Omitting the policy on execution keeps the legacy `none` for one release and returns `deprecatedDefaultApplied: true` with a warning.
- Generic `sessions.patch` / `update` and `agor_sessions_update` reject `archived` / `archived_reason` with guidance to the dedicated operations; archive fields leave the prompt-flow patch whitelist.
- Branch archive covers every active session (no 1,000-row cap), preserves `manual` / `parent_archived` / `btw_completed` reasons, and branch unarchive restores only `branch_archived` rows.
- Restoration is cause-aware across local genealogy and incoming remote creators, never revives a row inside an archived branch (explicit restores there return 409), and reports what stayed archived and why.
- Invariant: an active row never carries a stale `archived_reason`; repository restoration clears it.
- Exactly one `sessions.patched` event per changed row, none for no-ops.
- UI: archive confirmations request a dry-run first and show local / remote / running / skipped counts with the remote choice visible and checked; a session-tier denial offers an explicit "archive only this session" retry.

## Why / context

After #1842 only `POST /sessions/:id/archive` cascaded. `agor_sessions_update({ archived })`, bulk archive, branch archive, BTW cleanup, and prompt restore each wrote archive state on their own, so children were left active as orphaned roots, branch archive silently stopped at 1,000 sessions and overwrote earlier archive reasons, and branch unarchive resurrected sessions that had been archived independently. Remote-created children were never covered.

The full contract, decisions, and review resolutions are in `context/explorations/session-archive-cascade.md`.

## Implementation notes

- **Engine.** `planArchiveTransition` loads each involved branch once, builds local root closures (per branch for dedicated calls, merged root trees for bulk), authorizes each unit before traversal leaves it, then expands remote units from authorized members only. `applyArchiveTransitionPlan` writes one unit at a time through `SessionRepository.updateArchiveStateForTargets`, which re-reads current state inside its transaction and skips rows that already match.
- **Tenant scope.** The engine opens its own tenant scope (`runWithTenantDatabaseScope`) so internal callers (BTW cleanup, prompt restore, branch archive) satisfy the guard armed by #2662 without holding a transaction across the call. A guarded-SQLite test covers each internal entry point.
- **Disclosure.** A skipped remote unit is reported by its relationship target ID (already visible through `remote_relationships`), never the denied branch ID.
- **Remote default.** Decision 3 reverses the provenance-only reading of `remote_create` from #1527 / #1842 / #2336. It is isolated in `expandRemoteArchiveUnits`, the incoming-remote check in `planRestoreTargets`, and the `includeRemoteChildren` option, so it can be reviewed or defaulted off independently. The design doc sketched this as a separate PR; it ships here in one PR at the requester's instruction. Reviewer decision point.
- **Types.** `SessionArchiveResult` keeps `count` as a deprecated alias and adds `dryRun`, `wouldChangeCount`, per-unit results, `remainingArchived`, `runningCount`, and `limitExceeded`.

## Validation / test plan

- [x] `apps/agor-daemon`: `vitest run src/services/sessions.archive.test.ts` (22 tests: local/remote cascade, opt-outs, RBAC denial and skip, reason upgrade, chain and remote-parent restoration, archived-branch conflict, BTW, prompt restore, >1,000-session branch archive, stale-reason invariant, one event per row, bulk none/eligible/all and skipped units, bound overflow, armed scope guard)
- [x] `apps/agor-daemon`: `sessions.test.ts` (MCP tools), `branches.test.ts`, `boards.test.ts` (board exemption), `register-hooks.test.ts`, `guard-regression.test.ts`
- [x] `apps/agor-daemon`: full `vitest run` — 4153 passed; the 3 failures in `sandbox-context.test.ts` / `spawn-executor.configured.test.ts` are the macOS `/private/var` symlink canonicalization and fail identically without this change
- [x] `apps/agor-ui`: full `vitest run` — 2169 passed, including `useSessionActions.test.tsx` and the new `SessionArchiveConfirm.test.tsx`
- [x] `packages/core`: `vitest run src/db/repositories/sessions src/db/repositories/tasks`
- [x] `tsc --noEmit` for `@agor/daemon` and `agor-ui`
- [x] `pnpm lint`, `pnpm check:multitenancy-boundaries`, `check:shortid`, `check:daemon-filesystem-boundaries`, `check:realtime-boundaries`, `prettier --check` on touched docs, `git diff --check`
- [ ] PostgreSQL/RLS integration run at the changed boundary (not executed locally)
- [ ] Live daemon QA of the UI confirmation flow (not executed; hook and component tests cover the wiring)

## Screenshots / demos

Not included; the UI change is the archive confirmation body and result toasts, covered by component tests.

## Risks / rollout / rollback

- **API behavior change.** `agor_sessions_update` no longer accepts `archived`; generic archive patches are rejected with guidance. Dedicated archive follows remote-created sessions by default (opt-out available). Bulk gains an explicit policy; omission is deprecated, not yet rejected.
- **Realtime fan-out** is unchanged (one event per changed row); very large branch archives still emit one event per session. Coalescing is listed as deferred hardening in the design doc.
- **Rollback** is reverting the PR. No schema migration or data backfill; existing rows are untouched until the next archive operation.

## Out of scope / follow-ups

- PostgreSQL/RLS integration coverage for the engine boundary.
- OpenAPI snapshot refresh: the archive routes' request bodies are not modeled in the checked-in document today.
- `scripts/archive-old-gateway-sessions.ts` still writes through the repository and bypasses the engine.
- Coalesced realtime updates for very large archive transitions.
- A historical orphan-repair operation (a dry-run-first reconciliation tool, if production inventory justifies it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RDUYi5KXCXtKnvhUqDSc8o
