### PR TITLE
chore(release): bump Agor to 0.26.2

### DIFF
--- a/apps/agor-cli/package.json
+++ b/apps/agor-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor/cli",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/agor-claude/package.json
+++ b/packages/agor-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/claude",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "description": "Version-aligned claude agentic tool integration for Agor",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agor-claude/src/index.ts
+++ b/packages/agor-claude/src/index.ts
@@ -1,4 +1,4 @@
 /** Agor-managed, release-aligned claude integration. */
-export const AGOR_INTEGRATION_VERSION = '0.26.1';
+export const AGOR_INTEGRATION_VERSION = '0.26.2';
 export const VENDOR_PACKAGE = '@anthropic-ai/claude-agent-sdk';
 export * as sdk from '@anthropic-ai/claude-agent-sdk';

--- a/packages/agor-codex/package.json
+++ b/packages/agor-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/codex",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "description": "Version-aligned codex agentic tool integration for Agor",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agor-codex/src/index.ts
+++ b/packages/agor-codex/src/index.ts
@@ -1,4 +1,4 @@
 /** Agor-managed, release-aligned codex integration. */
-export const AGOR_INTEGRATION_VERSION = '0.26.1';
+export const AGOR_INTEGRATION_VERSION = '0.26.2';
 export const VENDOR_PACKAGE = '@openai/codex-sdk';
 export * as sdk from '@openai/codex-sdk';

--- a/packages/agor-copilot/package.json
+++ b/packages/agor-copilot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/copilot",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "description": "Version-aligned copilot agentic tool integration for Agor",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agor-copilot/src/index.ts
+++ b/packages/agor-copilot/src/index.ts
@@ -1,4 +1,4 @@
 /** Agor-managed, release-aligned copilot integration. */
-export const AGOR_INTEGRATION_VERSION = '0.26.1';
+export const AGOR_INTEGRATION_VERSION = '0.26.2';
 export const VENDOR_PACKAGE = '@github/copilot-sdk';
 export * as sdk from '@github/copilot-sdk';

--- a/packages/agor-cursor/package.json
+++ b/packages/agor-cursor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/cursor",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "description": "Version-aligned cursor agentic tool integration for Agor",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agor-cursor/src/index.ts
+++ b/packages/agor-cursor/src/index.ts
@@ -1,4 +1,4 @@
 /** Agor-managed, release-aligned cursor integration. */
-export const AGOR_INTEGRATION_VERSION = '0.26.1';
+export const AGOR_INTEGRATION_VERSION = '0.26.2';
 export const VENDOR_PACKAGE = '@cursor/sdk';
 export * as sdk from '@cursor/sdk';

--- a/packages/agor-gemini/package.json
+++ b/packages/agor-gemini/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/gemini",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "description": "Version-aligned gemini agentic tool integration for Agor",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agor-gemini/src/index.ts
+++ b/packages/agor-gemini/src/index.ts
@@ -1,4 +1,4 @@
 /** Agor-managed, release-aligned gemini integration. */
-export const AGOR_INTEGRATION_VERSION = '0.26.1';
+export const AGOR_INTEGRATION_VERSION = '0.26.2';
 export const VENDOR_PACKAGE = '@google/gemini-cli-core';
 export * as sdk from '@google/gemini-cli-core';

--- a/packages/agor-live/package.json
+++ b/packages/agor-live/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agor-live",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "description": "Team command center for all things agentic — shared canvas for coding agents and assistants on isolated git branches, with real-time multiplayer and an MCP surface agents drive themselves.",
   "type": "module",
   "bin": {

--- a/packages/agor-opencode/package.json
+++ b/packages/agor-opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/opencode",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "description": "Version-aligned opencode agentic tool integration for Agor",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agor-opencode/src/index.ts
+++ b/packages/agor-opencode/src/index.ts
@@ -1,5 +1,5 @@
 /** Agor-managed, release-aligned opencode integration. */
-export const AGOR_INTEGRATION_VERSION = '0.26.1';
+export const AGOR_INTEGRATION_VERSION = '0.26.2';
 export const VENDOR_PACKAGE = '@opencode-ai/sdk';
 export * as sdk from '@opencode-ai/sdk';
 export * as sdkV2 from '@opencode-ai/sdk/v2';

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/client",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "description": "TypeScript client for connecting to the Agor daemon",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Bump Agor **0.26.1 → 0.26.2** from verified current `main` (`4f34cbaa`) using `packages/agor-live/build.sh --bump patch --skip-install` after a frozen-lockfile install.
- Align nine release manifests and six integration version constants. Reviewed all 15 changes: no dependency, lockfile, unrelated code, or tenant-boundary changes; the script generates no changelog.
- Build eight local release tarballs only. No publication, release tag, merge, or deployment.

## Validation
- `pnpm install --frozen-lockfile` (before and after bump)
- Full release script: package alignment, dependency alignment, workspace production builds, client pack validation, internal package contract, and package-content budget
- `pnpm typecheck`
- `pnpm lint` (including 330 design-system fixtures)
- `pnpm --filter agor-live test` (4 passed)
- Packed manifest check: version/client dependency `0.26.2`, no workspace references or install lifecycle hooks
- Version-only diff/whitespace checks; commit hooks passed without bypass
