### PR TITLE
fix(daemon): restore tenant-scoped artifact routes

### DIFF
--- a/apps/agor-daemon/src/register-hooks.artifact-routes.test.ts
+++ b/apps/agor-daemon/src/register-hooks.artifact-routes.test.ts
@@ -1,0 +1,219 @@
+import type { Server } from 'node:http';
+import {
+  ArtifactRepository,
+  BoardRepository,
+  createTenantScopedDatabaseProxy,
+  generateId,
+  UsersRepository,
+} from '@agor/core/db';
+import {
+  AuthenticationService,
+  authenticate,
+  errorHandler,
+  feathers,
+  feathersExpress,
+  rest,
+} from '@agor/core/feathers';
+import type { HookContext, UUID } from '@agor/core/types';
+import { ROLES } from '@agor/core/types';
+import jwt from 'jsonwebtoken';
+import { expect } from 'vitest';
+import { dbTest } from '../../../packages/core/src/db/test-helpers.js';
+import { RuntimeJWTStrategy } from './auth/runtime-jwt-strategy.js';
+import { type RegisterHooksContext, registerHooks } from './register-hooks.js';
+import {
+  ARTIFACTS_SERVICE_TRANSPORT_METHODS,
+  createArtifactsService,
+} from './services/artifacts.js';
+import { createUsersService } from './services/users.js';
+
+const JWT_SECRET = 'artifact-custom-route-test-secret';
+const STATIC_TENANT = 'artifact-custom-route-test';
+
+const authenticationConfig = {
+  secret: JWT_SECRET,
+  entity: 'user',
+  entityId: 'user_id',
+  service: 'users',
+  authStrategies: ['jwt'],
+  jwtOptions: {
+    header: { typ: 'access' },
+    audience: 'https://agor.dev',
+    issuer: 'agor',
+    algorithm: 'HS256',
+    expiresIn: '15m',
+  },
+};
+
+function accessToken(userId: UUID): string {
+  return jwt.sign({ sub: userId, type: 'access' }, JWT_SECRET, {
+    issuer: 'agor',
+    audience: 'https://agor.dev',
+    expiresIn: '15m',
+  });
+}
+
+const inertService = {
+  async find() {
+    return [];
+  },
+  async get() {
+    return null;
+  },
+  async create(data: unknown) {
+    return data;
+  },
+  async update(_id: unknown, data: unknown) {
+    return data;
+  },
+  async patch(_id: unknown, data: unknown) {
+    return data;
+  },
+  async remove() {
+    return null;
+  },
+};
+
+dbTest(
+  'authenticated artifact payload and console routes enter the guarded SQLite tenant scope',
+  async ({ db: rawDb }) => {
+    const ownerId = generateId() as UUID;
+    const viewerId = generateId() as UUID;
+    const memberId = generateId() as UUID;
+    const users = new UsersRepository(rawDb);
+    await users.create({
+      user_id: ownerId,
+      email: 'artifact-owner@example.test',
+      role: ROLES.MEMBER,
+    });
+    await users.create({
+      user_id: viewerId,
+      email: 'artifact-viewer@example.test',
+      role: ROLES.VIEWER,
+    });
+    await users.create({
+      user_id: memberId,
+      email: 'artifact-member@example.test',
+      role: ROLES.MEMBER,
+    });
+    const board = await new BoardRepository(rawDb).create({
+      name: 'Artifact custom route test board',
+      created_by: ownerId,
+    });
+    const artifact = await new ArtifactRepository(rawDb).create({
+      artifact_id: generateId(),
+      board_id: board.board_id,
+      name: 'Guarded custom route artifact',
+      template: 'static',
+      files: { '/index.html': '<h1>Scoped artifact payload</h1>' },
+      content_hash: 'guarded-custom-route-hash',
+      public: true,
+      created_by: ownerId,
+    });
+
+    // Production wraps the daemon handle with this guard. It is armed for
+    // SQLite too, so an unscoped custom-route repository access fails exactly
+    // as it did after #2662.
+    const db = createTenantScopedDatabaseProxy(rawDb, {
+      label: 'artifact custom route test database',
+    });
+    const config = {
+      database: { dialect: 'sqlite' },
+      multi_tenancy: { mode: 'static', static_tenant_id: STATIC_TENANT },
+      execution: { branch_rbac: false },
+    } as RegisterHooksContext['config'];
+    const app = feathersExpress(feathers());
+    app.use(feathersExpress.json());
+    app.configure(rest());
+    (app as unknown as { publish: () => void }).publish = () => undefined;
+    app.set('config', config);
+    app.set('authentication', authenticationConfig);
+
+    // registerHooks expects the ordinary daemon services to exist. Only users
+    // and artifacts participate in this focused request; the rest are inert.
+    for (const path of [
+      'messages',
+      'repos',
+      'branches',
+      'sessions',
+      'leaderboard',
+      'schedules',
+      'tasks',
+    ]) {
+      app.use(`/${path}`, inertService);
+    }
+    app.use('/users', createUsersService(db, app, config));
+    const authentication = new AuthenticationService(app);
+    authentication.register('jwt', new RuntimeJWTStrategy());
+    app.use('/authentication', authentication);
+    app.use('/artifacts', createArtifactsService(db, app), {
+      methods: [...ARTIFACTS_SERVICE_TRANSPORT_METHODS],
+    });
+
+    registerHooks({
+      db,
+      app,
+      config,
+      jwtSecret: JWT_SECRET,
+      requireAuth: authenticate({ strategies: ['jwt'] }) as (
+        context: HookContext
+      ) => Promise<HookContext>,
+      superadminOpts: { allowSuperadmin: false },
+      deployment: { mode: 'standalone' },
+      sessionsService: app.service('sessions') as never,
+      messagesService: app.service('messages') as never,
+      boardsService: undefined,
+      branchRepository: { findById: async () => null } as never,
+      usersRepository: users,
+      sessionsRepository: {} as never,
+    });
+    app.use(errorHandler());
+
+    const server = (await app.listen(0)) as Server;
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('Expected a TCP test server');
+    const baseUrl = `http://127.0.0.1:${address.port}`;
+    const authHeaders = (userId: UUID) => ({
+      authorization: `Bearer ${accessToken(userId)}`,
+    });
+
+    try {
+      const unauthenticated = await fetch(`${baseUrl}/artifacts/${artifact.artifact_id}/payload`);
+      expect(unauthenticated.status).toBe(401);
+
+      // Viewer remains sufficient for a public payload and the repository read
+      // succeeds through the armed guard only because the custom route is scoped.
+      const payload = await fetch(`${baseUrl}/artifacts/${artifact.artifact_id}/payload`, {
+        headers: authHeaders(viewerId),
+      });
+      expect(payload.status, await payload.clone().text()).toBe(200);
+      await expect(payload.json()).resolves.toMatchObject({
+        artifact_id: artifact.artifact_id,
+        files: { '/index.html': '<h1>Scoped artifact payload</h1>' },
+      });
+
+      // The same shared registrar scopes custom writes without changing their
+      // role floor: viewers remain forbidden, while members can append logs.
+      const viewerWrite = await fetch(`${baseUrl}/artifacts/${artifact.artifact_id}/console`, {
+        method: 'POST',
+        headers: { ...authHeaders(viewerId), 'content-type': 'application/json' },
+        body: JSON.stringify({ entries: [] }),
+      });
+      expect(viewerWrite.status).toBe(403);
+
+      const memberWrite = await fetch(`${baseUrl}/artifacts/${artifact.artifact_id}/console`, {
+        method: 'POST',
+        headers: { ...authHeaders(memberId), 'content-type': 'application/json' },
+        body: JSON.stringify({
+          entries: [{ timestamp: 1, level: 'log', message: 'scoped console write' }],
+        }),
+      });
+      expect(memberWrite.status, await memberWrite.clone().text()).toBe(201);
+      await expect(memberWrite.json()).resolves.toEqual({ success: true });
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    }
+  }
+);

--- a/apps/agor-daemon/src/register-hooks.artifact-routes.test.ts
+++ b/apps/agor-daemon/src/register-hooks.artifact-routes.test.ts
@@ -107,6 +107,7 @@ dbTest(
       template: 'static',
       files: { '/index.html': '<h1>Scoped artifact payload</h1>' },
       content_hash: 'guarded-custom-route-hash',
+      required_env_vars: ['ARTIFACT_ROUTE_TEST_SECRET'],
       public: true,
       created_by: ownerId,
     });
@@ -210,6 +211,46 @@ dbTest(
       });
       expect(memberWrite.status, await memberWrite.clone().text()).toBe(201);
       await expect(memberWrite.json()).resolves.toEqual({ success: true });
+
+      // Exercise both persisted trust write routes through the real REST
+      // boundary. The service's trust repository uses the guarded database,
+      // so create and revoke would fail if either custom route lost its tenant
+      // database scope.
+      const trust = await fetch(`${baseUrl}/artifacts/${artifact.artifact_id}/trust`, {
+        method: 'POST',
+        headers: { ...authHeaders(memberId), 'content-type': 'application/json' },
+        body: JSON.stringify({ scopeType: 'artifact' }),
+      });
+      expect(trust.status, await trust.clone().text()).toBe(201);
+      await expect(trust.json()).resolves.toEqual({ scope: 'artifact', persisted: true });
+
+      const grants = await fetch(`${baseUrl}/me/artifact-trust-grants`, {
+        headers: authHeaders(memberId),
+      });
+      expect(grants.status, await grants.clone().text()).toBe(200);
+      const grantList = (await grants.json()) as Array<{ grant_id: string; scope_value: string }>;
+      expect(grantList).toEqual([
+        expect.objectContaining({
+          grant_id: expect.any(String),
+          scope_value: artifact.artifact_id,
+        }),
+      ]);
+
+      const revoke = await fetch(`${baseUrl}/me/artifact-trust-grants/${grantList[0]?.grant_id}`, {
+        method: 'DELETE',
+        headers: authHeaders(memberId),
+      });
+      expect(revoke.status, await revoke.clone().text()).toBe(200);
+      await expect(revoke.json()).resolves.toMatchObject({
+        revoked: true,
+        grantId: grantList[0]?.grant_id,
+      });
+
+      const afterRevoke = await fetch(`${baseUrl}/me/artifact-trust-grants`, {
+        headers: authHeaders(memberId),
+      });
+      expect(afterRevoke.status, await afterRevoke.clone().text()).toBe(200);
+      await expect(afterRevoke.json()).resolves.toEqual([]);
     } finally {
       await new Promise<void>((resolve, reject) => {
         server.close((error) => (error ? reject(error) : resolve()));

--- a/apps/agor-daemon/src/register-hooks.static-scope.test.ts
+++ b/apps/agor-daemon/src/register-hooks.static-scope.test.ts
@@ -81,13 +81,14 @@ describe('static-mode tenant DB scope for owned services', () => {
 describe('registerHooks static-mode owned-service scope wiring', () => {
   type AroundHook = (ctx: HookContext, next: () => Promise<void>) => Promise<void>;
 
-  const artifactCustomRoutePaths = [
-    'artifacts/:id/payload',
-    'artifacts/:id/console',
-    'artifacts/:id/sandpack-error',
-    'artifacts/:id/runtime-response/:requestId',
-    'artifacts/:id/trust',
-    'me/artifact-trust-grants',
+  const artifactCustomRouteProbes = [
+    ['artifacts/:id/payload', 'find'],
+    ['artifacts/:id/console', 'create'],
+    ['artifacts/:id/sandpack-error', 'create'],
+    ['artifacts/:id/runtime-response/:requestId', 'create'],
+    ['artifacts/:id/trust', 'create'],
+    ['me/artifact-trust-grants', 'find'],
+    ['me/artifact-trust-grants', 'remove'],
   ] as const;
 
   /** Run registerHooks against a recorder app and return around hooks per path. */
@@ -162,10 +163,28 @@ describe('registerHooks static-mode owned-service scope wiring', () => {
     expect(scopeKind).toBe('tenant');
   });
 
-  it.each(artifactCustomRoutePaths)(
-    'installs the shared tenant scope and write gate around /%s',
-    (path) => {
-      expect(captureAroundHooks().get(path)).toHaveLength(2);
+  it.each(artifactCustomRouteProbes)(
+    'runs %s#%s inside the guarded tenant database scope',
+    async (path, method) => {
+      const around = captureAroundHooks().get(path) ?? [];
+      expect(around.length).toBeGreaterThan(0);
+
+      // Exercise the installed chain instead of relying on its structural
+      // arity. Any refactor that leaves identity but drops database scope will
+      // trip this guarded SQLite touch, including the trust write routes.
+      const probe = createTenantScopedDatabaseProxy({ run: () => undefined } as never, {
+        label: `${path} wiring probe db`,
+      });
+      const innermost = async () => {
+        (probe as unknown as { run(): void }).run();
+      };
+      const composed = around.reduceRight<() => Promise<void>>(
+        (next, hook) => () => hook({ path, method, params: {} } as unknown as HookContext, next),
+        innermost
+      );
+
+      await expect(composed()).resolves.toBeUndefined();
+      expect(getCurrentTenantDatabaseScope()).toBeUndefined();
     }
   );
 });

--- a/apps/agor-daemon/src/register-hooks.static-scope.test.ts
+++ b/apps/agor-daemon/src/register-hooks.static-scope.test.ts
@@ -81,6 +81,15 @@ describe('static-mode tenant DB scope for owned services', () => {
 describe('registerHooks static-mode owned-service scope wiring', () => {
   type AroundHook = (ctx: HookContext, next: () => Promise<void>) => Promise<void>;
 
+  const artifactCustomRoutePaths = [
+    'artifacts/:id/payload',
+    'artifacts/:id/console',
+    'artifacts/:id/sandpack-error',
+    'artifacts/:id/runtime-response/:requestId',
+    'artifacts/:id/trust',
+    'me/artifact-trust-grants',
+  ] as const;
+
   /** Run registerHooks against a recorder app and return around hooks per path. */
   function captureAroundHooks(): Map<string, AroundHook[]> {
     const captured = new Map<string, AroundHook[]>();
@@ -152,4 +161,11 @@ describe('registerHooks static-mode owned-service scope wiring', () => {
     await expect(composed()).resolves.toBeUndefined();
     expect(scopeKind).toBe('tenant');
   });
+
+  it.each(artifactCustomRoutePaths)(
+    'installs the shared tenant scope and write gate around /%s',
+    (path) => {
+      expect(captureAroundHooks().get(path)).toHaveLength(2);
+    }
+  );
 });

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -138,7 +138,6 @@ import { resolveWebTerminalCapability } from './terminal-capability.js';
 import { buildSessionCreatedAnalyticsProperties } from './utils/analytics-payloads.js';
 import {
   ensureMinimumRole,
-  registerAuthenticatedRoute,
   requireAdminForEnvConfig,
   requireMinimumRole,
 } from './utils/authorization.js';
@@ -207,6 +206,7 @@ import {
   isTerminalQueueProcessingSuppressed,
   sessionCanStartTask,
 } from './utils/session-task-state.js';
+import { createTenantScopedAuthenticatedRouteRegistrar } from './utils/tenant-authenticated-route.js';
 import {
   createTenantDatabaseScopeAroundHook,
   createTenantWriteAdmissionAroundHook,
@@ -1137,6 +1137,11 @@ export function registerHooks(ctx: RegisterHooksContext): void {
 
   const multiTenancy = resolveMultiTenancyConfig(config);
   const tenantColumnsEnabled = resolveMultiTenancyDatabaseDialect(config) === 'postgresql';
+  const registerTenantScopedAuthenticatedRoute = createTenantScopedAuthenticatedRouteRegistrar({
+    db,
+    config,
+    jwtSecret,
+  });
   const executionMode = resolveExecutionSecurityMode(config);
   const sessionMcpTokenAfterHooks = createSessionMcpTokenAfterHooks({
     app,
@@ -1873,7 +1878,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
 
   // Custom REST routes for artifact payload and console
   {
-    registerAuthenticatedRoute(
+    registerTenantScopedAuthenticatedRoute(
       app,
       '/artifacts/:id/payload',
       {
@@ -1888,7 +1893,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       requireAuth
     );
 
-    registerAuthenticatedRoute(
+    registerTenantScopedAuthenticatedRoute(
       app,
       '/artifacts/:id/console',
       {
@@ -1926,7 +1931,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       requireAuth
     );
 
-    registerAuthenticatedRoute(
+    registerTenantScopedAuthenticatedRoute(
       app,
       '/artifacts/:id/sandpack-error',
       {
@@ -1975,7 +1980,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     // here too so a wrongly-sized payload doesn't bloat the daemon's
     // pending-query map or the agent's MCP context.
     const RUNTIME_RESPONSE_BYTE_CAP = 512 * 1024;
-    registerAuthenticatedRoute(
+    registerTenantScopedAuthenticatedRoute(
       app,
       '/artifacts/:id/runtime-response/:requestId',
       {
@@ -2029,7 +2034,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     // Per-artifact: POST creates a grant covering the artifact's currently-
     // requested env vars and grants. Caller MUST be authenticated; the grant
     // is attributed to the calling user.
-    registerAuthenticatedRoute(
+    registerTenantScopedAuthenticatedRoute(
       app,
       '/artifacts/:id/trust',
       {
@@ -2061,7 +2066,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
     );
 
     // List the calling user's active trust grants. Used by the settings page.
-    registerAuthenticatedRoute(
+    registerTenantScopedAuthenticatedRoute(
       app,
       '/me/artifact-trust-grants',
       {

--- a/apps/agor-daemon/src/register-routes.board-comments.test.ts
+++ b/apps/agor-daemon/src/register-routes.board-comments.test.ts
@@ -7,8 +7,8 @@ import {
   authorizeBoardCommentRouteAccess,
   boardCommentReactionInput,
   boardCommentReplyInput,
-  createTenantScopedAuthenticatedRouteRegistrar,
 } from './register-routes.js';
+import { createTenantScopedAuthenticatedRouteRegistrar } from './utils/tenant-authenticated-route.js';
 
 const USER = '018f0000-0000-7000-8000-000000000001';
 const OTHER = '018f0000-0000-7000-8000-000000000002';

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -202,7 +202,7 @@ import { appendSystemMessage } from './utils/append-system-message.js';
 import { buildAuthRateLimitKey } from './utils/auth-rate-limit-key.js';
 import {
   ensureMinimumRole,
-  registerAuthenticatedRoute as registerAuthenticatedRouteBase,
+  registerAuthenticatedRoute as registerAuthenticatedRouteUnscoped,
   requireMinimumRole,
 } from './utils/authorization.js';
 import { authorizeBranchArchiveDelete } from './utils/branch-archive-delete-authorization.js';
@@ -879,7 +879,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     jwtSecret,
   });
 
-  const registerLongAuthenticatedRoute: typeof registerAuthenticatedRouteBase = (
+  const registerLongAuthenticatedRoute: typeof registerAuthenticatedRouteUnscoped = (
     routeApp,
     path,
     service,
@@ -887,7 +887,7 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
     routeRequireAuth,
     options = {}
   ) =>
-    registerAuthenticatedRouteBase(routeApp, path, service, authConfig, routeRequireAuth, {
+    registerAuthenticatedRouteUnscoped(routeApp, path, service, authConfig, routeRequireAuth, {
       ...options,
       around: [tenantIdentityAround, tenantWriteAdmissionAround, ...(options.around ?? [])],
     });

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -250,10 +250,10 @@ import {
 import { buildTaskLaunchState } from './utils/task-launch-state.js';
 import { normalizeMessageSource, runExistingTask } from './utils/task-runner.js';
 import { isAgenticToolEnabledForTenant } from './utils/tenant-agentic-tool-validation.js';
+import { createTenantScopedAuthenticatedRouteRegistrar } from './utils/tenant-authenticated-route.js';
 import {
   createTenantDatabaseScopeAroundHook,
   createTenantWriteAdmissionAroundHook,
-  createTenantWriteGateAroundHook,
   deferWithTenantContext,
   withFreshTenantWrite,
 } from './utils/tenant-db-scope.js';
@@ -512,26 +512,6 @@ export function createRequiredTenantDatabaseRunner(db: TenantScopeAwareDatabase)
     if (!tenantId) throw new Error('Missing active tenant context for database operation');
     return runWithTenantDatabaseScope(db, tenantId, work);
   };
-}
-
-/**
- * Register an authenticated custom route with the same tenant transaction and
- * write-freeze gate as ordinary tenant-owned Feathers services. Custom routes
- * are installed after `registerHooks()`, so this registrar—not a static path
- * list—is their authoritative database boundary.
- */
-export function createTenantScopedAuthenticatedRouteRegistrar(options: {
-  db: TenantScopeAwareDatabase;
-  config: AgorConfig;
-  jwtSecret: string;
-}): typeof registerAuthenticatedRouteBase {
-  const tenantDatabaseScopeAround = createTenantDatabaseScopeAroundHook(options);
-  const tenantWriteGateAround = createTenantWriteGateAroundHook(options.db);
-  return (routeApp, path, service, authConfig, routeRequireAuth, routeOptions = {}) =>
-    registerAuthenticatedRouteBase(routeApp, path, service, authConfig, routeRequireAuth, {
-      ...routeOptions,
-      around: [tenantDatabaseScopeAround, tenantWriteGateAround, ...(routeOptions.around ?? [])],
-    });
 }
 
 type BoardCommentRouteParams = Pick<AuthenticatedParams, 'provider' | 'user'>;

--- a/apps/agor-daemon/src/utils/tenant-authenticated-route.ts
+++ b/apps/agor-daemon/src/utils/tenant-authenticated-route.ts
@@ -1,0 +1,29 @@
+import type { AgorConfig } from '@agor/core/config';
+import type { TenantScopeAwareDatabase } from '@agor/core/db';
+import { registerAuthenticatedRoute as registerAuthenticatedRouteBase } from './authorization.js';
+import {
+  createTenantDatabaseScopeAroundHook,
+  createTenantWriteGateAroundHook,
+} from './tenant-db-scope.js';
+
+/**
+ * Register an authenticated custom route with the same tenant database scope
+ * and write-freeze gate as an ordinary tenant-owned Feathers service.
+ *
+ * Custom routes are not necessarily present when the static tenant-owned
+ * service hook list is installed, so this registrar is their authoritative
+ * database boundary.
+ */
+export function createTenantScopedAuthenticatedRouteRegistrar(options: {
+  db: TenantScopeAwareDatabase;
+  config: AgorConfig;
+  jwtSecret: string;
+}): typeof registerAuthenticatedRouteBase {
+  const tenantDatabaseScopeAround = createTenantDatabaseScopeAroundHook(options);
+  const tenantWriteGateAround = createTenantWriteGateAroundHook(options.db);
+  return (routeApp, path, service, authConfig, routeRequireAuth, routeOptions = {}) =>
+    registerAuthenticatedRouteBase(routeApp, path, service, authConfig, routeRequireAuth, {
+      ...routeOptions,
+      around: [tenantDatabaseScopeAround, tenantWriteGateAround, ...(routeOptions.around ?? [])],
+    });
+}

--- a/apps/agor-daemon/src/utils/tenant-authenticated-route.ts
+++ b/apps/agor-daemon/src/utils/tenant-authenticated-route.ts
@@ -1,6 +1,6 @@
 import type { AgorConfig } from '@agor/core/config';
 import type { TenantScopeAwareDatabase } from '@agor/core/db';
-import { registerAuthenticatedRoute as registerAuthenticatedRouteBase } from './authorization.js';
+import { registerAuthenticatedRoute as registerAuthenticatedRouteUnscoped } from './authorization.js';
 import {
   createTenantDatabaseScopeAroundHook,
   createTenantWriteGateAroundHook,
@@ -10,19 +10,20 @@ import {
  * Register an authenticated custom route with the same tenant database scope
  * and write-freeze gate as an ordinary tenant-owned Feathers service.
  *
- * Custom routes are not necessarily present when the static tenant-owned
- * service hook list is installed, so this registrar is their authoritative
- * database boundary.
+ * Custom-route registrations do not pass through the centralized
+ * TENANT_OWNED_SERVICE_PATHS hook inventory. Callers must use this registrar
+ * so tenant database scope and write fencing are installed at the route's
+ * registration boundary.
  */
 export function createTenantScopedAuthenticatedRouteRegistrar(options: {
   db: TenantScopeAwareDatabase;
   config: AgorConfig;
   jwtSecret: string;
-}): typeof registerAuthenticatedRouteBase {
+}): typeof registerAuthenticatedRouteUnscoped {
   const tenantDatabaseScopeAround = createTenantDatabaseScopeAroundHook(options);
   const tenantWriteGateAround = createTenantWriteGateAroundHook(options.db);
   return (routeApp, path, service, authConfig, routeRequireAuth, routeOptions = {}) =>
-    registerAuthenticatedRouteBase(routeApp, path, service, authConfig, routeRequireAuth, {
+    registerAuthenticatedRouteUnscoped(routeApp, path, service, authConfig, routeRequireAuth, {
       ...routeOptions,
       around: [tenantDatabaseScopeAround, tenantWriteGateAround, ...(routeOptions.around ?? [])],
     });

--- a/context/concepts/multitenancy.md
+++ b/context/concepts/multitenancy.md
@@ -88,6 +88,17 @@ Long-lived work should carry tenant identity without holding an HTTP-long
 transaction; open short tenant database units at the actual database call.
 Globally unique UUIDs identify resources but do not authorize tenant access.
 
+Authenticated custom Feathers routes must use
+`createTenantScopedAuthenticatedRouteRegistrar`; the unscoped
+`registerAuthenticatedRoute` base installs authentication and role hooks only.
+Direct uses of that base should remain limited to the tenant-scoped registrar
+and the explicitly reviewed long-route adapter in `register-routes.ts`, which
+carries tenant identity and opens short database units instead of holding an
+HTTP-long transaction. Registered services that read tenant repositories
+belong in `TENANT_OWNED_SERVICE_PATHS` unless they intentionally cross a
+long-running external boundary and open short scoped units at each database
+call.
+
 ## Proportional validation
 
 Add only the checks implicated by the changed boundary:


### PR DESCRIPTION
## Summary

Restores tenant-owned artifact custom routes after every artifact payload request began returning HTTP 500 in production.

- Adds one scoped authenticated-route registrar and uses it for all six artifact route registrations.
- Preserves the existing authentication/role contract while installing tenant DB scope and the tenant write-freeze gate at the custom-route boundary.
- Rebased onto current `main` at `94ea31a8`, which includes the now-merged gateway probe fix from #2675.

## Production symptom and root cause

After #2662 armed the tenant database-scope guard in every deployment mode, **all custom artifact payload requests returned 500** with `Missing tenant database scope`.

The artifact handlers are custom Feathers routes. They were registered through the base `registerAuthenticatedRoute`, which installs authentication and role hooks but does not participate in the centralized `TENANT_OWNED_SERVICE_PATHS` hook inventory. Their direct calls into artifact service/repository methods therefore reached the guarded database proxy without an ambient tenant DB scope. Before #2662, that missing boundary was silent in static/SQLite and tests; once the guard became default-on, it failed closed as intended and exposed the gap.

This is distinct from #2653. That PR fixed propagation of per-user sandbox home and tenant storage mounts for artifact **publish/validate/land executor launches**. It did not scope the custom HTTP routes used to fetch payloads or operate console/error/runtime/trust data, so it could not fix this 500.

## Fix

`createTenantScopedAuthenticatedRouteRegistrar` composes the existing authenticated-route helper with:

1. `createTenantDatabaseScopeAroundHook`, and
2. `createTenantWriteGateAroundHook`.

The registrar is created from trusted daemon `db`, `config`, and `jwtSecret` dependencies and is used for all six artifact route registrations:

1. `GET /artifacts/:id/payload`
2. `POST /artifacts/:id/console`
3. `POST /artifacts/:id/sandpack-error`
4. `POST /artifacts/:id/runtime-response/:requestId`
5. `POST /artifacts/:id/trust`
6. `GET /me/artifact-trust-grants` and `DELETE /me/artifact-trust-grants/:id`

Existing route-specific `around` hooks remain ordered after those boundary hooks. The base registrar remains available only behind this scoped wrapper and the explicitly reviewed long-route adapter; the multitenancy guide records that contract.

## #2675 reconciliation / takeover

With the PR owner's explicit approval, this branch was taken over and rebased from merge base `c118a939` onto current `main` at `94ea31a8`. #2675 had merged into that base and contains the superior gateway-specific result: identity-only request propagation, short repository units of work outside provider I/O, a nested-call SQLite regression test, and PostgreSQL cross-tenant/non-disclosure coverage. Those changes are therefore retained through ancestry. The earlier overlapping #2674 gateway commit/tests were dropped during the history rewrite rather than duplicating or weakening #2675; the remaining two attributed commits are artifact-only.

## Validation

- [x] `pnpm check` passed: all workspace typechecks, full lint, short-ID policy, multitenancy/filesystem/realtime boundary checks, and production builds.
- [x] Focused daemon suite: 186 passed, 7 PostgreSQL tests skipped locally because no PostgreSQL test URL was configured.
- [x] GitHub's PostgreSQL non-superuser RLS integration check passed on the rebased head.
- [x] `git diff --check` passed.

## Risks and rollback

The change is deliberately narrow: it changes hook composition for six existing artifact route registrations; it does not change artifact schemas, payload shape, authorization roles, or external provider behavior. The main regression risk is hook ordering. Focused guarded-database, route-order, write-gate, role, and trust create/list/revoke tests cover those boundaries.

Rollback is a straight revert of this PR. That restores the prior registrations, but with #2662 still present it also restores the production artifact-route 500s, so rollback should only be paired with an alternative scoped registration fix.

## Deferred follow-ups

- Stage B's `TenantScopedService` work remains the structural path for folding scope/write admission into service operations.
- Global hook ordering remains a separate architectural concern; this fix intentionally scopes only the affected custom-route boundary.
- Mechanical import/use enforcement for custom authenticated route registrars remains follow-up work. The attempted broad route scanner was removed rather than landing incomplete protection; the runtime fix, focused tests, and documented contract remain in this PR.
