### PR TITLE
fix(gateway): keep mapped threads routing after a proactive emit

### DIFF
--- a/apps/agor-daemon/src/services/gateway.test.ts
+++ b/apps/agor-daemon/src/services/gateway.test.ts
@@ -1301,6 +1301,87 @@ describe('GatewayService Slack thread catch-up', () => {
   });
 });
 
+describe('GatewayService mapped-thread follow-ups', () => {
+  const mappedThreadId = 'C123-100.000000';
+
+  function makeSeedInMappedThread(): GatewayOutboundMessage {
+    return {
+      id: 'seed-in-mapped-thread',
+      gateway_channel_id: slackChannel.id,
+      channel_type: 'slack',
+      platform_channel_id: 'C123',
+      platform_message_id: '102.000000',
+      platform_thread_id: mappedThreadId,
+      platform_permalink: null,
+      target_branch_id: slackChannel.target_branch_id,
+      emitted_by_user_id: 'user-1',
+      emitted_by_session_id: 'sess-1',
+      emitted_by_task_id: 'task-origin',
+      emitted_by_schedule_id: null,
+      message_text: 'Status update from the mapped session.',
+      message_preview: 'Status update from the mapped session.',
+      metadata: null,
+      consumed_by_session_id: null,
+      consumed_at: null,
+      created_at: '2026-06-22T00:00:00.000Z',
+      updated_at: '2026-06-22T00:00:00.000Z',
+    } as unknown as GatewayOutboundMessage;
+  }
+
+  it('prompts the mapped session after a proactive message was emitted into the same thread', async () => {
+    const fetchThreadHistory = vi.fn(async () => ({
+      threadId: mappedThreadId,
+      channel: 'C123',
+      thread_ts: '100.000000',
+      has_more: false,
+      messages: [
+        {
+          ts: '103.000000',
+          iso_time: '2026-06-22T00:00:03.000Z',
+          actor_label: 'Alice',
+          text: '<@U_BOT> any update?',
+          is_bot: false,
+          is_trigger: true,
+        },
+      ],
+    }));
+    const sendMessage = vi.fn(async () => '104.000000');
+    const { service, promptCreate, sessionsCreate, admitReplySession, completeReplyAdmission } =
+      makeGatewayHarness({
+        existingMapping: makeMapping({ thread_id: mappedThreadId }),
+        connector: { fetchThreadHistory, sendMessage },
+        outboundSeed: makeSeedInMappedThread(),
+      });
+
+    const result = await service.create({
+      channel_key: 'slack-key',
+      thread_id: mappedThreadId,
+      text: 'any update?',
+      metadata: {
+        channel: 'C123',
+        channel_type: 'channel',
+        slack_has_mention: true,
+        slack_message_ts: '103.000000',
+        slack_thread_ts: '100.000000',
+      },
+    });
+
+    expect(result).toMatchObject({ success: true, sessionId: 'sess-1', created: false });
+    expect(promptCreate).toHaveBeenCalledTimes(1);
+    expect(promptCreate.mock.calls[0][1]).toMatchObject({ route: { id: 'sess-1' } });
+    expect(sessionsCreate).not.toHaveBeenCalled();
+    // The mapping — not the proactive message — owns the thread, so the seed
+    // is never reserved or consumed and the reply keeps ordinary follow-up
+    // shape instead of a seeded thread's initial prompt.
+    expect(admitReplySession).not.toHaveBeenCalled();
+    expect(completeReplyAdmission).not.toHaveBeenCalled();
+    expect(fetchThreadHistory).toHaveBeenCalledOnce();
+    const prompt = promptCreate.mock.calls[0][0].prompt as string;
+    expect(prompt).toContain('any update?');
+    expect(prompt).not.toContain('This Slack thread began from a proactive Agor gateway message');
+  });
+});
+
 describe('GatewayService startup/bootstrap hint (#1982)', () => {
   const STARTUP_BOOTSTRAP_HINT =
     'Startup/bootstrap note: Follow any startup/bootstrap instructions defined by the working directory before answering the gateway message above.';

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -2623,7 +2623,22 @@ export class GatewayService {
     // Seed admission is the one durable mutation that must happen before
     // creating a session. It also replaces the old lookup-then-late-claim
     // sequence, so competing provider aliases receive one stable ID.
-    if (channel.channel_type === 'slack' || channel.channel_type === 'discord') {
+    //
+    // Seed admission only decides which Session a thread that has none yet
+    // belongs to. A thread that already carries a canonical mapping the seed
+    // did not create is not a seed reply: a proactive outbound message can be
+    // sent into a thread that is already routed to a Session, and the mapping
+    // stays that thread's owner. Skip admission entirely for those threads so
+    // no seed is reserved or consumed for a thread it does not own, and the
+    // message continues down the ordinary follow-up path below.
+    const existingMappingSeedId = (existingMapping?.metadata as Record<string, unknown> | null)
+      ?.outbound_seed_id;
+    const threadOwnedByUnseededMapping =
+      !!existingMapping && typeof existingMappingSeedId !== 'string';
+    if (
+      (channel.channel_type === 'slack' || channel.channel_type === 'discord') &&
+      !threadOwnedByUnseededMapping
+    ) {
       outboundAdmission = await this.outboundRepo.admitReplySession(channel.id, data.thread_id);
       if (outboundAdmission) {
         outboundSeed = outboundAdmission.message;


### PR DESCRIPTION
### Problem

Once a proactive gateway message has been emitted into a Slack or Discord thread that is already mapped to a session, every later inbound message on that thread is dropped: no task is admitted, no session is created, and nothing is reported back on the thread. Threads that have never received a proactive message are unaffected.

### Cause

Seed admission ran for every Slack and Discord inbound message. It resolves a reply seed by the inbound thread key, and a proactive outbound row records `platform_thread_id` in exactly the form a thread mapping records `thread_id`. A proactive message can be sent into a thread that is already mapped to a session, so from that point on the thread resolved a seed it did not open.

The canonical mapping then carried no `outbound_seed_id` and its session was not the seed's reserved session, so admission threw `Gateway outbound seed admission does not match canonical mapping`. That throw sits upstream of the try/catch that wraps prompt admission and escapes `GatewayService.create()` into the connector callback, which has no catch — hence the silent drop. The condition is durable rather than transient, so it repeats for every later message on that one thread.

### Fix

Seed admission only decides which session a thread that has none yet belongs to. Skip it when the thread already carries a canonical mapping the seed did not create, so no seed is reserved or consumed for a thread it does not own and the message continues down the ordinary follow-up path.

Threads whose mapping *was* created by a seed keep the existing admission and consistency checks, including crash recovery of an initial delivery. The non-DM require-mention gate is unchanged.

### Tests

New regression test: a follow-up to an existing mapped thread that has since received a proactive message prompts the mapped session, creates no new session, never reserves or consumes the seed, and keeps ordinary follow-up prompt shape. It fails on `main` with the admission error and passes with the fix.

Full `@agor/daemon` (4153 passed) and `@agor/core` (4112 passed) suites pass, along with typecheck and lint.