### PR TITLE
fix(rbac): restore primary-owner board metadata editing

### DIFF
--- a/apps/agor-daemon/src/register-hooks.board-metadata.postgres.test.ts
+++ b/apps/agor-daemon/src/register-hooks.board-metadata.postgres.test.ts
@@ -1,0 +1,111 @@
+import {
+  BoardRepository,
+  createDatabase,
+  createTenantScopedDatabaseProxy,
+  type Database,
+  executeRaw,
+  initializeDatabase,
+  runWithTenantDatabaseScope,
+  sql,
+  UsersRepository,
+} from '@agor/core/db';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { boardMetadataTestApp } from '../test/board-metadata-app.js';
+import type { RegisterHooksContext } from './register-hooks.js';
+
+const postgresUrl = process.env.AGOR_TEST_POSTGRES_URL;
+describe.skipIf(!postgresUrl || process.env.AGOR_DB_DIALECT !== 'postgresql')(
+  'board metadata tenant boundary (PostgreSQL/RLS)',
+  () => {
+    let rawDb: Database;
+    beforeAll(async () => {
+      rawDb = createDatabase({ dialect: 'postgresql', url: postgresUrl! });
+      await initializeDatabase(rawDb);
+      const result = await executeRaw(
+        rawDb,
+        sql`SELECT rolsuper, rolbypassrls FROM pg_roles WHERE rolname = current_user`
+      );
+      const rows = Array.isArray(result) ? result : (result as { rows: unknown[] }).rows;
+      expect(rows[0]).toMatchObject({ rolsuper: false, rolbypassrls: false });
+    }, 60_000);
+    afterAll(async () => {
+      await (rawDb as Database & { $client: { end: () => Promise<void> } }).$client.end();
+    });
+
+    it('denies foreign-tenant projections and metadata writes, even for an administrator', async () => {
+      const db = createTenantScopedDatabaseProxy(rawDb, { label: 'board-metadata-postgres-test' });
+      const tenantA = 'board-metadata-tenant-a';
+      const tenantB = 'board-metadata-tenant-b';
+      const seed = (tenantId: string, role: 'member' | 'admin') =>
+        runWithTenantDatabaseScope(db, tenantId, async (scoped) => {
+          const owner = await new UsersRepository(scoped).create({
+            email: `${role}@example.test`,
+            role,
+          });
+          const board = await new BoardRepository(scoped).create({
+            name: 'Private board',
+            created_by: owner.user_id,
+          });
+          return { owner, board };
+        });
+      const a = await seed(tenantA, 'member');
+      const b = await seed(tenantB, 'admin');
+      const server = await boardMetadataTestApp(db, {
+        database: { dialect: 'postgresql' },
+        multi_tenancy: {
+          mode: 'required_from_auth',
+          auth_claim: 'tenant_id',
+          filesystem_isolation_enabled: true,
+        },
+        execution: {},
+      } as RegisterHooksContext['config']);
+      const resource = `${server.url}/boards/${a.board.board_id}`;
+      const metadata = {
+        name: 'Tenant A renamed',
+        icon: '🍊',
+        description: 'Tenant A description',
+      };
+      try {
+        const ownAccess = await fetch(`${resource}/effective-access`, {
+          headers: server.headers(a.owner.user_id, tenantA),
+        });
+        expect(ownAccess.status, await ownAccess.clone().text()).toBe(200);
+        await expect(ownAccess.json()).resolves.toMatchObject({
+          is_primary_owner: true,
+          capabilities: expect.arrayContaining(['board.edit']),
+        });
+        for (const headers of [
+          server.headers(b.owner.user_id, tenantB),
+          server.headers(a.owner.user_id, tenantB),
+        ]) {
+          const foreignAccess = await fetch(`${resource}/effective-access`, { headers });
+          expect([400, 401, 403, 404]).toContain(foreignAccess.status);
+          for (const method of ['PATCH', 'PUT']) {
+            const denied = await fetch(resource, {
+              method,
+              headers,
+              body: JSON.stringify({ ...metadata, tenant_id: tenantA }),
+            });
+            expect([400, 401, 403, 404]).toContain(denied.status);
+          }
+        }
+        await runWithTenantDatabaseScope(db, tenantA, async (scoped) => {
+          expect(await new BoardRepository(scoped).findById(a.board.board_id)).toEqual(a.board);
+        });
+        const saved = await fetch(resource, {
+          method: 'PATCH',
+          headers: server.headers(a.owner.user_id, tenantA),
+          body: JSON.stringify(metadata),
+        });
+        expect(saved.status, await saved.clone().text()).toBe(200);
+        await expect(saved.json()).resolves.toMatchObject(metadata);
+        await runWithTenantDatabaseScope(db, tenantB, async (scoped) => {
+          expect(await new BoardRepository(scoped).findById(b.board.board_id)).toEqual(b.board);
+          expect(await new BoardRepository(scoped).findById(a.board.board_id)).toBeNull();
+        });
+      } finally {
+        await server.close();
+      }
+    });
+  }
+);

--- a/apps/agor-daemon/src/register-hooks.board-metadata.test.ts
+++ b/apps/agor-daemon/src/register-hooks.board-metadata.test.ts
@@ -1,0 +1,126 @@
+import {
+  BoardRepository,
+  CapabilityPolicyRepository,
+  createTenantScopedDatabaseProxy,
+  generateId,
+  UsersRepository,
+} from '@agor/core/db';
+import type { UserID } from '@agor/core/types';
+import { expect } from 'vitest';
+import { dbTest } from '../../../packages/core/src/db/test-helpers.js';
+import { boardMetadataTestApp } from '../test/board-metadata-app.js';
+import type { RegisterHooksContext } from './register-hooks.js';
+
+dbTest(
+  'board projection authenticates and enters tenant scope; metadata retains owner and capability authority',
+  async ({ db: rawDb }) => {
+    const users = new UsersRepository(rawDb);
+    const owner = await users.create({ email: 'owner@example.test', role: 'member' });
+    const viewer = await users.create({ email: 'viewer@example.test', role: 'member' });
+    const editor = await users.create({ email: 'editor@example.test', role: 'member' });
+    const boards = new BoardRepository(rawDb);
+    const board = await boards.create({ name: 'Original', created_by: owner.user_id });
+    const policies = new CapabilityPolicyRepository(rawDb);
+    const policy = await policies.getBoardPolicies(board.board_id);
+    await policies.replaceBoardPolicies(
+      board.board_id,
+      {
+        ...policy,
+        board_access: {
+          ...policy.board_access,
+          sharing_mode: 'shared',
+          // Even an explicit No access entry cannot demote the immutable owner.
+          entries: [
+            {
+              entry_id: generateId(),
+              principal: { principal_type: 'user', user_id: owner.user_id },
+              preset: 'none',
+              capabilities: [],
+              fs_access: 'none',
+            },
+            {
+              entry_id: generateId(),
+              principal: { principal_type: 'user', user_id: editor.user_id },
+              preset: 'editor',
+              capabilities: ['board.view', 'board.edit', 'board.attach_branch'],
+              fs_access: 'none',
+            },
+          ],
+          others: { preset: 'viewer', capabilities: ['board.view'], fs_access: 'none' },
+        },
+      },
+      owner.user_id
+    );
+    const baselinePolicy = await policies.getBoardPolicies(board.board_id);
+    const db = createTenantScopedDatabaseProxy(rawDb, { label: 'board-metadata-test' });
+    const server = await boardMetadataTestApp(db, {
+      database: { dialect: 'sqlite' },
+      multi_tenancy: { mode: 'static', static_tenant_id: 'board-metadata-test' },
+      execution: {},
+    } as RegisterHooksContext['config']);
+    const resource = `${server.url}/boards/${board.board_id}`;
+    const metadata = { name: 'Renamed', icon: '👩🏽‍💻', description: 'Owner updated all metadata' };
+    const mutate = (userId: UserID, method: string, data: unknown) =>
+      fetch(resource, {
+        method,
+        headers: server.headers(userId),
+        body: JSON.stringify(data),
+      });
+    try {
+      expect((await fetch(`${resource}/effective-access`)).status).toBe(401);
+      const access = await fetch(`${resource}/effective-access`, {
+        headers: server.headers(owner.user_id),
+      });
+      expect(access.status, await access.clone().text()).toBe(200);
+      await expect(access.json()).resolves.toMatchObject({
+        is_primary_owner: true,
+        source: 'primary_owner',
+        capabilities: expect.arrayContaining(['board.edit']),
+      });
+      const viewerAccess = await fetch(`${resource}/effective-access`, {
+        headers: server.headers(viewer.user_id),
+      });
+      expect(viewerAccess.status).toBe(200);
+      await expect(viewerAccess.json()).resolves.toMatchObject({
+        is_primary_owner: false,
+        capabilities: ['board.view'],
+      });
+
+      // Both exposed mutation verbs must enforce the same capability. Exercise
+      // individual fields as well as the payload emitted by the real modal.
+      for (const method of ['PATCH', 'PUT']) {
+        for (const data of [
+          { name: metadata.name },
+          { icon: metadata.icon },
+          { description: metadata.description },
+          metadata,
+        ]) {
+          const denied = await mutate(viewer.user_id, method, data);
+          expect(denied.status).toBe(403);
+          const allowed = await mutate(owner.user_id, method, data);
+          expect(allowed.status, await allowed.clone().text()).toBe(200);
+          await expect(allowed.json()).resolves.toMatchObject(data);
+        }
+      }
+      expect(await boards.findById(board.board_id)).toMatchObject(metadata);
+      const editorSave = await mutate(editor.user_id, 'PATCH', {
+        ...metadata,
+        name: 'Editor updated',
+      });
+      expect(editorSave.status, await editorSave.clone().text()).toBe(200);
+      const forgedOwner = await mutate(viewer.user_id, 'PATCH', {
+        ...metadata,
+        primary_owner_user_id: viewer.user_id,
+      });
+      expect(forgedOwner.status).toBe(403);
+      const reassign = await mutate(owner.user_id, 'PATCH', {
+        primary_owner_user_id: editor.user_id,
+      });
+      expect(reassign.ok).toBe(false);
+      expect((await boards.findById(board.board_id))?.primary_owner_user_id).toBe(owner.user_id);
+      expect(await policies.getBoardPolicies(board.board_id)).toEqual(baselinePolicy);
+    } finally {
+      await server.close();
+    }
+  }
+);

--- a/apps/agor-daemon/src/register-hooks.test.ts
+++ b/apps/agor-daemon/src/register-hooks.test.ts
@@ -800,6 +800,9 @@ describe('registered RBAC authentication boundary', () => {
   };
 
   it('keeps every authenticated RBAC service inside tenant database scope', () => {
+    // Pin the board projection explicitly: iterating the registry alone cannot
+    // detect a service accidentally omitted from that registry.
+    expect(AUTHENTICATED_RBAC_SERVICE_PATHS).toContain('boards/:id/effective-access');
     expect(TENANT_OWNED_SERVICE_PATHS).toEqual(
       expect.arrayContaining([...AUTHENTICATED_RBAC_SERVICE_PATHS])
     );

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -466,6 +466,7 @@ export const AUTHENTICATED_RBAC_SERVICE_PATHS = [
   'branches/:id/effective-access',
   'branches/:id/fs-access-users',
   'boards/:id/permissions',
+  'boards/:id/effective-access',
   'boards/:id/aligned-branches',
   'workspace-preferences',
 ] as const;

--- a/apps/agor-daemon/test/board-metadata-app.ts
+++ b/apps/agor-daemon/test/board-metadata-app.ts
@@ -1,0 +1,120 @@
+import type { Server } from 'node:http';
+import { resolveMultiTenancyConfig } from '@agor/core/config';
+import {
+  BoardRepository,
+  BranchRepository,
+  type TenantScopeAwareDatabase,
+  UsersRepository,
+} from '@agor/core/db';
+import {
+  AuthenticationService,
+  authenticate,
+  errorHandler,
+  feathers,
+  feathersExpress,
+  rest,
+} from '@agor/core/feathers';
+import type { HookContext, UserID } from '@agor/core/types';
+import express from 'express';
+import jwt from 'jsonwebtoken';
+import { RuntimeJWTStrategy } from '../src/auth/runtime-jwt-strategy.js';
+import { type RegisterHooksContext, registerHooks } from '../src/register-hooks.js';
+import { createBoardsService } from '../src/services/boards.js';
+import { setupCapabilityPolicyServices } from '../src/services/capability-policies.js';
+import { setupBoardEffectiveAccessService } from '../src/services/groups.js';
+import { createUsersService } from '../src/services/users.js';
+
+const JWT_SECRET = 'board-metadata-disposable-test-secret';
+
+/** Real REST/auth/hooks/repositories; only unrelated daemon services are inert. */
+export async function boardMetadataTestApp(
+  db: TenantScopeAwareDatabase,
+  config: RegisterHooksContext['config']
+) {
+  const app = feathersExpress(feathers());
+  app.use(express.json());
+  app.configure(rest());
+  (app as unknown as { publish: () => void }).publish = () => undefined;
+  app.set('config', config);
+  app.set('authentication', {
+    secret: JWT_SECRET,
+    entity: 'user',
+    entityId: 'user_id',
+    service: 'users',
+    authStrategies: ['jwt'],
+    jwtOptions: {
+      header: { typ: 'access' },
+      audience: 'https://agor.dev',
+      issuer: 'agor',
+      algorithm: 'HS256',
+      expiresIn: '15m',
+    },
+  });
+  for (const path of [
+    'messages',
+    'repos',
+    'branches',
+    'sessions',
+    'leaderboard',
+    'schedules',
+    'tasks',
+  ]) {
+    app.use(path, {
+      async find() {
+        return [];
+      },
+    });
+  }
+  app.use('users', createUsersService(db, app, config));
+  const authentication = new AuthenticationService(app);
+  authentication.register(
+    'jwt',
+    new RuntimeJWTStrategy({ multiTenancy: resolveMultiTenancyConfig(config) })
+  );
+  app.use('authentication', authentication);
+  const boardsService = createBoardsService(db);
+  app.use('boards', boardsService);
+  setupBoardEffectiveAccessService(app, new BoardRepository(db), { allowSuperadmin: false });
+  setupCapabilityPolicyServices(app, db, { allowSuperadmin: false });
+  registerHooks({
+    db,
+    app,
+    config,
+    jwtSecret: JWT_SECRET,
+    requireAuth: authenticate({ strategies: ['jwt'] }) as (
+      context: HookContext
+    ) => Promise<HookContext>,
+    superadminOpts: { allowSuperadmin: false },
+    deployment: { mode: 'standalone' },
+    sessionsService: app.service('sessions') as never,
+    messagesService: app.service('messages') as never,
+    // Match registerServices' custom-method transport declaration adapter.
+    boardsService: boardsService as unknown as RegisterHooksContext['boardsService'],
+    branchRepository: new BranchRepository(db),
+    usersRepository: new UsersRepository(db),
+    sessionsRepository: {} as RegisterHooksContext['sessionsRepository'],
+  });
+  app.use(errorHandler());
+  const server = (await app.listen(0)) as Server;
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('Expected test TCP server');
+  return {
+    app,
+    url: `http://127.0.0.1:${address.port}`,
+    headers(userId: UserID, tenantId?: string) {
+      const token = jwt.sign(
+        { sub: userId, type: 'access', ...(tenantId ? { tenant_id: tenantId } : {}) },
+        JWT_SECRET,
+        {
+          issuer: 'agor',
+          audience: 'https://agor.dev',
+          expiresIn: '15m',
+        }
+      );
+      return { authorization: `Bearer ${token}`, 'content-type': 'application/json' };
+    },
+    async close() {
+      await app.teardown();
+    },
+  };
+}

--- a/apps/agor-docs/content/guide/boards.mdx
+++ b/apps/agor-docs/content/guide/boards.mdx
@@ -154,6 +154,11 @@ enable shared prompting for branch-home Sessions, but do not become owners.
 The workspace preference must also be enabled, and execution-home Sessions are
 never shareable.
 
+The primary owner can edit the board's name, emoji, and description independently
+of named entries and the **Others** fallback. Other members need Board Editor or
+Manager access to edit this metadata. Ownership never grants access across
+workspace tenant boundaries.
+
 ---
 
 ## Related

--- a/apps/agor-ui/src/components/BoardEditModal/BoardEditModal.icon.test.tsx
+++ b/apps/agor-ui/src/components/BoardEditModal/BoardEditModal.icon.test.tsx
@@ -1,4 +1,4 @@
-import type { AgorClient, Board } from '@agor-live/client';
+import type { AgorClient, Board, EffectiveCapabilityPolicyAccess, User } from '@agor-live/client';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { App as AntApp } from 'antd';
 import { describe, expect, it, vi } from 'vitest';
@@ -25,11 +25,18 @@ const listedBoard = {
   board_id: 'board-1',
   name: 'Emoji board',
   created_by: 'owner-1',
+  primary_owner_user_id: 'owner-1',
   created_at: '',
   last_updated: '',
 } as Board;
+const owner = { user_id: 'owner-1', role: 'member' } as User;
+const collaborator = { user_id: 'collaborator-1', role: 'member' } as User;
 
-function makeClient(getBoard: () => Board): AgorClient {
+function makeClient(
+  getBoard: () => Board,
+  capabilities: EffectiveCapabilityPolicyAccess['capabilities'] = ['board.view', 'board.edit'],
+  permissionsPatch = vi.fn(async (_id: unknown, value: unknown) => value)
+): AgorClient {
   const policy = {
     primary_owner_user_id: 'owner-1',
     board_access_revision: 1,
@@ -58,7 +65,7 @@ function makeClient(getBoard: () => Board): AgorClient {
       if (name === 'boards/:id/permissions') {
         return {
           find: vi.fn().mockResolvedValue(policy),
-          patch: vi.fn(async (_id: unknown, value: unknown) => value),
+          patch: permissionsPatch,
         };
       }
       if (name === 'workspace-preferences') {
@@ -67,7 +74,7 @@ function makeClient(getBoard: () => Board): AgorClient {
       if (name === 'boards/:id/effective-access') {
         return {
           find: vi.fn().mockResolvedValue({
-            capabilities: ['board.view', 'board.edit', 'board.attach_branch'],
+            capabilities,
           }),
         };
       }
@@ -76,13 +83,14 @@ function makeClient(getBoard: () => Board): AgorClient {
   } as unknown as AgorClient;
 }
 
-describe('BoardEditModal — board icon', () => {
-  it('selects and persists a multi-codepoint emoji, then restores it on reopen', async () => {
+describe('BoardEditModal — board metadata', () => {
+  it('edits name, emoji and description on an owner-only board, without rewriting permissions', async () => {
     let savedBoard = { ...listedBoard, icon: '🚩' } as Board;
     const onUpdate = vi.fn(async (_id: string, updates: Partial<Board>) => {
       savedBoard = { ...savedBoard, ...updates };
     });
-    const client = makeClient(() => savedBoard);
+    const permissionsPatch = vi.fn();
+    const client = makeClient(() => savedBoard, undefined, permissionsPatch);
     const view = render(
       <AntApp>
         <BoardEditModal
@@ -91,6 +99,7 @@ describe('BoardEditModal — board icon', () => {
           open
           onClose={vi.fn()}
           onUpdate={onUpdate}
+          currentUser={owner}
         />
       </AntApp>
     );
@@ -105,10 +114,21 @@ describe('BoardEditModal — board icon', () => {
     );
     fireEvent.click(pickerButton);
     expect(trigger).toHaveTextContent('👩🏽‍💻');
+    fireEvent.change(screen.getByPlaceholderText('My Board'), {
+      target: { value: 'Renamed board' },
+    });
+    fireEvent.change(screen.getByLabelText('Description'), {
+      target: { value: 'New description' },
+    });
 
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
     await waitFor(() => expect(onUpdate).toHaveBeenCalled());
-    expect(onUpdate.mock.calls[0]?.[1]).toMatchObject({ icon: '👩🏽‍💻' });
+    expect(onUpdate.mock.calls[0]?.[1]).toMatchObject({
+      name: 'Renamed board',
+      icon: '👩🏽‍💻',
+      description: 'New description',
+    });
+    expect(permissionsPatch).not.toHaveBeenCalled();
 
     view.rerender(
       <AntApp>
@@ -118,6 +138,7 @@ describe('BoardEditModal — board icon', () => {
           open={false}
           onClose={vi.fn()}
           onUpdate={onUpdate}
+          currentUser={owner}
         />
       </AntApp>
     );
@@ -129,9 +150,63 @@ describe('BoardEditModal — board icon', () => {
           open
           onClose={vi.fn()}
           onUpdate={onUpdate}
+          currentUser={owner}
         />
       </AntApp>
     );
     expect(await screen.findByRole('button', { name: 'Choose emoji' })).toHaveTextContent('👩🏽‍💻');
+    expect(screen.getByPlaceholderText('My Board')).toHaveValue('Renamed board');
+    expect(screen.getByLabelText('Description')).toHaveValue('New description');
+  });
+
+  it('disables all metadata fields and Save for a non-owner without board.edit', async () => {
+    const onUpdate = vi.fn();
+    render(
+      <AntApp>
+        <BoardEditModal
+          board={listedBoard}
+          client={makeClient(() => listedBoard, ['board.view'])}
+          currentUser={collaborator}
+          open
+          onClose={vi.fn()}
+          onUpdate={onUpdate}
+        />
+      </AntApp>
+    );
+    expect(await screen.findByRole('button', { name: 'Choose emoji' })).toBeDisabled();
+    expect(screen.getByPlaceholderText('My Board')).toBeDisabled();
+    expect(screen.getByLabelText('Description')).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  it('lets an Editor save metadata without attempting a Manager-only policy write', async () => {
+    const permissionsPatch = vi.fn().mockRejectedValue(new Error('Cannot manage policy'));
+    const onUpdate = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <AntApp>
+        <BoardEditModal
+          board={listedBoard}
+          client={makeClient(() => listedBoard, ['board.view', 'board.edit'], permissionsPatch)}
+          currentUser={collaborator}
+          open
+          onClose={onClose}
+          onUpdate={onUpdate}
+        />
+      </AntApp>
+    );
+    expect(await screen.findByRole('button', { name: 'Choose emoji' })).toBeEnabled();
+    fireEvent.change(screen.getByPlaceholderText('My Board'), {
+      target: { value: 'Editor rename' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(onClose).toHaveBeenCalledOnce());
+    expect(onUpdate).toHaveBeenCalledWith(
+      listedBoard.board_id,
+      expect.objectContaining({ name: 'Editor rename' })
+    );
+    expect(permissionsPatch).not.toHaveBeenCalled();
   });
 });

--- a/apps/agor-ui/src/components/BoardEditModal/BoardEditModal.test.tsx
+++ b/apps/agor-ui/src/components/BoardEditModal/BoardEditModal.test.tsx
@@ -45,10 +45,15 @@ vi.mock('../forms/BoardFormFields', () => ({
         {editor && (
           <button
             type="button"
+            data-sharing-mode={editor.value.board_access.sharing_mode}
             onClick={() =>
               editor.onChange({
                 ...editor.value,
-                board_access: { ...editor.value.board_access, sharing_mode: 'private' },
+                board_access: {
+                  ...editor.value.board_access,
+                  sharing_mode:
+                    editor.value.board_access.sharing_mode === 'shared' ? 'private' : 'shared',
+                },
               })
             }
           >
@@ -248,6 +253,31 @@ describe('BoardEditModal', () => {
       { ...policy, board_access: { ...policy.board_access, sharing_mode: 'private' } },
       { route: { id: listedBoard.board_id } }
     );
+  });
+
+  it('does not rewrite permissions when an edit is reverted before saving metadata', async () => {
+    const { client, permissionsPatch } = makeClient();
+    const onUpdate = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <BoardEditModal
+        board={listedBoard}
+        client={client}
+        open
+        onClose={onClose}
+        onUpdate={onUpdate}
+      />
+    );
+    const changeAccess = await screen.findByRole('button', { name: 'Change board access' });
+    fireEvent.click(changeAccess);
+    expect(changeAccess).toHaveAttribute('data-sharing-mode', 'private');
+    fireEvent.click(changeAccess);
+    expect(changeAccess).toHaveAttribute('data-sharing-mode', 'shared');
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Renamed' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(onClose).toHaveBeenCalledOnce());
+    expect(onUpdate).toHaveBeenCalledWith(listedBoard.board_id, { name: 'Renamed' });
+    expect(permissionsPatch).not.toHaveBeenCalled();
   });
 
   it('keeps normalized group principals selectable', async () => {

--- a/apps/agor-ui/src/components/BoardEditModal/BoardEditModal.test.tsx
+++ b/apps/agor-ui/src/components/BoardEditModal/BoardEditModal.test.tsx
@@ -1,6 +1,7 @@
-import type { AgorClient, Board, BoardCapabilityPolicies } from '@agor-live/client';
+import type { AgorClient, Board, BoardCapabilityPolicies, UserID } from '@agor-live/client';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { Form, Input } from 'antd';
+import { isValidElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { BoardEditModal } from './BoardEditModal';
 
@@ -20,6 +21,12 @@ vi.mock('../forms/BoardFormFields', () => ({
     capabilityPolicyEditor?: React.ReactNode;
     canEditGeneral?: boolean;
   }) => {
+    const editor = isValidElement<{
+      value: BoardCapabilityPolicies;
+      onChange: (value: BoardCapabilityPolicies) => void;
+    }>(capabilityPolicyEditor)
+      ? capabilityPolicyEditor.props
+      : null;
     // The edit modal passes groups straight to the capability-policy editor
     // element; assert propagation by inspecting that element's props.
     const editorGroups =
@@ -35,6 +42,19 @@ vi.mock('../forms/BoardFormFields', () => ({
           <Input />
         </Form.Item>
         <div data-testid="board-modal-can-edit-general" data-value={String(canEditGeneral)} />
+        {editor && (
+          <button
+            type="button"
+            onClick={() =>
+              editor.onChange({
+                ...editor.value,
+                board_access: { ...editor.value.board_access, sharing_mode: 'private' },
+              })
+            }
+          >
+            Change board access
+          </button>
+        )}
         {capabilityPolicyEditor && (
           <div
             data-testid="board-modal-policy-editor"
@@ -58,8 +78,8 @@ const listedBoard = {
   last_updated: '',
 } as Board;
 const freshBoard = { ...listedBoard, name: 'Fresh name', icon: '✨' } as Board;
-const policy = {
-  primary_owner_user_id: 'owner-1',
+const policy: BoardCapabilityPolicies = {
+  primary_owner_user_id: 'owner-1' as UserID,
   board_access_revision: 1,
   branch_template_revision: 1,
   board_access: {
@@ -79,9 +99,12 @@ const policy = {
     },
     allow_shared_session_prompts: false,
   },
-} as BoardCapabilityPolicies;
+};
 
-function makeClient(metadataError: { code?: number; message?: string } = { code: 404 }) {
+function makeClient(
+  metadataError: { code?: number; message?: string } = { code: 404 },
+  accessError?: Error
+) {
   const get = vi.fn().mockResolvedValue(freshBoard);
   const permissionsFind = vi
     .fn()
@@ -90,16 +113,20 @@ function makeClient(metadataError: { code?: number; message?: string } = { code:
         ? Promise.reject(metadataError)
         : Promise.resolve(policy)
     );
+  const permissionsPatch = vi
+    .fn()
+    .mockImplementation(async (_id: unknown, value: unknown) => value);
   return {
     get,
     permissionsFind,
+    permissionsPatch,
     client: {
       service: (name: string) => {
         if (name === 'boards') return { get };
         if (name === 'boards/:id/permissions') {
           return {
             find: permissionsFind,
-            patch: vi.fn().mockImplementation(async (_id: unknown, value: unknown) => value),
+            patch: permissionsPatch,
           };
         }
         if (name === 'workspace-preferences') {
@@ -107,13 +134,15 @@ function makeClient(metadataError: { code?: number; message?: string } = { code:
         }
         if (name === 'boards/:id/effective-access') {
           return {
-            find: vi.fn().mockResolvedValue({
-              capabilities: ['board.view', 'board.edit', 'board.attach_branch'],
-              fs_access: 'none',
-              source: 'primary_owner',
-              group_ids: [],
-              is_primary_owner: true,
-            }),
+            find: accessError
+              ? vi.fn().mockRejectedValue(accessError)
+              : vi.fn().mockResolvedValue({
+                  capabilities: ['board.view', 'board.edit', 'board.attach_branch'],
+                  fs_access: 'none',
+                  source: 'primary_owner',
+                  group_ids: [],
+                  is_primary_owner: true,
+                }),
           };
         }
         return { findAll: vi.fn().mockResolvedValue([]) };
@@ -199,6 +228,28 @@ describe('BoardEditModal', () => {
     expect(onClose).toHaveBeenCalledOnce();
   });
 
+  it('still persists deliberately edited permissions through the policy service', async () => {
+    const { client, permissionsPatch } = makeClient();
+    const onClose = vi.fn();
+    render(
+      <BoardEditModal
+        board={listedBoard}
+        client={client}
+        open
+        onClose={onClose}
+        onUpdate={vi.fn()}
+      />
+    );
+    fireEvent.click(await screen.findByRole('button', { name: 'Change board access' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(onClose).toHaveBeenCalledOnce());
+    expect(permissionsPatch).toHaveBeenCalledWith(
+      null,
+      { ...policy, board_access: { ...policy.board_access, sharing_mode: 'private' } },
+      { route: { id: listedBoard.board_id } }
+    );
+  });
+
   it('keeps normalized group principals selectable', async () => {
     const get = vi.fn().mockResolvedValue(freshBoard);
     const client = {
@@ -267,6 +318,27 @@ describe('BoardEditModal', () => {
     expect(await screen.findByText('Board settings unavailable')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
     expect(screen.queryByDisplayValue('Stale name')).not.toBeInTheDocument();
+  });
+
+  it('surfaces a failed effective-access request instead of misreporting an owner policy denial', async () => {
+    const { client } = makeClient(undefined, new Error('Authentication required'));
+    const onUpdate = vi.fn();
+    render(
+      <BoardEditModal
+        board={listedBoard}
+        client={client}
+        open
+        onClose={vi.fn()}
+        onUpdate={onUpdate}
+      />
+    );
+    expect(await screen.findByText('Board settings unavailable')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Could not load current board settings: Authentication required/)
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+    expect(screen.queryByTestId('board-modal-can-edit-general')).not.toBeInTheDocument();
+    expect(onUpdate).not.toHaveBeenCalled();
   });
 
   it('awaits the board mutation before closing', async () => {

--- a/apps/agor-ui/src/components/BoardEditModal/BoardEditModal.tsx
+++ b/apps/agor-ui/src/components/BoardEditModal/BoardEditModal.tsx
@@ -41,6 +41,7 @@ export function BoardEditModal({
   const [allUsers, setAllUsers] = useState<User[]>([]);
   const [allGroups, setAllGroups] = useState<Group[]>([]);
   const [policy, setPolicy] = useState<BoardCapabilityPolicies | null>(null);
+  const [loadedPolicy, setLoadedPolicy] = useState<BoardCapabilityPolicies | null>(null);
   const [workspacePreferences, setWorkspacePreferences] =
     useState<CapabilityPolicyWorkspacePreferences>({ session_sharing_enabled: false });
   const [effectiveAccess, setEffectiveAccess] = useState<EffectiveCapabilityPolicyAccess | null>(
@@ -62,6 +63,7 @@ export function BoardEditModal({
     setLoadError(null);
     setLoadedBoard(null);
     setPolicy(null);
+    setLoadedPolicy(null);
     setEffectiveAccess(null);
 
     // Re-read the board as the modal opens. The selector uses a lean board list,
@@ -97,20 +99,18 @@ export function BoardEditModal({
         if (cancelled) return;
         if (policyResult.status === 'fulfilled') {
           setPolicy(policyResult.value);
+          setLoadedPolicy(policyResult.value);
         } else {
           throw policyResult.reason;
         }
         if (preferencesResult.status === 'fulfilled') {
           setWorkspacePreferences(preferencesResult.value);
         }
-        // A failed fetch here fails closed: canEditGeneral (below) treats a
-        // null effectiveAccess as "no board.edit capability", same as an
-        // explicit denial.
-        setEffectiveAccess(
-          accessResult.status === 'fulfilled'
-            ? (accessResult.value as unknown as EffectiveCapabilityPolicyAccess)
-            : null
-        );
+        // A failed projection is not a policy denial. Surface the load error
+        // and prevent saving rather than silently locking the owner's fields.
+        // Do not replace server authority with a client-side ownership bypass.
+        if (accessResult.status === 'rejected') throw accessResult.reason;
+        setEffectiveAccess(accessResult.value as unknown as EffectiveCapabilityPolicyAccess);
         if (cancelled) return;
         // Populate the form BEFORE exposing loadedBoard so the background
         // editor mounts against fully-initialized field values (rather than
@@ -144,11 +144,14 @@ export function BoardEditModal({
   const canEditGeneral = Boolean(effectiveAccess?.capabilities.includes('board.edit'));
 
   const syncPermissions = async () => {
-    if (!client || !board || !policy) return;
+    // Metadata-only saves must not require board.policy.manage or rewrite a
+    // policy the user did not edit (including its optimistic revisions).
+    if (!client || !board || !policy || policy === loadedPolicy) return;
     const saved = await client
       .service('boards/:id/permissions')
       .patch(null, policy, { route: { id: board.board_id } });
     setPolicy(saved);
+    setLoadedPolicy(saved);
   };
 
   const close = () => {
@@ -157,7 +160,7 @@ export function BoardEditModal({
   };
 
   const save = async () => {
-    if (!board) return;
+    if (!board || loading || loadError || !canEditGeneral) return;
     try {
       setSaving(true);
       await form.validateFields();
@@ -181,7 +184,7 @@ export function BoardEditModal({
       open={open}
       width={760}
       confirmLoading={loading || saving}
-      okButtonProps={{ disabled: loading || saving || Boolean(loadError) }}
+      okButtonProps={{ disabled: loading || saving || Boolean(loadError) || !canEditGeneral }}
       onOk={() => void save()}
       onCancel={close}
       okText="Save"

--- a/apps/agor-ui/src/components/BoardEditModal/BoardEditModal.tsx
+++ b/apps/agor-ui/src/components/BoardEditModal/BoardEditModal.tsx
@@ -146,7 +146,11 @@ export function BoardEditModal({
   const syncPermissions = async () => {
     // Metadata-only saves must not require board.policy.manage or rewrite a
     // policy the user did not edit (including its optimistic revisions).
-    if (!client || !board || !policy || policy === loadedPolicy) return;
+    // Compare JSON drafts like the branch editor: change-then-revert creates
+    // new objects but must not trigger a permission write.
+    if (!client || !board || !policy || JSON.stringify(policy) === JSON.stringify(loadedPolicy)) {
+      return;
+    }
     const saved = await client
       .service('boards/:id/permissions')
       .patch(null, policy, { route: { id: board.board_id } });

--- a/apps/agor-ui/src/hooks/useCanManageBoard.test.tsx
+++ b/apps/agor-ui/src/hooks/useCanManageBoard.test.tsx
@@ -25,6 +25,24 @@ afterEach(() => {
 });
 
 describe('useCanManageBoard', () => {
+  it('offers the primary owner the board editor even if ordinary access cannot be fetched', async () => {
+    const find = vi.fn().mockRejectedValue(new Error('Authentication required'));
+    const client = { service: () => ({ find }) } as unknown as AgorClient;
+    const { result } = renderHook(() =>
+      useCanManageBoard(client, board, { ...member, user_id: 'user-1' as User['user_id'] })
+    );
+    await waitFor(() => expect(result.current).toBe(true));
+    expect(find).not.toHaveBeenCalled();
+  });
+
+  it('does not offer a non-owner an edit shortcut when board.edit is absent', async () => {
+    const find = vi.fn().mockResolvedValue({ capabilities: ['board.view'] });
+    const client = { service: () => ({ find }) } as unknown as AgorClient;
+    const { result } = renderHook(() => useCanManageBoard(client, board, member));
+    await waitFor(() => expect(find).toHaveBeenCalledOnce());
+    expect(result.current).toBe(false);
+  });
+
   it('ignores object patches but refetches effective access after authenticated reconnect', async () => {
     let resolveReconnect: ((access: { capabilities: string[] }) => void) | undefined;
     const reconnectAccess = new Promise<{ capabilities: string[] }>((resolve) => {


### PR DESCRIPTION
## Summary

Fix the reported primary-owner metadata lockout without weakening authorization:

- Register `boards/:id/effective-access` at the shared authentication **and tenant database scope** boundary.
- Distinguish an unavailable access projection from an actual policy denial in the board editor; keep fields and Save fail-closed.
- Do not PATCH unchanged permission packages when saving metadata. An Editor's metadata save must not also require Manager-only policy authority or bump policy revisions.
- Document the existing immutable-owner metadata contract.

## Investigation and evidence

Read-only checks against the reported board on **2026-09-07 UTC**:

- The board's immutable primary owner matches the reporting caller; no ownership repair is needed.
- With the **same existing caller credential**, `GET /boards/<reported-board>/permissions` returned **200**, while `GET /boards/<reported-board>/effective-access` returned **401**, `Authentication required`.
- `/health` reported **0.26.1**, build **95e5c26d4a9f39aa68044414342efbbffd8a7ee8**, built **2026-09-05T23:14:04.484Z**, with board RBAC enabled.
- Compared that deployed source with branch base **fe48ecfd516384ee008df6787efac90cb243b0ed**: both omit the board projection from `AUTHENTICATED_RBAC_SERVICE_PATHS`. Updating to that current main alone would not resolve this defect.
- No production PATCH/PUT, policy changes, DB writes, or unrelated production-data inspection was used. Board identifiers, policy principals, and credentials are intentionally omitted here.

### Trace / classification

1. `BoardSwitcher` / `useCanManageBoard` offer the owner the edit shortcut. Settings uses the same `BoardEditModal`.
2. The modal reloads the board, policies, and effective access. Previously it silently converted a rejected access request into `null`; `BoardFormFields` then disabled name, emoji (`icon`), and description together.
3. `setupBoardEffectiveAccessService` exists and is registered, but lacked the shared authentication/tenant registration. REST has not materialized `params.user` yet, so it returns 401. A transport already supplying the user still needs the missing tenant database scope; adding only authentication is insufficient.
4. `boards.patch` and `boards.update` already share `boardUpdateAuthorization`: member floor, `ensureCanMutateBoard`, then repository mutation. `BoardRepository.canMutateResolved` resolves normalized policy and checks `board.edit`.
5. `resolveCapabilityPolicyAccess` checks active principal status, then grants the immutable owner the complete board capabilities **before** considering direct/group/`Others` entries. The deployed evaluator has this same contract. The repository rejects owner reassignment and generic legacy-policy writes.
6. This is a **missing authenticated/tenant-scoped projection boundary with misleading UI error handling**, not an owner capability-evaluator bug, stale cached grant, or board data/config problem. No owner shortcut was added to the mutation authorization or modal.

## Regression coverage

- Real REST authentication + registered hooks + real guarded SQLite repositories: primary owner succeeds even with an explicit No access entry; non-owner Viewer is denied; Editor succeeds.
- Name, multi-codepoint emoji, and description work independently and together through **PATCH and PUT**; primary ownership and policy revisions remain unchanged. Forged owner/reassignment writes fail.
- PostgreSQL **NOSUPERUSER/NOBYPASSRLS**, `required_from_auth`, two disposable tenants: foreign administrator and wrong-tenant owner identity cannot obtain the projection or mutate the target via PATCH/PUT, including a forged payload tenant. Both tenants' boards are checked for unintended changes.
- UI: all three fields save and reload, Viewer fields/Save disabled, access-load failure visible, metadata-only Editor save avoids policy PATCH, deliberately changed permissions still save, owner shortcut and reconnect fail-closed behavior preserved.
- Removed the one-line registration fix temporarily: the new REST regression failed with the **same 401** seen on the reported board; restoring it passes.

## Validation

Follow-up validation on 2026-09-07: `pnpm i` and the full `pnpm check` both passed (including standard workspace typechecks and builds). All 377 focused tests below were rerun successfully, including the disposable PostgreSQL/RLS suite. GitHub CI is green, and this PR is attached to the Agor worktree via MCP. The working tree is clean at `5507d90c58da9a69a377a93ec461d6e798a693f8`; no follow-up source commit was needed.

- Daemon focused suites: **226 passed**.
- UI focused suites: **24 passed**.
- Core policy/board suites: **126 passed**.
- PostgreSQL/RLS focused suite: **1 passed**, not skipped; fresh disposable pgvector PostgreSQL 16 container removed afterward.
- Daemon and UI TypeScript checks against workspace **source** exports, including the new daemon tests/helper and edited modal/hook tests. Used temporary extending configs with `noEmit`, widened `rootDir`, and `customConditions: ["source"]`; UI source checking disables `erasableSyntaxOnly` because source dependencies contain enums/parameter properties. No builds or generated artifacts required.
- Full lint (Biome plus 330 frontend plugin fixtures), multitenancy, realtime, daemon-filesystem, short-ID, CI test-coverage and published-dependency checks.

Focused commands:

```sh
pnpm --filter @agor/daemon exec vitest run src/register-hooks.board-metadata.test.ts src/register-hooks.test.ts src/register-hooks.update-gating.test.ts src/services/groups.test.ts
pnpm --filter agor-ui exec vitest run src/components/BoardEditModal src/hooks/useCanManageBoard.test.tsx src/components/BoardSwitcher/BoardSwitcher.test.tsx
pnpm --filter @agor/core exec vitest run src/types/capability-policy.test.ts src/db/repositories/capability-policies.test.ts src/db/repositories/boards.test.ts
# Only against a disposable non-superuser PostgreSQL test database:
AGOR_DB_DIALECT=postgresql AGOR_TEST_POSTGRES_URL=<disposable-test-url> pnpm --filter @agor/daemon exec vitest run src/register-hooks.board-metadata.postgres.test.ts
```

## Rollout / rollback (not performed)

- No migration, ownership backfill, policy edits, or configuration changes required.
- Release the daemon boundary fix to all replicas; ship the UI improvements with it. Refresh/reopen the editor so it fetches the repaired projection. Existing clients benefit from the server fix; a new UI against an old daemon correctly shows an unavailable-settings error rather than granting access.
- Smoke-check the owner projection includes `board.edit`, edit/reopen each metadata field on a disposable board, confirm a Viewer remains unable to mutate, and verify cross-tenant denial in staging.
- Monitor access-endpoint 401/scope errors and metadata PATCH errors. Rolling back the code restores the lockout; it does not require changing persisted data. Do not work around it by broadening `Others`, changing owners, or disabling RBAC.

**No merge or deployment performed.**


## AI review follow-up

The first Codex review (gpt-6-astra/high) found no substantive issues or merge blockers. Its optional change-then-revert suggestion was reproduced: restoring the loaded board-access setting still caused a permission PATCH. The follow-up compares JSON drafts using the same pattern as the existing branch modal, and adds a change/revert regression. Ordinary metadata saves and deliberately changed policy writes remain covered. No feedback was intentionally skipped; no generic equality framework or authorization changes were needed.

Validation: the new regression failed before the fix and passes afterward; all 25 focused UI tests pass, the edited test is typechecked, and full `pnpm check` passes again. The same Codex reviewer (gpt-6-astra/high) approved follow-up commit `a1c20901570e0eddaacc9f4d2a174566f8d9458d` with no remaining substantive findings or merge blockers, and independently reran all 25 focused UI tests successfully. The optional P3 is addressed. Review session: `01a07959-e0f6-7741-8dbc-421370b26fce`; follow-up task: `01a0795f-406d-76eb-9db9-968d6b97fe59`. Review completed through Agor system callbacks. Labeled `ai-reviewed-gpt-6-astra`; no merge or deployment performed.
