### PR TITLE
fix: bound worktree session lists and correct MCP pagination

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/sessions.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.test.ts
@@ -16,6 +16,7 @@
 import { AGENTIC_TOOL_NAMES } from '@agor/core/types';
 import type { McpServer } from '@modelcontextprotocol/server';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { z } from 'zod';
 
 vi.mock('../resolve-ids.js', () => ({
   resolveBoardId: async (_ctx: unknown, id: string) => id,
@@ -70,7 +71,8 @@ vi.mock('@agor/core/db', () => ({
 // Helper to build a minimal fake Feathers app. Each test supplies spies for
 // the services it exercises; unknown services throw so we don't silently drop
 // side-effects the assertion cares about.
-type ServiceStub = Record<string, (...args: unknown[]) => unknown>;
+// These stubs are passed to the runtime, not invoked through this erased type.
+type ServiceStub = Record<string, (...args: never[]) => unknown>;
 function makeFakeApp(services: Record<string, ServiceStub>) {
   return {
     service: (name: string) => {
@@ -92,7 +94,7 @@ type ToolHandler = (args: Record<string, unknown>) => Promise<{
  * exercise Zod validation/coercion (the fake server below bypasses the SDK's
  * automatic schema parsing). */
 type CapturedTool = {
-  cfg: { inputSchema?: { parse: (v: unknown) => unknown; safeParse: (v: unknown) => any } };
+  cfg: { inputSchema?: z.ZodType };
   cb: ToolHandler;
 };
 
@@ -236,6 +238,165 @@ describe('agor_sessions_list', () => {
     vi.clearAllMocks();
   });
 
+  it.each([
+    {},
+    { branchId: 'branch-1' },
+    { boardId: 'board-1' },
+    { branchId: 'branch-1', boardId: 'board-1' },
+  ])('preserves totals, continuation and trusted context for optional scope %j', async (scope) => {
+    const baseServiceParams = {
+      provider: 'rest',
+      authenticated: true,
+      user: { user_id: 'user-1' },
+      tenant: { tenant_id: 'tenant-1' },
+    };
+    const find = vi.fn(async () => ({
+      total: 53,
+      limit: 2,
+      skip: 2,
+      data: [2, 3].map((id) => ({
+        session_id: `session-${id}`,
+        branch_id: 'branch-1',
+        branch_board_id: 'board-1',
+        mcp_token: 'must-not-leak',
+        tasks: [],
+      })),
+    }));
+    const app = makeFakeApp({
+      branches: { get: async () => ({ branch_id: 'branch-1' }) },
+      sessions: { find },
+    });
+    const { agor_sessions_list } = await registerAndCaptureHandlers(
+      { app, userId: 'user-1', baseServiceParams },
+      ['agor_sessions_list']
+    );
+    const result = JSON.parse(
+      (await agor_sessions_list({ ...scope, limit: 2, offset: 2 })).content[0].text
+    );
+    expect(result).toMatchObject({ total: 53, limit: 2, offset: 2, hasMore: true, nextOffset: 4 });
+    expect(result.data).toHaveLength(2);
+    expect(result.data[0]).not.toHaveProperty('mcp_token');
+    expect(find).toHaveBeenCalledWith({
+      ...baseServiceParams,
+      query: {
+        $limit: 2,
+        $skip: 2,
+        $sort: { created_at: -1 },
+        archived: false,
+        ...(scope.branchId ? { branch_id: scope.branchId } : {}),
+        ...(scope.boardId ? { board_id: scope.boardId } : {}),
+      },
+    });
+  });
+
+  it('paginates a complete derived-type scan with the requested envelope, including the last page', async () => {
+    const app = makeFakeApp({
+      sessions: {
+        find: async () => ({
+          total: 4,
+          limit: 10000,
+          skip: 0,
+          data: [0, 1, 2, 3].map((id) => ({
+            session_id: `session-${id}`,
+            tasks: [],
+            scheduled_from_branch: id !== 0,
+            mcp_token: 'must-not-leak',
+          })),
+        }),
+      },
+    });
+    const { agor_sessions_list } = await registerAndCaptureHandlers({ app, userId: 'user-1' }, [
+      'agor_sessions_list',
+    ]);
+    const page = JSON.parse(
+      (await agor_sessions_list({ sessionType: 'scheduled', limit: 2, offset: 1, lean: false }))
+        .content[0].text
+    );
+    expect(page).toMatchObject({ total: 3, limit: 2, offset: 1, hasMore: false, nextOffset: null });
+    expect(page.data.map((s: { session_id: string }) => s.session_id)).toEqual([
+      'session-2',
+      'session-3',
+    ]);
+    expect(page.data[0]).not.toHaveProperty('mcp_token');
+  });
+
+  it('fails closed on a truncated derived-type scan rather than claiming an empty or complete result', async () => {
+    const app = makeFakeApp({
+      sessions: { find: async () => ({ total: 10001, limit: 10000, skip: 0, data: [] }) },
+    });
+    const { agor_sessions_list } = await registerAndCaptureHandlers({ app, userId: 'user-1' }, [
+      'agor_sessions_list',
+    ]);
+    await expect(agor_sessions_list({ sessionType: 'scheduled' })).rejects.toThrow(
+      /Narrow with branchId, boardId/
+    );
+  });
+
+  it('rejects an adapter response larger than the requested page', async () => {
+    const app = makeFakeApp({
+      sessions: { find: async () => [{ session_id: 'one' }, { session_id: 'two' }] },
+    });
+    const { agor_sessions_list } = await registerAndCaptureHandlers({ app, userId: 'user-1' }, [
+      'agor_sessions_list',
+    ]);
+    await expect(agor_sessions_list({ limit: 1 })).rejects.toThrow(
+      'exceeded the requested page limit'
+    );
+  });
+
+  it('accepts the exact derived scan ceiling and the maximum output page', async () => {
+    const app = makeFakeApp({
+      sessions: {
+        find: async () => ({
+          total: 10000,
+          limit: 10000,
+          skip: 0,
+          data: Array.from({ length: 10000 }, (_, index) => ({
+            session_id: `session-${index}`,
+            tasks: [],
+          })),
+        }),
+      },
+    });
+    const { agor_sessions_list } = await registerAndCaptureHandlers({ app, userId: 'user-1' }, [
+      'agor_sessions_list',
+    ]);
+    const page = JSON.parse(
+      (await agor_sessions_list({ sessionType: 'agent', limit: 100 })).content[0].text
+    );
+    expect(page).toMatchObject({
+      total: 10000,
+      limit: 100,
+      offset: 0,
+      hasMore: true,
+      nextOffset: 100,
+    });
+    expect(page.data).toHaveLength(100);
+  });
+
+  it('does not broaden to a global list when the requested branch cannot be authorized', async () => {
+    const resolvers = await import('../resolve-ids.js');
+    const actualResolvers =
+      await vi.importActual<typeof import('../resolve-ids.js')>('../resolve-ids.js');
+    const resolver = vi
+      .spyOn(resolvers, 'resolveBranchId')
+      .mockImplementationOnce(actualResolvers.resolveBranchId);
+    const find = vi.fn();
+    const get = vi.fn().mockRejectedValue(new Error('Branch not found'));
+    const baseServiceParams = { provider: 'rest', tenant: { tenant_id: 'tenant-b' } };
+    const app = makeFakeApp({ branches: { get }, sessions: { find } });
+    const { agor_sessions_list } = await registerAndCaptureHandlers(
+      { app, userId: 'user-b', baseServiceParams },
+      ['agor_sessions_list']
+    );
+    await expect(agor_sessions_list({ branchId: 'tenant-a-branch' })).rejects.toThrow(
+      'Branch not found'
+    );
+    expect(get).toHaveBeenCalledWith('tenant-a-branch', baseServiceParams);
+    expect(find).not.toHaveBeenCalled();
+    resolver.mockRestore();
+  });
+
   it('enforces branchId filtering even if the sessions service returns broader data', async () => {
     const findCalls: unknown[] = [];
     const app = makeFakeApp({
@@ -261,14 +422,10 @@ describe('agor_sessions_list', () => {
       ['agor_sessions_list']
     );
 
-    const result = await agor_sessions_list({ branchId: 'wt-1' });
-    const parsed = JSON.parse(result.content[0].text);
-
+    await expect(agor_sessions_list({ branchId: 'wt-1' })).rejects.toThrow(
+      'outside the requested branch or board scope'
+    );
     expect(findCalls[0]).toMatchObject({ query: { branch_id: 'wt-1', archived: false } });
-    expect(parsed.total).toBe(1);
-    expect(parsed.data).toHaveLength(1);
-    expect(parsed.data[0].session_id).toBe('sess-target');
-    expect(parsed.data[0]).not.toHaveProperty('mcp_token');
   });
 
   it('filters boardId using session.branch_board_id instead of legacy sessions.board_id', async () => {
@@ -307,17 +464,12 @@ describe('agor_sessions_list', () => {
       ['agor_sessions_list']
     );
 
-    const result = await agor_sessions_list({ boardId: 'board-1', limit: 10 });
-    const parsed = JSON.parse(result.content[0].text);
-
+    await expect(agor_sessions_list({ boardId: 'board-1', limit: 10 })).rejects.toThrow(
+      'outside the requested branch or board scope'
+    );
     expect(findCalls[0]).toMatchObject({
-      query: { archived: false, $limit: 10000 },
+      query: { board_id: 'board-1', archived: false, $limit: 10, $skip: 0 },
     });
-    expect(findCalls[0]).not.toMatchObject({ query: { board_id: 'board-1' } });
-    expect(parsed.total).toBe(1);
-    expect(parsed.data).toHaveLength(1);
-    expect(parsed.data[0].session_id).toBe('sess-on-board');
-    expect(parsed.data[0]).not.toHaveProperty('mcp_token');
   });
 });
 
@@ -1574,7 +1726,7 @@ describe('MCP session input validation clarity', () => {
     const result = tools.agor_sessions_get.cfg.inputSchema!.safeParse({});
 
     expect(result.success).toBe(false);
-    expect(String(result.error.message)).toMatch(/sessionId is required and must be a string/);
+    expect(String(result.error?.message)).toMatch(/sessionId is required and must be a string/);
   });
 
   it('rejects empty required prompts and optional titles when provided', async () => {
@@ -1589,7 +1741,7 @@ describe('MCP session input validation clarity', () => {
       prompt: '',
     });
     expect(emptyPrompt.success).toBe(false);
-    expect(String(emptyPrompt.error.message)).toMatch(/prompt cannot be empty/);
+    expect(String(emptyPrompt.error?.message)).toMatch(/prompt cannot be empty/);
 
     const emptyTitle = tools.agor_sessions_prompt.cfg.inputSchema!.safeParse({
       sessionId: 'sess-target',
@@ -1598,7 +1750,7 @@ describe('MCP session input validation clarity', () => {
       title: '',
     });
     expect(emptyTitle.success).toBe(false);
-    expect(String(emptyTitle.error.message)).toMatch(/title cannot be empty/);
+    expect(String(emptyTitle.error?.message)).toMatch(/title cannot be empty/);
   });
 
   it('rejects invalid pagination limits before handlers run', async () => {
@@ -1610,7 +1762,20 @@ describe('MCP session input validation clarity', () => {
     const result = tools.agor_sessions_list.cfg.inputSchema!.safeParse({ limit: 0 });
 
     expect(result.success).toBe(false);
-    expect(String(result.error.message)).toMatch(/limit must be greater than 0/);
+    expect(String(result.error?.message)).toMatch(/limit must be greater than 0/);
+    const schema = tools.agor_sessions_list.cfg.inputSchema!;
+    expect(schema.parse({})).toMatchObject({ limit: 25, offset: 0 });
+    expect(schema.safeParse({ limit: 100 }).success).toBe(true);
+    for (const invalid of [
+      { limit: 101 },
+      { limit: 1.5 },
+      { offset: -1 },
+      { offset: 0.5 },
+      { branchId: '' },
+      { boardId: null },
+    ]) {
+      expect(schema.safeParse(invalid).success).toBe(false);
+    }
   });
 });
 
@@ -1873,10 +2038,7 @@ describe('inputSchema → JSON Schema conversion (MCP discovery)', () => {
 
     for (const name of ['agor_sessions_create', 'agor_sessions_spawn', 'agor_sessions_prompt']) {
       const schema = tools[name].cfg.inputSchema!;
-      const jsonSchema = toJSONSchema(schema as Parameters<typeof toJSONSchema>[0]) as Record<
-        string,
-        any
-      >;
+      const jsonSchema = toJSONSchema(schema) as Record<string, any>;
 
       // Sanity: real param surface, not the `{ type: 'object' }` fallback
       expect(jsonSchema.type).toBe('object');

--- a/apps/agor-daemon/src/mcp/tools/sessions.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.test.ts
@@ -321,8 +321,12 @@ describe('agor_sessions_list', () => {
   });
 
   it('fails closed on a truncated derived-type scan rather than claiming an empty or complete result', async () => {
+    const find = vi
+      .fn()
+      .mockResolvedValueOnce({ total: 10001, limit: 10000, skip: 0, data: [] })
+      .mockResolvedValueOnce([]);
     const app = makeFakeApp({
-      sessions: { find: async () => ({ total: 10001, limit: 10000, skip: 0, data: [] }) },
+      sessions: { find },
     });
     const { agor_sessions_list } = await registerAndCaptureHandlers({ app, userId: 'user-1' }, [
       'agor_sessions_list',
@@ -330,6 +334,8 @@ describe('agor_sessions_list', () => {
     await expect(agor_sessions_list({ sessionType: 'scheduled' })).rejects.toThrow(
       /Narrow with branchId, boardId/
     );
+    // Legacy bare-array adapters supply no evidence that their scan is complete.
+    await expect(agor_sessions_list({ sessionType: 'scheduled' })).rejects.toThrow(/complete scan/);
   });
 
   it('rejects an adapter response larger than the requested page', async () => {

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -24,7 +24,6 @@ import {
   type Board,
   getSessionType,
   type Session,
-  type SessionType,
   type ZoneBoardObject,
 } from '@agor/core/types';
 import type { McpServer } from '@modelcontextprotocol/server';
@@ -135,29 +134,9 @@ function coerceModelConfig(
   return input;
 }
 
-function filterSessionsByBranch<T extends { branch_id?: string }>(
-  result: T[] | { data: T[]; total?: number; [key: string]: unknown },
-  branchId: string
-): T[] | { data: T[]; total?: number; [key: string]: unknown } {
-  if (Array.isArray(result)) {
-    return result.filter((session) => session.branch_id === branchId);
-  }
-
-  const data = result.data.filter((session) => session.branch_id === branchId);
-  return { ...result, data, total: data.length };
-}
-
-function filterSessionsByBoard<T extends { branch_board_id?: string | null }>(
-  result: T[] | { data: T[]; total?: number; [key: string]: unknown },
-  boardId: string
-): T[] | { data: T[]; total?: number; [key: string]: unknown } {
-  if (Array.isArray(result)) {
-    return result.filter((session) => session.branch_board_id === boardId);
-  }
-
-  const data = result.data.filter((session) => session.branch_board_id === boardId);
-  return { ...result, data, total: data.length };
-}
+// Keep derived-type scans within the existing API page ceiling. Never present
+// a truncated candidate scan as a complete filtered inventory.
+const SESSION_TYPE_SCAN_LIMIT = 10_000;
 
 function redactSessionForMcp<T extends { mcp_token?: unknown }>(session: T): Omit<T, 'mcp_token'> {
   const { mcp_token: _mcpToken, ...safeSession } = session;
@@ -183,23 +162,13 @@ function compactSessionForMcp(session: Session) {
   };
 }
 
-function redactSessionFindResult<T extends { mcp_token?: unknown }>(
-  result: T[] | { data: T[]; [key: string]: unknown }
-): Array<Omit<T, 'mcp_token'>> | { data: Array<Omit<T, 'mcp_token'>>; [key: string]: unknown } {
-  if (Array.isArray(result)) {
-    return result.map(redactSessionForMcp);
-  }
-
-  return { ...result, data: result.data.map(redactSessionForMcp) };
-}
-
 export function registerSessionTools(server: McpServer, ctx: McpContext): void {
   // Tool 1: agor_sessions_list
   server.registerTool(
     'agor_sessions_list',
     {
       description:
-        'List a lean page of sessions accessible to the current user. Runtime configuration, context files, task ID arrays, and SDK state are omitted by default; use agor_sessions_get for details or lean:false when required. Advance with offset=nextOffset while hasMore is true.',
+        'List a lean page of sessions accessible to the current user. Branch and board filters are optional. sessionType scans at most 10000 candidates and errors if the scan is incomplete. Runtime configuration, context files, task ID arrays, and SDK state are omitted by default; use agor_sessions_get for details or lean:false when required. Advance with offset=nextOffset while hasMore is true.',
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
         limit: mcpListLimit(),
@@ -236,70 +205,69 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
       }),
     },
     async (args) => {
-      const query: Record<string, unknown> = {};
-      // When sessionType or boardId is set, skip service-level pagination
-      // (it runs before our post-query filters) and apply the requested limit
-      // ourselves after filtering.
-      // Keep handler defaults explicit because unit/in-process callers may
-      // invoke captured handlers without going through Zod defaulting.
+      // Handler defaults also serve captured/in-process callers. The registered
+      // schema validates positive limits (max 100) and nonnegative offsets.
       const requestedLimit = args.limit ?? 25;
       const requestedOffset = args.offset ?? 0;
       const boardId = args.boardId ? await resolveBoardId(ctx, args.boardId) : undefined;
-      const needsPostQueryLimit = Boolean(args.sessionType || boardId);
-      if (!needsPostQueryLimit) {
-        query.$limit = requestedLimit;
-        query.$skip = requestedOffset;
-      }
-      query.$sort = { created_at: -1, session_id: 1 };
-      if (args.status) query.status = args.status;
       const branchId = args.branchId ? await resolveBranchId(ctx, args.branchId) : undefined;
+      const needsTypeScan = Boolean(args.sessionType);
+      const query: Record<string, unknown> = {
+        $limit: needsTypeScan ? SESSION_TYPE_SCAN_LIMIT : requestedLimit,
+        $skip: needsTypeScan ? 0 : requestedOffset,
+        // findPage supplies the session_id tie-breaker. Adding it here would
+        // select the generic in-memory fallback instead of the SQL page path.
+        $sort: { created_at: -1 },
+      };
+      if (boardId) query.board_id = boardId;
       if (branchId) query.branch_id = branchId;
+      if (args.status) query.status = args.status;
       if (args.archived === true) {
         query.archived = true;
       } else if (!args.includeArchived) {
         query.archived = false;
       }
       const result = await ctx.app.service('sessions').find({
-        query: needsPostQueryLimit ? { ...query, $limit: 10000, $skip: 0 } : query,
+        query,
         ...ctx.baseServiceParams,
       });
+      const data: Session[] = Array.isArray(result) ? result : result.data;
+      // A dropped narrowing filter is an adapter/authorization contract error,
+      // not a reason to leak rows or fabricate a new total from this one page.
+      if (
+        data.some(
+          (session) =>
+            (branchId && session.branch_id !== branchId) ||
+            (boardId && session.branch_board_id !== boardId)
+        )
+      ) {
+        throw new Error(
+          'Session list returned records outside the requested branch or board scope.'
+        );
+      }
+      if (data.length > (needsTypeScan ? SESSION_TYPE_SCAN_LIMIT : requestedLimit)) {
+        throw new Error('Session list exceeded the requested page limit.');
+      }
+      const project = (session: Session) =>
+        args.lean === false ? redactSessionForMcp(session) : compactSessionForMcp(session);
 
-      // Defense-in-depth: the sessions service normally handles branch_id in
-      // its query filter, but MCP callers rely on this tool contract. Keep the
-      // response scoped even if an adapter/hook layer drops or rewrites the
-      // query before it reaches the repository.
-      const branchScopedResult = branchId ? filterSessionsByBranch(result, branchId) : result;
-      const boardScopedResult = boardId
-        ? filterSessionsByBoard(branchScopedResult, boardId)
-        : branchScopedResult;
-
-      // Apply post-query filters. sessionType is derived from fields that are
-      // not in the query schema. boardId is exposed on Session as
-      // branch_board_id via the branch join, not sessions.board_id (legacy
-      // column is null for branch-backed sessions).
-      if (needsPostQueryLimit) {
-        const allData: Session[] = Array.isArray(boardScopedResult)
-          ? boardScopedResult
-          : boardScopedResult.data;
-        const filtered = args.sessionType
-          ? allData.filter((s) => getSessionType(s) === (args.sessionType as SessionType))
-          : allData;
-        const limited = filtered.slice(requestedOffset, requestedOffset + requestedLimit);
-
-        if (Array.isArray(boardScopedResult)) {
-          const data = limited.map((session) =>
-            args.lean === false ? redactSessionForMcp(session) : compactSessionForMcp(session)
+      if (needsTypeScan) {
+        const complete = Array.isArray(result)
+          ? data.length < SESSION_TYPE_SCAN_LIMIT
+          : result.skip === 0 && result.total === data.length;
+        if (!complete) {
+          throw new Error(
+            `sessionType requires a complete scan of at most ${SESSION_TYPE_SCAN_LIMIT} candidate sessions. Narrow with branchId, boardId, status or archive filters, or omit sessionType and page normally.`
           );
-          return textResult(mcpPageResult(data, requestedLimit, requestedOffset));
         }
+        const filtered = data.filter((session) => getSessionType(session) === args.sessionType);
         return textResult(
           mcpPageResult(
             {
-              ...boardScopedResult,
-              data: limited.map((session) =>
-                args.lean === false ? redactSessionForMcp(session) : compactSessionForMcp(session)
-              ),
+              data: filtered.slice(requestedOffset, requestedOffset + requestedLimit).map(project),
               total: filtered.length,
+              limit: requestedLimit,
+              skip: requestedOffset,
             },
             requestedLimit,
             requestedOffset
@@ -307,20 +275,12 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         );
       }
 
-      const page = mcpPageResult(
-        redactSessionFindResult(boardScopedResult) as {
-          data: Array<Omit<Session, 'mcp_token'>>;
-          total?: number;
-          limit?: number;
-          skip?: number;
-        },
-        requestedLimit,
-        requestedOffset
-      );
       return textResult(
-        args.lean === false
-          ? page
-          : { ...page, data: page.data.map((session) => compactSessionForMcp(session as Session)) }
+        mcpPageResult(
+          Array.isArray(result) ? data.map(project) : { ...result, data: data.map(project) },
+          requestedLimit,
+          requestedOffset
+        )
       );
     }
   );

--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -252,9 +252,9 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
         args.lean === false ? redactSessionForMcp(session) : compactSessionForMcp(session);
 
       if (needsTypeScan) {
-        const complete = Array.isArray(result)
-          ? data.length < SESSION_TYPE_SCAN_LIMIT
-          : result.skip === 0 && result.total === data.length;
+        // A bare array cannot prove whether an adapter truncated the scan.
+        const complete =
+          !Array.isArray(result) && result.skip === 0 && result.total === data.length;
         if (!complete) {
           throw new Error(
             `sessionType requires a complete scan of at most ${SESSION_TYPE_SCAN_LIMIT} candidate sessions. Narrow with branchId, boardId, status or archive filters, or omit sessionType and page normally.`

--- a/apps/agor-daemon/src/services/sessions.find.test.ts
+++ b/apps/agor-daemon/src/services/sessions.find.test.ts
@@ -12,6 +12,8 @@
 import {
   BoardRepository,
   BranchRepository,
+  createTenantScopedDatabaseProxy,
+  type Database,
   generateId,
   RepoRepository,
   SessionRepository,
@@ -19,13 +21,21 @@ import {
 import type { Application } from '@agor/core/feathers';
 import type { Session, UUID } from '@agor/core/types';
 import { SessionStatus } from '@agor/core/types';
-import { describe, expect } from 'vitest';
+import { describe, expect, vi } from 'vitest';
 import { ownedDbTest as dbTest } from '../../../../packages/core/src/db/test-helpers';
 import { SessionsService } from './sessions';
 
 // The find() board_id path only touches the session repos built from `db`; the
 // stored `app` is never read. A bare cast keeps the harness minimal.
 const STUB_APP = {} as unknown as Application;
+
+function createService(db: Database) {
+  // Standalone SQLite query tests deliberately install no tenant around-hook.
+  return new SessionsService(
+    createTenantScopedDatabaseProxy(db, { requireScope: false }),
+    STUB_APP
+  );
+}
 
 async function createBoard(db: any): Promise<UUID> {
   const boardRepo = new BoardRepository(db);
@@ -93,7 +103,7 @@ function orderedIds(result: Awaited<ReturnType<SessionsService['find']>>): strin
 
 describe('SessionsService.find — board_id pushdown', () => {
   dbTest('returns only sessions whose branch is on the requested board', async ({ db }) => {
-    const service = new SessionsService(db, STUB_APP);
+    const service = createService(db);
 
     const boardA = await createBoard(db);
     const boardB = await createBoard(db);
@@ -116,7 +126,7 @@ describe('SessionsService.find — board_id pushdown', () => {
   });
 
   dbTest('returns empty for a board with no branches/sessions', async ({ db }) => {
-    const service = new SessionsService(db, STUB_APP);
+    const service = createService(db);
     const boardA = await createBoard(db);
     const emptyBoard = await createBoard(db);
     const branchA = await createBranchOnBoard(db, boardA);
@@ -127,7 +137,7 @@ describe('SessionsService.find — board_id pushdown', () => {
   });
 
   dbTest('keeps other filters working alongside board_id', async ({ db }) => {
-    const service = new SessionsService(db, STUB_APP);
+    const service = createService(db);
     const boardA = await createBoard(db);
     const branchA = await createBranchOnBoard(db, boardA);
 
@@ -166,8 +176,50 @@ describe('SessionsService.find — recency sort + pagination (SQL pushdown)', ()
   const T_MID = '2026-02-01T00:00:00.000Z';
   const T_NEW = '2026-03-01T00:00:00.000Z';
 
+  dbTest(
+    'pages exact status with board/branch intersection in SQL, without materializing candidates',
+    async ({ db }) => {
+      const service = createService(db);
+      const board = await createBoard(db);
+      const branch = await createBranchOnBoard(db, board);
+      const otherBranch = await createBranchOnBoard(db, await createBoard(db));
+      await createSession(db, branch, { status: SessionStatus.IDLE });
+      const first = await createSession(db, branch, {
+        status: SessionStatus.RUNNING,
+        created_at: T_OLD,
+      });
+      const second = await createSession(db, branch, {
+        status: SessionStatus.RUNNING,
+        created_at: T_NEW,
+      });
+      await createSession(db, otherBranch, { status: SessionStatus.RUNNING });
+      const fallback = vi
+        .spyOn(SessionRepository.prototype, 'findAll')
+        .mockRejectedValue(new Error('unbounded fallback'));
+      try {
+        const query = {
+          board_id: board,
+          branch_id: branch,
+          status: SessionStatus.RUNNING,
+          $sort: { created_at: -1 as const },
+          $limit: 1,
+        };
+        const page = await service.find({ query });
+        expect(orderedIds(page)).toEqual([second]);
+        expect(page).toMatchObject({ total: 2, limit: 1, skip: 0 });
+        expect(orderedIds(await service.find({ query: { ...query, $skip: 1 } }))).toEqual([first]);
+        expect(
+          orderedIds(await service.find({ query: { ...query, branch_id: otherBranch } }))
+        ).toEqual([]);
+        expect(fallback).not.toHaveBeenCalled();
+      } finally {
+        fallback.mockRestore();
+      }
+    }
+  );
+
   dbTest('orders board-scoped sessions by updated_at desc', async ({ db }) => {
-    const service = new SessionsService(db, STUB_APP);
+    const service = createService(db);
     const boardA = await createBoard(db);
     const branchA = await createBranchOnBoard(db, boardA);
 
@@ -183,7 +235,7 @@ describe('SessionsService.find — recency sort + pagination (SQL pushdown)', ()
   });
 
   dbTest('recency sort composes with $limit/$skip (board-scoped)', async ({ db }) => {
-    const service = new SessionsService(db, STUB_APP);
+    const service = createService(db);
     const boardA = await createBoard(db);
     const branchA = await createBranchOnBoard(db, boardA);
 
@@ -206,7 +258,7 @@ describe('SessionsService.find — recency sort + pagination (SQL pushdown)', ()
   });
 
   dbTest('uses the SQL page path for branch created_at pagination', async ({ db }) => {
-    const service = new SessionsService(db, STUB_APP);
+    const service = createService(db);
     const boardA = await createBoard(db);
     const branchA = await createBranchOnBoard(db, boardA);
 
@@ -245,7 +297,7 @@ describe('SessionsService.find — recency sort + pagination (SQL pushdown)', ()
   });
 
   dbTest('orders the global recent-N slice by updated_at desc across boards', async ({ db }) => {
-    const service = new SessionsService(db, STUB_APP);
+    const service = createService(db);
     const boardA = await createBoard(db);
     const boardB = await createBoard(db);
     const branchA = await createBranchOnBoard(db, boardA);
@@ -263,7 +315,7 @@ describe('SessionsService.find — recency sort + pagination (SQL pushdown)', ()
   });
 
   dbTest('board_id composes with the $in operator (generic pipeline)', async ({ db }) => {
-    const service = new SessionsService(db, STUB_APP);
+    const service = createService(db);
     const boardA = await createBoard(db);
     const branchA = await createBranchOnBoard(db, boardA);
 

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -209,11 +209,24 @@ function shouldSqlPageSessionQuery(query?: Record<string, unknown>, forcePage = 
   const wantsBranch = query.branch_id !== undefined;
   if (!wantsRecency && !wantsCreatedAt && !wantsBoard && !wantsBranch && !forcePage) return false;
 
-  const allowedKeys = new Set(['archived', 'board_id', 'branch_id', '$sort', '$limit', '$skip']);
+  const allowedKeys = new Set([
+    'archived',
+    'status',
+    'board_id',
+    'branch_id',
+    '$sort',
+    '$limit',
+    '$skip',
+  ]);
   for (const key of Object.keys(query)) {
     if (!allowedKeys.has(key)) return false;
   }
   if (query.archived !== undefined && typeof query.archived !== 'boolean') return false;
+  if (
+    query.status !== undefined &&
+    !Object.values(SessionStatus).includes(query.status as SessionStatus)
+  )
+    return false;
   if (wantsBoard && typeof query.board_id !== 'string') return false;
   if (wantsBranch) {
     const branchFilter = query.branch_id;
@@ -1687,6 +1700,7 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
       const limit = (query?.$limit as number | undefined) ?? PAGINATION.DEFAULT_LIMIT;
       const skip = (query?.$skip as number | undefined) ?? 0;
       const { data, total } = await this.sessionRepo.findPage({
+        status: query?.status as SessionStatus | undefined,
         boardId: query?.board_id as string | undefined,
         branchId: typeof branchFilter === 'string' ? (branchFilter as BranchID) : undefined,
         branchIds,

--- a/apps/agor-docs/content/guide/sessions.mdx
+++ b/apps/agor-docs/content/guide/sessions.mdx
@@ -90,6 +90,31 @@ _A btw question runs in an ephemeral fork; the answer is delivered back inline i
 
 The tree is rendered on the branch card on the board, and in full detail in the session view.
 
+### Large session lists
+
+Branch cards and the branch teammate panel keep manual and gateway genealogy
+trees in a virtual, scrollable viewport (up to 400 pixels high). Scroll inside
+the tree to reach older sessions; collapsing a parent still hides its descendants.
+Scheduled runs and panel search results show 20 sessions per page. Search matches
+the loaded collection, not just the current page. The branch settings Sessions
+tab also paginates its table.
+
+These are rendering bounds, not a retention policy or a data-fetch limit: the
+UI still hydrates accessible sessions, and no sessions are deleted or archived
+because a list is large.
+
+For integrations, `agor_sessions_list` supports optional `branchId` and `boardId`
+filters; omitting both lists across the caller's accessible branches in the
+authenticated workspace, not across tenants. A session must belong to a branch,
+but a list query need not name one. MCP list pages default to 25 records, with
+a maximum requested limit of 100. The derived `sessionType` filter scans at most
+10,000 candidate sessions; if the complete candidate set does not fit, the tool
+returns an error rather than an incomplete result. Narrow with branch, board,
+status, or archive filters, or omit `sessionType` and page normally. The Feathers API uses `branch_id` / `board_id`
+and `$limit` / `$skip` instead. Use `find()` for one page: the TypeScript client's
+`findAll()` follows continuation pages and accumulates the entire result, even
+when its query includes `$limit`.
+
 ---
 
 ## Spawned subsessions with callbacks

--- a/apps/agor-ui/src/components/BranchCard/BranchCard.bounds.test.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.bounds.test.tsx
@@ -1,0 +1,55 @@
+import type { Branch, Repo, Session } from '@agor-live/client';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, expect, it, vi } from 'vitest';
+import { COLLAPSED_BRANCH_NODES_STORAGE_KEY } from '../../utils/collapsedBranchNodes';
+import BranchCard from './BranchCard';
+
+// Hold the actual card in its deferred state, as when earlier cards consume
+// the board's progressive-mount slots during the initial fit-to-view.
+vi.mock('../../hooks/useProgressiveMount', () => ({ useProgressiveMount: () => false }));
+
+beforeEach(() => localStorage.clear());
+
+it.each([
+  { count: 2, collapsed: false, height: 138 },
+  { count: 1001, collapsed: false, height: 454 },
+  { count: 1001, collapsed: true, height: 54 },
+])(
+  'bounds the deferred shell for $count sessions (collapsed: $collapsed)',
+  ({ count, collapsed, height }) => {
+    const branch = {
+      branch_id: 'branch-1',
+      name: 'feature/bounded-sessions',
+      repo_id: 'repo-1',
+      filesystem_status: 'ready',
+    } as Branch;
+    const sessions = Array.from({ length: count }, (_, index) => ({
+      session_id: `session-${index}`,
+      branch_id: branch.branch_id,
+      status: 'idle',
+      agentic_tool: 'codex',
+      archived: false,
+    })) as Session[];
+    if (collapsed) {
+      localStorage.setItem(
+        COLLAPSED_BRANCH_NODES_STORAGE_KEY,
+        JSON.stringify({ [branch.branch_id]: { sections: ['sessions'] } })
+      );
+    }
+
+    render(
+      <BranchCard
+        branch={branch}
+        repo={{ repo_id: 'repo-1', slug: 'preset-io/agor' } as Repo}
+        sessions={sessions}
+        userById={new Map()}
+        client={null}
+      />
+    );
+
+    expect(screen.getByText(`Sessions (${count})`).parentElement).toHaveStyle({
+      minHeight: `${height}px`,
+    });
+    expect(screen.queryByRole('tree')).not.toBeInTheDocument();
+  }
+);

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.bounds.browser.test.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.bounds.browser.test.tsx
@@ -1,0 +1,110 @@
+import type { Branch, Session } from '@agor-live/client';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { App } from 'antd';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BranchSessionSections } from './BranchSessionSections';
+
+const branch = { branch_id: 'branch-1', filesystem_status: 'ready' } as Branch;
+
+function makeSession(index: number, overrides: Partial<Session> = {}): Session {
+  return {
+    session_id: `session-${index}`,
+    branch_id: branch.branch_id,
+    title: `Conversation ${index}`,
+    agentic_tool: 'codex',
+    status: 'idle',
+    archived: false,
+    created_at: '2026-09-01T00:00:00.000Z',
+    last_updated: new Date(Date.UTC(2026, 8, 1) - index * 1000).toISOString(),
+    genealogy: { children: [] },
+    ...overrides,
+  } as Session;
+}
+
+function mount(sessions: Session[], mode: 'card' | 'panel' = 'card') {
+  const onSessionClick = vi.fn();
+  const view = render(
+    <App>
+      <div style={{ width: 280 }}>
+        <BranchSessionSections
+          branch={branch}
+          sessions={sessions}
+          userById={new Map()}
+          client={null}
+          mode={mode}
+          onSessionClick={onSessionClick}
+        />
+      </div>
+    </App>
+  );
+  return { ...view, onSessionClick };
+}
+
+beforeEach(() => localStorage.clear());
+
+describe('large branch session collections', () => {
+  it.each(['card', 'panel'] as const)(
+    'virtualizes expanded manual and gateway descendants in %s mode without hiding the tail',
+    async (mode) => {
+      const sessions = Array.from({ length: 1001 }, (_, index) =>
+        makeSession(index, {
+          genealogy: {
+            children: [],
+            ...(index > 0 ? { parent_session_id: 'session-0' as Session['session_id'] } : {}),
+          },
+          ...(mode === 'panel' && index === 0
+            ? {
+                custom_context: {
+                  gateway_source: {
+                    channel_id: 'channel-1',
+                    channel_type: 'slack',
+                    channel_name: 'Team',
+                    thread_id: 'thread-1',
+                  },
+                },
+              }
+            : {}),
+        })
+      );
+      const { container, onSessionClick } = mount(sessions, mode);
+      await waitFor(() => {
+        const rows = screen.getAllByRole('button', { name: /^Open session Conversation/ });
+        expect(rows.length).toBeGreaterThan(0);
+        expect(rows.length).toBeLessThan(40);
+      });
+      const scroller = container.querySelector<HTMLElement>('.ant-tree-list-holder');
+      expect(scroller).not.toBeNull();
+      expect(scroller!.getBoundingClientRect().height).toBeLessThanOrEqual(400);
+      // Variable-height rows (two-line titles / gateway metadata) remain reachable.
+      for (let attempt = 0; attempt < 10; attempt++) {
+        await act(async () => {
+          scroller!.scrollTop = scroller!.scrollHeight;
+          fireEvent.scroll(scroller!);
+          await new Promise((resolve) => setTimeout(resolve, 50));
+        });
+      }
+      expect(screen.getByRole('button', { name: 'Open session Conversation 1000' })).toBeVisible();
+      fireEvent.click(screen.getByRole('button', { name: 'Open session Conversation 1000' }));
+      expect(onSessionClick).toHaveBeenCalledWith('session-1000');
+    }
+  );
+
+  it('paginates scheduled runs and broad search matches instead of mounting every row', async () => {
+    const sessions = Array.from({ length: 1000 }, (_, index) =>
+      makeSession(index, { scheduled_from_branch: true, scheduled_run_at: 1000 - index })
+    );
+    const { onSessionClick } = mount(sessions, 'panel');
+    expect(screen.getAllByRole('button', { name: /^Open session Conversation/ })).toHaveLength(20);
+    fireEvent.click(screen.getByTitle('Next Page'));
+    fireEvent.click(screen.getByRole('button', { name: 'Open session Conversation 20' }));
+    expect(onSessionClick).toHaveBeenCalledWith('session-20');
+    fireEvent.change(screen.getByPlaceholderText('Search sessions...'), {
+      target: { value: 'Conversation' },
+    });
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: /^Open session Conversation/ })).toHaveLength(
+        20
+      );
+    });
+  });
+});

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -69,6 +69,7 @@ import {
   SessionSortButton,
 } from '../SessionSearchControls';
 import { ToolIcon } from '../ToolIcon';
+import { BRANCH_SESSION_VIEWPORT_HEIGHT } from './branchCardLayout';
 import {
   buildSessionTree,
   collectSessionSubtreeIds,
@@ -981,7 +982,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
   ) => (
     <Tree
       className="agor-flat-tree nodrag nowheel"
-      height={400}
+      height={BRANCH_SESSION_VIEWPORT_HEIGHT}
       virtual
       treeData={treeData}
       expandedKeys={expandedKeys}

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -74,6 +74,7 @@ import {
   collectSessionSubtreeIds,
   type SessionTreeNode,
 } from './buildSessionTree';
+import { PagedSessions } from './PagedSessions';
 
 // Stable theme object so the ConfigProvider context value doesn't churn.
 const NO_MOTION_THEME = { token: { motion: false } };
@@ -979,7 +980,9 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
     expandableKeys: React.Key[]
   ) => (
     <Tree
-      className="agor-flat-tree"
+      className="agor-flat-tree nodrag nowheel"
+      height={400}
+      virtual
       treeData={treeData}
       expandedKeys={expandedKeys}
       onExpand={(keys) => handleSessionTreeExpand(keys as React.Key[], expandableKeys)}
@@ -1045,8 +1048,8 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
   );
 
   const scheduledRunsContent = isScheduledRunsOpen ? (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-      {scheduledSessions.map((session) => {
+    <PagedSessions key={branch.branch_id} sessions={scheduledSessions}>
+      {(session) => {
         const isActive = isSessionExecuting(session);
         const callbackToggle = getCallbackToggle(session);
         const remoteParentId = getRemoteParentId(session);
@@ -1092,8 +1095,8 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
             </button>
           </SessionItemWithActions>
         );
-      })}
-    </div>
+      }}
+    </PagedSessions>
   ) : null;
 
   const gatewaySessionsHeader = (
@@ -1161,9 +1164,9 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
             </Typography.Text>
           </div>
         ) : (
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-            {searchResults.map((session) => renderFlatSessionRow(session, trimmedSearchQuery))}
-          </div>
+          <PagedSessions key={`${branch.branch_id}:${trimmedSearchQuery}`} sessions={searchResults}>
+            {(session) => renderFlatSessionRow(session, trimmedSearchQuery)}
+          </PagedSessions>
         )}
 
         {forkSpawnModal.session && (

--- a/apps/agor-ui/src/components/BranchCard/PagedSessions.test.tsx
+++ b/apps/agor-ui/src/components/BranchCard/PagedSessions.test.tsx
@@ -17,6 +17,9 @@ it('bounds each page and recovers when realtime removals empty a later page', ()
   rerender(<PagedSessions sessions={sessions.slice(0, 1)}>{row}</PagedSessions>);
   expect(screen.getByText('session-0')).toBeInTheDocument();
   expect(screen.queryByTitle('Next Page')).not.toBeInTheDocument();
+  rerender(<PagedSessions sessions={sessions}>{row}</PagedSessions>);
+  expect(screen.getByText('session-0')).toBeInTheDocument();
+  expect(screen.queryByText('session-20')).not.toBeInTheDocument();
   rerender(<PagedSessions sessions={[]}>{row}</PagedSessions>);
   expect(screen.queryByText(/^session-/)).not.toBeInTheDocument();
 });

--- a/apps/agor-ui/src/components/BranchCard/PagedSessions.test.tsx
+++ b/apps/agor-ui/src/components/BranchCard/PagedSessions.test.tsx
@@ -1,0 +1,22 @@
+import type { Session } from '@agor-live/client';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { expect, it } from 'vitest';
+import { PagedSessions } from './PagedSessions';
+
+it('bounds each page and recovers when realtime removals empty a later page', () => {
+  const sessions = Array.from({ length: 1000 }, (_, index) => ({
+    session_id: `session-${index}`,
+  })) as Session[];
+  const row = (session: Session) => <div key={session.session_id}>{session.session_id}</div>;
+  const { rerender } = render(<PagedSessions sessions={sessions}>{row}</PagedSessions>);
+  expect(screen.getAllByText(/^session-/)).toHaveLength(20);
+  fireEvent.click(screen.getByTitle('Next Page'));
+  expect(screen.getByText('session-20')).toBeInTheDocument();
+  expect(screen.queryByText('session-0')).not.toBeInTheDocument();
+
+  rerender(<PagedSessions sessions={sessions.slice(0, 1)}>{row}</PagedSessions>);
+  expect(screen.getByText('session-0')).toBeInTheDocument();
+  expect(screen.queryByTitle('Next Page')).not.toBeInTheDocument();
+  rerender(<PagedSessions sessions={[]}>{row}</PagedSessions>);
+  expect(screen.queryByText(/^session-/)).not.toBeInTheDocument();
+});

--- a/apps/agor-ui/src/components/BranchCard/PagedSessions.tsx
+++ b/apps/agor-ui/src/components/BranchCard/PagedSessions.tsx
@@ -1,6 +1,7 @@
 import type { Session } from '@agor-live/client';
 import { Flex, Pagination } from 'antd';
 import { type ReactNode, useState } from 'react';
+import { BRANCH_SESSION_VIEWPORT_HEIGHT } from './branchCardLayout';
 
 const PAGE_SIZE = 20;
 
@@ -15,9 +16,17 @@ export function PagedSessions({
   const [requestedPage, setPage] = useState(1);
   // Archive/removal events can shrink the collection while a later page is open.
   const page = Math.min(requestedPage, Math.max(1, Math.ceil(sessions.length / PAGE_SIZE)));
+  // Keep the recovered page when the collection grows again; do not jump back
+  // to a page that disappeared during the removal.
+  if (page !== requestedPage) setPage(page);
   return (
     <Flex vertical gap={4} className="nodrag nowheel">
-      <Flex vertical gap={4} style={{ maxHeight: 400, overflowY: 'auto' }} key={page}>
+      <Flex
+        vertical
+        gap={4}
+        style={{ maxHeight: BRANCH_SESSION_VIEWPORT_HEIGHT, overflowY: 'auto' }}
+        key={page}
+      >
         {sessions.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE).map(children)}
       </Flex>
       {sessions.length > PAGE_SIZE && (

--- a/apps/agor-ui/src/components/BranchCard/PagedSessions.tsx
+++ b/apps/agor-ui/src/components/BranchCard/PagedSessions.tsx
@@ -1,0 +1,36 @@
+import type { Session } from '@agor-live/client';
+import { Flex, Pagination } from 'antd';
+import { type ReactNode, useState } from 'react';
+
+const PAGE_SIZE = 20;
+
+/** Bound flat rows as well as height; a scrollbar alone still mounts every row. */
+export function PagedSessions({
+  sessions,
+  children,
+}: {
+  sessions: Session[];
+  children: (session: Session) => ReactNode;
+}) {
+  const [requestedPage, setPage] = useState(1);
+  // Archive/removal events can shrink the collection while a later page is open.
+  const page = Math.min(requestedPage, Math.max(1, Math.ceil(sessions.length / PAGE_SIZE)));
+  return (
+    <Flex vertical gap={4} className="nodrag nowheel">
+      <Flex vertical gap={4} style={{ maxHeight: 400, overflowY: 'auto' }} key={page}>
+        {sessions.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE).map(children)}
+      </Flex>
+      {sessions.length > PAGE_SIZE && (
+        <Pagination
+          simple
+          current={page}
+          total={sessions.length}
+          pageSize={PAGE_SIZE}
+          showSizeChanger={false}
+          onChange={setPage}
+          size="small"
+        />
+      )}
+    </Flex>
+  );
+}

--- a/apps/agor-ui/src/components/BranchCard/branchCardLayout.ts
+++ b/apps/agor-ui/src/components/BranchCard/branchCardLayout.ts
@@ -1,6 +1,9 @@
 import type { Session } from '@agor-live/client';
 import { isGatewaySession } from '@agor-live/client';
 
+// Keep mounted lists and the deferred card's fit-to-view footprint in sync.
+export const BRANCH_SESSION_VIEWPORT_HEIGHT = 400;
+
 const EMPTY_SESSIONS_SHELL_HEIGHT = 72;
 const SECTION_HEADER_HEIGHT = 46;
 const SESSION_ROW_HEIGHT = 42;
@@ -23,7 +26,9 @@ export function estimateBranchSessionSectionsHeight(
 
   if (manualCount > 0) {
     height += SECTION_HEADER_HEIGHT;
-    if (sessionsExpanded) height += manualCount * SESSION_ROW_HEIGHT;
+    if (sessionsExpanded) {
+      height += Math.min(manualCount * SESSION_ROW_HEIGHT, BRANCH_SESSION_VIEWPORT_HEIGHT);
+    }
   } else {
     // The card still shows a Sessions header with the New Session action when
     // only scheduled/gateway sessions exist.

--- a/docs/internal/session-list-bounds-2026-09-07.md
+++ b/docs/internal/session-list-bounds-2026-09-07.md
@@ -56,10 +56,13 @@ The shipped correction bounds **rendering and MCP list candidate materialization
 
 - Manual and gateway genealogy retain their structure, expansion state, actions,
   and ordering, with a 400px virtual Tree viewport. `nodrag nowheel` keeps local
-  tree interaction from dragging/zooming the board.
+  tree interaction from dragging/zooming the board. The deferred branch-card
+  shell caps its manual-row estimate at that same shared viewport height, so
+  initial board fitting cannot measure thousands of rows before hydration.
 - Scheduled runs and search matches use 20-row pages in a max-400px scroll area.
   Filtering/search happens before paging, so later records remain searchable.
   Branch/query switches reset the page; realtime removals clamp an invalid page.
+  The clamped page is retained if new sessions arrive afterward.
 - MCP board filtering now goes through the service's branch/board SQL join;
   exact status filters join the SQL page path. MCP uses its single created-time
   sort plus the repository's ID tie-breaker instead of selecting the generic
@@ -276,3 +279,39 @@ SQL status change is an additional shared Drizzle predicate under existing
 visibility/tenant scope, with real SQLite hidden-branch/count negatives and
 MCP tenant propagation/denied-resolution coverage. Further end-to-end data-fetch
 and byte-budget performance work remains as described above.
+
+### Codex review follow-up
+
+The independent reviewer identified a real integration gap: the progressive-mount
+shell still estimated 42px per manual session before the bounded tree mounted.
+For 1,001 sessions this reserved 42,096px and could distort the initial board fit.
+The estimate now caps the manual rows at the same domain-owned viewport constant
+used by Tree and flat-list rendering. Small and collapsed shells keep their
+existing estimates. No mount-scheduler or canvas-fitting redesign was needed.
+
+The review also found that a removed page's number remained in React state, so
+later collection growth jumped back to it. The component now stores the clamped
+page immediately. Both findings were reproduced by new/extended regression tests
+against the pre-fix implementation (two failures). The deferred-shell regression
+mounts the actual BranchCard with only the progressive-mount readiness held false;
+it checks small, 1,001-session, and persisted-collapsed shells. Pagination coverage
+now includes growth after removal.
+
+These changes only adjust derived UI layout and local navigation state over the
+already supplied sessions. They introduce no fetching, tenant identity source,
+shared persisted state, or authorization changes.
+
+```sh
+pnpm --filter agor-ui exec vitest run src/components/BranchCard/BranchCard.bounds.test.tsx src/components/BranchCard/BranchCard.drag.test.tsx src/components/BranchCard/PagedSessions.test.tsx src/components/BranchCard/BranchSessionSections.test.tsx src/components/BranchCard/buildSessionTree.test.ts src/hooks/useAgorData.test.tsx src/hooks/useProgressiveMount.test.tsx
+# 61 passed
+pnpm --filter agor-ui exec vitest run --config vitest.browser.config.ts src/components/BranchCard/BranchSessionSections.bounds.browser.test.tsx
+# 12 passed across all four Chromium projects
+pnpm check
+# Full workspace typecheck, lint, all four boundary checks, builds: exit 0
+```
+
+A separate strict no-emit TypeScript check passed for the new deferred-card test
+and extended pagination test, using a temporary config extending
+`apps/agor-ui/tsconfig.app.json`, `exclude:[]`, and only those two tests plus
+`src/test/setup.ts` as includes. This follow-up used built package declarations
+without source-mode overrides. Both review findings were addressed; none skipped.

--- a/docs/internal/session-list-bounds-2026-09-07.md
+++ b/docs/internal/session-list-bounds-2026-09-07.md
@@ -172,7 +172,7 @@ bounded performance:
   Derived-type scans still inspect up to 10,000 full candidate records per
   request; they are bounded, not cheap, and now fail explicitly on truncation.
 - `findAll` is intentionally aggregate-unbounded. It checks stable totals,
-  advancing offsets, nonempty continuation and complete membership, raising
+  advancing offsets, nonempty continuation and the advertised row count, raising
   useful errors rather than claiming a partial walk is complete. Its current
   session offset walk also encounters the API's 10,000-offset ceiling for
   larger inventories. Silently lowering its page/aggregate limit is unsafe.

--- a/docs/internal/session-list-bounds-2026-09-07.md
+++ b/docs/internal/session-list-bounds-2026-09-07.md
@@ -240,8 +240,8 @@ pnpm check:realtime-boundaries
 pnpm check:shortid
 ```
 
-No package builds or daemon/UI background servers were started. Source-condition
-no-emit typechecks avoid Turbo's `typecheck -> ^build` dependency. UI source-mode
+The initial investigation used no package builds or daemon/UI background servers.
+Source-condition no-emit typechecks avoid Turbo's `typecheck -> ^build` dependency. UI source-mode
 checking needs `erasableSyntaxOnly:false` because imported core source contains
 existing enums and constructor parameter properties; this does not disable
 strict type checking. A temporary config extending the UI config with those
@@ -250,6 +250,26 @@ plus all five changed/new test files checks tests too. Existing test helper type
 erasures were corrected to accept typed callbacks and actual Zod schemas; the
 standalone SQLite service fixture now explicitly creates the scope-aware proxy
 without a tenant hook, instead of passing an incorrectly branded raw database.
+
+### Requested full-workspace validation follow-up
+
+On 2026-09-07, the user explicitly requested dependency installation and the full
+workspace check (including its builds). Both completed successfully:
+
+```sh
+pnpm i
+# All 18 workspace projects; already up to date, no lockfile changes
+pnpm check
+# Standard workspace typecheck, lint, short-ID/multitenancy/filesystem/realtime
+# boundary checks, then Turbo builds excluding @agor/docs; exit 0
+```
+
+All four focused Vitest commands above were rerun after the full check: browser
+12, UI 51, daemon 97, and core 168 tests passed (**328 total**), each with exit 0.
+
+No persistent daemon/UI dev servers, deployment, merge, or issue closure were
+performed. The existing PR #2687 was attached to this worktree using
+`agor_branches_update` with its `pullRequestUrl`.
 
 No fresh PostgreSQL/RLS integration or production load benchmark was run. The
 SQL status change is an additional shared Drizzle predicate under existing

--- a/docs/internal/session-list-bounds-2026-09-07.md
+++ b/docs/internal/session-list-bounds-2026-09-07.md
@@ -67,7 +67,7 @@ The shipped correction bounds **rendering and MCP list candidate materialization
   limit (default 25, maximum 100).
 - Derived `sessionType` filtering retains the existing 10,000-candidate scan
   ceiling, but errors if the scan is incomplete (including a server-clamped
-  scan), rather than reporting partial data as complete. Narrowing with branch,
+  scan or a legacy bare-array response without completeness metadata), rather than reporting partial data as complete. Narrowing with branch,
   board, status, or archive filters is optional; callers may instead omit
   `sessionType` and page normally. Exact counts still cost a matching-row scan.
 - Branch-scoped results retain their service total instead of replacing it with

--- a/docs/internal/session-list-bounds-2026-09-07.md
+++ b/docs/internal/session-list-bounds-2026-09-07.md
@@ -1,0 +1,258 @@
+# Session-list bounds: issue #2645
+
+## Evidence and scope
+
+Investigated `origin/main` at `bde5a0c0f406c161c589f6f5a1fb2fd353c62369`
+(0.26.2), fetched and confirmed equal to the starting worktree HEAD on
+2026-09-07. Main subsequently advanced to
+`33a428b95dc4a0f42a1ac8d551d533ce81ebd16d` via unrelated Knowledge-memory PR
+#2615; the fix branch is rebased onto that main. Its only two changed files are
+`mcp/tools/knowledge.ts` and `knowledge-memory-append.test.ts`, not these list
+paths. No production data or managed environment was mutated.
+
+- [Issue #2645](https://github.com/preset-io/agor/issues/2645) reports a worktree
+  list growing without bound with thousands of sessions. It was open, with no
+  comments or linked/cross-referenced PRs in its GitHub timeline when checked.
+- [Merged #2194](https://github.com/preset-io/agor/pull/2194) bounds MCP collection
+  output; it does not virtualize branch trees or bound all query materialization.
+- [Merged #2504](https://github.com/preset-io/agor/pull/2504) indexes recent-session
+  pages. Its report explicitly distinguishes ordered-page cost from exact-count
+  cost and full hydration. It does not fix rendering.
+- [Open #1814](https://github.com/preset-io/agor/pull/1814), including its comment,
+  addresses clipping in the separate board-wide session drawer (#1813), not the
+  worktree genealogy tree. Neither its status nor an overflow scrollbar proves
+  that rendered rows are bounded. The two merged PRs above had no comments/reviews.
+
+## Root cause: real, but three different bounds
+
+1. **Rendered rows:** `BranchSessionSections.tsx` serves both `BranchCard` and
+   `BoardTeammatePanel`. Both manual and gateway trees use expanded genealogy
+   by default. Previously Tree had no `height`, so its virtual list was inactive.
+   Scheduled runs and search results used unrestricted `.map()` calls. All
+   loaded records could mount their row, tooltip, and action components.
+2. **Client materialization:** `useAgorData` initially fetches a recent global
+   50-session page and displayed-board sessions, then hydrates all active
+   accessible sessions. Silent reconnect/resync fetches the full active set.
+   The branch modal `SessionsTab` already has a 20-row AntD table and 70vh
+   wrapper, but uses `findAll({ $limit: 1000 })` for active and lazily archived
+   records. `$limit` is a page size, not an aggregate cap. Prop seeding, realtime
+   upserts, and archive results can also grow its local collection.
+3. **Server work:** a bounded HTTP/MCP response is not necessarily a bounded
+   database read. Several shapes fall back to loading candidates before sorting,
+   filtering, selecting fields, and slicing. Requiring a branch still permits
+   arbitrarily many sessions in that branch.
+
+## Contract decision
+
+**Do not require `branchId` on a list operation.** The required `Session.branch_id`
+foreign key is a creation/ownership invariant, not a required query filter.
+Branch, board, and workspace-wide inventories are all legitimate. Optional
+filters must narrow by intersection, never expand authority; absence means all
+authorized branches in the authenticated tenant, never all tenants. It must not
+silently default to the MCP caller's current branch (external API-key MCP callers
+may have no session at all).
+
+The shipped correction bounds **rendering and MCP list candidate materialization**:
+
+- Manual and gateway genealogy retain their structure, expansion state, actions,
+  and ordering, with a 400px virtual Tree viewport. `nodrag nowheel` keeps local
+  tree interaction from dragging/zooming the board.
+- Scheduled runs and search matches use 20-row pages in a max-400px scroll area.
+  Filtering/search happens before paging, so later records remain searchable.
+  Branch/query switches reset the page; realtime removals clamp an invalid page.
+- MCP board filtering now goes through the service's branch/board SQL join;
+  exact status filters join the SQL page path. MCP uses its single created-time
+  sort plus the repository's ID tie-breaker instead of selecting the generic
+  multi-sort fallback. Normal MCP list candidates are bounded by its requested
+  limit (default 25, maximum 100).
+- Derived `sessionType` filtering retains the existing 10,000-candidate scan
+  ceiling, but errors if the scan is incomplete (including a server-clamped
+  scan), rather than reporting partial data as complete. Narrowing with branch,
+  board, status, or archive filters is optional; callers may instead omit
+  `sessionType` and page normally. Exact counts still cost a matching-row scan.
+- Branch-scoped results retain their service total instead of replacing it with
+  this page's length. Derived-type pages report the requested limit/offset, not
+  the candidate scan's envelope. Out-of-scope rows or an oversized adapter page
+  cause a useful error before any records are returned, rather than fabricated
+  totals or disclosure of unexpected rows.
+- No API/MCP input schema, database migration, authentication, retention, or list
+  DTO changes. Small lists do not gain an artificial 400px minimum height.
+
+## Security and tenant assessment
+
+Sessions and branches are **tenant-owned**, with session access derived through
+the branch. UI lists are derived read models, not authorization boundaries.
+UI slicing consumes the same supplied collection and never fetches omitted
+records through an unscoped fallback. MCP continues forwarding trusted
+`baseServiceParams`; the exact-status SQL condition composes with the unchanged
+branch visibility predicate and tenant-scoped repository. Tests check trusted
+params propagation, reject out-of-scope adapter results, and prove that an
+explicit hidden branch/status filter returns neither rows nor a count. Existing
+MCP tenant-context negative suites are exercised. No new tenant identity source,
+cache, or persisted resource is introduced.
+
+Relevant existing enforcement owners:
+
+- `register-hooks.ts`: sessions is in `TENANT_OWNED_SERVICE_PATHS`; the sessions
+  hooks run `sessionQueryValidator`, `requireAuth`, and
+  `scopeFindToAccessibleSessionsSql`.
+- `utils/branch-authorization.ts`: trusted access decisions stamp the internal
+  `_agorSqlSessionAccessUserId` marker. Internal/service-account and configured
+  superadmin paths are explicit exceptions to user RBAC, **not** permission to
+  discard tenant scope. Transport queries cannot supply this root params marker.
+- `SessionsService.find/fetchData`: SQL fast path, board fallback, branch fallback,
+  and global fallback all forward the marker to the repository.
+- `SessionRepository.findPage/findAll/findByBoard`: branch visibility in SQL;
+  pagination totals are computed under the same visibility predicate. Board
+  membership is `sessions.branch_id -> branches.board_id`, not the legacy
+  `sessions.board_id` field.
+- MCP `server.ts` constructs authenticated `baseServiceParams` including tenant
+  and provider; `mcp/tenant-scope.ts` preserves tenant operation context. List and
+  ID resolver calls forward these params into the hooked services. Required-auth
+  PostgreSQL scope/RLS, not a client-provided branch UUID, isolates tenant rows.
+- Realtime delivery remains under existing tenant/RBAC publication controls.
+
+## Caller inventory before any schema change
+
+Production `sessions.find/findAll` call sites, including service aliases:
+
+| Caller                                      | Scope / continuation / fallback                                                                                                                                                                             |
+| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| UI `hooks/useAgorData.ts`                   | Global recent-50 first paint; full displayed-board active list; global active background hydration and silent resync via `findAll`; direct archived/deep links repaired with `get`, not broadening the list |
+| UI `BranchModal/tabs/SessionsTab.tsx`       | Exact branch active/archived `findAll`; prop seed on load failure; realtime created/patched/updated/removed and archive response caches                                                                     |
+| UI `ScheduleRunsPanel.tsx`                  | `schedule_id`, active, limited recent runs; no branch required; retains prior state/logs on fetch error                                                                                                     |
+| UI `utils/seedOnboardingTeammate.ts`        | Exact known session `get` first; branch-filtered `find` fallback, followed by an explicit branch match                                                                                                      |
+| CLI `session/list.ts`                       | Global by default, optional board/status/tool filters and limit; one page                                                                                                                                   |
+| CLI `board/add-session.ts`                  | Global `findAll` to resolve the chosen session by full/short ID before finding its branch                                                                                                                   |
+| CLI `branch/list.ts`                        | Global `findAll` for per-branch counts; fetch failure leaves counts zero                                                                                                                                    |
+| CLI `branch/{show,rm,archive,unarchive}.ts` | Exact branch `findAll`, sometimes archive-state filters; previews/counts, not just the first page                                                                                                           |
+| MCP `tools/sessions.ts: agor_sessions_list` | Optional global/board/branch/status/archive/type scopes; details below                                                                                                                                      |
+| MCP `agor_sessions_bulk_archive`            | Optional branch/status candidate pages of 200; global by default; board/type/age post-filter; dry-run preview or individually authorized patches                                                            |
+| MCP `agor_sessions_get_current_context`     | Optional exact-branch sibling find, limit 11, excludes caller and returns 10; errors omit noncritical sibling section                                                                                       |
+| Daemon `startup.ts`                         | Global status pages of 1,000 via `collectAllPages` for orphaned/idle-not-ready reconciliation; trusted startup params                                                                                       |
+| Daemon `services/branches.ts`               | Exact-branch archive/unarchive cascade finds, `$limit:1000`, `paginate:false`; changing generic list semantics risks lifecycle truncation                                                                   |
+
+Other sessions-service references (App, SDK repositories/executors, task/gateway/
+scheduler services, session actions, MCP branch tools) use `get`, `create`,
+`patch`, `remove`, custom routes, or realtime subscriptions, not collection finds.
+Public TypeScript/API documentation also demonstrates unscoped session lists.
+In-process repository methods are intentionally not interchangeable with public
+list schemas. Global queries must remain usable by cleanup/reconciliation code.
+
+Rendering consumers additionally include `BranchListDrawer/BoardSessionList`
+(also mounted by the teammate panel), the branch modal, session peeks, and board
+selectors. The board-wide drawer is a separate surface from this fix.
+
+## API/MCP fallback findings and remaining work
+
+Baseline findings, which must not be hidden behind a claim of end-to-end
+bounded performance:
+
+- Feathers `createQuerySchema` currently accepts integer `$limit` and `$skip`
+  from 0 through 10,000; default session limit is the shared
+  `PAGINATION.DEFAULT_LIMIT` (10,000). API names are snake_case; MCP uses camelCase.
+  The shared validator removes additional fields. Making one filter required
+  or globally rejecting unknown fields would affect existing callers, including
+  internal residual filters, and is not a safe incidental schema edit.
+- Baseline `shouldSqlPageSessionQuery` modeled archive, board/branch, pagination and a
+  single `created_at` or `updated_at` sort. Other filters, operators, `$select`,
+  and multiple sort keys take fallback paths. This PR adds exact status only. Board fallback scopes candidates
+  via the branch join; branch fallback uses `findAll`; global fallback uses
+  `super.find -> fetchData -> findAll`. They preserve RBAC but materialize more
+  than one page. Exact counts and full session JSON also have nonconstant cost.
+- MCP output defaults to 25 lean records, max requested limit 100; offsets are
+  nonnegative integers. Nonempty supplied IDs are resolved through authorized
+  entity gets. Branch/board response assertions now reject inconsistent scope.
+- Baseline MCP requested 10,000 candidates for `boardId` or derived `sessionType`
+  and filtered/paginated in memory. It could truncate logical results/counts
+  above that candidate ceiling and spread the scan's `limit/skip` into the
+  requested page's envelope. Branch post-filtering independently reset totals
+  to page length, ending pagination after one page. Normal MCP listing sorted
+  by two fields, missing the SQL fast path. **Fixed here** as described above.
+  Derived-type scans still inspect up to 10,000 full candidate records per
+  request; they are bounded, not cheap, and now fail explicitly on truncation.
+- `findAll` is intentionally aggregate-unbounded. It checks stable totals,
+  advancing offsets, nonempty continuation and complete membership, raising
+  useful errors rather than claiming a partial walk is complete. Its current
+  session offset walk also encounters the API's 10,000-offset ceiling for
+  larger inventories. Silently lowering its page/aggregate limit is unsafe.
+
+A subsequent query-contract change should push every supported narrowing filter
+and stable order into SQL **before** pagination/count, reject unsupported or
+malformed narrowing inputs with field-specific errors rather than silently
+broadening, and define a cursor or explicit scan budget for derived filters.
+An exceeded scan budget must return a useful error suggesting narrower filters,
+not fabricated totals or `hasMore:false` (the MCP derived-type scan now does this). Global/board scope must remain valid.
+Any new cursor/cache must be tenant- and authorization-bound. Full-hydration
+replacement also requires honest counts/search and realtime/deep-link behavior;
+do not replace it with a silent first-N snapshot. This deserves separate scoped
+work rather than an API compatibility break bundled with rendering.
+
+## Rollout
+
+UI rendering works with the current daemon. MCP fixes require the updated
+server code; existing clients keep the same optional filters and response
+shape. No schema/version handshake or data migration. Correct totals now let
+branch/board callers reach later pages. Previously truncated derived-type scans
+now fail with narrowing guidance; inconsistent adapter results now fail rather
+than silently returning a partial list. No sessions become inaccessible, deleted, or archived. Rendering
+and mounted component cost are bounded per section; full hydration, search,
+sorting and tree construction still scale with loaded sessions. Offset pages of
+changing live data are not snapshot isolation. No merge, deployment, or issue
+closure is part of this investigation.
+
+## Validation
+
+Browser coverage uses actual AntD Tree/virtual-list components, not the existing
+genealogy test's Tree mock. It checks tail navigation in a 1,001-record expanded
+tree, gateway descendants, 1,000 flat rows, paging, and broad search matches.
+
+Baseline evidence:
+
+- Restoring the main UI component and running the card-mode browser regression
+  with only 101 fixture records failed: `expected 101 to be less than 40`.
+  The initial 1,001-record baseline run exceeded the 90-second harness deadline
+  and was terminated; this is not reported as a measured production latency.
+- Restoring main's MCP tool and running the new `preserves totals` tests failed
+  all four scope variants; branch-scoped totals became 2 instead of 53 and board
+  queries requested 10,000 instead of the requested 2. The modified sources
+  were restored after both checks.
+
+Final focused validation:
+
+```sh
+pnpm --filter agor-ui exec vitest run --config vitest.browser.config.ts src/components/BranchCard/BranchSessionSections.bounds.browser.test.tsx
+# 12 passed: desktop, phone, tablet, short-landscape Chromium projects
+pnpm --filter agor-ui exec vitest run src/components/BranchCard/PagedSessions.test.tsx src/components/BranchCard/BranchSessionSections.test.tsx src/components/BranchCard/buildSessionTree.test.ts src/hooks/useAgorData.test.tsx
+# 51 passed
+pnpm --filter @agor/daemon exec vitest run src/services/sessions.find.test.ts src/mcp/tools/sessions.test.ts src/mcp/tenant-scope.test.ts src/utils/rbac-find-scoping.test.ts src/register-hooks.tenant-identity.test.ts
+# 97 passed
+pnpm --filter @agor/core exec vitest run src/db/repositories/sessions.test.ts src/lib/feathers-validation.test.ts src/api/index.test.ts
+# 168 passed
+pnpm --filter @agor/daemon exec tsc --noEmit --customConditions source --rootDir ../..
+pnpm --filter @agor/core exec tsc --noEmit --customConditions source --rootDir ../..
+pnpm --filter agor-ui exec tsc -p tsconfig.app.json --noEmit --customConditions source --erasableSyntaxOnly false
+pnpm lint
+# Biome plus 330 named frontend design-system fixture cases
+pnpm check:multitenancy-boundaries
+pnpm check:daemon-filesystem-boundaries
+pnpm check:realtime-boundaries
+pnpm check:shortid
+```
+
+No package builds or daemon/UI background servers were started. Source-condition
+no-emit typechecks avoid Turbo's `typecheck -> ^build` dependency. UI source-mode
+checking needs `erasableSyntaxOnly:false` because imported core source contains
+existing enums and constructor parameter properties; this does not disable
+strict type checking. A temporary config extending the UI config with those
+same two overrides, `exclude:[]`, and an include list containing its test setup
+plus all five changed/new test files checks tests too. Existing test helper type
+erasures were corrected to accept typed callbacks and actual Zod schemas; the
+standalone SQLite service fixture now explicitly creates the scope-aware proxy
+without a tenant hook, instead of passing an incorrectly branded raw database.
+
+No fresh PostgreSQL/RLS integration or production load benchmark was run. The
+SQL status change is an additional shared Drizzle predicate under existing
+visibility/tenant scope, with real SQLite hidden-branch/count negatives and
+MCP tenant propagation/denied-resolution coverage. Further end-to-end data-fetch
+and byte-budget performance work remains as described above.

--- a/packages/core/src/db/repositories/sessions.test.ts
+++ b/packages/core/src/db/repositories/sessions.test.ts
@@ -594,6 +594,22 @@ describe('SessionRepository.findAll', () => {
       const page = await repo.findPage({ visibleToUserId: userId, limit: 10, skip: 0 });
       expect(page.total).toBe(1);
       expect(page.data.map((session) => session.session_id)).toEqual([visibleSession.session_id]);
+      const statusPage = await repo.findPage({
+        visibleToUserId: userId,
+        status: visibleSession.status,
+        limit: 1,
+      });
+      expect(statusPage.total).toBe(1);
+      expect(statusPage.data.map((session) => session.session_id)).toEqual([
+        visibleSession.session_id,
+      ]);
+      const hiddenStatusPage = await repo.findPage({
+        visibleToUserId: userId,
+        status: visibleSession.status,
+        branchId: hiddenBranch.branch_id,
+        limit: 1,
+      });
+      expect(hiddenStatusPage).toEqual({ data: [], total: 0 });
     }
   );
 });

--- a/packages/core/src/db/repositories/sessions.ts
+++ b/packages/core/src/db/repositories/sessions.ts
@@ -118,6 +118,7 @@ function isSessionTimestampNeutralPatch(updates: SessionUpdate): boolean {
 
 /** Options for the SQL-backed session list page used by board/branch views. */
 export interface SessionPageOptions {
+  status?: SessionStatus;
   boardId?: string;
   branchId?: BranchID;
   branchIds?: BranchID[];
@@ -574,6 +575,7 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
       const baseUrl = await getBaseUrl();
 
       const conditions = [];
+      if (opts.status !== undefined) conditions.push(eq(sessions.status, opts.status));
       if (opts.boardId !== undefined) conditions.push(eq(branches.board_id, opts.boardId));
       if (opts.branchId !== undefined) conditions.push(eq(sessions.branch_id, opts.branchId));
       if (opts.branchIds !== undefined)


### PR DESCRIPTION
## Summary

Refs #2645. **Do not make `branchId` required.** Branch membership is a session ownership invariant, not a required list filter. Global and board-scoped lists are legitimate and remain constrained by trusted tenant context and branch RBAC.

- Virtualize branch-card/teammate manual and gateway trees in a 400px viewport, preserving genealogy and access to the tail.
- Page scheduled runs and panel search results at 20 rendered rows; keep search over the loaded collection and clamp pages after realtime removals.
- Fix MCP branch totals being reset to one page's length, and derived-filter pages inheriting the candidate scan's limit/offset.
- Push MCP board filters and exact status filters into SQL pagination; use the repository's stable ID tie-breaker rather than selecting the generic in-memory sort fallback.
- Preserve the existing 10,000-candidate derived `sessionType` scan ceiling, but reject incomplete scans with actionable narrowing guidance. Fail closed on out-of-scope or oversized adapter results.

## Investigation and contract

[Full report: issue/PR history, API/MCP/UI trace, every collection caller and fallback, tenant assessment, compatibility, residual risks, exact commands](https://github.com/preset-io/agor/blob/investigate-issue-2645-bounds/docs/internal/session-list-bounds-2026-09-07.md).

Issue #2645 had no comments or linked PRs. Reviewed related #2194, #2504, and #1814 (including its comment); none fixes the worktree rendering path. Started at main `bde5a0c0`, then rebased onto `33a428b9` after the unrelated #2615 landed.

The old UI mounts all expanded rows. A reduced 101-record browser fixture against main fails `expected 101 to be less than 40`; the new actual-AntD browser tests reach the end of a 1,001-record tree. Main's MCP implementation fails the new pagination regression tests (branch total 2 rather than 53; board query requests 10,000 rather than 2).

## Security and compatibility

- No input schema, migration, tenant/RBAC policy, session retention, or response-shape change. `branchId` / `boardId` remain optional; no silent default to the current branch.
- Existing authenticated tenant params and SQL visibility predicates are retained. Tests cover missing tenant context, trusted context propagation, denied branch resolution without global fallback, and hidden-branch rows/counts under the new status predicate.
- MCP clients now get correct continuation metadata. Previously truncated derived scans return a useful error instead of a misleading partial result; callers can narrow scope or omit `sessionType` and page normally.
- UI rendering works with the current daemon; MCP corrections require the updated daemon.
- **Not a complete data-fetch rewrite:** full UI hydration, generic API residual-filter materialization, exact counts, per-record payload size, and the existing API offset ceiling remain documented follow-up work. No fresh PostgreSQL/RLS integration or production load benchmark was run.

## Validation

- `pnpm i`: passed, dependencies already up to date; no lockfile changes.
- Full `pnpm check`: passed (standard workspace typecheck, lint, all four boundary checks, and Turbo builds excluding docs).
- All four focused suites below were rerun after the full check: **328 tests passed**.
- Chromium browser regression: **12 passed** across desktop, phone, tablet, short-landscape.
- UI pagination/genealogy/hydration suites: **51 passed**.
- Daemon session find, MCP sessions, MCP tenant scope, RBAC find scoping, tenant identity: **97 passed**.
- Core session repository, query validation, client pagination: **168 passed**.
- Core, daemon, UI source-condition no-emit typechecks; separate strict no-emit check of all five changed/new test files.
- `pnpm lint`: Biome + **330** frontend design-system fixture cases.
- Multitenancy, daemon-filesystem, realtime, short-ID boundary checks; diff whitespace checks.
- Normal pre-commit hooks passed. The initial stash-backup failure was fixed by matching the git subprocess's `PWD` to `process.cwd()` in this aliased workspace, not by skipping hooks.

PR attached to the worktree through MCP (`agor_branches_update.pullRequestUrl`). No persistent dev servers, merge, deploy, or issue closure. Exact validation commands, initial source-mode typecheck caveats, and the requested full-check follow-up are in the report.

## Codex review follow-up

Addressed both review findings:

- Bound the deferred BranchCard shell using the same 400px viewport constant as mounted trees/flat lists; prevents the initial board fit from measuring a 42,096px placeholder for 1,001 sessions. Regression mounts the actual deferred card and preserves small/collapsed estimates.
- Retain the clamped pagination state after removals so new sessions do not jump back to an obsolete page. Extended regression covers subsequent growth.

Both regressions failed before the fixes. Follow-up validation: **61 UI tests + 12 browser tests passed**, strict no-emit check of both changed/new tests passed, and full **`pnpm check` passed again**. Backend code is unchanged from the previously validated 265 daemon/core tests. No feedback was intentionally skipped. Follow-up independent review by Codex / `gpt-6-astra` found **no blockers or substantive issues remaining** at `11b19c01d5f0e8a6c4e5e29135b97da27dcbfdb2`. The reviewer independently reran all 61 focused UI and 12 Chromium browser tests successfully. The `ai-reviewed-gpt-6-astra` label records that review; GitHub CI was still running when the review completed.
