### PR TITLE
feat: add GPT-6 Astra model support

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/sessions.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.test.ts
@@ -1785,7 +1785,13 @@ describe('agor_models_list', () => {
     expect(parsed.codex.note).toContain('omit modelConfig');
 
     const codexIds = parsed.codex.models.map((m: { id: string }) => m.id);
-    expect(codexIds.slice(0, 3)).toEqual(['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']);
+    expect(parsed.codex.default).toBe('gpt-6-astra');
+    expect(codexIds.slice(0, 4)).toEqual([
+      'gpt-6-astra',
+      'gpt-5.6-sol',
+      'gpt-5.6-terra',
+      'gpt-5.6-luna',
+    ]);
     expect(codexIds).toContain('gpt-5.5');
     expect(codexIds).toContain('gpt-5.4-mini');
     expect(codexIds).toContain('gpt-5.4');

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -1754,7 +1754,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         codex: {
           default: DEFAULT_CODEX_MODEL,
           models: codexModels,
-          note: 'Latest models are listed first; omit modelConfig to use the default. Current models are supported defaults; older entries marked provider-dependent may vary by Codex account and are checked by Codex at startup. This is Agor’s known-model registry, not a dynamic Codex CLI/provider listing. Provider-specific IDs absent from this list must be passed with mode "exact". Known unsupported legacy aliases are omitted.',
+          note: 'Latest models are listed first; omit modelConfig to use the default. Entries marked provider-dependent, including newly rolling-out models, may vary by Codex account and are checked by Codex at startup. This is Agor’s known-model registry, not a dynamic Codex CLI/provider listing. Provider-specific IDs absent from this list must be passed with mode "exact". Known unsupported legacy aliases are omitted.',
         },
         gemini: {
           default: DEFAULT_GEMINI_MODEL,

--- a/packages/core/src/models/codex.test.ts
+++ b/packages/core/src/models/codex.test.ts
@@ -12,14 +12,21 @@ import {
 
 describe('Codex model registry', () => {
   it('keeps current defaults on supported Codex models', () => {
-    expect(DEFAULT_CODEX_MODEL).toBe('gpt-5.6-sol');
+    expect(DEFAULT_CODEX_MODEL).toBe('gpt-6-astra');
     expect(CODEX_MINI_MODEL).toBe('gpt-5.6-terra');
   });
 
   it('surfaces supported and provider-dependent models newest-first', () => {
     const selectableIds = Object.keys(CODEX_MODEL_METADATA);
 
-    expect(selectableIds.slice(0, 3)).toEqual(['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']);
+    expect(selectableIds.slice(0, 4)).toEqual([
+      'gpt-6-astra',
+      'gpt-5.6-sol',
+      'gpt-5.6-terra',
+      'gpt-5.6-luna',
+    ]);
+    expect(CODEX_MODEL_METADATA['gpt-6-astra'].availability).toBe('provider-dependent');
+    expect(CODEX_MODEL_REGISTRY['gpt-5.6'].replacement).toBe('gpt-5.6-sol');
     expect(selectableIds).toContain('gpt-5.5');
     expect(selectableIds).toContain('gpt-5.4-mini');
     expect(selectableIds).toContain('gpt-5.4');
@@ -31,7 +38,7 @@ describe('Codex model registry', () => {
     expect(CODEX_MODEL_REGISTRY['gpt-5-codex']).toMatchObject({
       selectable: false,
       availability: 'unsupported',
-      replacement: 'gpt-5.6-sol',
+      replacement: 'gpt-6-astra',
     });
   });
 
@@ -62,12 +69,13 @@ describe('Codex model registry', () => {
     const message = formatUnsupportedAgorCodexModelMessage('gpt-5-codex');
 
     expect(message).toContain('gpt-5-codex');
-    expect(message).toContain('gpt-5.6-sol');
+    expect(message).toContain('gpt-6-astra');
     expect(message).toContain('user defaults');
     expect(message).toContain('omit modelConfig');
   });
 
   it('accepts curated aliases and rejects unknown alias selections actionably', () => {
+    expect(getCodexModelSelectionError({ mode: 'alias', model: 'gpt-6-astra' })).toBeUndefined();
     expect(getCodexModelSelectionError({ mode: 'alias', model: 'gpt-5.6-sol' })).toBeUndefined();
     expect(getCodexModelSelectionError({ mode: 'alias', model: 'gpt-5.4' })).toBeUndefined();
 

--- a/packages/core/src/models/codex.ts
+++ b/packages/core/src/models/codex.ts
@@ -5,7 +5,7 @@
  */
 
 /** Default Codex model */
-export const DEFAULT_CODEX_MODEL = 'gpt-5.6-sol';
+export const DEFAULT_CODEX_MODEL = 'gpt-6-astra';
 
 /** Codex Mini model for cost-effective usage */
 export const CODEX_MINI_MODEL = 'gpt-5.6-terra';
@@ -30,9 +30,16 @@ export type CodexModelLifecycleMetadata = {
  * Uses `as const satisfies` to preserve literal key types for CodexModel.
  */
 const _CODEX_MODEL_REGISTRY = {
+  'gpt-6-astra': {
+    name: 'GPT-6 Astra (Recommended)',
+    description: 'Most capable model for complex reasoning, coding, and end-to-end work',
+    status: 'current',
+    selectable: true,
+    availability: 'provider-dependent',
+  },
   // GPT-5.6 models
   'gpt-5.6-sol': {
-    name: 'GPT-5.6 Sol (Recommended)',
+    name: 'GPT-5.6 Sol',
     description: 'Flagship GPT-5.6 model for complex, open-ended work',
     status: 'current',
     selectable: true,
@@ -58,7 +65,7 @@ const _CODEX_MODEL_REGISTRY = {
     status: 'current',
     selectable: true,
     availability: 'provider-dependent',
-    replacement: DEFAULT_CODEX_MODEL,
+    replacement: 'gpt-5.6-sol',
   },
   // GPT-5.5 models
   'gpt-5.5': {
@@ -360,6 +367,7 @@ const DEFAULT_CODEX_CONTEXT_LIMIT = 200_000;
  * Unknown models fall back to 200k.
  */
 export const CODEX_CONTEXT_LIMITS: Record<string, number> = {
+  'gpt-6-astra': 1_050_000,
   // GPT-5.6 models
   'gpt-5.6-sol': 1_050_000,
   'gpt-5.6-terra': 1_050_000,

--- a/packages/core/src/models/resolve-config.test.ts
+++ b/packages/core/src/models/resolve-config.test.ts
@@ -122,7 +122,7 @@ describe('resolveModelConfigPrecedence', () => {
 describe('getDefaultModelForTool', () => {
   it('returns the static default for tools that have one', () => {
     expect(getDefaultModelForTool('claude-code')).toBe('claude-sonnet-5');
-    expect(getDefaultModelForTool('codex')).toBe('gpt-5.6-sol');
+    expect(getDefaultModelForTool('codex')).toBe('gpt-6-astra');
     expect(getDefaultModelForTool('gemini')).toBe('gemini-2.0-flash');
     expect(getDefaultModelForTool('copilot')).toBe('claude-sonnet-4.6');
   });
@@ -149,7 +149,7 @@ describe('resolveModelConfigWithFallback', () => {
     const result = resolveModelConfigWithFallback('codex', [undefined, null], { now });
     expect(result).toEqual({
       mode: 'alias',
-      model: 'gpt-5.6-sol',
+      model: 'gpt-6-astra',
       updated_at: '2026-04-23T00:00:00.000Z',
     });
   });

--- a/packages/core/src/sessions/resolve-child-session-config.test.ts
+++ b/packages/core/src/sessions/resolve-child-session-config.test.ts
@@ -54,7 +54,7 @@ describe('resolveChildSessionConfig', () => {
       });
       expect(r.model_config).toEqual({
         mode: 'alias',
-        model: 'gpt-5.6-sol',
+        model: 'gpt-6-astra',
         updated_at: now.toISOString(),
       });
       expect(r.model_config?.model).not.toBe('claude-opus-4-7');

--- a/packages/core/src/sessions/resolve-session-defaults.test.ts
+++ b/packages/core/src/sessions/resolve-session-defaults.test.ts
@@ -173,7 +173,7 @@ describe('resolveSessionDefaults', () => {
       const r = resolveSessionDefaults({ agenticTool: 'codex', now });
       expect(r.model_config).toMatchObject({
         mode: 'alias',
-        model: 'gpt-5.6-sol',
+        model: 'gpt-6-astra',
       });
       expect(r.model_config).not.toHaveProperty('effort');
     });
@@ -185,7 +185,7 @@ describe('resolveSessionDefaults', () => {
         now,
       });
       expect(r.model_config).toMatchObject({
-        model: 'gpt-5.6-sol',
+        model: 'gpt-6-astra',
         effort: 'xhigh',
       });
     });

--- a/packages/core/src/telemetry/model-normalization.ts
+++ b/packages/core/src/telemetry/model-normalization.ts
@@ -2,6 +2,7 @@ const KNOWN_MODEL_PATTERNS: Array<[RegExp, string]> = [
   [/claude.*opus/i, 'claude-opus'],
   [/claude.*sonnet/i, 'claude-sonnet'],
   [/claude.*haiku/i, 'claude-haiku'],
+  [/gpt-6/i, 'gpt-6'],
   [/gpt-5/i, 'gpt-5'],
   [/gpt-4\.1/i, 'gpt-4.1'],
   [/gpt-4o/i, 'gpt-4o'],

--- a/packages/core/src/telemetry/telemetry.test.ts
+++ b/packages/core/src/telemetry/telemetry.test.ts
@@ -65,6 +65,7 @@ describe('open-source telemetry payload hygiene', () => {
     expect(normalizeTelemetryProvider('Gemini')).toBe('google');
     expect(normalizeTelemetryProvider('AcmeInternal')).toBe('other');
     expect(normalizeTelemetryModelFamily('claude-sonnet-4-5')).toBe('claude-sonnet');
+    expect(normalizeTelemetryModelFamily('gpt-6-astra')).toBe('gpt-6');
     expect(normalizeTelemetryModelFamily('acme-prod-secure-westus')).toBe('custom');
   });
 

--- a/packages/executor/src/sdk-handlers/codex/models.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/models.test.ts
@@ -6,6 +6,7 @@ describe('getCodexContextWindowLimit', () => {
 
   it('returns expected limits for known Codex-compatible models', () => {
     const cases: Array<{ model: string; expected: number }> = [
+      { model: 'gpt-6-astra', expected: 1_050_000 },
       { model: 'gpt-5.6-sol', expected: 1_050_000 },
       { model: 'gpt-5.6-terra', expected: 1_050_000 },
       { model: 'gpt-5.6-luna', expected: 1_050_000 },
@@ -34,6 +35,7 @@ describe('getCodexContextWindowLimit', () => {
   });
 
   it('uses base model limit when version suffix is present', () => {
+    expect(getCodexContextWindowLimit('gpt-6-astra-2026-09-04')).toBe(1_050_000);
     expect(getCodexContextWindowLimit('gpt-5.6-sol-2026-07-09')).toBe(
       getCodexContextWindowLimit('gpt-5.6-sol')
     );

--- a/packages/executor/src/sdk-handlers/codex/pricing/README.md
+++ b/packages/executor/src/sdk-handlers/codex/pricing/README.md
@@ -7,3 +7,11 @@ https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_
 Only entries whose `litellm_provider` is `openai` are kept to avoid vendoring the full upstream multi-provider catalog. It is used only for **estimated** Codex API-equivalent costs. OpenAI/Codex SDK
 responses do not currently include a per-turn `cost_usd` field. Refresh this
 snapshot periodically from the upstream URL, then run the Codex normalizer tests.
+
+The `gpt-6-astra` entry is supplemented from OpenAI's
+[model reference](https://developers.openai.com/api/docs/models/gpt-6-astra) and
+[pricing table](https://developers.openai.com/api/docs/pricing), checked on
+2026-09-04. Standard per-million-token rates are $10 input, $1 cached input,
+and $50 output; requests above 272k input tokens use $20, $2, and $75 respectively.
+The estimator uses standard base rates because cumulative SDK usage does not
+identify individual requests crossing the long-context threshold.

--- a/packages/executor/src/sdk-handlers/codex/pricing/litellm-openai-model-prices.json
+++ b/packages/executor/src/sdk-handlers/codex/pricing/litellm-openai-model-prices.json
@@ -2222,6 +2222,21 @@
     "supports_web_search": true,
     "supports_xhigh_reasoning_effort": true
   },
+  "gpt-6-astra": {
+    "cache_creation_input_token_cost": 0.0000125,
+    "cache_creation_input_token_cost_above_272k_tokens": 0.000025,
+    "cache_read_input_token_cost": 0.000001,
+    "cache_read_input_token_cost_above_272k_tokens": 0.000002,
+    "input_cost_per_token": 0.00001,
+    "input_cost_per_token_above_272k_tokens": 0.00002,
+    "litellm_provider": "openai",
+    "max_input_tokens": 922000,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "mode": "chat",
+    "output_cost_per_token": 0.00005,
+    "output_cost_per_token_above_272k_tokens": 0.000075
+  },
   "gpt-5.6-sol": {
     "cache_creation_input_token_cost": 0.00000625,
     "cache_creation_input_token_cost_above_272k_tokens": 0.0000125,

--- a/packages/executor/src/sdk-handlers/codex/pricing/litellm-pricing.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/pricing/litellm-pricing.test.ts
@@ -3,13 +3,32 @@ import { estimateCodexCostUsd, getLiteLlmPricingForModel } from './litellm-prici
 
 describe('LiteLLM Codex pricing snapshot', () => {
   it('contains current Codex default model pricing', () => {
-    for (const model of ['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']) {
+    for (const model of ['gpt-6-astra', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']) {
       const pricing = getLiteLlmPricingForModel(model);
 
       expect(pricing?.input_cost_per_token).toBeGreaterThan(0);
       expect(pricing?.output_cost_per_token).toBeGreaterThan(0);
       expect(pricing?.cache_read_input_token_cost).toBeGreaterThan(0);
     }
+  });
+
+  it('estimates Astra costs with cached input and provider-prefixed IDs', () => {
+    expect(
+      estimateCodexCostUsd({
+        modelId: 'openai/gpt-6-astra',
+        inputTokens: 10_000,
+        cacheReadTokens: 4_000,
+        outputTokens: 1_000,
+      })
+    ).toBeCloseTo(0.114, 8);
+    expect(
+      estimateCodexCostUsd({
+        modelId: 'gpt-6-astra',
+        inputTokens: 300_000,
+        cacheReadTokens: 100_000,
+        outputTokens: 10_000,
+      })
+    ).toBeCloseTo(2.6, 8);
   });
 
   it('estimates cost with cached input tokens as a subset of input tokens', () => {

--- a/packages/executor/src/sdk-handlers/codex/pricing/litellm-pricing.ts
+++ b/packages/executor/src/sdk-handlers/codex/pricing/litellm-pricing.ts
@@ -1,6 +1,7 @@
 // Filtered vendored snapshot from LiteLLM's pricing catalog. When OpenAI ships
 // new Codex models or prices change, refresh this file from:
 // https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json
+// New-release supplements sourced directly from OpenAI are documented in README.md.
 import modelPrices from './litellm-openai-model-prices.json' with { type: 'json' };
 
 interface LiteLlmModelPricing {


### PR DESCRIPTION
## Linked issue

Related implementation: #1870 and #2056.

## Summary

Add GPT-6 Astra to the model picker and make it the recommended default. Sessions without an explicit model now select `gpt-6-astra`; existing model selections remain available.

## Why / context

The shared model registry did not recognize Astra, so users could not select it as a known alias. This follows the previous model additions and retains the selection validation introduced in #2056.

## Implementation notes

- Register Astra with a 1,050,000-token context window and account-dependent availability.
- The pricing metadata records the documented 922,000-token maximum input separately from the 1,050,000-token total context window and 128,000-token maximum output; see the [model reference](https://developers.openai.com/api/docs/models/gpt-6-astra). The existing cost estimator does not consume these limit fields.
- Add published pricing for usage estimates and recognize the GPT-6 telemetry family.
- Preserve Terra as the mini-tier default and keep the `gpt-5.6` alias pointing to Sol.
- Reuse the existing model picker, effort settings, and runtime dispatch. No dependency upgrade or migration is required.
- Changes affect global model metadata and defaults; tenant identity, credentials, and resource access paths are unchanged.

## Validation / test plan

- [x] 94 core tests: model selection, defaults, session inheritance, and telemetry.
- [x] 99 executor tests: context limits, pricing, normalization, and mocked prompt dispatch.
- [x] 47 session-tool tests, including model discovery.
- [x] 32 model-picker and default tests.
- [x] Changed-file lint and whitespace checks.
- [x] Live Astra inference through the pinned SDK and bundled CLI, both 0.153.0: `gpt-6-astra` with effort `low` returned `ASTRA_OK` and a successful `turn.completed`, using ChatGPT authentication in a read-only sandbox.
- [x] CI at `16acf64ce359086d717db57b83200d359f03104b`: lint/policy checks, typecheck/build, all unit-test lanes, PostgreSQL integration, Redis HA isolation, browser layout tests, and representative packaged-install smoke passed.
- [ ] Production-account Astra session and browser smoke test after deployment.

## Screenshots / demos

No layout changes; the existing picker renders the shared registry entry.

## Risks / rollout / rollback

Changing the fallback model affects new sessions without an explicit model and may change cost and account-access requirements. Astra is marked account-dependent during rollout. Live inference succeeded with an eligible development account; production-account access still needs verification. Explicit existing selections remain unchanged. Revert this commit to restore the previous default and registry.

## Out of scope / follow-ups

After deployment, validate an Astra session with the production account. Cost reporting remains an estimate using standard base rates; cumulative usage cannot identify individual requests crossing the long-context pricing threshold.
