### PR TITLE
fix(gateway): preserve tenant context for channel probes

### DIFF
--- a/apps/agor-daemon/src/register-hooks.test.ts
+++ b/apps/agor-daemon/src/register-hooks.test.ts
@@ -1470,10 +1470,13 @@ describe('canReceiveMcpTokenForSession', () => {
 });
 
 describe('TENANT_IDENTITY_ONLY_SERVICE_PATHS', () => {
-  it.each(['file', 'files'])('%s is identity-only and never request-transaction owned', (path) => {
-    expect(TENANT_IDENTITY_ONLY_SERVICE_PATHS).toContain(path);
-    expect(TENANT_OWNED_SERVICE_PATHS).not.toContain(path);
-  });
+  it.each(['file', 'files', 'gateway-channels/test', 'gateway-channels/app-info'])(
+    '%s is identity-only and never request-transaction owned',
+    (path) => {
+      expect(TENANT_IDENTITY_ONLY_SERVICE_PATHS).toContain(path);
+      expect(TENANT_OWNED_SERVICE_PATHS).not.toContain(path);
+    }
+  );
 
   // Regression: the codex-auth endpoints do network/process work after a short
   // tenant DB read, then call getCurrentTenantId() to open their own units of

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -569,6 +569,10 @@ export const TENANT_IDENTITY_ONLY_SERVICE_PATHS = [
   // short tenant DB units around metadata phases and never holds one across
   // that provider call.
   'gateway-channels',
+  // Gateway probes carry tenant identity while their repository opens a short
+  // read unit before provider I/O; they must not inherit an HTTP-long transaction.
+  'gateway-channels/test',
+  'gateway-channels/app-info',
 ] as const;
 
 /** Identity-only Claude endpoints that must clear the tenant freeze before side effects. */

--- a/apps/agor-daemon/src/services/gateway-channels-app-info.ts
+++ b/apps/agor-daemon/src/services/gateway-channels-app-info.ts
@@ -14,7 +14,11 @@
  * rather than an error, so the UI degrades to a generic Slack link.
  */
 
-import { GatewayChannelRepository, type TenantScopeAwareDatabase } from '@agor/core/db';
+import {
+  bindRepositoryToTenantUnitOfWork,
+  GatewayChannelRepository,
+  type TenantScopeAwareDatabase,
+} from '@agor/core/db';
 import { BadRequest, NotFound } from '@agor/core/feathers';
 import { getConnector } from '@agor/core/gateway';
 import type { AuthenticatedParams, SlackAppInfo } from '@agor/core/types';
@@ -29,7 +33,7 @@ const UNRESOLVED: SlackAppInfo = { appId: null, teamId: null };
  * Factory for the `gateway-channels/app-info` service.
  */
 export function createGatewayChannelsAppInfoService(db: TenantScopeAwareDatabase) {
-  const channelRepo = new GatewayChannelRepository(db);
+  const channelRepo = bindRepositoryToTenantUnitOfWork(db, new GatewayChannelRepository(db));
 
   return {
     async create(

--- a/apps/agor-daemon/src/services/gateway-channels-tenant-scope.test.ts
+++ b/apps/agor-daemon/src/services/gateway-channels-tenant-scope.test.ts
@@ -1,0 +1,200 @@
+import type { AgorConfig } from '@agor/core/config';
+import {
+  BranchRepository,
+  createTenantScopedDatabaseProxy,
+  GatewayChannelRepository,
+  generateId,
+  getCurrentTenantDatabaseScope,
+  RepoRepository,
+  UsersRepository,
+} from '@agor/core/db';
+import { feathers } from '@agor/core/feathers';
+import type { GatewayConnector } from '@agor/core/gateway';
+import { getConnector } from '@agor/core/gateway';
+import type { GatewayConnectionTestResult, SlackAppInfo, TenantID } from '@agor/core/types';
+import { afterEach, describe, expect, vi } from 'vitest';
+import { dbTest } from '../../../../packages/core/src/db/test-helpers';
+import { type RegisterHooksContext, registerHooks } from '../register-hooks.js';
+import { createGatewayChannelsAppInfoService } from './gateway-channels-app-info.js';
+import { createGatewayChannelsTestService } from './gateway-channels-test.js';
+
+vi.mock('@agor/core/gateway', () => ({ getConnector: vi.fn() }));
+
+process.env.AGOR_MASTER_SECRET ||= 'gateway-channel-tenant-scope-test-secret';
+
+describe('gateway channel probe tenant boundary', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  dbTest(
+    'opens repository reads for nested calls and closes the scope before provider I/O',
+    async ({ db }) => {
+      const tenantId = 'tenant-a' as TenantID;
+      const owner = await new UsersRepository(db).create({
+        user_id: generateId(),
+        email: 'gateway-probe@example.test',
+        name: 'Gateway probe scope test',
+        role: 'admin',
+      });
+      const repo = await new RepoRepository(db).create({
+        repo_id: generateId(),
+        slug: `gateway-probe-${generateId()}`,
+        name: 'Gateway probe scope test',
+        repo_type: 'remote',
+        remote_url: 'https://example.invalid/gateway-probe.git',
+        local_path: `/tmp/${generateId()}`,
+        default_branch: 'main',
+      });
+      const branch = await new BranchRepository(db).create({
+        branch_id: generateId(),
+        repo_id: repo.repo_id,
+        name: `gateway-probe-${generateId()}`,
+        ref: 'main',
+        branch_unique_id: 1,
+        path: `/tmp/${generateId()}`,
+        created_by: owner.user_id,
+      });
+      const channel = await new GatewayChannelRepository(db).create({
+        id: generateId(),
+        name: 'Gateway probe scope test',
+        channel_type: 'slack',
+        channel_key: `gateway-probe-${generateId()}`,
+        enabled: false,
+        target_branch_id: branch.branch_id,
+        agor_user_id: owner.user_id,
+        created_by: owner.user_id,
+        config: { bot_token: 'xoxb-probe-token', app_token: 'xapp-probe-token' },
+      });
+
+      const guardedDb = createTenantScopedDatabaseProxy(db, {
+        requireScope: true,
+        label: 'gateway probe SQLite database',
+      });
+      const providerScopes: Array<unknown> = [];
+      const testResult: GatewayConnectionTestResult = {
+        ok: true,
+        failures: [],
+        notVerifiable: [],
+      };
+      const appInfo: SlackAppInfo = { appId: 'app-a', teamId: 'team-a' };
+      const connector = {
+        channelType: 'slack',
+        testConnection: vi.fn(async () => {
+          providerScopes.push(getCurrentTenantDatabaseScope());
+          return testResult;
+        }),
+        getAppInfo: vi.fn(async () => {
+          providerScopes.push(getCurrentTenantDatabaseScope());
+          return appInfo;
+        }),
+      } as unknown as GatewayConnector;
+      vi.mocked(getConnector).mockReturnValue(connector);
+
+      const app = feathers();
+      app.use('gateway-channels/test', createGatewayChannelsTestService(guardedDb));
+      app.use('gateway-channels/app-info', createGatewayChannelsAppInfoService(guardedDb));
+      app.use('check-auth', {
+        async create() {
+          // These are deliberately nested internal calls with no params. The
+          // outer production identity-only hook is the only source of ambient
+          // tenant identity available to both registered child services.
+          expect(getCurrentTenantDatabaseScope()).toBeUndefined();
+          const test = await app
+            .service('gateway-channels/test')
+            .create({ gatewayChannelId: channel.id });
+          expect(getCurrentTenantDatabaseScope()).toBeUndefined();
+          const resolvedAppInfo = await app
+            .service('gateway-channels/app-info')
+            .create({ gatewayChannelId: channel.id });
+          expect(getCurrentTenantDatabaseScope()).toBeUndefined();
+          return { test, appInfo: resolvedAppInfo };
+        },
+      });
+
+      const registeredAroundHooks = new Map<string, unknown[]>();
+      for (const path of ['gateway-channels/test', 'gateway-channels/app-info']) {
+        const service = app.service(path) as unknown as {
+          hooks: (hooks: { around?: { all?: unknown[] } }) => unknown;
+        };
+        const installHooks = service.hooks.bind(service);
+        service.hooks = (hooks) => {
+          if (hooks.around?.all) registeredAroundHooks.set(path, [...hooks.around.all]);
+          return installHooks(hooks);
+        };
+      }
+
+      const placeholderService = () => ({
+        async find() {
+          return [];
+        },
+        async get() {
+          return {};
+        },
+        async create(data: unknown) {
+          return data;
+        },
+        async update(_id: unknown, data: unknown) {
+          return data;
+        },
+        async patch(_id: unknown, data: unknown) {
+          return data;
+        },
+        async remove() {
+          return {};
+        },
+      });
+      for (const path of [
+        'messages',
+        'repos',
+        'branches',
+        'users',
+        'sessions',
+        'leaderboard',
+        'schedules',
+        'tasks',
+      ]) {
+        app.use(path, placeholderService());
+      }
+      (app as unknown as { publish: (publisher: unknown) => unknown }).publish = () => app;
+
+      registerHooks({
+        db: guardedDb,
+        app: app as RegisterHooksContext['app'],
+        config: {
+          database: { dialect: 'sqlite' },
+          multi_tenancy: { mode: 'required_from_auth', auth_claim: 'tenant_id' },
+          execution: { branch_rbac: false, unix_user_mode: 'simple' },
+        } as AgorConfig,
+        jwtSecret: 'gateway-probe-test-secret',
+        requireAuth: async (context) => context,
+        superadminOpts: { allowSuperadmin: true },
+        sessionsService: {} as RegisterHooksContext['sessionsService'],
+        messagesService: {} as RegisterHooksContext['messagesService'],
+        boardsService: undefined,
+        branchRepository: {} as RegisterHooksContext['branchRepository'],
+        usersRepository: {} as RegisterHooksContext['usersRepository'],
+        sessionsRepository: {} as RegisterHooksContext['sessionsRepository'],
+        deployment: { mode: 'standalone' },
+      });
+
+      // The child paths themselves, not a manually reconstructed hook, must be
+      // in the production identity-only registration loop. This assertion is
+      // intentionally tied to the real service registration calls above.
+      expect(registeredAroundHooks.get('gateway-channels/test')).toHaveLength(1);
+      expect(registeredAroundHooks.get('gateway-channels/app-info')).toHaveLength(1);
+
+      const authenticatedParams = {
+        provider: 'rest',
+        authenticated: true,
+        user: { user_id: owner.user_id, role: 'admin' },
+        tenant: { tenant_id: tenantId, source: 'auth_claim' },
+      };
+      const result = await app.service('check-auth').create({}, authenticatedParams);
+
+      expect(result).toEqual({ test: testResult, appInfo });
+      expect(providerScopes).toEqual([undefined, undefined]);
+      expect(getCurrentTenantDatabaseScope()).toBeUndefined();
+    }
+  );
+});

--- a/apps/agor-daemon/src/services/gateway-channels-test.ts
+++ b/apps/agor-daemon/src/services/gateway-channels-test.ts
@@ -10,7 +10,11 @@
  * values.
  */
 
-import { GatewayChannelRepository, type TenantScopeAwareDatabase } from '@agor/core/db';
+import {
+  bindRepositoryToTenantUnitOfWork,
+  GatewayChannelRepository,
+  type TenantScopeAwareDatabase,
+} from '@agor/core/db';
 import { NotFound } from '@agor/core/feathers';
 import { getConnector } from '@agor/core/gateway';
 import type {
@@ -59,7 +63,7 @@ function resolveEffectiveConfig(
  * Factory for the `gateway-channels/test` service.
  */
 export function createGatewayChannelsTestService(db: TenantScopeAwareDatabase) {
-  const channelRepo = new GatewayChannelRepository(db);
+  const channelRepo = bindRepositoryToTenantUnitOfWork(db, new GatewayChannelRepository(db));
 
   return {
     async create(

--- a/apps/agor-daemon/src/services/gateway-channels.postgres.test.ts
+++ b/apps/agor-daemon/src/services/gateway-channels.postgres.test.ts
@@ -11,7 +11,7 @@ import {
   runWithTenantDatabaseScope,
   UsersRepository,
 } from '@agor/core/db';
-import { getConnector } from '@agor/core/gateway';
+import { type GatewayConnector, getConnector } from '@agor/core/gateway';
 import {
   DEFAULT_DISCORD_CATCH_UP,
   type GatewayChannel,
@@ -20,6 +20,8 @@ import {
 } from '@agor/core/types';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { GatewayChannelsService } from './gateway-channels.js';
+import { createGatewayChannelsAppInfoService } from './gateway-channels-app-info.js';
+import { createGatewayChannelsTestService } from './gateway-channels-test.js';
 
 vi.mock('@agor/core/gateway', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@agor/core/gateway')>();
@@ -352,6 +354,50 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
         provider_installation_id: applicationId,
         enabled: true,
       });
+    }, 30_000);
+
+    it('scopes both gateway probes to tenant A and does not call a provider for tenant B', async () => {
+      const ownerTenant = `gateway-probe-owner-${generateId()}` as TenantID;
+      const otherTenant = `gateway-probe-other-${generateId()}` as TenantID;
+      const { channel } = await seedChannel(dbA, ownerTenant);
+      const guardedDb = createTenantScopedDatabaseProxy(dbB, {
+        requireScope: true,
+        label: 'gateway probe PostgreSQL database',
+      });
+      const testService = createGatewayChannelsTestService(guardedDb);
+      const appInfoService = createGatewayChannelsAppInfoService(guardedDb);
+      const connector = {
+        testConnection: vi.fn(async () => ({ ok: true, failures: [], notVerifiable: [] })),
+        getAppInfo: vi.fn(async () => ({ appId: 'app-a', teamId: 'team-a' })),
+      } as unknown as GatewayConnector;
+      vi.mocked(getConnector).mockReturnValue(connector);
+
+      await expect(
+        runWithTenantContext(ownerTenant, () =>
+          testService.create({ gatewayChannelId: channel.id })
+        )
+      ).resolves.toMatchObject({ ok: true });
+      await expect(
+        runWithTenantContext(ownerTenant, () =>
+          appInfoService.create({ gatewayChannelId: channel.id })
+        )
+      ).resolves.toEqual({ appId: 'app-a', teamId: 'team-a' });
+      expect(connector.testConnection).toHaveBeenCalledOnce();
+      expect(connector.getAppInfo).toHaveBeenCalledOnce();
+
+      vi.mocked(getConnector).mockClear();
+      const foreignTestError = await runWithTenantContext(otherTenant, () =>
+        testService.create({ gatewayChannelId: channel.id })
+      ).catch((error) => error);
+      const foreignAppInfoError = await runWithTenantContext(otherTenant, () =>
+        appInfoService.create({ gatewayChannelId: channel.id })
+      ).catch((error) => error);
+
+      expect(String(foreignTestError)).toMatch(/not found/i);
+      expect(String(foreignAppInfoError)).toMatch(/not found/i);
+      expect(String(foreignTestError)).not.toContain('app-a');
+      expect(String(foreignAppInfoError)).not.toContain('app-a');
+      expect(vi.mocked(getConnector)).not.toHaveBeenCalled();
     }, 30_000);
   }
 );


### PR DESCRIPTION
## Linked issue

Fixes #2672

## Summary

- Preserve authenticated tenant identity for gateway connection and app-info probes.
- Run each probe repository access inside a short tenant-scoped database unit of work.
- Add nested-call and PostgreSQL cross-tenant regression coverage.

## Why / context

The secure gateway-token flow calls `gateway-channels/test` internally without transport params before saving credentials. The probe sub-services were not registered as identity-only tenant paths, and their repositories did not open short tenant database scopes. In hosted `required_from_auth` mode, that could lose the tenant boundary before the channel lookup and fail token submission.

## Implementation notes

- Classify `gateway-channels/test` and `gateway-channels/app-info` as identity-only paths so nested calls inherit the authenticated tenant.
- Bind each `GatewayChannelRepository` with the existing tenant unit-of-work helper.
- Keep provider network calls outside database transactions.
- Return a non-disclosing not-found result for a foreign tenant without constructing or calling its provider connector.

## Validation / test plan

- [x] Focused daemon regression suite: 5 files, 219 tests passed.
- [x] PostgreSQL gateway-channel suite: 1 suite, 7 passed, 0 failed, 0 skipped.
- [x] PostgreSQL application role verified as `NOSUPERUSER` and `NOBYPASSRLS`.
- [x] Nested tenant-scope boundary test passed.
- [x] HA tenant/RLS smoke: PostgreSQL, Redis, two daemons, and nginx ready; cross-replica tenant isolation passed.
- [x] `pnpm --filter @agor/daemon typecheck`
- [x] Biome on all touched files.
- [x] `pnpm check:multitenancy-boundaries`
- [x] `git diff --check`

## Screenshots / demos

Not applicable; no UI changes.

## Risks / rollout / rollback

The change affects tenant isolation around decrypted gateway credentials and provider probes. Coverage verifies that the owning tenant succeeds, a foreign tenant receives not-found, and provider code is not invoked for the foreign tenant. Rollback is the single commit in this PR.

## Out of scope / follow-ups

- No connector, UI, schema, or Stage B/C tenant-API refactor.
- No live provider credential was used. The generic HA harness later reached an unrelated Claude OAuth check that requires a private PID namespace unavailable on Docker Desktop; the targeted tenant/RLS checks above completed successfully.
