### PR TITLE
fix(ui): restore SDK task list rendering

### DIFF
--- a/apps/agor-ui/src/components/StickyTodoRenderer/StickyTodoRenderer.test.tsx
+++ b/apps/agor-ui/src/components/StickyTodoRenderer/StickyTodoRenderer.test.tsx
@@ -1,0 +1,132 @@
+import { type Message, TaskStatus } from '@agor-live/client';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { deriveLatestTodos, StickyTodoRenderer } from './StickyTodoRenderer';
+
+function message(index: number, content: Array<Record<string, unknown>>): Message {
+  return {
+    message_id: `message-${index}`,
+    session_id: 'session-1',
+    task_id: 'task-1',
+    type: index % 2 === 0 ? 'assistant' : 'user',
+    role: index % 2 === 0 ? 'assistant' : 'user',
+    index,
+    timestamp: new Date(index * 1000).toISOString(),
+    content_preview: '',
+    content,
+  } as Message;
+}
+
+describe('StickyTodoRenderer provider task shapes', () => {
+  it('keeps rendering Codex normalized TodoWrite snapshots', () => {
+    const messages = [
+      message(0, [
+        {
+          type: 'tool_use',
+          id: 'todo-1',
+          name: 'TodoWrite',
+          input: {
+            todos: [
+              { content: 'First step', activeForm: 'Doing first step', status: 'completed' },
+              { content: 'Second step', activeForm: 'Doing second step', status: 'in_progress' },
+            ],
+          },
+        },
+      ]),
+    ];
+
+    expect(deriveLatestTodos(messages)).toEqual([
+      { content: 'First step', activeForm: 'Doing first step', status: 'completed' },
+      { content: 'Second step', activeForm: 'Doing second step', status: 'in_progress' },
+    ]);
+  });
+
+  it('correlates Claude TaskCreate output and folds TaskUpdate calls', () => {
+    const messages = [
+      message(0, [
+        {
+          type: 'tool_use',
+          id: 'create-1',
+          name: 'TaskCreate',
+          input: { subject: 'Verify the fix', activeForm: 'Verifying the fix' },
+        },
+      ]),
+      message(1, [
+        {
+          type: 'tool_result',
+          tool_use_id: 'create-1',
+          content: 'Task created',
+          tool_use_result: { task: { id: 'task-7', subject: 'Verify the fix' } },
+        },
+      ]),
+      message(2, [
+        {
+          type: 'tool_use',
+          id: 'update-1',
+          name: 'TaskUpdate',
+          input: { taskId: 'task-7', status: 'in_progress', active_form: 'Checking it' },
+        },
+      ]),
+      message(3, [{ type: 'tool_result', tool_use_id: 'update-1', content: 'Task updated' }]),
+      message(4, [
+        {
+          type: 'tool_use',
+          id: 'update-2',
+          name: 'TaskUpdate',
+          input: { task_id: 'task-7', status: 'completed' },
+        },
+      ]),
+      message(5, [
+        {
+          type: 'tool_result',
+          tool_use_id: 'update-2',
+          content: 'Task updated',
+          tool_use_result: { success: true, taskId: 'task-7', updatedFields: ['status'] },
+        },
+      ]),
+    ];
+
+    expect(deriveLatestTodos(messages)).toEqual([
+      {
+        id: 'task-7',
+        content: 'Verify the fix',
+        activeForm: 'Checking it',
+        status: 'completed',
+      },
+    ]);
+
+    render(<StickyTodoRenderer messages={messages} taskStatus={TaskStatus.COMPLETED} />);
+    expect(screen.getByText('Task List')).toBeInTheDocument();
+    expect(screen.getByText('1/1 completed')).toBeInTheDocument();
+    expect(screen.getByText('Verify the fix')).toBeInTheDocument();
+  });
+
+  it('shows an optimistic TaskCreate and removes it when the tool result fails', () => {
+    const create = message(0, [
+      {
+        type: 'tool_use',
+        id: 'create-1',
+        name: 'TaskCreate',
+        input: { subject: 'Temporary task' },
+      },
+    ]);
+    expect(deriveLatestTodos([create])).toEqual([
+      {
+        id: 'pending:create-1',
+        content: 'Temporary task',
+        activeForm: 'Temporary task',
+        status: 'pending',
+      },
+    ]);
+
+    const failed = message(1, [
+      {
+        type: 'tool_result',
+        tool_use_id: 'create-1',
+        content: 'failed',
+        is_error: true,
+      },
+    ]);
+    expect(deriveLatestTodos([create, failed])).toBeNull();
+  });
+});

--- a/apps/agor-ui/src/components/StickyTodoRenderer/StickyTodoRenderer.tsx
+++ b/apps/agor-ui/src/components/StickyTodoRenderer/StickyTodoRenderer.tsx
@@ -1,11 +1,11 @@
 /**
  * StickyTodoRenderer - Displays latest TODO above typing indicator
  *
- * Scans backward through messages to find the latest TodoWrite tool use,
- * rendering it above the typing indicator when a task is running.
+ * Reconstructs the latest list from either Codex/legacy TodoWrite snapshots or
+ * Claude's TaskCreate/TaskUpdate lifecycle, then renders it above the typing
+ * indicator.
  *
  * Features:
- * - Scans messages in reverse for performance (early exit)
  * - Caches result with useMemo (dependency: messages)
  * - Reuses existing TodoListRenderer for consistent styling
  * - Subtle visual distinction (dashed border, light background)
@@ -24,7 +24,7 @@ import {
 
 interface StickyTodoRendererProps {
   /**
-   * Messages from the task - will be scanned in reverse to find latest TodoWrite
+   * Messages from the task, including provider tool-use and tool-result blocks.
    */
   messages: Message[];
 
@@ -60,34 +60,187 @@ function inProgressOverrideFor(taskStatus: TaskStatus): RenderableTodoStatus | n
   }
 }
 
+type TaskToolName = 'taskcreate' | 'taskupdate' | 'taskget' | 'tasklist';
+
+interface TaskTodo extends RenderableTodoItem {
+  id: string;
+}
+
+interface TaskToolCall {
+  name: TaskToolName;
+  input: Record<string, unknown>;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function stringField(record: Record<string, unknown> | undefined, ...keys: string[]) {
+  for (const key of keys) {
+    const value = record?.[key];
+    if (typeof value === 'string' && value.length > 0) return value;
+  }
+  return undefined;
+}
+
+function todoStatus(value: unknown): RenderableTodoStatus | undefined {
+  return value === 'pending' || value === 'in_progress' || value === 'completed'
+    ? value
+    : undefined;
+}
+
+function taskFromRecord(
+  record: Record<string, unknown>,
+  fallback?: TaskTodo
+): TaskTodo | undefined {
+  const id = stringField(record, 'id', 'taskId', 'task_id') ?? fallback?.id;
+  const content = stringField(record, 'subject') ?? fallback?.content;
+  if (!id || !content) return undefined;
+  return {
+    id,
+    content,
+    activeForm: stringField(record, 'activeForm', 'active_form') ?? fallback?.activeForm ?? content,
+    status: todoStatus(record.status) ?? fallback?.status ?? 'pending',
+  };
+}
+
+function structuredToolResult(block: Record<string, unknown>) {
+  const structured = asRecord(block.tool_use_result);
+  if (structured) return structured;
+
+  // Some importers may serialize structured output into content. Prefer the
+  // SDK field above, but accept a JSON object for durable historical records.
+  if (typeof block.content === 'string') {
+    try {
+      return asRecord(JSON.parse(block.content));
+    } catch {
+      return undefined;
+    }
+  }
+  return asRecord(block.content);
+}
+
 /**
- * Virtual component that scans backward through messages to find and display
- * the latest TodoWrite tool use. Renders nothing if no TODOs found.
+ * Fold persisted tool calls/results into the latest renderable task list.
  *
- * Performance: Uses useMemo + early exit strategy (O(1) to O(5) in practice)
+ * TodoWrite is a complete snapshot (including Codex's normalized todo_list
+ * event). Claude Task* calls are incremental and TaskCreate receives its ID in
+ * the following SDKUserMessage.tool_use_result, so calls are correlated by
+ * tool_use_id. This function is intentionally pure so hydrated and realtime
+ * message arrays follow the same path.
+ */
+export function deriveLatestTodos(messages: Message[]): RenderableTodoItem[] | null {
+  let mode: 'todo-write' | 'task-tools' | null = null;
+  let todoWriteSnapshot: RenderableTodoItem[] = [];
+  const tasks = new Map<string, TaskTodo>();
+  const calls = new Map<string, TaskToolCall>();
+
+  for (const message of messages) {
+    if (!Array.isArray(message.content)) continue;
+
+    for (const rawBlock of message.content) {
+      const block = rawBlock as Record<string, unknown>;
+      if (block.type === 'tool_use' && typeof block.name === 'string') {
+        const name = block.name.toLowerCase();
+        const input = asRecord(block.input) ?? {};
+
+        if (name === 'todowrite') {
+          if (mode !== 'todo-write') {
+            tasks.clear();
+            calls.clear();
+          }
+          mode = 'todo-write';
+          todoWriteSnapshot = parseTodosInput(input.todos);
+          continue;
+        }
+
+        if (!['taskcreate', 'taskupdate', 'taskget', 'tasklist'].includes(name)) continue;
+        if (mode !== 'task-tools') {
+          tasks.clear();
+          calls.clear();
+        }
+        mode = 'task-tools';
+        const toolUseId = typeof block.id === 'string' ? block.id : undefined;
+        const toolName = name as TaskToolName;
+
+        if (toolName === 'taskcreate' && toolUseId) {
+          const subject = stringField(input, 'subject');
+          if (subject) {
+            tasks.set(`pending:${toolUseId}`, {
+              id: `pending:${toolUseId}`,
+              content: subject,
+              activeForm: stringField(input, 'activeForm', 'active_form') ?? subject,
+              status: 'pending',
+            });
+          }
+        }
+
+        if (toolName === 'taskupdate') {
+          if (toolUseId) calls.set(toolUseId, { name: toolName, input });
+          continue;
+        }
+
+        if (toolUseId) calls.set(toolUseId, { name: toolName, input });
+        continue;
+      }
+
+      if (block.type !== 'tool_result' || typeof block.tool_use_id !== 'string') continue;
+      const call = calls.get(block.tool_use_id);
+      if (!call) continue;
+
+      if (block.is_error === true) {
+        if (call.name === 'taskcreate') tasks.delete(`pending:${block.tool_use_id}`);
+        calls.delete(block.tool_use_id);
+        continue;
+      }
+
+      const result = structuredToolResult(block);
+      if (call.name === 'taskcreate') {
+        const created = asRecord(result?.task) ?? result;
+        const pending = tasks.get(`pending:${block.tool_use_id}`);
+        const task = created ? taskFromRecord(created, pending) : undefined;
+        if (task) {
+          tasks.delete(`pending:${block.tool_use_id}`);
+          tasks.set(task.id, task);
+        }
+      } else if (call.name === 'taskupdate' && result?.success !== false) {
+        const taskId = stringField(call.input, 'taskId', 'task_id', 'id');
+        if (taskId && call.input.status === 'deleted') {
+          tasks.delete(taskId);
+        } else if (taskId) {
+          const updated = taskFromRecord(call.input, tasks.get(taskId));
+          if (updated) tasks.set(taskId, updated);
+        }
+      } else if (call.name === 'taskget') {
+        const returned = asRecord(result?.task) ?? result;
+        const task = returned ? taskFromRecord(returned) : undefined;
+        if (task) tasks.set(task.id, task);
+      } else if (call.name === 'tasklist' && Array.isArray(result?.tasks)) {
+        tasks.clear();
+        for (const rawTask of result.tasks) {
+          const taskRecord = asRecord(rawTask);
+          const task = taskRecord ? taskFromRecord(taskRecord) : undefined;
+          if (task) tasks.set(task.id, task);
+        }
+      }
+      calls.delete(block.tool_use_id);
+    }
+  }
+
+  const latest = mode === 'task-tools' ? Array.from(tasks.values()) : todoWriteSnapshot;
+  return latest.length > 0 ? latest : null;
+}
+
+/**
+ * Virtual component that derives and displays the latest task list. Renders
+ * nothing if neither provider has produced task state.
  */
 export function StickyTodoRenderer({ messages, taskStatus }: StickyTodoRendererProps) {
   const { token } = theme.useToken();
 
-  // Scan messages in reverse to find latest TodoWrite
-  // Early exit on first match for performance
-  const latestTodo = useMemo(() => {
-    for (let i = messages.length - 1; i >= 0; i--) {
-      const message = messages[i];
-
-      if (Array.isArray(message.content)) {
-        for (const block of message.content) {
-          if (block.type === 'tool_use' && block.name === 'TodoWrite') {
-            // Found the latest TodoWrite - return its todos and exit immediately
-            const input = block.input as Record<string, unknown> | undefined;
-            const todos = parseTodosInput(input?.todos);
-            return todos.length > 0 ? todos : null;
-          }
-        }
-      }
-    }
-    return null;
-  }, [messages]);
+  const latestTodo = useMemo(() => deriveLatestTodos(messages), [messages]);
 
   // Apply display-only transform: items still `in_progress` are rewritten when
   // the parent task can no longer be making progress. Underlying message data

--- a/packages/client/src/reactive-session.test.ts
+++ b/packages/client/src/reactive-session.test.ts
@@ -330,6 +330,28 @@ describe('ReactiveSessionHandle bootstrap hydration', () => {
 });
 
 describe('ReactiveSessionHandle message snapshot reconciliation', () => {
+  it('delivers structured Claude task results unchanged over the message realtime path', async () => {
+    const task = makeTask('task-tools', TaskStatus.RUNNING);
+    const mock = createMockClient({ tasks: [task], messagesByTask: { [task.task_id]: [] } });
+    const handle = new ReactiveSessionHandle(mock.client, SESSION_ID, { taskHydration: 'lazy' });
+    await handle.ready();
+
+    const result = {
+      ...makeMessage(task.task_id, 0),
+      content: [
+        {
+          type: 'tool_result',
+          tool_use_id: 'create-1',
+          content: 'Task created',
+          tool_use_result: { task: { id: 'task-7', subject: 'Verify the fix' } },
+        },
+      ],
+    } as Message;
+    mock.emitServiceEvent('messages', 'created', result);
+
+    expect(handle.getTaskMessages(task.task_id)).toEqual([result]);
+  });
+
   it.each([
     ['immediate', false],
     ['drained queue', true],

--- a/packages/executor/src/sdk-handlers/claude/constants.ts
+++ b/packages/executor/src/sdk-handlers/claude/constants.ts
@@ -43,3 +43,19 @@ export const CLAUDE_CODE_DISALLOWED_TOOLS = [
   'ExitWorktree',
   'ScheduleWakeup',
 ] as const satisfies readonly string[];
+
+/**
+ * Claude Code's current task-list tools.
+ *
+ * Claude Agent SDK 0.3.233 stopped exposing both the legacy TodoWrite tool and
+ * these replacement tools by default on newer model families. Naming a task
+ * tool in `Options.allowedTools` is the SDK's documented opt-in. Agor consumes
+ * these calls to render the sticky task list, so keep the complete family
+ * enabled rather than relying on model-specific defaults.
+ */
+export const CLAUDE_CODE_TODO_TOOLS = [
+  'TaskCreate',
+  'TaskUpdate',
+  'TaskGet',
+  'TaskList',
+] as const satisfies readonly string[];

--- a/packages/executor/src/sdk-handlers/claude/message-builder.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/message-builder.test.ts
@@ -564,6 +564,31 @@ describe('createUserMessageFromContent', () => {
     expect(result.content_preview).toBe('Tool result: Tool execution result');
   });
 
+  it('persists structured task-tool output without folding it into the preview', async () => {
+    const messagesService = createMockMessagesService();
+    const content = [
+      {
+        type: 'tool_result',
+        tool_use_id: 'create-1',
+        content: 'Task created',
+        tool_use_result: { task: { id: 'task-7', subject: 'Verify the fix' } },
+      },
+    ];
+
+    const result = await createUserMessageFromContent(
+      generateId() as SessionID,
+      generateId() as MessageID,
+      content,
+      undefined,
+      1,
+      messagesService
+    );
+
+    expect(result.content).toEqual(content);
+    expect(result.content_preview).toBe('Tool result: Task created');
+    expect(messagesService.create).toHaveBeenCalledWith(result);
+  });
+
   it('should create preview from tool_result with object content', async () => {
     const messagesService = createMockMessagesService();
     const sessionId = generateId() as SessionID;

--- a/packages/executor/src/sdk-handlers/claude/message-builder.ts
+++ b/packages/executor/src/sdk-handlers/claude/message-builder.ts
@@ -118,6 +118,7 @@ export async function createUserMessageFromContent(
     text?: string;
     tool_use_id?: string;
     content?: unknown;
+    tool_use_result?: unknown;
     is_error?: boolean;
   }>,
   taskId: TaskID | undefined,

--- a/packages/executor/src/sdk-handlers/claude/message-processor.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/message-processor.test.ts
@@ -420,4 +420,88 @@ describe('SDKMessageProcessor tool lifecycle', () => {
     ]);
     expect(replayed).toEqual([]);
   });
+
+  it('preserves the structured TaskCreate result used to correlate its assigned ID', async () => {
+    const processor = createProcessor();
+    await processor.process({
+      type: 'assistant',
+      message: {
+        content: [
+          {
+            type: 'tool_use',
+            id: 'create-1',
+            name: 'TaskCreate',
+            input: { subject: 'Verify the fix' },
+          },
+        ],
+      },
+    } as never);
+    const events = await processor.process({
+      type: 'user',
+      message: {
+        content: [{ type: 'tool_result', tool_use_id: 'create-1', content: 'Task created' }],
+      },
+      tool_use_result: {
+        task: { id: 'task-7', subject: 'Verify the fix' },
+      },
+    } as never);
+
+    const complete = events.find(
+      (event): event is Extract<ProcessedEvent, { type: 'complete' }> => event.type === 'complete'
+    );
+    expect(complete?.content).toEqual([
+      {
+        type: 'tool_result',
+        tool_use_id: 'create-1',
+        content: 'Task created',
+        tool_use_result: { task: { id: 'task-7', subject: 'Verify the fix' } },
+      },
+    ]);
+  });
+
+  it('does not misattribute an uncorrelated top-level result to parallel tool results', async () => {
+    const processor = createProcessor();
+    const events = await processor.process({
+      type: 'user',
+      message: {
+        content: [
+          { type: 'tool_result', tool_use_id: 'tool-1', content: 'one' },
+          { type: 'tool_result', tool_use_id: 'tool-2', content: 'two' },
+        ],
+      },
+      tool_use_result: { task: { id: 'ambiguous' } },
+    } as never);
+
+    const complete = events.find(
+      (event): event is Extract<ProcessedEvent, { type: 'complete' }> => event.type === 'complete'
+    );
+    expect(complete?.content).toEqual([
+      { type: 'tool_result', tool_use_id: 'tool-1', content: 'one' },
+      { type: 'tool_result', tool_use_id: 'tool-2', content: 'two' },
+    ]);
+  });
+
+  it('does not persist unrelated structured tool output', async () => {
+    const processor = createProcessor();
+    await processor.process({
+      type: 'assistant',
+      message: {
+        content: [{ type: 'tool_use', id: 'read-1', name: 'Read', input: { file_path: '/tmp/x' } }],
+      },
+    } as never);
+    const events = await processor.process({
+      type: 'user',
+      message: {
+        content: [{ type: 'tool_result', tool_use_id: 'read-1', content: 'bounded text' }],
+      },
+      tool_use_result: { unboundedProviderObject: 'must not be persisted' },
+    } as never);
+
+    const complete = events.find(
+      (event): event is Extract<ProcessedEvent, { type: 'complete' }> => event.type === 'complete'
+    );
+    expect(complete?.content).toEqual([
+      { type: 'tool_result', tool_use_id: 'read-1', content: 'bounded text' },
+    ]);
+  });
 });

--- a/packages/executor/src/sdk-handlers/claude/message-processor.ts
+++ b/packages/executor/src/sdk-handlers/claude/message-processor.ts
@@ -28,6 +28,9 @@ import type {
 } from '@agor/core/sdk';
 import type { ContextUsageSnapshot, SessionID } from '@agor/core/types';
 import { MessageRole } from '@agor/core/types';
+import { CLAUDE_CODE_TODO_TOOLS } from './constants.js';
+
+const CLAUDE_CODE_TODO_TOOL_NAMES = new Set<string>(CLAUDE_CODE_TODO_TOOLS);
 
 /**
  * Content block interface for SDK messages
@@ -41,6 +44,7 @@ interface ContentBlock {
   id?: string;
   name?: string;
   input?: Record<string, unknown>;
+  tool_use_result?: unknown;
   [key: string]: unknown;
 }
 
@@ -74,6 +78,7 @@ export type ProcessedEvent =
         input?: Record<string, unknown>;
         tool_use_id?: string;
         content?: unknown;
+        tool_use_result?: unknown;
         is_error?: boolean;
         signature?: string; // For thinking blocks
         status?: string; // For system_status blocks
@@ -204,6 +209,8 @@ interface ProcessorState {
   // Available slash commands and skills (captured from init message)
   slashCommands: string[];
   skills: string[];
+  /** Built-in tool names keyed by call ID until the matching result arrives. */
+  toolNamesByUseId: Map<string, string>;
 }
 
 /**
@@ -230,6 +237,7 @@ export class SDKMessageProcessor {
       textChunkBufferSize: 0,
       slashCommands: [],
       skills: [],
+      toolNamesByUseId: new Map(),
     };
   }
 
@@ -313,6 +321,9 @@ export class SDKMessageProcessor {
 
     const contentBlocks = this.processContentBlocks(msg.message?.content as ContentBlock[]);
     const toolUses = this.extractToolUses(contentBlocks);
+    for (const toolUse of toolUses) {
+      this.state.toolNamesByUseId.set(toolUse.id, toolUse.name);
+    }
 
     return [
       {
@@ -346,6 +357,35 @@ export class SDKMessageProcessor {
       // Tool result messages - save to database for conversation continuity
       const toolResults = content.filter((b) => b.type === 'tool_result');
 
+      // The SDK exposes structured built-in-tool output (including the ID
+      // assigned by TaskCreate) on SDKUserMessage.tool_use_result rather than
+      // inside the Anthropic tool_result content block. Preserve it on the
+      // single matching block so persistence/realtime consumers receive the
+      // provider's correlation data. Do not guess when one SDK message contains
+      // parallel results because the top-level value has no tool-use ID.
+      const structuredResultBlock = toolResults.length === 1 ? toolResults[0] : undefined;
+      const structuredResultToolName = structuredResultBlock?.tool_use_id
+        ? this.state.toolNamesByUseId.get(structuredResultBlock.tool_use_id)
+        : undefined;
+      const topLevelToolUseResult =
+        structuredResultToolName &&
+        CLAUDE_CODE_TODO_TOOL_NAMES.has(structuredResultToolName) &&
+        'tool_use_result' in msg
+          ? (msg as SDKUserMessage).tool_use_result
+          : undefined;
+      const normalizedContent =
+        topLevelToolUseResult !== undefined && toolResults.length === 1
+          ? content.map((block) =>
+              block === structuredResultBlock
+                ? { ...block, tool_use_result: topLevelToolUseResult }
+                : block
+            )
+          : content;
+
+      for (const result of toolResults) {
+        if (result.tool_use_id) this.state.toolNamesByUseId.delete(result.tool_use_id);
+      }
+
       // A tool is complete when Claude reports its result, not when the
       // preceding tool-use content block finishes streaming.
       return [
@@ -363,7 +403,7 @@ export class SDKMessageProcessor {
         {
           type: 'complete',
           role: MessageRole.USER,
-          content: content, // Tool result content
+          content: normalizedContent, // Tool result content plus structured SDK output
           toolUses: undefined,
           parent_tool_use_id: msg.parent_tool_use_id || null,
           agentSessionId: this.state.capturedAgentSessionId,
@@ -423,6 +463,7 @@ export class SDKMessageProcessor {
       if (block?.type === 'tool_use') {
         const toolName = block.name as string;
         const toolId = block.id as string;
+        this.state.toolNamesByUseId.set(toolId, toolName);
 
         events.push({
           type: 'tool_start',

--- a/packages/executor/src/sdk-handlers/claude/query-builder.test.ts
+++ b/packages/executor/src/sdk-handlers/claude/query-builder.test.ts
@@ -48,7 +48,7 @@ vi.mock('../base/permission-hooks.js', () => ({
 import { getMcpServersForSession } from '@agor/core/mcp';
 import { resolveMCPAuthHeaders } from '@agor/core/tools/mcp/jwt-auth';
 import * as Claude from '@anthropic-ai/claude-agent-sdk';
-import { CLAUDE_CODE_DISALLOWED_TOOLS } from './constants.js';
+import { CLAUDE_CODE_DISALLOWED_TOOLS, CLAUDE_CODE_TODO_TOOLS } from './constants.js';
 import { formatListForLog, type QuerySetupDeps, setupQuery } from './query-builder.js';
 
 describe('MCP logging helpers', () => {
@@ -235,6 +235,14 @@ describe('setupQuery - Local Settings Support', () => {
 
     const callArgs = vi.mocked(Claude.query).mock.calls[0][0];
     expect(callArgs.options.disallowedTools).toEqual([...CLAUDE_CODE_DISALLOWED_TOOLS]);
+  });
+
+  it('opts into the Claude task tools that back Agor todo rendering', async () => {
+    await setupQuery('test-session' as SessionID, 'test prompt', createMockDeps());
+
+    const callArgs = vi.mocked(Claude.query).mock.calls[0][0];
+    expect(CLAUDE_CODE_TODO_TOOLS).toEqual(['TaskCreate', 'TaskUpdate', 'TaskGet', 'TaskList']);
+    expect(callArgs.options.allowedTools).toEqual([...CLAUDE_CODE_TODO_TOOLS]);
   });
 
   it('blocks on MCP startup for gateway sessions', async () => {

--- a/packages/executor/src/sdk-handlers/claude/query-builder.ts
+++ b/packages/executor/src/sdk-handlers/claude/query-builder.ts
@@ -50,7 +50,7 @@ import {
   mcpToolNameAliasesForTool,
 } from '../base/mcp-tool-permissions.js';
 import { createCanUseToolCallback } from '../base/permission-hooks.js';
-import { CLAUDE_CODE_DISALLOWED_TOOLS } from './constants.js';
+import { CLAUDE_CODE_DISALLOWED_TOOLS, CLAUDE_CODE_TODO_TOOLS } from './constants.js';
 import { DEFAULT_CLAUDE_MODEL } from './models.js';
 
 export function formatListForLog(items: string[], maxItems = 5): string {
@@ -231,6 +231,10 @@ export async function setupQuery(
       append: agorSystemPrompt,
     },
     settingSources: ['user', 'project', 'local'], // Load user + project + local permissions, auto-loads CLAUDE.md
+    // SDK 0.3.233+ omits task-list tools on newer model families unless the
+    // embedding application opts in. Agor reads their calls for the sticky
+    // task-list UI, so use the SDK's targeted opt-in rather than rolling back.
+    allowedTools: [...CLAUDE_CODE_TODO_TOOLS],
     // Defensive copy — the const is readonly but the SDK option is typed `string[]`.
     disallowedTools: [...CLAUDE_CODE_DISALLOWED_TOOLS],
     model, // Use configured model or default

--- a/packages/executor/src/sdk-handlers/codex/launch-policy.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/launch-policy.test.ts
@@ -26,6 +26,9 @@ describe('applyAgorCodexLaunchPolicy', () => {
         memories: true,
         multi_agent: false,
       },
+      tools: {
+        update_plan: { enabled: true },
+      },
       model_instructions_file: '/tmp/agor-instructions.md',
       mcp_servers: {
         agor: {
@@ -40,15 +43,52 @@ describe('applyAgorCodexLaunchPolicy', () => {
     });
   });
 
-  it('creates the required per-process override when no other config exists', () => {
+  it('creates the required per-process overrides when no other config exists', () => {
     expect(applyAgorCodexLaunchPolicy(undefined)).toEqual({
       features: { multi_agent: false },
+      tools: { update_plan: { enabled: true } },
+    });
+  });
+
+  it('forces update_plan on while preserving sibling tool toggles and sub-fields', () => {
+    const config: CodexConfigObject = {
+      tools: {
+        web_search: true,
+        update_plan: { enabled: false, some_future_field: 'keep' },
+      },
+    };
+
+    expect(applyAgorCodexLaunchPolicy(config)).toEqual({
+      features: { multi_agent: false },
+      tools: {
+        web_search: true,
+        update_plan: { enabled: true, some_future_field: 'keep' },
+      },
+    });
+    // Input is not mutated.
+    expect((config.tools as CodexConfigObject).update_plan).toEqual({
+      enabled: false,
+      some_future_field: 'keep',
     });
   });
 
   it('fails clearly instead of dropping the policy when features cannot be merged', () => {
     expect(() => applyAgorCodexLaunchPolicy({ features: true } as CodexConfigObject)).toThrow(
       'Cannot launch Codex with Agor policy: config.features must be an object so features.multi_agent can be disabled'
+    );
+  });
+
+  it('fails clearly when tools cannot be merged', () => {
+    expect(() => applyAgorCodexLaunchPolicy({ tools: true } as CodexConfigObject)).toThrow(
+      'Cannot launch Codex with Agor policy: config.tools must be an object so tools.update_plan can be enabled'
+    );
+  });
+
+  it('fails clearly when tools.update_plan cannot be merged', () => {
+    expect(() =>
+      applyAgorCodexLaunchPolicy({ tools: { update_plan: true } } as CodexConfigObject)
+    ).toThrow(
+      'Cannot launch Codex with Agor policy: config.tools.update_plan must be an object so its enabled flag can be set'
     );
   });
 });

--- a/packages/executor/src/sdk-handlers/codex/launch-policy.ts
+++ b/packages/executor/src/sdk-handlers/codex/launch-policy.ts
@@ -10,10 +10,18 @@ function isCodexConfigObject(value: unknown): value is CodexConfigObject {
  * Apply Agor-owned Codex process policy without changing the user's
  * `~/.codex/config.toml`.
  *
- * The Codex SDK flattens this object into per-process
- * `--config features.multi_agent=false`. That override intentionally wins over
- * user configuration while every unrelated config key, including other
- * feature flags, remains intact.
+ * The Codex SDK flattens these objects into per-process overrides such as
+ * `--config features.multi_agent=false` and
+ * `--config tools.update_plan.enabled=true`. They intentionally win over user
+ * configuration while every unrelated config key, including other feature
+ * flags and tool toggles, remains intact.
+ *
+ * `tools.update_plan.enabled` is forced on because Agor renders the Codex
+ * `update_plan` (todo_list) tool as its sticky task list. Newer Codex CLI
+ * builds no longer expose that tool by default, so — mirroring the Claude
+ * `allowedTools` opt-in — Agor always enables it rather than relying on the
+ * runtime default. `update_plan` is a nested table (`{ enabled: bool }`), not a
+ * scalar toggle like `tools.web_search`.
  */
 export function applyAgorCodexLaunchPolicy(
   config: CodexConfigObject | undefined
@@ -25,12 +33,34 @@ export function applyAgorCodexLaunchPolicy(
     );
   }
 
+  const tools = config?.tools;
+  if (tools !== undefined && !isCodexConfigObject(tools)) {
+    throw new Error(
+      'Cannot launch Codex with Agor policy: config.tools must be an object so tools.update_plan can be enabled'
+    );
+  }
+
+  const updatePlan = tools?.update_plan;
+  if (updatePlan !== undefined && !isCodexConfigObject(updatePlan)) {
+    throw new Error(
+      'Cannot launch Codex with Agor policy: config.tools.update_plan must be an object so its enabled flag can be set'
+    );
+  }
+
   return {
     ...config,
     features: {
       ...features,
       // Agor sessions/subsessions are the supported, observable orchestration boundary.
       multi_agent: false,
+    },
+    tools: {
+      ...tools,
+      update_plan: {
+        ...updatePlan,
+        // Agor's sticky task list is driven by Codex's update_plan tool.
+        enabled: true,
+      },
     },
   };
 }

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
@@ -554,6 +554,8 @@ describe('CodexPromptService - prompt flow client initialization', () => {
       expect(mockInstanceConfigs).toEqual([
         {
           features: { goals: false, multi_agent: false },
+          // Agor always opts Codex into its sticky-task-list planning tool.
+          tools: { update_plan: { enabled: true } },
           model_instructions_file: '/tmp/agor-codex-instructions-flow.md',
           mcp_servers: {
             agor: {


### PR DESCRIPTION
## Linked issue

Related: runtime regression introduced when #2667 crossed the Claude Code task-tool behavior change in SDK 0.3.233.

## Summary

- Explicitly opt Claude Agent SDK 0.3.259 into `TaskCreate`, `TaskUpdate`, `TaskGet`, and `TaskList`.
- Preserve the SDK's structured task result for the matching task-tool result, including the ID assigned by `TaskCreate`, while refusing ambiguous or unrelated provider objects.
- Reconstruct the sticky bottom task list from Claude `Task*` lifecycles as well as existing Codex/legacy `TodoWrite` snapshots.
- Add provider-event, persistence, realtime hydration, and UI rendering regression coverage.

## Why / context

The current pins are Claude Agent SDK `0.3.259` and Codex SDK `0.153.0`. Claude Code 2.1.233/Agent SDK 0.3.233 stopped exposing TodoWrite and the replacement task tools by default for newer model families unless an embedding application opts in. Agor upgraded from Claude 0.3.197 to 0.3.259 in #2667 without opting in, while the sticky renderer still only recognized `TodoWrite`.

Official semantics:
- https://code.claude.com/docs/en/agent-sdk/todo-tracking
- https://code.claude.com/docs/en/changelog

The current Codex SDK still emits `ThreadItem` with `type: "todo_list"`, and Agor's existing adapter continues to normalize it to a synthetic `TodoWrite`; no rollback or Codex schema change is needed.

Pre-fix sibling runtime probes on this branch found no task tool available:
- Codex: https://agor.sandbox.preset.zone/ui/s/01a073dae3d072bc9cfbd48a/
- Claude Code: https://agor.sandbox.preset.zone/ui/s/01a073daea0d70cd9de403ee/

## Implementation notes

- `allowedTools` is the SDK's targeted task-tool opt-in; dependency versions are unchanged.
- Claude reports structured built-in output on top-level `SDKUserMessage.tool_use_result`. The processor correlates this by `tool_use_id` and only persists it for the known task-tool family and a single unambiguous result.
- The UI folds `TaskCreate`/`TaskUpdate`/`TaskGet`/`TaskList` calls and results into the same render model used by normalized Codex `TodoWrite` snapshots.
- Tenant/security boundary is unchanged: structured task data remains content on the existing tenant-derived session message, through the existing message service authorization/RBAC hooks and branch-or-session realtime audience. No new storage, route, credential, or cross-tenant lookup was introduced.

## Validation / test plan

- [x] Biome check on all 10 changed files.
- [x] Executor focused tests: 107 passed (`message-processor`, `message-builder`, `query-builder`).
- [x] Client realtime hydration test: 41 passed.
- [x] Sticky renderer UI tests: 3 passed.
- [x] Existing Codex todo normalization tests: 3 passed.
- [x] Typecheck: `@agor/executor`, `@agor-live/client`, `agor-ui`.
- [x] Build: `@agor/executor`, `@agor-live/client`, `agor-ui`.
- [x] Managed Docker environment healthy; real REST persistence round-trip retained `tool_use_result` exactly.
- [x] Playwright/Chromium browser smoke verified one bottom-positioned task list after TaskUpdate and before the composer: `0/1 completed • 1 in progress`, item `Verify sticky task widget`.

## Screenshots / demos

Managed smoke session: http://10.33.92.175:10349/ui/s/01a073e415677b9a88ff0960/

## Risks / rollout / rollback

Task tools become available to Claude sessions because Agor consumes them. Existing permission handling remains in place. If provider semantics change again, remove the explicit opt-in and task folding together rather than rolling the SDK back.

## Out of scope / follow-ups

The Codex sibling's current runtime did not expose a planning tool, although SDK 0.153.0 and the Agor normalization contract still support `todo_list` events. Add a provider tool-inventory contract probe to SDK upgrade/release checks so availability changes are caught before UI regressions.
