### PR TITLE
fix(mcp): scope child session admission to authenticated tenant

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/sessions.tenant-scope.postgres.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.tenant-scope.postgres.test.ts
@@ -1,0 +1,99 @@
+import {
+  acquireTenantWriteGate,
+  createDatabase,
+  type Database,
+  executeRaw,
+  initializeDatabase,
+  isPostgresDatabase,
+  releaseTenantWriteGate,
+  runWithTenantDatabaseScope,
+  sql,
+  UsersRepository,
+} from '@agor/core/db';
+import type { TenantID } from '@agor/core/types';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { generateId } from '../../../../../packages/core/src/lib/ids';
+import { childAdmissionFixture } from '../../../test/session-child-admission';
+
+const postgresUrl = process.env.AGOR_TEST_POSTGRES_URL;
+const usesPostgresSchema = process.env.AGOR_DB_DIALECT === 'postgresql';
+
+describe.skipIf(!postgresUrl || !usesPostgresSchema)('MCP child admission (PostgreSQL/RLS)', () => {
+  let rawDb: Database;
+
+  beforeAll(async () => {
+    vi.stubEnv('AGOR_BASE_URL', 'http://agor.test');
+    rawDb = createDatabase({ dialect: 'postgresql', url: postgresUrl! });
+    await initializeDatabase(rawDb);
+    if (!isPostgresDatabase(rawDb)) throw new Error('PostgreSQL required');
+    const result = await executeRaw(
+      rawDb,
+      sql`
+      SELECT rolsuper, rolbypassrls FROM pg_roles WHERE rolname = current_user
+    `
+    );
+    const rows = Array.isArray(result) ? result : (result as { rows: unknown[] }).rows;
+    expect(rows[0]).toMatchObject({ rolsuper: false, rolbypassrls: false });
+  }, 60_000);
+
+  afterAll(async () => {
+    vi.unstubAllEnvs();
+    await (rawDb as Database & { $client: { end: () => Promise<void> } }).$client.end();
+  });
+
+  it('admits a shared caller but rejects replay of the same parent ID from another tenant', async () => {
+    const tenantA = `spawn-a-${generateId()}` as TenantID;
+    const tenantB = `spawn-b-${generateId()}` as TenantID;
+    const f = await childAdmissionFixture(rawDb, 'branch', tenantA);
+    await f.sharing();
+    const foreignUser = await runWithTenantDatabaseScope(f.db, tenantB, (db) =>
+      new UsersRepository(db).create({ email: `${tenantB}@example.invalid`, role: 'superadmin' })
+    );
+    const args = { prompt: 'RLS smoke', enableCallback: false, mcpServerIds: [] };
+    const allowed = f.toolsFor(f.caller);
+    await allowed.handlers.agor_sessions_spawn(args);
+    expect(f.prompt).toHaveBeenCalledOnce();
+    expect(await f.count()).toHaveLength(2);
+
+    const denied = f.toolsFor(foreignUser, tenantB);
+    // Same real parent ID, real tenant-B principal (even superadmin), RLS on.
+    await expect(denied.handlers.agor_sessions_spawn(args)).rejects.toThrow(/not found/i);
+    await expect(
+      denied.handlers.agor_sessions_prompt({
+        ...args,
+        sessionId: f.parent.session_id,
+        mode: 'subsession',
+      })
+    ).rejects.toThrow(/not found/i);
+    expect(await f.count()).toHaveLength(2);
+    expect(f.prompt).toHaveBeenCalledOnce();
+  });
+
+  it('enforces the tenant write freeze before custom spawn/fork and resumes only after release', async () => {
+    const tenant = `spawn-freeze-${generateId()}` as TenantID;
+    const f = await childAdmissionFixture(rawDb, 'branch', tenant);
+    const { generation } = await acquireTenantWriteGate(rawDb, tenant, {
+      holder: 'spawn-test',
+      reason: 'test child admission freeze',
+    });
+    const { handlers } = f.toolsFor();
+    const args = { prompt: 'Freeze smoke', enableCallback: false, mcpServerIds: [] };
+    try {
+      await expect(handlers.agor_sessions_spawn(args)).rejects.toThrow(/write-gated/i);
+      await expect(
+        handlers.agor_sessions_prompt({
+          ...args,
+          sessionId: f.parent.session_id,
+          mode: 'fork',
+        })
+      ).rejects.toThrow(/write-gated/i);
+      expect(await f.count()).toHaveLength(1);
+      expect(f.prompt).not.toHaveBeenCalled();
+    } finally {
+      await releaseTenantWriteGate(rawDb, tenant, { generation });
+    }
+    await handlers.agor_sessions_spawn(args);
+    expect(await f.count()).toHaveLength(2);
+    expect(f.prompt).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/agor-daemon/src/mcp/tools/sessions.tenant-scope.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.tenant-scope.test.ts
@@ -1,0 +1,218 @@
+import {
+  BranchRepository,
+  CapabilityPolicyRepository,
+  getCurrentTenantDatabaseScope,
+  MissingTenantDatabaseScopeError,
+  runWithTenantContext,
+  runWithTenantDatabaseScope,
+  SessionRepository,
+} from '@agor/core/db';
+import type { Session } from '@agor/core/types';
+import { afterEach, beforeEach, describe, expect, vi } from 'vitest';
+import { dbTest } from '../../../../../packages/core/src/db/test-helpers';
+import { generateId } from '../../../../../packages/core/src/lib/ids';
+import { childAdmissionFixture as fixture } from '../../../test/session-child-admission';
+import type { SessionsService } from '../../services/sessions';
+
+const spawnArgs = { prompt: 'Scope regression', enableCallback: false, mcpServerIds: [] };
+
+describe('MCP child admission with the armed tenant database guard', () => {
+  beforeEach(() => vi.stubEnv('AGOR_BASE_URL', 'http://agor.test'));
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  dbTest(
+    'reproduces the exact pre-fix catch-all and its underlying scope error',
+    async ({ db }) => {
+      const f = await fixture(db);
+      const authority = vi.spyOn(BranchRepository.prototype, 'resolveSessionPromptAuthority');
+      const { ctx } = f.toolsFor();
+      await expect(
+        runWithTenantContext(f.tenantId, () =>
+          (f.app.service('sessions') as unknown as SessionsService).spawn(
+            f.parent.session_id,
+            spawnArgs,
+            ctx.baseServiceParams
+          )
+        )
+      ).rejects.toThrow('Cannot resolve session-sharing authority for this branch.');
+      expect(authority).toHaveBeenCalledOnce();
+      await expect(authority.mock.results[0].value).rejects.toBeInstanceOf(
+        MissingTenantDatabaseScopeError
+      );
+      expect(await f.count()).toHaveLength(1);
+      expect(f.prompt).not.toHaveBeenCalled();
+    }
+  );
+
+  for (const mode of ['spawn', 'subsession', 'fork', 'btw']) {
+    dbTest(
+      `${mode} admits an owner without enabling sharing and prompts outside the DB scope`,
+      async ({ db }) => {
+        const f = await fixture(db);
+        const { handlers } = f.toolsFor();
+        const result = await handlers[
+          mode === 'spawn' ? 'agor_sessions_spawn' : 'agor_sessions_prompt'
+        ]({
+          ...spawnArgs,
+          sessionId: f.parent.session_id,
+          mode,
+        });
+        const child = JSON.parse(result.content[0].text).session as Session;
+        expect(child).toMatchObject({
+          created_by: f.owner.user_id,
+          unix_username: 'owner-home',
+          branch_id: f.branch.branch_id,
+          sdk_home_scope: 'branch',
+        });
+        expect(await f.count()).toHaveLength(2);
+        expect(f.prompt).toHaveBeenCalledOnce();
+        expect(getCurrentTenantDatabaseScope()).toBeUndefined();
+      }
+    );
+  }
+
+  dbTest(
+    'inherits Others sharing for a foreign caller without requiring board visibility',
+    async ({ db }) => {
+      const f = await fixture(db);
+      await f.sharing();
+      const { handlers } = f.toolsFor(f.caller);
+      const result = await handlers.agor_sessions_spawn(spawnArgs);
+      expect(JSON.parse(result.content[0].text).session).toMatchObject({
+        created_by: f.caller.user_id,
+        unix_username: 'caller-home',
+        sdk_home_scope: 'branch',
+      });
+      await runWithTenantDatabaseScope(f.db, f.tenantId, async () => {
+        expect(
+          (
+            await new CapabilityPolicyRepository(f.db).resolveBoardAccess(
+              f.board.board_id,
+              f.caller.user_id
+            )
+          ).capabilities
+        ).toEqual([]);
+      });
+    }
+  );
+
+  dbTest(
+    'a cross-branch subsession uses the target parent policy and stays in that branch',
+    async ({ db }) => {
+      const f = await fixture(db);
+      await f.sharing();
+      const source = await runWithTenantDatabaseScope(f.db, f.tenantId, async () => {
+        const sourceBranch = await new BranchRepository(f.db).create({
+          repo_id: f.branch.repo_id,
+          created_by: f.caller.user_id,
+          name: 'remote-source',
+          ref: 'main',
+          branch_unique_id: 8_690_002,
+          path: `/tmp/${generateId()}`,
+        });
+        return new SessionRepository(f.db).create({
+          branch_id: sourceBranch.branch_id,
+          created_by: f.caller.user_id,
+          agentic_tool: 'claude-code',
+          sdk_home_scope: 'branch',
+        });
+      });
+      const { ctx, handlers } = f.toolsFor(f.caller);
+      ctx.sessionId = source.session_id;
+      const result = await handlers.agor_sessions_prompt({
+        ...spawnArgs,
+        mode: 'subsession',
+        sessionId: f.parent.session_id,
+      });
+      expect(JSON.parse(result.content[0].text).session).toMatchObject({
+        branch_id: f.branch.branch_id,
+        created_by: f.caller.user_id,
+        genealogy: { parent_session_id: f.parent.session_id },
+      });
+      // Owning the orchestration branch does not authorize a revoked target.
+      await f.sharing(false);
+      await expect(
+        handlers.agor_sessions_prompt({
+          ...spawnArgs,
+          mode: 'subsession',
+          sessionId: f.parent.session_id,
+        })
+      ).rejects.toThrow(/sharing/i);
+      expect(await f.count()).toHaveLength(3);
+      expect(f.prompt).toHaveBeenCalledOnce();
+    }
+  );
+
+  for (const denial of [
+    'workspace',
+    'branch',
+    'viewer',
+    'superadmin',
+    'execution_home',
+    'missing_policy',
+  ]) {
+    dbTest(`fails closed without persisting or prompting a child: ${denial}`, async ({ db }) => {
+      const f = await fixture(db, denial === 'execution_home' ? 'execution_home' : 'branch');
+      await f.sharing(
+        denial !== 'workspace',
+        ['viewer', 'superadmin'].includes(denial) ? 'viewer' : 'collaborator'
+      );
+      await runWithTenantDatabaseScope(f.db, f.tenantId, async () => {
+        const policies = new CapabilityPolicyRepository(f.db);
+        if (denial === 'branch' || denial === 'missing_policy') {
+          const policy = await policies.getBranchPolicy(f.branch.branch_id);
+          await policies.replaceBranchPolicy(
+            f.branch.branch_id,
+            {
+              ...policy,
+              binding_mode: 'override',
+              override_config: { ...policy.inherited_config!, allow_shared_session_prompts: false },
+            },
+            f.owner.user_id
+          );
+        }
+      });
+      if (denial === 'missing_policy') {
+        vi.spyOn(BranchRepository.prototype, 'resolveSessionPromptAuthority').mockRejectedValueOnce(
+          new Error('policy unavailable')
+        );
+      }
+      const { handlers } = f.toolsFor(
+        denial === 'superadmin' ? { ...f.caller, role: 'superadmin' } : f.caller
+      );
+      await expect(handlers.agor_sessions_spawn(spawnArgs)).rejects.toThrow(
+        denial === 'missing_policy'
+          ? 'Cannot resolve session-sharing authority'
+          : ['viewer', 'superadmin'].includes(denial)
+            ? /Only Collaborators and Managers/
+            : /shar/i
+      );
+      expect(await f.count()).toHaveLength(1);
+      expect(f.prompt).not.toHaveBeenCalled();
+    });
+  }
+
+  dbTest(
+    'refuses missing tenant identity and conflicting tenant context before child side effects',
+    async ({ db }) => {
+      const f = await fixture(db);
+      const missing = f.toolsFor(f.owner, undefined);
+      // Explicitly remove identity; the helper's optional parameter defaults for normal callers.
+      delete missing.ctx.baseServiceParams.tenant;
+      await expect(missing.handlers.agor_sessions_spawn(spawnArgs)).rejects.toThrow(
+        'Cannot resolve session-sharing authority'
+      );
+      const { handlers } = f.toolsFor();
+      await expect(
+        Promise.resolve().then(() =>
+          runWithTenantContext('foreign-tenant', () => handlers.agor_sessions_spawn(spawnArgs))
+        )
+      ).rejects.toThrow(/tenant/i);
+      expect(await f.count()).toHaveLength(1);
+      expect(f.prompt).not.toHaveBeenCalled();
+    }
+  );
+});

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -693,9 +693,13 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         modelConfig: coerceModelConfig(args.modelConfig),
       };
 
-      const childSession = await (
-        ctx.app.service('sessions') as unknown as SessionsServiceImpl
-      ).spawn(currentSessionId, spawnData, ctx.baseServiceParams);
+      // spawn/fork are custom methods, not Feathers transport methods. Scope
+      // only child admission/persistence; prompting must run after this unit
+      // commits, without holding a transaction across executor orchestration.
+      const sessionsService = ctx.app.service('sessions') as unknown as SessionsServiceImpl;
+      const childSession = await runWithMcpTenantDatabaseWrite(ctx, () =>
+        sessionsService.spawn(currentSessionId, spawnData, ctx.baseServiceParams)
+      );
 
       const task = await ctx.app.service('/sessions/:id/prompt').create(
         {
@@ -834,9 +838,10 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         const forkData: { prompt: string; task_id?: string } = { prompt: args.prompt };
         if (args.taskId) forkData.task_id = args.taskId;
 
-        const forkedSession = await (
-          ctx.app.service('sessions') as unknown as SessionsServiceImpl
-        ).fork(sessionId, forkData, ctx.baseServiceParams);
+        const sessionsService = ctx.app.service('sessions') as unknown as SessionsServiceImpl;
+        const forkedSession = await runWithMcpTenantDatabaseWrite(ctx, () =>
+          sessionsService.fork(sessionId, forkData, ctx.baseServiceParams)
+        );
 
         // Build patch for the fork — title for both modes, btw-specific metadata for btw
         const forkPatch: Record<string, unknown> = {};
@@ -893,9 +898,10 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         if (args.agenticTool) spawnData.agent = args.agenticTool as AgenticToolName;
         if (args.taskId) spawnData.task_id = args.taskId;
 
-        const childSession = await (
-          ctx.app.service('sessions') as unknown as SessionsServiceImpl
-        ).spawn(sessionId, spawnData, ctx.baseServiceParams);
+        const sessionsService = ctx.app.service('sessions') as unknown as SessionsServiceImpl;
+        const childSession = await runWithMcpTenantDatabaseWrite(ctx, () =>
+          sessionsService.spawn(sessionId, spawnData, ctx.baseServiceParams)
+        );
 
         const task = await ctx.app.service('/sessions/:id/prompt').create(
           {

--- a/apps/agor-daemon/src/mcp/tools/tenant-scope-audit.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/tenant-scope-audit.test.ts
@@ -1,5 +1,6 @@
 import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
 /**
@@ -88,6 +89,8 @@ const MUTATION_TOKENS = new Set([
   'boardsService.unarchive',
   'sessionsService.archive',
   'sessionsService.unarchive',
+  'sessionsService.spawn',
+  'sessionsService.fork',
 ]);
 
 /** Balanced-paren spans of every call matching `opener`. */
@@ -186,6 +189,45 @@ describe('MCP tool tenant database scope audit', () => {
     expect(stale, `Stale MUTATION_TOKENS entries (no longer called): ${stale.join(', ')}`).toEqual(
       []
     );
+  });
+
+  it('does not let inline service casts hide unscoped custom methods from the audit', () => {
+    const violations: string[] = [];
+    for (const file of files) {
+      const code = readFileSync(join(TOOLS_DIR, file), 'utf8');
+      const source = ts.createSourceFile(file, code, ts.ScriptTarget.Latest, true);
+      const spans = scopeSpans(code);
+      const visit = (node: ts.Node): void => {
+        if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression)) {
+          const method = node.expression.name.text;
+          let receiver: ts.Expression = node.expression.expression;
+          while (ts.isParenthesizedExpression(receiver) || ts.isAsExpression(receiver)) {
+            receiver = receiver.expression;
+          }
+          if (
+            !TRANSPORT_METHODS.has(method) &&
+            ts.isCallExpression(receiver) &&
+            ts.isPropertyAccessExpression(receiver.expression) &&
+            receiver.expression.name.text === 'service'
+          ) {
+            const service = receiver.arguments[0];
+            if (
+              service &&
+              ts.isStringLiteral(service) &&
+              CALL_SITE_SCOPED_SERVICES.includes(service.text) &&
+              !spans.some(([start, end]) => node.getStart(source) >= start && node.end <= end + 1)
+            ) {
+              violations.push(
+                `${file}:${lineOf(code, node.getStart(source))} ${service.text}.${method}`
+              );
+            }
+          }
+        }
+        ts.forEachChild(node, visit);
+      };
+      visit(source);
+    }
+    expect(violations, 'Inline custom service calls must enter a tenant DB unit').toEqual([]);
   });
 
   it('does not alias a call-site-scoped service to a non-<name>Service local (which would evade the scan)', () => {

--- a/apps/agor-daemon/test/session-child-admission.ts
+++ b/apps/agor-daemon/test/session-child-admission.ts
@@ -1,0 +1,171 @@
+import {
+  BoardRepository,
+  BranchRepository,
+  CapabilityPolicyRepository,
+  createTenantScopedDatabaseProxy,
+  getCurrentTenantDatabaseScope,
+  RepoRepository,
+  runWithTenantDatabaseScope,
+  SessionRepository,
+  UsersRepository,
+} from '@agor/core/db';
+import { feathers } from '@agor/core/feathers';
+import {
+  capabilityPolicyPresetCapabilities,
+  type HookContext,
+  type Session,
+  SessionStatus,
+  type TenantID,
+} from '@agor/core/types';
+import type { McpServer } from '@modelcontextprotocol/server';
+import { expect, vi } from 'vitest';
+import { generateId } from '../../../packages/core/src/lib/ids';
+import type { McpContext } from '../src/mcp/server';
+import { tenantScopedToolProxy } from '../src/mcp/tenant-scope';
+import { registerSessionTools } from '../src/mcp/tools/sessions';
+import { SessionsService } from '../src/services/sessions';
+import { ensureCanView, loadSessionBranch } from '../src/utils/branch-authorization';
+
+type Handler = (args: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text: string }>;
+}>;
+
+// Real repositories + Feathers standard-method scopes, but no executor or
+// external credentials. Custom spawn/fork deliberately are NOT hook-wrapped.
+export async function childAdmissionFixture(
+  rawDb: Parameters<typeof createTenantScopedDatabaseProxy>[0],
+  sdkHomeScope: Session['sdk_home_scope'] = 'branch',
+  tenantId = 'default' as TenantID
+) {
+  const db = createTenantScopedDatabaseProxy(rawDb, { label: 'daemon database' });
+  const seeded = await runWithTenantDatabaseScope(db, tenantId, async () => {
+    const users = new UsersRepository(db);
+    const owner = await users.create({
+      email: `${generateId()}@example.invalid`,
+      unix_username: 'owner-home',
+      role: 'member',
+    });
+    const caller = await users.create({
+      email: `${generateId()}@example.invalid`,
+      unix_username: 'caller-home',
+      role: 'member',
+    });
+    const repo = await new RepoRepository(db).create({
+      slug: `spawn-scope-${generateId()}`,
+      repo_type: 'remote',
+      remote_url: 'https://example.invalid/test.git',
+      local_path: `/tmp/${generateId()}`,
+      default_branch: 'main',
+    });
+    const board = await new BoardRepository(db).create({
+      name: 'Spawn scope test',
+      created_by: owner.user_id,
+      access_mode: 'private',
+    });
+    const branch = await new BranchRepository(db).create({
+      repo_id: repo.repo_id,
+      board_id: board.board_id,
+      permission_binding: 'inherit',
+      created_by: owner.user_id,
+      name: 'spawn-scope',
+      ref: 'main',
+      branch_unique_id: Math.floor(Math.random() * 1_000_000),
+      path: `/tmp/${generateId()}`,
+    });
+    const parent = await new SessionRepository(db).create({
+      branch_id: branch.branch_id,
+      created_by: owner.user_id,
+      unix_username: 'old-owner-home',
+      sdk_home_scope: sdkHomeScope,
+      agentic_tool: 'claude-code',
+      status: SessionStatus.IDLE,
+      model_config: { mode: 'alias', model: 'sonnet', updated_at: new Date().toISOString() },
+      tasks: [],
+      genealogy: { children: [] },
+    });
+    return { owner, caller, board, branch, parent };
+  });
+
+  const app = feathers();
+  app.set('config', { execution: { unix_user_mode: 'simple' } });
+  const sessionsService = new SessionsService(db, app as unknown as McpContext['app']);
+  app.use('sessions', sessionsService as never);
+  app.use('branches', { get: (id: string) => new BranchRepository(db).findById(id) });
+  app.use('users', { get: (id: string) => new UsersRepository(db).findById(id) });
+  for (const path of ['sessions', 'branches', 'users']) {
+    app.service(path).hooks({
+      around: {
+        all: [
+          async (context: HookContext, next) => {
+            await runWithTenantDatabaseScope(
+              db,
+              context.params.tenant?.tenant_id ?? tenantId,
+              next
+            );
+          },
+        ],
+      },
+    });
+  }
+  app.service('sessions').hooks({
+    before: {
+      get: [
+        loadSessionBranch(new SessionRepository(db), new BranchRepository(db)),
+        ensureCanView(),
+      ],
+    },
+  });
+  const prompt = vi.fn(async () => {
+    // The child transaction must end before prompt/executor orchestration.
+    expect(getCurrentTenantDatabaseScope()).toBeUndefined();
+    return { task_id: generateId(), status: 'queued' };
+  });
+  app.use('/sessions/:id/prompt', { create: prompt });
+
+  function toolsFor(user = seeded.owner, tenant: string | undefined = tenantId) {
+    const ctx = {
+      app,
+      db,
+      sessionId: seeded.parent.session_id,
+      userId: user.user_id,
+      authenticatedUser: user,
+      baseServiceParams: {
+        user,
+        provider: 'mcp',
+        authenticated: true,
+        ...(tenant ? { tenant: { tenant_id: tenant, source: 'explicit' } } : {}),
+      },
+    } as unknown as McpContext;
+    const handlers: Record<string, Handler> = {};
+    const server = {
+      registerTool: (name: string, _config: unknown, handler: Handler) => {
+        handlers[name] = handler;
+      },
+    } as unknown as McpServer;
+    registerSessionTools(tenantScopedToolProxy(server, ctx), ctx);
+    return { handlers, ctx };
+  }
+
+  async function sharing(enabled = true, preset: 'collaborator' | 'viewer' = 'collaborator') {
+    await runWithTenantDatabaseScope(db, tenantId, async () => {
+      const policies = new CapabilityPolicyRepository(db);
+      await policies.setWorkspacePreferences(
+        { session_sharing_enabled: enabled },
+        seeded.owner.user_id
+      );
+      const policy = await policies.getBoardPolicies(seeded.board.board_id);
+      policy.branch_template.allow_shared_session_prompts = enabled;
+      policy.branch_template.access.sharing_mode = 'shared';
+      policy.branch_template.access.others = {
+        preset,
+        capabilities: capabilityPolicyPresetCapabilities('branch_access', preset, 'read') ?? [],
+        fs_access: 'read',
+      };
+      await policies.replaceBoardPolicies(seeded.board.board_id, policy, seeded.owner.user_id);
+    });
+  }
+
+  const count = () =>
+    runWithTenantDatabaseScope(db, tenantId, () => new SessionRepository(db).findAll());
+  return { ...seeded, db, tenantId, app, sessionsService, prompt, toolsFor, sharing, count };
+}

--- a/docs/internal/session-spawn-authority-investigation-2026-09-07.md
+++ b/docs/internal/session-spawn-authority-investigation-2026-09-07.md
@@ -1,0 +1,231 @@
+# MCP spawn: misleading session-sharing authority failure
+
+## Finding
+
+**A genuine MCP database-scope bug, not a missing sharing grant.** The tenant
+database guard correctly fails closed, but a permitted operation reaches it
+without a database scope. The child-identity catch replaces the guard error
+with `Cannot resolve session-sharing authority for this branch.`
+
+Confirmed against the current investigation session on 2026-09-07. The original
+report did not identify its failing session/task, so these observations prove
+the reproduced instance, not the provenance of every occurrence of this message.
+
+- Investigated checkout/base: `fe48ecfd516384ee008df6787efac90cb243b0ed`.
+- Final main check: `64e17cfa5a29206a4130e6ee68fc991c39860840`; its only
+  additional commit was unrelated MCP catalog PR #2638, with no spawn-path changes.
+- Live `/health`: version `0.26.1`, build `95e5c26d4`, built
+  `2026-09-05T23:14:04.484Z`; database healthy, `branchRbac: true`, realtime
+  `required: false, ready: true`. This is not evidence of an HA outage.
+- Main is newer, but has the same failing MCP calls and child-authority code.
+  Merely updating to the main SHA above does **not** fix this error.
+
+## Exact origin and failure chain
+
+`apps/agor-daemon/src/services/sessions.ts`,
+`SessionsService.resolveChildIdentity()`, line 822 at the investigated SHA:
+
+```ts
+} catch (error) {
+  if (error instanceof Forbidden) throw error;
+  throw new Forbidden('Cannot resolve session-sharing authority for this branch.');
+}
+```
+
+The outer phrase “Agor blocked the spawn with:” is not a repository error
+literal. The inner error is a Feathers `Forbidden` (403).
+
+1. MCP authenticates a user/session token or user API key, resolves trusted
+   tenant identity, and builds `baseServiceParams` with `provider: 'mcp'`, user,
+   authentication state, and tenant (`mcp/server.ts`). The session-aware token
+   path validates its session rather than accepting an arbitrary client actor.
+2. `tenantScopedToolProxy` enters **tenant identity**, deliberately not a
+   request-long database transaction (`mcp/tenant-scope.ts`).
+3. `agor_sessions_spawn` directly calls the registered service's custom
+   `.spawn()`. The same omission exists in `agor_sessions_prompt` modes
+   `subsession`, `fork`, and `btw`. These custom methods are not Feathers
+   transport methods and do not acquire the standard request scope.
+4. The standard `sessions.get` and nested `branches.get` have their own scoped
+   hooks. Returning from either restores the caller's identity-only context.
+5. `resolveChildIdentity` calls its **unbound** `branchRepo`'s
+   `resolveSessionPromptAuthority`. Its first normalized branch-policy read
+   touches the guarded daemon database outside a database unit.
+6. `MissingTenantDatabaseScopeError('daemon database')` is thrown, with message
+   `Missing tenant database scope for daemon database access`. The catch above
+   hides it. No child or initial task is written at this point.
+
+The real-service SQLite regression captures the rejected policy-repository
+promise and checks the underlying exception type as well as the outer message.
+It does not merely mock the expected text. Registered Feathers reads succeed;
+the direct authority read fails exactly as in the live reproduction.
+
+The same catch could also mask an unavailable database, a branch deleted during
+admission, missing board template/override policy, an invalid inherited branch
+without a board, or a runtime/core API mismatch. Ordinary policy denials are
+already `Forbidden` and retain their specific, actionable messages. This generic
+message alone is not evidence that session sharing should be enabled.
+
+## Scoped live records and reproduction
+
+Only the investigation session, its task, branch, board policy, and workspace
+sharing preference were inspected through authenticated services. No database
+dump, secret values, other tenants, or broad transcript search was used.
+
+| Record                                         | Observed state                                                                                                                             |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| Session `01a07934-0ed7-7335-b680-b8e0196a2d02` | `sdk_home_scope: branch`; creator is the authenticated caller                                                                              |
+| Task `01a07934-1376-7338-9a52-3452c078f552`    | Running; `created_by` is that same caller                                                                                                  |
+| Branch `01a07933-5cf0-7178-8bcb-864180bc7899`  | Ready, unarchived, `sdk_home: per_branch`; caller is immutable primary owner; `permission_binding: inherit`                                |
+| Board `9833703b-b9e6-4b7b-b0eb-70f783fba715`   | Caller is primary owner; branch-template and board-access revisions both 5                                                                 |
+| Effective branch template                      | Shared; `allow_shared_session_prompts: true`; unmatched Others = Collaborator/write; named group = Viewer/read; named user = Manager/write |
+| Board access                                   | Others = Viewer; named group and user = Manager; independent of branch roles                                                               |
+| Workspace preference                           | `session_sharing_enabled: true`                                                                                                            |
+
+The legacy branch `others_can: none` and `others_fs_access: none` are inert
+compatibility fields, **not** the effective Others grant. No fallback repair is
+needed. Primary ownership wins for this caller even if a group grants less.
+
+Live transport comparison, same parent and caller:
+
+1. `agor_sessions_spawn` with a harmless acknowledgment prompt, callbacks off,
+   and `mcpServerIds: []` returned the exact reported error.
+2. Authenticated `POST /sessions/<same-parent>/spawn` with a harmless prompt,
+   callbacks off, and `mcpServerIds: []` returned **201** and an **idle** child,
+   `01a07936-e5aa-72f5-9ab9-9ce38d24c8ce`. Its branch, caller attribution, and
+   branch-home scope were correct. No prompt was submitted to that child.
+3. That exact idle smoke child was archived afterward. No live permissions,
+   user records, configuration, runtime stamp, or credentials were changed.
+
+## Expected authorization semantics
+
+- `spawn` and `fork` always keep the selected parent's branch and immutable
+  SDK-home scope. A `branchId` is not a spawn destination override.
+- Same-user children still require `sessions.prompt_own` in the branch. They
+  do **not** require either sharing switch. Ownership of a _session_ does not
+  override loss of access to its branch.
+- A foreign caller needs Collaborator/Manager branch capability, a branch-home
+  parent, the tenant sharing preference, and the effective package opt-in.
+  Execution-home parents are never shareable. Superadmin status, board
+  management, or branch management alone is not foreign-session prompt authority.
+- Branch access uses primary owner, then a direct-user entry (shadowing groups),
+  otherwise additive active groups, otherwise unmatched same-tenant Others.
+  A matched Viewer or No-access entry does not fall through to a stronger Others
+  grant. The current repository checks user existence and non-archived groups;
+  it does not introduce a new persisted user-active-state mechanism.
+- `inherit` resolves the board's complete branch template, including sharing.
+  `override` uses the complete branch-owned package, not a merge. Board access
+  governs the canvas, not standalone branch prompting. A caller can have branch
+  work rights without board visibility. Turning off the workspace sharing gate
+  also clears that tenant's narrower opt-ins; re-enabling is not restoration.
+- The child is attributed to the actual authorized caller and receives that
+  caller's **current** execution-home key. Selected environment names and MCP
+  IDs may carry forward, but execution resolves credentials/visibility for the
+  caller. It must not borrow the parent creator's private home. Delegated mode
+  additionally requires the caller's execution-home key; failures there have
+  different messages. Internal provider-less calls preserve parent attribution
+  and rely on their trusted producer's authorization; the fix does not convert
+  MCP calls into such internal calls.
+
+### Cross-branch orchestration
+
+`agor_sessions_prompt(mode: 'subsession')` can select a parent in another branch.
+Authority is checked against **that target parent and branch**; owning the
+orchestrator's branch supplies no additional grant. The child stays in the target
+branch. The regression covers an allowed cross-branch call and denial after the
+target sharing gate is revoked.
+
+`agor_sessions_create(branchId: ...)` is a different path: standard scoped
+`sessions.create`, target-branch `sessions.create` capability, caller-owned fresh
+session, and target branch's new-session SDK-home admission. Same-branch creates
+can add genealogy metadata; cross-branch creates use a separate `remote_create`
+relationship. An explicit genealogy parent in another branch is rejected.
+Provenance does not share native conversation state or confer prompt rights.
+Explicit/enabled callback targets require their own prompt-authority check.
+This independent-create path does not execute the failing `resolveChildIdentity`.
+
+### UI, task launch, realtime, and HA
+
+The UI uses `/sessions/:id/spawn` or `/fork`, then prompts the returned child
+(`useSessionActions.ts`). The custom route registrar supplies a tenant database
+unit and write gate around admission. That is why the REST smoke succeeds.
+
+MCP submits the initial prompt **after** child admission. Prompt admission,
+task execution identity, and launch/heartbeat branch authorization remain
+separate checks. PostgreSQL runtime checks revalidate current policy and the
+original filesystem access floor; Redis is not required to enforce those checks.
+Realtime audiences use tenant-qualified normalized visibility, with HA cache
+invalidation for policy changes. They are not used by this direct authority
+read and cannot explain the reproduced failure. This change adds no raw socket
+broadcast or ambient prompt authority and does not change callback routing.
+
+## History and patch
+
+- [#2555](https://github.com/preset-io/agor/pull/2555) introduced the current
+  normalized sharing resolver and this catch-all.
+- [#2612](https://github.com/preset-io/agor/pull/2612) fixed the same missing-scope
+  class for other MCP custom methods. Its audit recognized `*Service.method()`
+  locals; these inline cast-and-call spawn/fork expressions escaped that scan.
+- [#2662](https://github.com/preset-io/agor/pull/2662), `8d43790c36`, armed the
+  database-scope guard in **every** mode, exposing this latent omission in
+  static/SQLite too. Required-from-auth guarded deployments were already at risk.
+- [#2587](https://github.com/preset-io/agor/pull/2587) added branch SDK-home
+  plumbing; [#2589](https://github.com/preset-io/agor/pull/2589) added runtime
+  authority revalidation. Neither supplies the missing MCP admission scope.
+- [#2669](https://github.com/preset-io/agor/pull/2669) made RBAC always on after
+  the inspected deployment. It does not repair these MCP calls.
+
+The production change is three `runWithMcpTenantDatabaseWrite` wrappers in
+`mcp/tools/sessions.ts`: spawn, fork/btw, and subsession. They retain the original
+external caller params, use the existing trusted tenant and write gate, and end
+before prompt/executor orchestration. The audit now tracks spawn/fork mutations
+and also recognizes inline service casts. No policy, schema, token, home,
+credential, or execution-mode semantics are relaxed.
+
+## Operator remedy (separate from the code fix)
+
+**This reproduced instance needs no config/data repair.** Keep both the tenant
+guard and existing policies intact. Until a reviewed fixed release is available,
+use the authenticated UI/REST fork/spawn path for permitted operations. Do not
+relabel the MCP request as internal, grant broad Manager access, mutate
+`sdk_home_scope`, populate legacy grants, or disable scope enforcement.
+
+After normal review/release, update the daemon to a build containing this patch.
+Verify `/health.buildSha`, not just `version: 0.26.1`; on HA, drain/replace all
+serving replicas and verify each so old replicas cannot intermittently reject
+MCP admission. No migration or permission reset accompanies this patch. A UI
+refresh alone cannot replace the server's custom-method implementation.
+
+For a different instance with genuine policy corruption, first identify the
+tenant-scoped branch binding, referenced board template/override, and immutable
+primary owner. Restore only the intended complete package using the authorized
+revision-checked permission service or a reviewed offline recovery. Do not guess
+an owner or reconstruct authority from the tombstoned legacy fields. If a
+historical normalized-policy migration is involved, follow its offline cutover
+runbook rather than running old and new daemons against the same schema.
+
+## Validation and rollback
+
+- Live MCP failure versus successful idle REST admission, as above.
+- Guarded real-service regression: exact underlying error, owner spawn/fork/btw/
+  subsession without sharing, caller-attributed inherited Others sharing without
+  board visibility, cross-branch target policy, denied workspace/override/Viewer/
+  superadmin/execution-home/error cases, and missing/conflicting tenant identity.
+- Focused daemon suite: **153 passed**; focused core capability/tenant suite:
+  **45 passed**.
+- Disposable PostgreSQL (application role verified `NOSUPERUSER`, `NOBYPASSRLS`):
+  **2 passed**, proving permitted shared spawn, foreign-tenant parent-ID replay
+  rejection, write-freeze rejection for spawn/fork, and success after release.
+  The test container was removed; no live tenant database was used.
+- Source-condition daemon no-emit typecheck and explicit regression-test
+  typecheck; full Biome/frontend-plugin lint; multitenancy, realtime, daemon
+  filesystem, and short-ID boundary checks. No managed dev environment was
+  started: the transport comparison and isolated SQLite/PostgreSQL tests exercise
+  the affected boundary without launching an agent or changing a deployment.
+  The root `pnpm typecheck` command unexpectedly scheduled upstream builds through
+  Turbo; it was stopped and replaced with the direct no-emit checks.
+
+Rollback is a **code-only revert** of this patch; it restores the MCP failure
+without changing stored policy or tenant isolation. Keep the guarded database
+and current migrations. This is not a reason to roll back #2662 or the normalized
+policy migration; rolling back those older schema cutovers requires their full
+pre-migration database backup. No merge or deployment was performed here.


### PR DESCRIPTION
## Root cause

Reproduced the exact `Cannot resolve session-sharing authority for this branch.` failure through live MCP, while REST spawn from the **same caller/session/branch** returned 201 with a correct idle child (subsequently archived, never prompted).

MCP custom `spawn`/`fork` methods bypass Feathers' tenant database hooks. The nested service reads complete in their own scopes, then the direct branch-policy read hits `MissingTenantDatabaseScopeError`, hidden by child identity's fail-closed catch. #2662 exposed the latent omission in static deployments too. The live build (`95e5c26d4`) is behind main, but main (`64e17cfa5`) still has the bug. The inspected instance needs **no permission/config/data repair**.

## Changes

- Wrap only MCP child admission/persistence in the existing authenticated tenant **write** unit: spawn, subsession, fork/btw.
- Keep caller/provider identity and all sharing/branch/tenant gates intact; initial prompting stays outside the child transaction.
- Extend the scope audit to cover spawn/fork and inline cast calls that previously escaped it.
- Add real-service SQLite and PostgreSQL/RLS regressions plus an investigation report with policy semantics, same/cross-branch paths, deployment remedy, and rollback notes.

[Full investigation and operator runbook](https://github.com/preset-io/agor/blob/df0de3e91ff77e450d06df2cdd2f9d7fdfbf7f39/docs/internal/session-spawn-authority-investigation-2026-09-07.md)

## Validation

- Focused daemon suites: **153 passed**.
- Core capability/tenant suites: **45 passed**.
- Disposable PostgreSQL: **2 passed** with verified non-superuser/NOBYPASSRLS application role; allowed shared spawn, foreign-tenant parent replay denied, write-frozen spawn/fork denied, successful retry after release. Container removed.
- Direct source-condition daemon no-emit typecheck and explicit new-test typecheck: pass.
- Full lint (Biome + 330 frontend fixtures), multitenancy, realtime, daemon-filesystem, short-ID boundaries: pass.
- Commit hooks ran normally; no bypass.

No migration, deployment, live permission changes, or merge. Code-only rollback reintroduces the MCP failure; do not disable the tenant guard or revert the normalized policy cutover.
