### PR TITLE
fix: preserve tenant scope during upload authorization

### DIFF
--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -88,6 +88,7 @@ import type {
   Task,
   TaskID,
   TaskMetadata,
+  TenantID,
   User,
   UserID,
   UUID,
@@ -516,7 +517,7 @@ export function createRequiredTenantDatabaseRunner(db: TenantScopeAwareDatabase)
 /** Resolve upload branch visibility and prompt authority using the authenticated tenant. */
 export async function resolveUploadPromptAccess(input: {
   db: TenantScopeAwareDatabase;
-  tenantId: string | undefined;
+  tenantId: TenantID | undefined;
   branchRepository: Pick<
     BranchRepository,
     'findById' | 'resolveUserPermission' | 'resolveSessionPromptAuthority'

--- a/apps/agor-daemon/src/register-routes.ts
+++ b/apps/agor-daemon/src/register-routes.ts
@@ -513,6 +513,29 @@ export function createRequiredTenantDatabaseRunner(db: TenantScopeAwareDatabase)
   };
 }
 
+/** Resolve upload branch visibility and prompt authority using the authenticated tenant. */
+export async function resolveUploadPromptAccess(input: {
+  db: TenantScopeAwareDatabase;
+  tenantId: string | undefined;
+  branchRepository: Pick<
+    BranchRepository,
+    'findById' | 'resolveUserPermission' | 'resolveSessionPromptAuthority'
+  >;
+  session: Session;
+  userId: UUID;
+}) {
+  return runWithTenantDatabaseScope(input.db, input.tenantId, async () => {
+    const branch = await input.branchRepository.findById(input.session.branch_id);
+    if (!branch) return null;
+    return resolveSessionPromptAccess({
+      branchRepository: input.branchRepository,
+      branch,
+      session: input.session,
+      userId: input.userId,
+    });
+  });
+}
+
 type BoardCommentRouteParams = Pick<AuthenticatedParams, 'provider' | 'user'>;
 
 /**
@@ -2680,25 +2703,19 @@ export async function registerRoutes(ctx: RegisterRoutesContext): Promise<void> 
       if (!session.branch_id) {
         return res.status(403).json({ error: 'Not authorized to upload to this session' });
       }
-      const access = await runWithTenantDatabaseScope(db, params.tenant?.tenant_id, async () => {
-        const wt = await branchRepo.findById(session.branch_id);
-        if (!wt) return null;
-        return { wt };
+      const access = await resolveUploadPromptAccess({
+        db,
+        tenantId: params.tenant?.tenant_id,
+        branchRepository: branchRepo,
+        session,
+        userId,
       });
       if (!access) {
         return res.status(404).json({ error: 'Branch not found' });
       }
-      const { wt } = access;
-      const { allowed, effectiveLevel } = await resolveSessionPromptAccess({
-        branchRepository: branchRepo,
-        branch: wt,
-        session,
-        userId,
-      });
-
-      if (!allowed) {
+      if (!access.allowed) {
         console.error(
-          `❌ [Upload Authz] User ${shortId(userId)} has '${effectiveLevel}' permission, cannot upload to branch ${shortId(wt.branch_id)}`
+          `❌ [Upload Authz] User ${shortId(userId)} has '${access.effectiveLevel}' permission, cannot upload to branch ${shortId(session.branch_id)}`
         );
         return res.status(403).json({ error: 'Not authorized to upload to this session' });
       }

--- a/apps/agor-daemon/src/register-routes.upload-boundary.test.ts
+++ b/apps/agor-daemon/src/register-routes.upload-boundary.test.ts
@@ -1,9 +1,13 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { createTenantScopedDatabaseProxy, runWithTenantDatabaseScope } from '@agor/core/db';
-import type { TenantContext } from '@agor/core/types';
+import {
+  createTenantScopedDatabaseProxy,
+  getCurrentTenantId,
+  runWithTenantDatabaseScope,
+} from '@agor/core/db';
+import type { Session, TenantContext, UUID } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
-import { createUploadAuthMiddleware } from './register-routes.js';
+import { createUploadAuthMiddleware, resolveUploadPromptAccess } from './register-routes.js';
 
 describe('browser upload route boundary ordering', () => {
   const source = readFileSync(join(__dirname, 'register-routes.ts'), 'utf8');
@@ -126,5 +130,64 @@ describe('browser upload route boundary ordering', () => {
     expect(helper).toMatch(/authentication\.create\([\s\S]*authParams\s*\)/);
     expect(helper).toContain('authParams.tenant ??');
     expect(executorRoutes.match(/authenticateBearerHttpRequest\(/g)).toHaveLength(2);
+  });
+});
+
+describe('upload prompt authorization tenant scope', () => {
+  function fixture() {
+    const rawDb = { run: vi.fn(), select: vi.fn(() => getCurrentTenantId()) };
+    const db = createTenantScopedDatabaseProxy(rawDb as never, {
+      requireScope: true,
+      label: 'upload authorization test database',
+    });
+    const session = {
+      session_id: 'session-a',
+      branch_id: 'branch-a',
+      created_by: 'user-a',
+      sdk_home_scope: 'branch',
+    } as Session;
+    const branchRepository = {
+      findById: vi.fn(async () =>
+        db.select() === 'tenant-a' ? { branch_id: session.branch_id } : null
+      ),
+      resolveUserPermission: vi.fn(async () => {
+        expect(db.select()).toBe('tenant-a');
+        return 'session' as const;
+      }),
+      resolveSessionPromptAuthority: vi.fn(async (_branchId, userId) => {
+        expect(db.select()).toBe('tenant-a');
+        return { allowed: userId === 'user-a', source: 'owner' };
+      }),
+    };
+    const authorize = (tenantId: string, userId = 'user-a') =>
+      resolveUploadPromptAccess({
+        db,
+        tenantId,
+        branchRepository: branchRepository as unknown as Parameters<
+          typeof resolveUploadPromptAccess
+        >[0]['branchRepository'],
+        session,
+        userId: userId as UUID,
+      });
+    return { authorize, branchRepository, rawDb };
+  }
+
+  it('keeps every branch permission query in tenant scope after branch lookup', async () => {
+    const { authorize, rawDb } = fixture();
+    await expect(authorize('tenant-a')).resolves.toMatchObject({ allowed: true });
+    expect(rawDb.select).toHaveBeenCalledTimes(3);
+    expect(getCurrentTenantId()).toBeUndefined();
+  });
+
+  it('does not resolve prompt authority for another tenant’s branch', async () => {
+    const { authorize, branchRepository } = fixture();
+    await expect(authorize('tenant-b')).resolves.toBeNull();
+    expect(branchRepository.resolveUserPermission).not.toHaveBeenCalled();
+    expect(branchRepository.resolveSessionPromptAuthority).not.toHaveBeenCalled();
+  });
+
+  it('preserves a same-tenant caller’s prompt denial', async () => {
+    const { authorize } = fixture();
+    await expect(authorize('tenant-a', 'user-b')).resolves.toMatchObject({ allowed: false });
   });
 });

--- a/apps/agor-daemon/src/register-routes.upload-boundary.test.ts
+++ b/apps/agor-daemon/src/register-routes.upload-boundary.test.ts
@@ -5,7 +5,7 @@ import {
   getCurrentTenantId,
   runWithTenantDatabaseScope,
 } from '@agor/core/db';
-import type { Session, TenantContext, UUID } from '@agor/core/types';
+import type { Branch, Session, TenantContext, User, UUID } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
 import { createUploadAuthMiddleware, resolveUploadPromptAccess } from './register-routes.js';
 
@@ -42,7 +42,8 @@ describe('browser upload route boundary ordering', () => {
 
   it('propagates the tenant verified by authentication on the same params object', async () => {
     const verifiedTenant = { tenant_id: 'verified-tenant', source: 'explicit' } as TenantContext;
-    const rawDb = { run: vi.fn(), select: vi.fn(() => ({ user_id: 'user-1' })) };
+    const verifiedUser = { user_id: 'user-1' } as User;
+    const rawDb = { run: vi.fn(), select: vi.fn(() => verifiedUser) };
     const guardedDb = createTenantScopedDatabaseProxy(rawDb as never, {
       requireScope: true,
       label: 'upload authentication test database',
@@ -52,8 +53,13 @@ describe('browser upload route boundary ordering', () => {
       create: vi.fn(async (_data, params) => {
         suppliedParams = params;
         params.tenant = verifiedTenant;
-        const user = await runWithTenantDatabaseScope(guardedDb, params.tenant.tenant_id, () =>
-          guardedDb.select()
+        const user = await runWithTenantDatabaseScope(
+          guardedDb,
+          params.tenant.tenant_id,
+          async () => {
+            guardedDb.select();
+            return verifiedUser;
+          }
         );
         return {
           user,
@@ -65,7 +71,7 @@ describe('browser upload route boundary ordering', () => {
       authentication,
       multiTenancy: {
         mode: 'required_from_auth',
-        static_tenant_id: 'static-tenant',
+        static_tenant_id: 'static-tenant' as TenantContext['tenant_id'],
         auth_claim: 'tenant_id',
         trusted_header: 'x-tenant-id',
       },
@@ -82,14 +88,14 @@ describe('browser upload route boundary ordering', () => {
     const passedParams = authentication.create.mock.calls[0]?.[1];
     expect(suppliedParams).toBe(passedParams);
     expect(next).toHaveBeenCalledOnce();
-    expect(req.feathers.tenant).toBe(verifiedTenant);
+    expect(req.feathers?.tenant).toBe(verifiedTenant);
     expect(rawDb.select).toHaveBeenCalledOnce();
   });
 
   it('fails closed when hosted authentication establishes no tenant identity', async () => {
     const authentication = {
       create: vi.fn(async () => ({
-        user: { user_id: 'user-1' },
+        user: { user_id: 'user-1' } as User,
         authentication: { payload: {} },
       })),
     };
@@ -97,7 +103,7 @@ describe('browser upload route boundary ordering', () => {
       authentication,
       multiTenancy: {
         mode: 'required_from_auth',
-        static_tenant_id: 'static-tenant',
+        static_tenant_id: 'static-tenant' as TenantContext['tenant_id'],
         auth_claim: 'tenant_id',
       },
     });
@@ -146,26 +152,30 @@ describe('upload prompt authorization tenant scope', () => {
       created_by: 'user-a',
       sdk_home_scope: 'branch',
     } as Session;
-    const branchRepository = {
-      findById: vi.fn(async () =>
-        db.select() === 'tenant-a' ? { branch_id: session.branch_id } : null
-      ),
+    const branchRepository: Parameters<typeof resolveUploadPromptAccess>[0]['branchRepository'] = {
+      findById: vi.fn(async () => {
+        db.select();
+        return getCurrentTenantId() === 'tenant-a'
+          ? ({ branch_id: session.branch_id } as Branch)
+          : null;
+      }),
       resolveUserPermission: vi.fn(async () => {
         expect(db.select()).toBe('tenant-a');
         return 'session' as const;
       }),
       resolveSessionPromptAuthority: vi.fn(async (_branchId, userId) => {
         expect(db.select()).toBe('tenant-a');
-        return { allowed: userId === 'user-a', source: 'owner' };
+        return {
+          allowed: userId === 'user-a',
+          source: userId === 'user-a' ? ('own_session' as const) : ('denied' as const),
+        };
       }),
     };
-    const authorize = (tenantId: string, userId = 'user-a') =>
+    const authorize = (tenantId: TenantContext['tenant_id'], userId = 'user-a') =>
       resolveUploadPromptAccess({
         db,
         tenantId,
-        branchRepository: branchRepository as unknown as Parameters<
-          typeof resolveUploadPromptAccess
-        >[0]['branchRepository'],
+        branchRepository,
         session,
         userId: userId as UUID,
       });
@@ -174,20 +184,24 @@ describe('upload prompt authorization tenant scope', () => {
 
   it('keeps every branch permission query in tenant scope after branch lookup', async () => {
     const { authorize, rawDb } = fixture();
-    await expect(authorize('tenant-a')).resolves.toMatchObject({ allowed: true });
+    await expect(authorize('tenant-a' as TenantContext['tenant_id'])).resolves.toMatchObject({
+      allowed: true,
+    });
     expect(rawDb.select).toHaveBeenCalledTimes(3);
     expect(getCurrentTenantId()).toBeUndefined();
   });
 
   it('does not resolve prompt authority for another tenant’s branch', async () => {
     const { authorize, branchRepository } = fixture();
-    await expect(authorize('tenant-b')).resolves.toBeNull();
+    await expect(authorize('tenant-b' as TenantContext['tenant_id'])).resolves.toBeNull();
     expect(branchRepository.resolveUserPermission).not.toHaveBeenCalled();
     expect(branchRepository.resolveSessionPromptAuthority).not.toHaveBeenCalled();
   });
 
   it('preserves a same-tenant caller’s prompt denial', async () => {
     const { authorize } = fixture();
-    await expect(authorize('tenant-a', 'user-b')).resolves.toMatchObject({ allowed: false });
+    await expect(
+      authorize('tenant-a' as TenantContext['tenant_id'], 'user-b')
+    ).resolves.toMatchObject({ allowed: false });
   });
 });


### PR DESCRIPTION
## Takeover / rebase validation — 2026-09-06

Refs #2659; related diagnostics remain in #2679. This is still a required, independent authorization fix, not a duplicate or merged PR.

### Exact Git boundaries and review

- Original PR head: `b80e5585e34277f93283eee6eaa45c20a72cccbb` (`fix/2659-upload-failure`), fetched from `refs/pull/2680/head` and verified against GitHub.
- Original merge base: `20243941bbcbc62e38fa502345655c8aa5e0408c`.
- Current main / new base / new merge base: `ac0861269cc40811b521e6c6765e59d363309665`.
- Rebased original commit: `733fac715cefd5f5531143de2754c5528c1bc3df`, preserving Richard Fogaça's author and author date.
- New PR head: `af314cee3ce576935e94038e98ae9e6ef5f699ef` (separate review follow-up retains `TenantID` branding and makes the regression fixture typecheck, including previously excluded test code).
- Updated only the PR ref using `--force-with-lease=refs/heads/fix/2659-upload-failure:b80e5585e34277f93283eee6eaa45c20a72cccbb`; remote head verified afterward. Main was not changed. No merge or deployment performed.

Inspected #2659, #2679, the PR's commit/review/inline comments, and recent main history. Main's #2674 extracted the tenant-authenticated route registrar; #2675 fixes a separate gateway-probe boundary; #2669 makes RBAC unconditional. None encloses upload permission queries in the tenant database unit. Patch-equivalence check also finds the PR commit absent from main. Main still closes the scope after branch lookup and then invokes `resolveSessionPromptAccess` outside it.

**Exact conflicts:** one file, `apps/agor-daemon/src/register-routes.ts`, two content hunks:
1. Helper insertion adjacent to the registrar deleted/extracted by #2674: keep the new upload helper, retain main's imported registrar, and do not restore its old inline implementation.
2. Upload authorization block changed by #2669: retain unconditional RBAC and missing-branch/prompt-denied handling, invoke the scoped helper, and do not restore `branchRbacEnabled` or its bypass.

The test file applied without conflicts. `range-diff` reviewed. Original PR author remains unchanged. Both Copilot tenant-branding comments are addressed.

### Local validation

- Focused daemon tests: **109 passed / 5 files** (`register-routes.upload-boundary`, `utils/upload`, `utils/upload-staging`, `host/local/upload-staging-store`, `utils/branch-authorization`).
- Core `src/db/tenant-scope.test.ts`: **23 passed**.
- Negative control: temporarily restoring main's split-scope ordering caused **2 failures with `MissingTenantDatabaseScopeError`**; foreign-branch rejection still passed. Restored fixed source and reran the focused suites successfully.
- Daemon typecheck passed: `pnpm --filter @agor/daemon exec tsc --noEmit --customConditions source --rootDir ../..`. Source resolution avoids an unnecessary local build.
- Explicit no-emit typecheck including `register-routes.upload-boundary.test.ts` passed (ordinary daemon tsconfig excludes tests).
- Changed-file Biome, `check:multitenancy-boundaries`, `check:daemon-filesystem-boundaries`, `check:realtime-boundaries`, `check:shortid`, and whitespace checks passed.
- Pre-commit hooks ran successfully, without bypass. An initial lint-staged stash/index failure in the mount-aliased checkout was resolved by supplying absolute `GIT_DIR` / `GIT_WORK_TREE` to the commit process; no hook configuration was changed.

### Managed HA validation

Used Agor `agor_environment_set(variant: "ha")`, then `agor_environment_start`, health, and logs for branch `01a0789f-56e5-76ff-b815-78ebc35bcbbd`.

- App: `http://10.33.92.175:8363/dev-auth/` — HTTP 200.
- Managed health: `http://localhost:8363/readyz` — **running / healthy, HTTP 200**, observed at `2026-09-06T21:44:02.116Z`.
- Direct replica readiness: `127.0.0.1:18363/readyz` and `127.0.0.1:19363/readyz` — HTTP 200.
- Both daemon containers healthy on image `sha256:d58e816d73e2c0938445776da800e33800dc477ac409bda5562fb54b0c0e9341`. Managed source build and migrations succeeded. The image contains the same production source as the final head; subsequent changes only tightened/formatted tests.
- PostgreSQL role check: `agor_app` is neither superuser nor BYPASSRLS. `branches`, `sessions`, and `uploads` have RLS enabled and forced.

HA is an appropriate production-shaped test topology because it exercises `required_from_auth`, PostgreSQL/RLS, and shared storage across two daemons. The root bug is scope lifetime, **not replica coordination**; HA is not necessary for the deterministic regression and the always-armed scope guard also matters outside HA.

Created an isolated development fixture through real external-launch login and APIs: Acme Alice owner, Acme Aaron viewer, Globex Beatrice admin; a public Hello-World clone, ready branch, and idle session. Sent a 68-byte PNG without notifying/running an agent. On **both** replicas:

| Check | Observed |
| --- | --- |
| Owner multipart upload | HTTP 200, stored upload ref, no physical path |
| Read bytes through opposite replica | HTTP 200, exact PNG bytes |
| Same-tenant viewer upload, after proving session visibility | HTTP 403 |
| Unauthenticated upload | HTTP 401 |
| Foreign-tenant read of uploaded content | HTTP 404 |
| Foreign-tenant upload to the session | **HTTP 500, generic `Upload failed`; expected 4xx assertion fails** |

Rejected requests did not add owner upload-inventory rows. Foreign-session ordinary GET returns 403; a nonexistent-session upload returns the same generic 500. **This is not an all-green HTTP-status smoke run.** The unchanged upload error handler uses `err.status || 500` and loses Feathers' numeric `err.code`; #2679's `toUploadErrorResponse` already handles `status`, `statusCode`, and `code`. Keep that diagnostics/status-mapping fix separate and rerun the negative HTTP-status assertions when combined. No cross-tenant content access was observed.

Evidence on the validation host: `/tmp/agor-pr2680-before-fix.log`, `/tmp/agor-pr2680-tests-final.log`, `/tmp/agor-pr2680-core-tests.log`, `/tmp/agor-pr2680-test-typecheck.log`, and `/tmp/agor-pr2680-ha-{smoke,diagnose}.{mjs,log}`. The HA environment and clearly named disposable fixtures are retained for review. No production state was inspected or asserted; no credentials were printed by the smoke harness.

### Follow-up risks

- New-head CI is running; prior-head green checks are not new-head evidence.
- Reconcile with #2679 and rerun foreign/missing-session 4xx assertions before claiming complete upload error-contract validation.
- Browser composer UX, executor notification, S3 staging, and failover/load testing are outside this focused smoke.
- The configured HA identity picker is development-only; do not expose this environment as production.

<details>
<summary>Original author description and historical validation (not independently revalidated by this takeover)</summary>

## Linked issue

Refs #2659. Related diagnostics: #2679.

## Summary

Fix file uploads returning HTTP 500 when branch RBAC and tenant database isolation are enabled.

## Why / context

A small PNG reproduced the failure in a hosted environment. Upload diagnostics located the failure in authorization, before multipart parsing or file storage. The branch lookup ran inside the authenticated tenant's database scope, but the subsequent permission queries ran after that scope ended. The database guard rejected those queries with `MissingTenantDatabaseScopeError`.

The local setup did not reproduce it because branch RBAC was disabled.

## Implementation notes

Keep branch lookup and prompt authorization in one tenant-scoped operation. Preserve missing-branch and permission-denied responses. The database scope ends before file streaming begins.

This PR targets `main` independently of the diagnostics changes in #2679.

## Validation / test plan

- [x] Reproduced the hosted upload failure and correlated its reference with an authorization-stage HTTP 500.
- [x] Regression tests fail with `MissingTenantDatabaseScopeError` before the fix and pass afterward.
- [x] Covered authorized uploads, foreign-tenant branch rejection, and same-tenant prompt denial.
- [x] Focused upload tests: 20 passed on this branch; 31 passed on the sandbox-compatible branch with diagnostics.
- [x] Daemon typecheck, changed-file lint, and multitenancy boundary checks passed.
- [x] Deployed the fix with diagnostics to sandbox after a rolling-compatible preflight. The same PNG now appears in the session message with a stored upload handle; no new upload failure events appeared during the check.
- [x] All applicable CI checks passed, including the full daemon suite, PostgreSQL RLS integration, Redis HA isolation, and packaged runtime smoke tests.

## Risks / rollout / rollback

No schema or configuration changes. The change affects upload authorization with branch RBAC enabled. Reverting the commit restores the previous authorization behavior and its upload failure.


</details>
