### PR TITLE
fix: validate board presence and push down MCP entity queries

### DIFF
--- a/apps/agor-daemon/src/mcp/schema.ts
+++ b/apps/agor-daemon/src/mcp/schema.ts
@@ -111,26 +111,28 @@ export function mcpRequiredPositiveInt(fieldName: string, description: string) {
     .describe(description);
 }
 
-export function mcpOptionalPositiveInt(fieldName: string, description: string) {
-  return z
+export function mcpOptionalPositiveInt(fieldName: string, description: string, maxValue?: number) {
+  const value = z
     .number({
       error: `${fieldName} must be a positive integer when provided.`,
     })
     .int(`${fieldName} must be an integer.`)
-    .positive(`${fieldName} must be greater than 0.`)
-    .optional()
-    .describe(description);
+    .positive(`${fieldName} must be greater than 0.`);
+  return (maxValue === undefined ? value : value.max(maxValue)).optional().describe(description);
 }
 
-export function mcpOptionalNonNegativeInt(fieldName: string, description: string) {
-  return z
+export function mcpOptionalNonNegativeInt(
+  fieldName: string,
+  description: string,
+  maxValue?: number
+) {
+  const value = z
     .number({
       error: `${fieldName} must be a non-negative integer when provided.`,
     })
     .int(`${fieldName} must be an integer.`)
-    .nonnegative(`${fieldName} must be greater than or equal to 0.`)
-    .optional()
-    .describe(description);
+    .nonnegative(`${fieldName} must be greater than or equal to 0.`);
+  return (maxValue === undefined ? value : value.max(maxValue)).optional().describe(description);
 }
 
 export function mcpPositiveIntWithDefault(
@@ -206,17 +208,21 @@ export function mcpPageResult<T>(result: unknown, requestedLimit: number, reques
   };
 }
 
-export function mcpOffset(defaultValue = 0) {
+export function mcpOffset(defaultValue = 0, maxValue?: number) {
   if (!Number.isSafeInteger(defaultValue) || defaultValue < 0) {
     throw new Error('MCP offset default must be a non-negative safe integer');
   }
 
-  return z
+  if (maxValue !== undefined && (!Number.isSafeInteger(maxValue) || maxValue < defaultValue)) {
+    throw new Error('MCP offset maximum must be a safe integer at least as large as its default');
+  }
+  const offset = z
     .number({
       error: 'offset must be a non-negative integer when provided.',
     })
     .int('offset must be an integer.')
-    .nonnegative('offset must be greater than or equal to 0.')
+    .nonnegative('offset must be greater than or equal to 0.');
+  return (maxValue === undefined ? offset : offset.max(maxValue))
     .optional()
     .default(defaultValue)
     .describe(`Number of results to skip (default: ${defaultValue})`);

--- a/apps/agor-daemon/src/mcp/tenant-scope.ts
+++ b/apps/agor-daemon/src/mcp/tenant-scope.ts
@@ -10,6 +10,7 @@ import { Unavailable } from '@agor/core/feathers';
 import type { McpServer } from '@modelcontextprotocol/server';
 import { wrapRegisterTool } from './register-tool-proxy.js';
 import type { McpContext } from './server.js';
+import { mcpValidationFailure } from './validation-errors.js';
 
 /**
  * Custom MCP service methods bypass the Feathers around hooks that normally
@@ -95,7 +96,15 @@ export function tenantScopedToolProxy(server: McpServer, ctx: McpContext): McpSe
   return wrapRegisterTool(server, (register, name, config, handler) =>
     register(name, config, (args, extra) => {
       const tenantId = ctx.baseServiceParams.tenant?.tenant_id;
-      const invoke = () => Promise.resolve(handler(args, extra));
+      const invoke = async () => {
+        try {
+          return await handler(args, extra);
+        } catch (error) {
+          const failure = mcpValidationFailure(error, name);
+          if (failure) return failure;
+          throw error;
+        }
+      };
       return tenantId ? runWithTenantContext(tenantId, invoke) : invoke();
     })
   );

--- a/apps/agor-daemon/src/mcp/tools/boards.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/boards.test.ts
@@ -237,217 +237,59 @@ describe('agor_boards_get', () => {
     expect(boardObjectsFind).not.toHaveBeenCalled();
   });
 
-  it('filters and paginates included positioned entities', async () => {
-    const boardObjectsFind = vi.fn(async () => ({
-      data: [
-        {
-          object_id: 'obj-branch-0',
+  it.each([
+    {
+      args: { entitiesLimit: 1, entitiesSkip: 1 },
+      query: { $limit: 1, $skip: 1 },
+      limit: 1,
+      skip: 1,
+    },
+    { args: { entitiesSkip: 1 }, query: { $skip: 1 }, limit: null, skip: 1 },
+    { args: {}, query: {}, limit: null, skip: 0 },
+    { args: { includeArchived: true }, query: {}, limit: null, skip: 0 },
+  ])(
+    'pushes archive filtering/count/pagination to one board-object read: $args',
+    async ({ args, query, limit, skip }) => {
+      const entity = { object_id: 'object-1', board_id: 'board-1', branch_id: 'branch-1' };
+      const boardObjectsFind = vi.fn(async () => ({
+        data: [entity],
+        total: 7,
+        limit: limit ?? 100,
+        skip,
+      }));
+      const branchesFind = vi.fn();
+      const { app } = makeApp({ boardObjectsFind, branchesFind });
+      const getBoard = registerAndCaptureHandler('agor_boards_get', {
+        app,
+        userId: 'user-1',
+        baseServiceParams,
+      });
+      const parsed = JSON.parse(
+        (
+          await getBoard({
+            boardId: 'board-1',
+            includeEntities: true,
+            entityZoneId: 'zone-review',
+            entityType: 'branch',
+            ...args,
+          })
+        ).content[0].text
+      );
+      expect(boardObjectsFind).toHaveBeenCalledExactlyOnceWith({
+        query: {
           board_id: 'board-1',
-          branch_id: 'branch-0',
-          entity_type: 'branch',
-          position: { x: 0, y: 0 },
           zone_id: 'zone-review',
-          created_at: '2026-06-01T00:00:00.000Z',
-        },
-        {
-          object_id: 'obj-branch-1',
-          board_id: 'board-1',
-          branch_id: 'branch-1',
           entity_type: 'branch',
-          position: { x: 10, y: 20 },
-          zone_id: 'zone-review',
-          created_at: '2026-06-01T00:00:00.000Z',
+          exclude_archived_branches: args.includeArchived !== true,
+          ...query,
         },
-        {
-          object_id: 'obj-branch-2',
-          board_id: 'board-1',
-          branch_id: 'branch-2',
-          entity_type: 'branch',
-          position: { x: 30, y: 40 },
-          zone_id: 'zone-review',
-          created_at: '2026-06-01T00:00:00.000Z',
-        },
-      ],
-      total: 3,
-      limit: 100,
-      skip: 0,
-    }));
-    const branchesFind = vi.fn(async () => [
-      { branch_id: 'branch-0', archived: false },
-      { branch_id: 'branch-1', archived: false },
-      { branch_id: 'branch-2', archived: false },
-    ]);
-    const { app } = makeApp({ boardObjectsFind, branchesFind });
-    const getBoard = registerAndCaptureHandler('agor_boards_get', {
-      app,
-      userId: 'user-1',
-      baseServiceParams,
-    });
-
-    const result = await getBoard({
-      boardId: 'board-1',
-      includeEntities: true,
-      entityZoneId: 'zone-review',
-      entityType: 'branch',
-      entitiesLimit: 1,
-      entitiesSkip: 1,
-    });
-    const parsed = JSON.parse(result.content[0].text);
-
-    expect(boardObjectsFind).toHaveBeenCalledWith({
-      query: {
-        board_id: 'board-1',
-        zone_id: 'zone-review',
-        entity_type: 'branch',
-      },
-      ...baseServiceParams,
-    });
-    expect(branchesFind).toHaveBeenCalledWith({
-      query: {
-        branch_id: { $in: ['branch-0', 'branch-1', 'branch-2'] },
-        archived: false,
-      },
-      paginate: false,
-      ...baseServiceParams,
-    });
-    expect(parsed.entities).toHaveLength(1);
-    expect(parsed.entities[0].branch_id).toBe('branch-1');
-    expect(parsed.entities_pagination).toEqual({ total: 3, limit: 1, skip: 1 });
-  });
-
-  it('excludes archived branch entities by default while preserving card entities', async () => {
-    const boardObjectsFind = vi.fn(async () => ({
-      data: [
-        {
-          object_id: 'obj-branch-1',
-          board_id: 'board-1',
-          branch_id: 'branch-1',
-          entity_type: 'branch',
-          position: { x: 10, y: 20 },
-          created_at: '2026-06-01T00:00:00.000Z',
-        },
-        {
-          object_id: 'obj-branch-2',
-          board_id: 'board-1',
-          branch_id: 'branch-2',
-          entity_type: 'branch',
-          position: { x: 30, y: 40 },
-          created_at: '2026-06-01T00:00:00.000Z',
-        },
-        {
-          object_id: 'obj-card-1',
-          board_id: 'board-1',
-          card_id: 'card-1',
-          entity_type: 'card',
-          position: { x: 50, y: 60 },
-          created_at: '2026-06-01T00:00:00.000Z',
-        },
-      ],
-      total: 3,
-      limit: 100,
-      skip: 0,
-    }));
-    const branchesFind = vi.fn(async () => [{ branch_id: 'branch-1', archived: false }]);
-    const { app } = makeApp({ boardObjectsFind, branchesFind });
-    const getBoard = registerAndCaptureHandler('agor_boards_get', {
-      app,
-      userId: 'user-1',
-      baseServiceParams,
-    });
-
-    const result = await getBoard({ boardId: 'board-1', includeEntities: true });
-    const parsed = JSON.parse(result.content[0].text);
-
-    expect(boardObjectsFind).toHaveBeenCalledWith({
-      query: { board_id: 'board-1' },
-      ...baseServiceParams,
-    });
-    expect(parsed.entities.map((entity: { object_id: string }) => entity.object_id)).toEqual([
-      'obj-branch-1',
-      'obj-card-1',
-    ]);
-    expect(parsed.entities_pagination).toEqual({ total: 2, limit: null, skip: 0 });
-  });
-
-  it('includes archived branch entities when includeArchived=true', async () => {
-    const boardObjectsFind = vi.fn(async () => ({
-      data: [
-        {
-          object_id: 'obj-branch-1',
-          board_id: 'board-1',
-          branch_id: 'branch-1',
-          entity_type: 'branch',
-          position: { x: 10, y: 20 },
-          created_at: '2026-06-01T00:00:00.000Z',
-        },
-      ],
-      total: 1,
-      limit: 100,
-      skip: 0,
-    }));
-    const branchesFind = vi.fn(async () => []);
-    const { app } = makeApp({ boardObjectsFind, branchesFind });
-    const getBoard = registerAndCaptureHandler('agor_boards_get', {
-      app,
-      userId: 'user-1',
-      baseServiceParams,
-    });
-
-    const result = await getBoard({
-      boardId: 'board-1',
-      includeEntities: true,
-      includeArchived: true,
-    });
-    const parsed = JSON.parse(result.content[0].text);
-
-    expect(branchesFind).not.toHaveBeenCalled();
-    expect(parsed.entities).toHaveLength(1);
-    expect(parsed.entities[0].branch_id).toBe('branch-1');
-    expect(parsed.entities_pagination).toEqual({ total: 1, limit: null, skip: 0 });
-  });
-
-  it('reports null pagination limit when only entitiesSkip is provided', async () => {
-    const boardObjectsFind = vi.fn(async () => ({
-      data: [
-        {
-          object_id: 'obj-branch-0',
-          board_id: 'board-1',
-          branch_id: 'branch-0',
-          entity_type: 'branch',
-          position: { x: 0, y: 0 },
-          created_at: '2026-06-01T00:00:00.000Z',
-        },
-        {
-          object_id: 'obj-branch-1',
-          board_id: 'board-1',
-          branch_id: 'branch-1',
-          entity_type: 'branch',
-          position: { x: 10, y: 20 },
-          created_at: '2026-06-01T00:00:00.000Z',
-        },
-      ],
-      total: 2,
-      limit: 100,
-      skip: 0,
-    }));
-    const { app } = makeApp({ boardObjectsFind });
-    const getBoard = registerAndCaptureHandler('agor_boards_get', {
-      app,
-      userId: 'user-1',
-      baseServiceParams,
-    });
-
-    const result = await getBoard({
-      boardId: 'board-1',
-      includeEntities: true,
-      entitiesSkip: 1,
-    });
-    const parsed = JSON.parse(result.content[0].text);
-
-    expect(parsed.entities).toHaveLength(1);
-    expect(parsed.entities[0].branch_id).toBe('branch-1');
-    expect(parsed.entities_pagination).toEqual({ total: 2, limit: null, skip: 1 });
-  });
+        ...baseServiceParams,
+      });
+      expect(branchesFind).not.toHaveBeenCalled();
+      expect(parsed.entities).toEqual([entity]);
+      expect(parsed.entities_pagination).toEqual({ total: 7, limit, skip });
+    }
+  );
 
   it('validates entity pagination input constraints in the MCP schema', () => {
     const { app } = makeApp();

--- a/apps/agor-daemon/src/mcp/tools/boards.ts
+++ b/apps/agor-daemon/src/mcp/tools/boards.ts
@@ -1,10 +1,5 @@
-import type {
-  Board,
-  BoardEntityType,
-  BoardObject,
-  BoardObjectType,
-  BranchID,
-} from '@agor/core/types';
+import { PAGINATION } from '@agor/core/config';
+import type { Board, BoardEntityType, BoardObject, BoardObjectType } from '@agor/core/types';
 import { BRANCH_PERMISSION_LEVELS } from '@agor/core/types';
 import type { McpServer } from '@modelcontextprotocol/server';
 import { z } from 'zod';
@@ -91,26 +86,14 @@ export function registerBoardTools(server: McpServer, ctx: McpContext): void {
           ),
         entitiesLimit: mcpOptionalPositiveInt(
           'entitiesLimit',
-          'When includeEntities=true, maximum number of positioned entities to return. Omit to preserve legacy behavior returning all matched entities.'
-        )
-          .refine(
-            (value) => value === undefined || value <= 10000,
-            'entitiesLimit must be less than or equal to 10000.'
-          )
-          .describe(
-            'When includeEntities=true, maximum number of positioned entities to return. Omit to preserve legacy behavior returning all matched entities.'
-          ),
+          'When includeEntities=true, maximum number of positioned entities to return. Omit to preserve legacy behavior returning all matched entities.',
+          PAGINATION.MAX_LIMIT
+        ),
         entitiesSkip: mcpOptionalNonNegativeInt(
           'entitiesSkip',
-          'When includeEntities=true, number of matched positioned entities to skip for pagination (default: 0).'
-        )
-          .refine(
-            (value) => value === undefined || value <= 10000,
-            'entitiesSkip must be less than or equal to 10000.'
-          )
-          .describe(
-            'When includeEntities=true, number of matched positioned entities to skip for pagination (default: 0).'
-          ),
+          'When includeEntities=true, number of matched positioned entities to skip for pagination (default: 0).',
+          PAGINATION.MAX_SKIP
+        ),
       }),
     },
     async (args) => {
@@ -130,50 +113,18 @@ export function registerBoardTools(server: McpServer, ctx: McpContext): void {
         const entityZoneId = coerceString(args.entityZoneId);
         if (entityZoneId) entityQuery.zone_id = entityZoneId;
         if (args.entityType) entityQuery.entity_type = args.entityType as BoardEntityType;
+        // Filter before count/page in SQL; never hydrate all entities and then
+        // issue a second branches.find (or one branches.get per entity).
+        entityQuery.exclude_archived_branches = args.includeArchived !== true;
+        if (args.entitiesLimit !== undefined) entityQuery.$limit = args.entitiesLimit;
+        if (args.entitiesSkip !== undefined) entityQuery.$skip = args.entitiesSkip;
 
         const boardObjectsResult = await ctx.app
           .service('board-objects')
           .find({ query: entityQuery, ...ctx.baseServiceParams });
-        const matchedEntities = (
-          boardObjectsResult as { data: import('@agor/core/types').BoardEntityObject[] }
-        ).data;
-        let visibleEntities = matchedEntities;
-
-        if (args.includeArchived !== true) {
-          const branchIds = matchedEntities
-            .map((entity) => entity.branch_id)
-            .filter((branchId): branchId is BranchID => typeof branchId === 'string');
-
-          if (branchIds.length > 0) {
-            const activeBranchesResult = await ctx.app.service('branches').find({
-              query: {
-                branch_id: { $in: Array.from(new Set(branchIds)) },
-                archived: false,
-              },
-              paginate: false,
-              ...ctx.baseServiceParams,
-            });
-            const activeBranches = Array.isArray(activeBranchesResult)
-              ? activeBranchesResult
-              : (activeBranchesResult as { data: Array<{ branch_id: string }> }).data;
-            const activeBranchIds = new Set(activeBranches.map((branch) => branch.branch_id));
-
-            visibleEntities = matchedEntities.filter(
-              (entity) => !entity.branch_id || activeBranchIds.has(entity.branch_id)
-            );
-          }
-        }
-
-        const total = visibleEntities.length;
+        const { data: entities, total } = boardObjectsResult;
         const skip = args.entitiesSkip ?? 0;
         const limit = args.entitiesLimit ?? null;
-        const entities =
-          args.entitiesLimit !== undefined || args.entitiesSkip !== undefined
-            ? visibleEntities.slice(
-                skip,
-                args.entitiesLimit === undefined ? undefined : skip + args.entitiesLimit
-              )
-            : visibleEntities;
 
         return textResult({
           ...board,
@@ -196,7 +147,7 @@ export function registerBoardTools(server: McpServer, ctx: McpContext): void {
       annotations: { readOnlyHint: true },
       inputSchema: z.object({
         limit: mcpListLimit(),
-        offset: mcpOffset(),
+        offset: mcpOffset(0, PAGINATION.MAX_SKIP),
         includeArchived: z
           .boolean()
           .optional()

--- a/apps/agor-daemon/src/mcp/tools/branches.ts
+++ b/apps/agor-daemon/src/mcp/tools/branches.ts
@@ -1,3 +1,4 @@
+import { PAGINATION } from '@agor/core/config';
 import { BranchRepository, CapabilityPolicyRepository, shortId } from '@agor/core/db';
 import type {
   Board,
@@ -335,7 +336,7 @@ export function registerBranchTools(server: McpServer, ctx: McpContext): void {
       inputSchema: z.object({
         repoId: mcpOptionalId('repoId', 'Repository', 'Repository ID to filter by'),
         limit: mcpLimit(BRANCH_LIST_DEFAULT_LIMIT, BRANCH_LIST_MAX_LIMIT),
-        offset: mcpOffset(0),
+        offset: mcpOffset(0, PAGINATION.MAX_SKIP),
         includeArchived: z
           .boolean()
           .optional()

--- a/apps/agor-daemon/src/mcp/tools/schedules.ts
+++ b/apps/agor-daemon/src/mcp/tools/schedules.ts
@@ -86,7 +86,7 @@ const agenticToolConfigSchema = z
     }
   })
   .describe(
-    'Agentic-tool configuration. MCP capability selection is configured separately on the schedule.'
+    'Agentic-tool configuration. Do not combine preset_id, configuration_reference, or inline fields (permission_mode, model_config, context_files). MCP capability selection is configured separately on the schedule.'
   );
 
 export function registerScheduleTools(server: McpServer, ctx: McpContext): void {
@@ -202,7 +202,7 @@ export function registerScheduleTools(server: McpServer, ctx: McpContext): void 
             .describe("'local' uses `timezone`; 'utc' fires in UTC."),
           timezone: mcpOptionalString(
             'timezone',
-            "IANA timezone (required when timezone_mode='local'), e.g. 'America/Los_Angeles'"
+            "IANA timezone (required when timezone_mode='local'; omit when timezone_mode='utc'), e.g. 'America/Los_Angeles'"
           ),
           prompt: mcpRequiredString('prompt', 'Handlebars prompt template'),
           agentic_tool_config: agenticToolConfigSchema,

--- a/apps/agor-daemon/src/mcp/tools/search.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/search.test.ts
@@ -169,10 +169,41 @@ describe('agor_execute_tool', () => {
     const parsed = JSON.parse(result.content[0].text);
 
     expect(result.isError).toBe(true);
-    expect(parsed.error).toMatch(/unknown argument "definitelyNotAParam"/);
+    expect(parsed.error).toMatch(/unknown argument/);
+    expect(parsed.code).toBe('invalid_tool_arguments');
     expect(parsed.error).toMatch(/agor_get_tool_details/);
     expect(targetHandler).not.toHaveBeenCalled();
   });
+
+  it.each([
+    { limit: 'sensitive-invalid-value' },
+    { branchId: { secret: 'sensitive-invalid-value' } },
+  ])('returns safe field/code guidance for malformed agent arguments', async (arguments_) => {
+    const { handler, targetHandler } = captureExecuteTool();
+    const result = await handler({ tool_name: 'agor_sessions_list', arguments: arguments_ });
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed).toMatchObject({
+      code: 'invalid_tool_arguments',
+      validation_stage: 'tool_input',
+      retryable: false,
+      issues: [{ field: Object.keys(arguments_)[0], code: 'invalid_type' }],
+    });
+    expect(result.content[0].text).not.toContain('sensitive-invalid-value');
+    expect(targetHandler).not.toHaveBeenCalled();
+  });
+
+  it.each(['not-json', '[]', null, 5])(
+    'rejects malformed proxy arguments without executing the tool',
+    async (arguments_) => {
+      const { handler, targetHandler } = captureExecuteTool();
+      const result = await handler({ tool_name: 'agor_sessions_list', arguments: arguments_ });
+      expect(JSON.parse(result.content[0].text)).toMatchObject({
+        code: 'invalid_tool_arguments',
+        retryable: false,
+      });
+      expect(targetHandler).not.toHaveBeenCalled();
+    }
+  );
 });
 
 describe('agor_get_tool_details', () => {

--- a/apps/agor-daemon/src/mcp/tools/search.ts
+++ b/apps/agor-daemon/src/mcp/tools/search.ts
@@ -5,6 +5,11 @@ import { ToolDispatcher } from '../register-tool-proxy.js';
 import { mcpPositiveIntWithDefault, mcpRequiredString } from '../schema.js';
 import { coerceJsonRecord, textResult } from '../server.js';
 import { ToolRegistry } from '../tool-registry.js';
+import {
+  inputValidationIssues,
+  McpInputValidationError,
+  mcpValidationFailure,
+} from '../validation-errors.js';
 
 const DISCOVERY_HINT =
   'Discover tool names with agor_search_tools (call with no args for domains, or with { "query": "sessions" }). Get an exact schema with agor_get_tool_details({ "tool_name": "..." }).';
@@ -30,8 +35,16 @@ function resolveToolArgs(
 ): Record<string, unknown> {
   // Defense-in-depth: coerce stringified arguments even if Zod preprocess
   // already handled it (e.g. if the SDK bypasses schema validation).
-  let toolArgs: Record<string, unknown> =
-    (coerceJsonRecord(proxyArgs.arguments) as Record<string, unknown>) ?? {};
+  const nested = coerceJsonRecord(proxyArgs.arguments);
+  if (
+    nested !== undefined &&
+    (nested === null || typeof nested !== 'object' || Array.isArray(nested))
+  ) {
+    throw new McpInputValidationError(
+      'Invalid arguments: expected an object (or a JSON-encoded object).'
+    );
+  }
+  let toolArgs: Record<string, unknown> = (nested as Record<string, unknown>) ?? {};
 
   if (Object.keys(toolArgs).length === 0) {
     // No nested arguments — check for flattened params at top level
@@ -55,20 +68,21 @@ function resolveToolArgs(
       const parsedArgs = parseResult.data as Record<string, unknown>;
       const unknownArgs = Object.keys(toolArgs).filter((key) => !Object.hasOwn(parsedArgs, key));
       if (unknownArgs.length > 0) {
-        throw new Error(
-          `Invalid arguments for tool ${toolName}: unknown argument${unknownArgs.length === 1 ? '' : 's'} ${unknownArgs.map((arg) => `"${arg}"`).join(', ')}. ` +
-            `Call agor_get_tool_details({ "tool_name": "${toolName}" }) for the exact schema.`
+        throw new McpInputValidationError(
+          `Invalid arguments for tool ${toolName}: unknown argument${unknownArgs.length === 1 ? '' : 's'}. ` +
+            `Call agor_get_tool_details({ "tool_name": "${toolName}" }) for the exact schema.`,
+          [{ field: 'arguments', code: 'unrecognized_keys' }]
         );
       }
       return parsedArgs;
     }
     // Surface validation errors instead of letting them manifest as
     // confusing downstream failures (e.g. "Board not found: undefined").
-    const errorDetail =
-      parseResult.error && typeof parseResult.error === 'object' && 'message' in parseResult.error
-        ? (parseResult.error as { message: string }).message
-        : JSON.stringify(parseResult.error);
-    throw new Error(`Invalid arguments for tool ${toolName}: ${errorDetail}`);
+    const issues = inputValidationIssues(parseResult.error, tool.inputSchema);
+    throw new McpInputValidationError(
+      `Invalid arguments for tool ${toolName}: ${issues.map(({ field, code }) => `${field} (${code})`).join(', ') || 'schema validation failed'}.`,
+      issues
+    );
   }
 
   return toolArgs;
@@ -272,6 +286,8 @@ export function registerSearchTools(
         const result = await tool.handler(toolArgs, requestContext);
         return result as { content: Array<{ type: 'text'; text: string }> };
       } catch (error) {
+        const failure = mcpValidationFailure(error, toolName ?? 'agor_execute_tool');
+        if (failure) return failure;
         return {
           content: [
             {

--- a/apps/agor-daemon/src/mcp/validation-errors.test.ts
+++ b/apps/agor-daemon/src/mcp/validation-errors.test.ts
@@ -1,0 +1,53 @@
+import { BadRequest, Forbidden } from '@agor/core/feathers';
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { inputValidationIssues, mcpValidationFailure } from './validation-errors.js';
+
+describe('MCP validation diagnostics', () => {
+  it('distinguishes downstream validation without attributing it to the caller or exposing raw AJV data', () => {
+    const error = new BadRequest(
+      'validation failed',
+      Array.from({ length: 20 }, () => ({
+        instancePath: '/branch_id/secret-value',
+        keyword: 'type',
+        message: 'secret-value',
+        params: { type: 'secret-value' },
+        data: 'secret-value',
+      }))
+    );
+    const result = mcpValidationFailure(error, 'agor_boards_get')!;
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content[0].text)).toMatchObject({
+      error: 'validation failed',
+      code: 'service_validation_failed',
+      validation_stage: 'service',
+      retryable: false,
+      issues: Array(8).fill({ field: 'branch_id', code: 'type' }),
+    });
+    expect(result.content[0].text).not.toContain('secret-value');
+  });
+  it('does not expose dynamic field names, arbitrary keywords, or input values', () => {
+    const result = mcpValidationFailure(
+      new BadRequest('validation failed', [
+        { instancePath: '/secret-field', keyword: 'secret-keyword' },
+        null,
+      ]),
+      'agor_boards_get'
+    )!;
+    expect(result.content[0].text).not.toContain('secret-');
+    const schema = z.object({ settings: z.record(z.string(), z.number()) });
+    const parsed = schema.safeParse({ settings: { 'secret-key': 'secret-value' } });
+    expect(inputValidationIssues(parsed.error, schema)).toEqual([
+      { field: 'settings', code: 'invalid_type' },
+    ]);
+  });
+  it('does not translate authorization or unrelated errors into validation failures', () => {
+    for (const error of [
+      new Forbidden('denied'),
+      new BadRequest('other'),
+      new Error('database unavailable'),
+    ]) {
+      expect(mcpValidationFailure(error, 'agor_boards_get')).toBeUndefined();
+    }
+  });
+});

--- a/apps/agor-daemon/src/mcp/validation-errors.ts
+++ b/apps/agor-daemon/src/mcp/validation-errors.ts
@@ -1,0 +1,110 @@
+import { BadRequest } from '@agor/core/feathers';
+
+const MAX_ISSUES = 8;
+const QUERY_FIELDS = new Set([
+  'board_id',
+  'branch_id',
+  'repo_id',
+  'card_id',
+  'zone_id',
+  'entity_type',
+  'exclude_archived_branches',
+  'archived',
+  'lean',
+  'name',
+  'slug',
+  'created_by',
+  'created_at',
+  'updated_at',
+  '$limit',
+  '$skip',
+  '$sort',
+  '$select',
+]);
+const VALIDATION_CODES = new Set([
+  'type',
+  'format',
+  'pattern',
+  'required',
+  'additionalProperties',
+  'anyOf',
+  'enum',
+  'minimum',
+  'maximum',
+  'minLength',
+  'maxLength',
+  'maxItems',
+  'uniqueItems',
+  'invalid_type',
+  'invalid_value',
+  'invalid_format',
+  'too_small',
+  'too_big',
+  'unrecognized_keys',
+  'invalid_union',
+  'custom',
+]);
+
+interface ValidationIssue {
+  field: string;
+  code: string;
+}
+
+/** Only schema-known top-level fields and fixed codes; never values or dynamic record keys. */
+export function inputValidationIssues(error: unknown, schema: unknown): ValidationIssue[] {
+  const shape = schema && typeof schema === 'object' && 'shape' in schema ? schema.shape : {};
+  const fields = new Set(Object.keys(shape ?? {}));
+  const issues = error && typeof error === 'object' && 'issues' in error ? error.issues : [];
+  if (!Array.isArray(issues)) return [];
+  return issues.slice(0, MAX_ISSUES).map((issue) => ({
+    field: fields.has(issue.path?.[0]) ? issue.path[0] : 'arguments',
+    code: VALIDATION_CODES.has(issue.code) ? issue.code : 'invalid',
+  }));
+}
+
+export class McpInputValidationError extends Error {
+  constructor(
+    message: string,
+    readonly issues: ValidationIssue[] = []
+  ) {
+    super(message);
+  }
+}
+
+/** Preserve the old error/tool fields while identifying where validation failed. */
+export function mcpValidationFailure(error: unknown, tool: string) {
+  const inputError = error instanceof McpInputValidationError;
+  const serviceError = error instanceof BadRequest && error.message === 'validation failed';
+  if (!inputError && !serviceError) return undefined;
+  const issues: ValidationIssue[] = inputError
+    ? error.issues
+    : Array.isArray(error.data)
+      ? error.data.slice(0, MAX_ISSUES).map((issue) => {
+          const field =
+            typeof issue?.instancePath === 'string' ? issue.instancePath.split('/')[1] : '';
+          return {
+            field: QUERY_FIELDS.has(field) ? field : 'query',
+            code: VALIDATION_CODES.has(issue?.keyword) ? issue.keyword : 'invalid',
+          };
+        })
+      : [];
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify({
+          error: error.message,
+          tool,
+          code: inputError ? 'invalid_tool_arguments' : 'service_validation_failed',
+          validation_stage: inputError ? 'tool_input' : 'service',
+          issues,
+          retryable: false,
+          hint: inputError
+            ? 'Correct the indicated fields using agor_get_tool_details before retrying.'
+            : 'A downstream service rejected the request. Check the indicated fields against agor_get_tool_details; if your payload matches, report a tool/service schema mismatch. Do not retry unchanged.',
+        }),
+      },
+    ],
+    isError: true,
+  };
+}

--- a/apps/agor-daemon/src/register-hooks.board-entities.postgres.test.ts
+++ b/apps/agor-daemon/src/register-hooks.board-entities.postgres.test.ts
@@ -1,0 +1,152 @@
+import { createRestClient } from '@agor/core/api';
+import {
+  BranchRepository,
+  createDatabase,
+  createTenantScopedDatabaseProxy,
+  type Database,
+  executeRaw,
+  initializeDatabase,
+  runWithTenantDatabaseScope,
+  sql,
+} from '@agor/core/db';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { seedBoardEntities } from '../test/board-entity-fixture.js';
+import { boardMetadataTestApp } from '../test/board-metadata-app.js';
+import type { RegisterHooksContext } from './register-hooks.js';
+
+const postgresUrl = process.env.AGOR_TEST_POSTGRES_URL;
+describe.skipIf(!postgresUrl || process.env.AGOR_DB_DIALECT !== 'postgresql')(
+  'board entity and branch zone pushdown (PostgreSQL/RLS)',
+  () => {
+    let rawDb: Database;
+    beforeAll(async () => {
+      rawDb = createDatabase({ dialect: 'postgresql', url: postgresUrl! });
+      await initializeDatabase(rawDb);
+      const result = await executeRaw(
+        rawDb,
+        sql`SELECT rolsuper, rolbypassrls FROM pg_roles WHERE rolname = current_user`
+      );
+      const rows = Array.isArray(result) ? result : (result as { rows: unknown[] }).rows;
+      expect(rows[0]).toMatchObject({ rolsuper: false, rolbypassrls: false });
+    }, 60000);
+    afterAll(async () => {
+      await (rawDb as Database & { $client: { end: () => Promise<void> } }).$client.end();
+    });
+
+    it('applies archive/zone/RBAC before total and page, including cross-tenant negative reads by an admin', async () => {
+      const db = createTenantScopedDatabaseProxy(rawDb);
+      const a = await runWithTenantDatabaseScope(db, 'entities-a', (scoped) =>
+        seedBoardEntities(scoped)
+      );
+      const b = await runWithTenantDatabaseScope(db, 'entities-b', (scoped) =>
+        seedBoardEntities(scoped, 'admin')
+      );
+      const server = await boardMetadataTestApp(db, {
+        database: { dialect: 'postgresql' },
+        multi_tenancy: {
+          mode: 'required_from_auth',
+          auth_claim: 'tenant_id',
+          filesystem_isolation_enabled: true,
+        },
+        execution: {},
+      } as RegisterHooksContext['config']);
+      try {
+        for (const [fixture, tenantId, foreign] of [
+          [a, 'entities-a', b],
+          [b, 'entities-b', a],
+        ] as const) {
+          const client = await createRestClient(server.url);
+          await client.authenticate({
+            strategy: 'jwt',
+            accessToken: server.headers(fixture.owner.user_id, tenantId).authorization.slice(7),
+          });
+          const query = {
+            board_id: fixture.board.board_id,
+            zone_id: 'zone-review',
+            exclude_archived_branches: true,
+            $limit: 1,
+            $skip: 1,
+          };
+          expect(
+            await client.service('branches').find({
+              query: {
+                board_id: fixture.board.board_id,
+                zone_id: 'zone-review',
+                archived: false,
+                $limit: 1,
+                $skip: 1,
+              },
+            })
+          ).toMatchObject({ total: 2, data: [{ branch_id: fixture.entities[2].branch_id }] });
+          expect(
+            await client.service('board-objects').find({
+              query: {
+                board_id: fixture.board.board_id,
+                zone_id: 'zone-review',
+                exclude_archived_branches: true,
+                $skip: 2,
+              },
+            })
+          ).toMatchObject({ total: 3, data: [{ object_id: fixture.cardObject.object_id }] });
+          expect(await client.service('board-objects').find({ query })).toMatchObject({
+            total: 3,
+            data: [{ object_id: fixture.entities[2].object_id }],
+            limit: 1,
+            skip: 1,
+          });
+          expect(
+            await client
+              .service('board-objects')
+              .find({ query: { ...query, $skip: 0, $limit: 10 } })
+          ).toMatchObject({
+            total: 3,
+            data: [
+              { object_id: fixture.entities[1].object_id },
+              { object_id: fixture.entities[2].object_id },
+              { object_id: fixture.cardObject.object_id },
+            ],
+          });
+          expect(
+            await client
+              .service('board-objects')
+              .find({ query: { ...query, exclude_archived_branches: false, $skip: 0 } })
+          ).toMatchObject({ total: 4, data: [{ object_id: fixture.entities[0].object_id }] });
+          expect(
+            await client.service('board-objects').find({ query: { ...query, $skip: 10 } })
+          ).toMatchObject({ total: 3, data: [] });
+          expect(
+            await client
+              .service('board-objects')
+              .find({ query: { ...query, board_id: foreign.board.board_id, $skip: 0 } })
+          ).toMatchObject({ total: 0, data: [] });
+          expect(
+            await client
+              .service('board-objects')
+              .find({ query: { ...query, branch_id: foreign.entities[1].branch_id, $skip: 0 } })
+          ).toMatchObject({ total: 0, data: [] });
+          await runWithTenantDatabaseScope(db, tenantId, async (scoped) => {
+            const repo = new BranchRepository(scoped);
+            const page = await repo.findPage({
+              zone_id: 'zone-review',
+              archived: false,
+              visibleToUserId: fixture.owner.user_id,
+              limit: 1,
+              offset: 1,
+            });
+            expect(page.total).toBe(2);
+            expect(page.data[0].branch_id).toBe(fixture.entities[2].branch_id);
+            expect(
+              await repo.findPage({
+                zone_id: 'zone-review',
+                board_id: foreign.board.board_id,
+                visibleToUserId: fixture.owner.user_id,
+              })
+            ).toEqual({ total: 0, data: [] });
+          });
+        }
+      } finally {
+        await server.close();
+      }
+    }, 30000);
+  }
+);

--- a/apps/agor-daemon/src/register-hooks.board-entities.test.ts
+++ b/apps/agor-daemon/src/register-hooks.board-entities.test.ts
@@ -2,6 +2,7 @@ import { createClient, createRestClient } from '@agor/core/api';
 import {
   BoardObjectRepository,
   BranchRepository,
+  CardRepository,
   createTenantScopedDatabaseProxy,
 } from '@agor/core/db';
 import type { McpServer } from '@modelcontextprotocol/server';
@@ -159,6 +160,39 @@ dbTest(
       expect(branchPage.data[0].branch_id).toBe(fixture.entities[2].branch_id);
       expect(execute).toHaveBeenCalledTimes(2);
       execute.mockRestore();
+
+      // Exceed the default 100-row page even after skipping the original three
+      // visible entities: omitted limits must still return the entire tail.
+      const cards = new CardRepository(db);
+      const addedObjects = [];
+      for (let index = 0; index < 105; index++) {
+        const card = await cards.create({
+          board_id: fixture.board.board_id,
+          title: `Unlimited-read fixture ${index}`,
+          created_by: fixture.owner.user_id,
+        });
+        addedObjects.push(
+          await objects.create({
+            board_id: fixture.board.board_id,
+            card_id: card.card_id,
+            position: { x: index, y: 1 },
+            zone_id: 'zone-review',
+          })
+        );
+      }
+      const unlimited = await getBoard({});
+      expect(unlimited.entities_pagination).toEqual({ total: 108, limit: null, skip: 0 });
+      expect(unlimited.entities).toHaveLength(108);
+      expect(unlimited.entities).toEqual(
+        expect.arrayContaining(
+          addedObjects.map(({ object_id }) => expect.objectContaining({ object_id }))
+        )
+      );
+      const tail = await getBoard({ entitiesSkip: 3 });
+      expect(tail.entities_pagination).toEqual({ total: 108, limit: null, skip: 3 });
+      expect(tail.entities).toHaveLength(105);
+      expect(tail.entities).toEqual(unlimited.entities.slice(3));
+      expect(findBranches).not.toHaveBeenCalled();
     } finally {
       socket.io.disconnect();
       await server.close();

--- a/apps/agor-daemon/src/register-hooks.board-entities.test.ts
+++ b/apps/agor-daemon/src/register-hooks.board-entities.test.ts
@@ -1,0 +1,168 @@
+import { createClient, createRestClient } from '@agor/core/api';
+import {
+  BoardObjectRepository,
+  BranchRepository,
+  createTenantScopedDatabaseProxy,
+} from '@agor/core/db';
+import type { McpServer } from '@modelcontextprotocol/server';
+import { expect, vi } from 'vitest';
+import { dbTest } from '../../../packages/core/src/db/test-helpers.js';
+import { seedBoardEntities } from '../test/board-entity-fixture.js';
+import { boardMetadataTestApp } from '../test/board-metadata-app.js';
+import { ToolDispatcher, toolDispatcherProxy } from './mcp/register-tool-proxy.js';
+import type { McpContext } from './mcp/server.js';
+import { tenantScopedToolProxy } from './mcp/tenant-scope.js';
+import { registerBoardTools } from './mcp/tools/boards.js';
+import type { RegisterHooksContext } from './register-hooks.js';
+
+dbTest(
+  'board entity archive/count/page pushdown preserves real transport authorization and MCP semantics',
+  async ({ db }) => {
+    const fixture = await seedBoardEntities(db);
+    const server = await boardMetadataTestApp(
+      createTenantScopedDatabaseProxy(db),
+      {
+        database: { dialect: 'sqlite' },
+        multi_tenancy: { mode: 'static', static_tenant_id: 'entity-audit' },
+        execution: {},
+      } as RegisterHooksContext['config'],
+      true
+    );
+    const accessToken = server.headers(fixture.owner.user_id).authorization.slice(7);
+    const rest = await createRestClient(server.url);
+    const socket = createClient(server.url, true, {
+      socketAuthentication: { accessToken },
+      ackTimeout: 2000,
+    });
+    const query = {
+      board_id: fixture.board.board_id,
+      zone_id: 'zone-review',
+      exclude_archived_branches: true,
+      $limit: 1,
+      $skip: 1,
+    };
+    try {
+      await rest.authenticate({ strategy: 'jwt', accessToken });
+      for (const client of [rest, socket]) {
+        const branchPage = await client.service('branches').find({
+          query: {
+            board_id: fixture.board.board_id,
+            zone_id: 'zone-review',
+            archived: false,
+            $limit: 1,
+            $skip: 1,
+          },
+        });
+        expect(branchPage).toMatchObject({
+          total: 2,
+          limit: 1,
+          skip: 1,
+          data: [{ branch_id: fixture.entities[2].branch_id }],
+        });
+        expect(await client.service('board-objects').find({ query })).toMatchObject({
+          total: 3,
+          limit: 1,
+          skip: 1,
+          data: [{ object_id: fixture.entities[2].object_id }],
+        });
+        expect(
+          await client.service('board-objects').find({ query: { ...query, $skip: 9 } })
+        ).toMatchObject({ total: 3, data: [] });
+        expect(
+          await client
+            .service('board-objects')
+            .find({ query: { ...query, $skip: 0, $limit: 10, entity_type: 'branch' } })
+        ).toMatchObject({
+          total: 2,
+          data: [
+            { object_id: fixture.entities[1].object_id },
+            { object_id: fixture.entities[2].object_id },
+          ],
+        });
+        expect(
+          await client
+            .service('board-objects')
+            .find({ query: { ...query, $skip: 0, $limit: 10, entity_type: 'card' } })
+        ).toMatchObject({ total: 1, data: [{ object_id: fixture.cardObject.object_id }] });
+        expect(
+          await client
+            .service('board-objects')
+            .find({ query: { ...query, $skip: 0, $limit: 10, exclude_archived_branches: false } })
+        ).toMatchObject({ total: 4 });
+        await expect(
+          client
+            .service('board-objects')
+            .find({ query: { ...query, exclude_archived_branches: 'invalid' } })
+        ).rejects.toMatchObject({ code: 400 });
+      }
+      const denied = await fetch(
+        `${server.url}/board-objects?board_id=${fixture.board.board_id}&exclude_archived_branches=true`,
+        { headers: server.headers(fixture.other.user_id) }
+      );
+      expect(await denied.json()).toMatchObject({ total: 0, data: [] });
+
+      // Real MCP handler plus registered services. A branch lookup here would
+      // reject on the old scalar-only query validator; no mocked archive filter.
+      const dispatcher = new ToolDispatcher();
+      const stub = { registerTool() {} } as unknown as McpServer;
+      const ctx = {
+        app: server.app,
+        db,
+        userId: fixture.owner.user_id,
+        authenticatedUser: fixture.owner,
+        baseServiceParams: { provider: 'mcp', authentication: { strategy: 'jwt', accessToken } },
+      } as unknown as McpContext;
+      registerBoardTools(tenantScopedToolProxy(toolDispatcherProxy(stub, dispatcher), ctx), ctx);
+      const findBranches = vi.spyOn(server.app.service('branches'), 'find');
+      const getBoard = async (args: Record<string, unknown>) => {
+        const result = (await dispatcher.get('agor_boards_get')!.handler({
+          boardId: fixture.board.board_id,
+          includeEntities: true,
+          entityZoneId: 'zone-review',
+          ...args,
+        })) as { content: { text: string }[] };
+        return JSON.parse(result.content[0].text);
+      };
+      expect(await getBoard({ entitiesLimit: 1, entitiesSkip: 1 })).toMatchObject({
+        entities: [{ object_id: fixture.entities[2].object_id }],
+        entities_pagination: { total: 3, limit: 1, skip: 1 },
+      });
+      expect(await getBoard({ entitiesSkip: 2 })).toMatchObject({
+        entities: [{ object_id: fixture.cardObject.object_id }],
+        entities_pagination: { total: 3, limit: null, skip: 2 },
+      });
+      expect((await getBoard({})).entities).toHaveLength(3);
+      expect((await getBoard({ includeArchived: true })).entities).toHaveLength(4);
+      expect(findBranches).not.toHaveBeenCalled();
+
+      // Two SQL statements regardless of returned row count: COUNT + bounded page.
+      const execute = vi.spyOn(
+        (db as unknown as { $client: { execute: (...args: unknown[]) => unknown } }).$client,
+        'execute'
+      );
+      const objects = new BoardObjectRepository(db);
+      execute.mockClear();
+      await objects.countVisibleToUser(fixture.owner.user_id, query);
+      await objects.findVisibleToUser(fixture.owner.user_id, query, { limit: 1, offset: 1 });
+      expect(execute).toHaveBeenCalledTimes(2);
+      expect(JSON.stringify(execute.mock.calls)).toMatch(/exists/i);
+      execute.mockClear();
+      const branchPage = await new BranchRepository(db).findPage({
+        board_id: fixture.board.board_id,
+        zone_id: 'zone-review',
+        archived: false,
+        visibleToUserId: fixture.owner.user_id,
+        limit: 1,
+        offset: 1,
+      });
+      expect(branchPage.total).toBe(2);
+      expect(branchPage.data[0].branch_id).toBe(fixture.entities[2].branch_id);
+      expect(execute).toHaveBeenCalledTimes(2);
+      execute.mockRestore();
+    } finally {
+      socket.io.disconnect();
+      await server.close();
+    }
+  },
+  30000
+);

--- a/apps/agor-daemon/src/register-hooks.board-mcp.test.ts
+++ b/apps/agor-daemon/src/register-hooks.board-mcp.test.ts
@@ -51,6 +51,43 @@ dbTest(
       return parsed.result as { isError?: boolean; content: { text: string }[] };
     };
     try {
+      // These refinements are not represented by published JSON Schema keywords.
+      // The facade's safe field/code error must lead to usable guidance.
+      for (const toolName of ['agor_schedules_create', 'agor_schedules_patch']) {
+        const details = JSON.parse(
+          (await call('agor_get_tool_details', { tool_name: toolName })).content[0].text
+        );
+        expect(details.tool.inputSchema.properties.agentic_tool_config.description).toMatch(
+          /Do not combine preset_id, configuration_reference, or inline fields \(permission_mode, model_config, context_files\)/
+        );
+      }
+      const getBranch = vi.spyOn(server.app.service('branches'), 'get');
+      const invalidConfig = await call('agor_execute_tool', {
+        tool_name: 'agor_schedules_create',
+        arguments: {
+          branchId: fixture.entities[1].branch_id,
+          name: 'Invalid configuration',
+          cron_expression: '0 9 * * *',
+          timezone_mode: 'utc',
+          prompt: 'private-prompt-value',
+          agentic_tool_config: {
+            agentic_tool: 'codex',
+            preset_id: 'private-preset-value',
+            model_config: { model: 'private-model-value' },
+          },
+        },
+      });
+      expect(invalidConfig.isError).toBe(true);
+      expect(JSON.parse(invalidConfig.content[0].text)).toMatchObject({
+        code: 'invalid_tool_arguments',
+        validation_stage: 'tool_input',
+        issues: [{ field: 'agentic_tool_config', code: 'custom' }],
+        hint: expect.stringContaining('agor_get_tool_details'),
+      });
+      expect(invalidConfig.content[0].text).not.toContain('private-');
+      expect(getBranch).not.toHaveBeenCalled();
+      getBranch.mockRestore();
+
       for (const toolName of ['agor_boards_list', 'agor_branches_list']) {
         const details = JSON.parse(
           (await call('agor_get_tool_details', { tool_name: toolName })).content[0].text

--- a/apps/agor-daemon/src/register-hooks.board-mcp.test.ts
+++ b/apps/agor-daemon/src/register-hooks.board-mcp.test.ts
@@ -1,0 +1,142 @@
+import { createTenantScopedDatabaseProxy, UserApiKeysRepository } from '@agor/core/db';
+import { BadRequest } from '@agor/core/feathers';
+import { expect, vi } from 'vitest';
+import { dbTest } from '../../../packages/core/src/db/test-helpers.js';
+import { seedBoardEntities } from '../test/board-entity-fixture.js';
+import { boardMetadataTestApp } from '../test/board-metadata-app.js';
+import type { RegisterHooksContext } from './register-hooks.js';
+
+dbTest(
+  'real HTTP MCP direct/facade board reads and validation failures',
+  async ({ db }) => {
+    const fixture = await seedBoardEntities(db);
+    const key = await new UserApiKeysRepository(db).create(
+      fixture.owner.user_id,
+      'disposable test'
+    );
+    const server = await boardMetadataTestApp(
+      createTenantScopedDatabaseProxy(db),
+      {
+        database: { dialect: 'sqlite' },
+        multi_tenancy: { mode: 'static', static_tenant_id: 'mcp-entity-audit' },
+        execution: {},
+      } as RegisterHooksContext['config'],
+      false,
+      true
+    );
+    const call = async (name: string, args: Record<string, unknown>) => {
+      const response = await fetch(`${server.url}/mcp`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          accept: 'application/json, text/event-stream',
+          'X-API-Key': key.rawKey,
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/call',
+          params: { name, arguments: args },
+        }),
+      });
+      expect(response.status).toBe(200);
+      const text = await response.text();
+      const parsed = JSON.parse(
+        text
+          .split('\n')
+          .find((line) => line.startsWith('data: '))
+          ?.slice(6) ?? text
+      );
+      expect(parsed.error).toBeUndefined();
+      return parsed.result as { isError?: boolean; content: { text: string }[] };
+    };
+    try {
+      for (const toolName of ['agor_boards_list', 'agor_branches_list']) {
+        const details = JSON.parse(
+          (await call('agor_get_tool_details', { tool_name: toolName })).content[0].text
+        );
+        expect(details.tool.inputSchema.properties.offset.maximum).toBe(10000);
+        const result = await call('agor_execute_tool', {
+          tool_name: toolName,
+          arguments: { offset: 10001 },
+        });
+        expect(result.isError).toBe(true);
+        expect(JSON.parse(result.content[0].text)).toMatchObject({
+          code: 'invalid_tool_arguments',
+          issues: [{ field: 'offset', code: 'too_big' }],
+        });
+      }
+      const boardDetails = JSON.parse(
+        (await call('agor_get_tool_details', { tool_name: 'agor_boards_get' })).content[0].text
+      );
+      for (const field of ['entitiesLimit', 'entitiesSkip'])
+        expect(boardDetails.tool.inputSchema.properties[field].maximum).toBe(10000);
+      for (const facade of [false, true]) {
+        const invoke = (args: Record<string, unknown>) =>
+          facade
+            ? call('agor_execute_tool', { tool_name: 'agor_boards_get', arguments: args })
+            : call('agor_boards_get', args);
+        const args = {
+          boardId: fixture.board.board_id,
+          includeEntities: true,
+          entityZoneId: 'zone-review',
+          entitiesLimit: 1,
+          entitiesSkip: 1,
+        };
+        const result = await invoke(args);
+        expect(result.isError).not.toBe(true);
+        expect(JSON.parse(result.content[0].text)).toMatchObject({
+          entities: [{ object_id: fixture.entities[2].object_id }],
+          entities_pagination: { total: 3, limit: 1, skip: 1 },
+        });
+        const find = vi.spyOn(server.app.service('board-objects'), 'find');
+        const invalid = await invoke({ ...args, entitiesLimit: 'sensitive-invalid-value' });
+        expect(invalid.isError).toBe(true);
+        expect(find).not.toHaveBeenCalled();
+        if (facade) {
+          expect(JSON.parse(invalid.content[0].text)).toMatchObject({
+            code: 'invalid_tool_arguments',
+            validation_stage: 'tool_input',
+            issues: [{ field: 'entitiesLimit', code: 'invalid_type' }],
+          });
+          expect(invalid.content[0].text).not.toContain('sensitive-invalid-value');
+        }
+        find.mockRestore();
+      }
+      // Simulated future service drift: both native and facade calls give the
+      // same bounded diagnostic, not an instruction to blindly change caller IDs.
+      server.app.service('board-objects').hooks({
+        before: {
+          find: [
+            () => {
+              throw new BadRequest('validation failed', [
+                {
+                  instancePath: '/branch_id/private-key',
+                  keyword: 'type',
+                  message: 'private-value',
+                },
+              ]);
+            },
+          ],
+        },
+      });
+      for (const facade of [false, true]) {
+        const args = { boardId: fixture.board.board_id, includeEntities: true };
+        const result = facade
+          ? await call('agor_execute_tool', { tool_name: 'agor_boards_get', arguments: args })
+          : await call('agor_boards_get', args);
+        expect(result.isError).toBe(true);
+        expect(JSON.parse(result.content[0].text)).toMatchObject({
+          code: 'service_validation_failed',
+          validation_stage: 'service',
+          retryable: false,
+          issues: [{ field: 'branch_id', code: 'type' }],
+        });
+        expect(result.content[0].text).not.toContain('private-');
+      }
+    } finally {
+      await server.close();
+    }
+  },
+  30000
+);

--- a/apps/agor-daemon/src/register-hooks.boards-query.postgres.test.ts
+++ b/apps/agor-daemon/src/register-hooks.boards-query.postgres.test.ts
@@ -1,0 +1,130 @@
+import { createClient, createRestClient } from '@agor/core/api';
+import {
+  BoardRepository,
+  createDatabase,
+  createTenantScopedDatabaseProxy,
+  type Database,
+  executeRaw,
+  initializeDatabase,
+  runWithTenantDatabaseScope,
+  sql,
+  UsersRepository,
+} from '@agor/core/db';
+import { PRESENCE_SOCKET_EVENTS } from '@agor/core/types';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { boardMetadataTestApp } from '../test/board-metadata-app.js';
+import { boardPresenceAssociationRoomName } from './realtime/routing.js';
+import type { RegisterHooksContext } from './register-hooks.js';
+
+const postgresUrl = process.env.AGOR_TEST_POSTGRES_URL;
+describe.skipIf(!postgresUrl || process.env.AGOR_DB_DIALECT !== 'postgresql')(
+  'registered board set queries (PostgreSQL/RLS)',
+  () => {
+    let rawDb: Database;
+    beforeAll(async () => {
+      rawDb = createDatabase({ dialect: 'postgresql', url: postgresUrl! });
+      await initializeDatabase(rawDb);
+      const result = await executeRaw(
+        rawDb,
+        sql`SELECT rolsuper, rolbypassrls FROM pg_roles WHERE rolname = current_user`
+      );
+      const rows = Array.isArray(result) ? result : (result as { rows: unknown[] }).rows;
+      expect(rows[0]).toMatchObject({ rolsuper: false, rolbypassrls: false });
+    }, 60000);
+    afterAll(async () => {
+      await (rawDb as Database & { $client: { end: () => Promise<void> } }).$client.end();
+    });
+
+    it('filters foreign IDs from REST/Socket.IO lists and native presence rooms, including for an admin', async () => {
+      const db = createTenantScopedDatabaseProxy(rawDb);
+      const tenantA = 'board-query-tenant-a';
+      const tenantB = 'board-query-tenant-b';
+      const seed = (tenantId: string, role: 'member' | 'admin') =>
+        runWithTenantDatabaseScope(db, tenantId, async (scoped) => {
+          const user = await new UsersRepository(scoped).create({
+            email: `${role}@example.test`,
+            role,
+          });
+          const board = await new BoardRepository(scoped).create({
+            name: 'Owned board',
+            created_by: user.user_id,
+            access_mode: 'private',
+          });
+          return { user, board };
+        });
+      const a = await seed(tenantA, 'member');
+      const b = await seed(tenantB, 'admin');
+      const server = await boardMetadataTestApp(
+        db,
+        {
+          database: { dialect: 'postgresql' },
+          multi_tenancy: {
+            mode: 'required_from_auth',
+            auth_claim: 'tenant_id',
+            filesystem_isolation_enabled: true,
+          },
+          execution: {},
+        } as RegisterHooksContext['config'],
+        true
+      );
+      const clients: ReturnType<typeof createClient>[] = [];
+      try {
+        const ids = [a.board.board_id, b.board.board_id];
+        for (const [fixture, tenantId, foreign] of [
+          [a, tenantA, b],
+          [b, tenantB, a],
+        ] as const) {
+          const accessToken = server.headers(fixture.user.user_id, tenantId).authorization.slice(7);
+          const socket = createClient(server.url, true, {
+            socketAuthentication: { accessToken },
+            ackTimeout: 2000,
+          });
+          clients.push(socket);
+          const rest = await createRestClient(server.url);
+          await rest.authenticate({ strategy: 'jwt', accessToken });
+          for (const client of [rest, socket]) {
+            expect(
+              await client.service('boards').findAll({
+                query: { board_id: { $in: ids }, lean: true, archived: false, $limit: 1 },
+              })
+            ).toMatchObject([{ board_id: fixture.board.board_id }]);
+            expect(
+              await client
+                .service('boards')
+                .findAll({ query: { board_id: { $in: [foreign.board.board_id] } } })
+            ).toEqual([]);
+          }
+          expect(
+            await socket.io
+              .timeout(2000)
+              .emitWithAck(PRESENCE_SOCKET_EVENTS.subscribeBoardAssociations, { boardIds: ids })
+          ).toEqual({ ok: true });
+          const rooms = server.app.io.sockets.sockets.get(socket.io.id!)!.rooms;
+          expect(
+            rooms.has(boardPresenceAssociationRoomName(tenantId, fixture.board.board_id))
+          ).toBe(true);
+          expect(
+            rooms.has(boardPresenceAssociationRoomName(tenantId, foreign.board.board_id))
+          ).toBe(false);
+          expect(
+            rooms.has(
+              boardPresenceAssociationRoomName(
+                tenantId === tenantA ? tenantB : tenantA,
+                foreign.board.board_id
+              )
+            )
+          ).toBe(false);
+        }
+        const conflict = await fetch(`${server.url}/boards?lean=true`, {
+          headers: server.headers(a.user.user_id, tenantB),
+        });
+        // The tenant-scoped user lookup may intentionally be non-enumerating.
+        expect([401, 403, 404]).toContain(conflict.status);
+        expect((await fetch(`${server.url}/boards`)).status).toBe(401);
+      } finally {
+        for (const client of clients) client.io.disconnect();
+        await server.close();
+      }
+    });
+  }
+);

--- a/apps/agor-daemon/src/register-hooks.boards-query.test.ts
+++ b/apps/agor-daemon/src/register-hooks.boards-query.test.ts
@@ -1,0 +1,138 @@
+import { createClient, createRestClient } from '@agor/core/api';
+import {
+  BoardRepository,
+  createTenantScopedDatabaseProxy,
+  generateId,
+  UsersRepository,
+} from '@agor/core/db';
+import { MAX_PRESENCE_BOARD_SUBSCRIPTIONS, PRESENCE_SOCKET_EVENTS } from '@agor/core/types';
+import { expect } from 'vitest';
+import { dbTest } from '../../../packages/core/src/db/test-helpers.js';
+import { boardMetadataTestApp } from '../test/board-metadata-app.js';
+import { boardPresenceAssociationRoomName } from './realtime/routing.js';
+import type { RegisterHooksContext } from './register-hooks.js';
+
+dbTest(
+  'validates presence set queries through registered REST/Socket.IO hooks without widening board access',
+  async ({ db: rawDb }) => {
+    const users = new UsersRepository(rawDb);
+    const owner = await users.create({ email: 'owner@example.test', role: 'member' });
+    const stranger = await users.create({ email: 'stranger@example.test', role: 'member' });
+    const repo = new BoardRepository(rawDb);
+    for (let i = 0; i < 3; i++)
+      await repo.create({ name: `Board ${i}`, created_by: owner.user_id, access_mode: 'private' });
+    const privateBoard = await repo.create({
+      name: 'Other owner',
+      created_by: stranger.user_id,
+      access_mode: 'private',
+    });
+    const server = await boardMetadataTestApp(
+      createTenantScopedDatabaseProxy(rawDb),
+      {
+        database: { dialect: 'sqlite' },
+        multi_tenancy: { mode: 'static', static_tenant_id: 'board-query-audit' },
+        execution: {},
+      } as RegisterHooksContext['config'],
+      true
+    );
+    const socket = createClient(server.url, true, {
+      socketAuthentication: { accessToken: server.headers(owner.user_id).authorization.slice(7) },
+      ackTimeout: 2000,
+    });
+    const rest = await createRestClient(server.url);
+    try {
+      await rest.authenticate({
+        strategy: 'jwt',
+        accessToken: server.headers(owner.user_id).authorization.slice(7),
+      });
+      for (const client of [rest, socket]) {
+        for (const query of [
+          { lean: true, $limit: 100 },
+          { $limit: 100 },
+          { lean: true, $limit: 1 },
+          { $limit: 1 },
+          {
+            lean: true,
+            archived: false,
+            $limit: 1,
+            $skip: 0,
+            $sort: { created_at: -1, board_id: 1 },
+          },
+        ]) {
+          const result = await client.service('boards').findAll({ query });
+          expect(result).toHaveLength(3);
+        }
+        for (const query of [
+          { lean: 'invalid' },
+          { board_id: 'not-a-uuid' },
+          { $limit: -1 },
+          { $skip: 10001 },
+          { board_id: { $in: ['not-a-uuid'] } },
+        ]) {
+          await expect(client.service('boards').find({ query })).rejects.toMatchObject({
+            code: 400,
+            message: 'validation failed',
+          });
+        }
+      }
+      // A maximum-size set exceeds HTTP header limits before REST validation;
+      // exercise the schema ceiling on Socket.IO, where presence sends it.
+      await expect(
+        socket.service('boards').find({
+          query: {
+            board_id: {
+              $in: Array(MAX_PRESENCE_BOARD_SUBSCRIPTIONS + 1).fill(privateBoard.board_id),
+            },
+          },
+        })
+      ).rejects.toMatchObject({ code: 400, message: 'validation failed' });
+      const denied = await fetch(`${server.url}/boards?lean=true&$limit=1`, {
+        headers: server.headers(stranger.user_id),
+      });
+      expect(denied.status).toBe(200);
+      expect(await denied.json()).toMatchObject({
+        total: 1,
+        data: [{ board_id: privateBoard.board_id }],
+      });
+      const boards = await rest.service('boards').findAll();
+      const requested = [boards[0].board_id, privateBoard.board_id, generateId()];
+      for (const client of [rest, socket]) {
+        expect(
+          await client.service('boards').findAll({
+            query: { board_id: { $in: requested }, archived: false, lean: true, $limit: 1 },
+          })
+        ).toMatchObject([{ board_id: boards[0].board_id }]);
+        expect(
+          await client.service('boards').findAll({ query: { board_id: boards[0].board_id } })
+        ).toHaveLength(1);
+      }
+      // The REST client's serializer omits empty arrays; native presence uses
+      // Socket.IO and explicitly bypasses find for an empty subscription set.
+      expect(await socket.service('boards').findAll({ query: { board_id: { $in: [] } } })).toEqual(
+        []
+      );
+      // This native UI event used to emit an unsupported board_id.$in query,
+      // fail before the list read, and acknowledge every nonempty set negatively.
+      const subscribe = (boardIds: string[]) =>
+        socket.io
+          .timeout(2000)
+          .emitWithAck(PRESENCE_SOCKET_EVENTS.subscribeBoardAssociations, { boardIds });
+      expect(await subscribe(requested)).toEqual({ ok: true });
+      const rooms = server.app.io.sockets.sockets.get(socket.io.id!)!.rooms;
+      expect(
+        rooms.has(boardPresenceAssociationRoomName('board-query-audit', boards[0].board_id))
+      ).toBe(true);
+      for (const id of [boards[1].board_id, ...requested.slice(1)]) {
+        expect(rooms.has(boardPresenceAssociationRoomName('board-query-audit', id))).toBe(false);
+      }
+      expect(await subscribe([])).toEqual({ ok: true });
+      expect(
+        rooms.has(boardPresenceAssociationRoomName('board-query-audit', boards[0].board_id))
+      ).toBe(false);
+    } finally {
+      socket.io.disconnect();
+      await server.close();
+    }
+  },
+  30000
+);

--- a/apps/agor-daemon/src/services/board-objects.ts
+++ b/apps/agor-daemon/src/services/board-objects.ts
@@ -45,6 +45,7 @@ export type BoardObjectParams = QueryParams<{
   card_id?: CardID;
   zone_id?: string;
   entity_type?: BoardEntityType;
+  exclude_archived_branches?: boolean;
 }> & {
   /** Internal RBAC SQL pushdown marker set by register-hooks for external regular users. */
   _agorSqlBoardAccessUserId?: UUID;
@@ -60,13 +61,18 @@ export interface NormalizedBoardObjectFindQuery {
 export function normalizeBoardObjectFindQuery(
   query: BoardObjectParams['query'] = {}
 ): NormalizedBoardObjectFindQuery {
-  const { board_id, branch_id, card_id, zone_id, entity_type } = query;
+  const { board_id, branch_id, card_id, zone_id, entity_type, exclude_archived_branches } = query;
   const requestedSkip = Number(query.$skip ?? 0);
   const requestedLimit = typeof query.$limit === 'number' ? query.$limit : undefined;
   const filters = Object.fromEntries(
-    Object.entries({ board_id, branch_id, card_id, zone_id, entity_type }).filter(
-      ([, value]) => value !== undefined
-    )
+    Object.entries({
+      board_id,
+      branch_id,
+      card_id,
+      zone_id,
+      entity_type,
+      exclude_archived_branches,
+    }).filter(([, value]) => value !== undefined)
   ) as BoardObjectFindFilters;
 
   return {

--- a/apps/agor-daemon/src/services/branches.test.ts
+++ b/apps/agor-daemon/src/services/branches.test.ts
@@ -318,8 +318,11 @@ function createFindHarness(opts: {
     archived?: boolean;
     branchIds?: BranchID[];
     visibleToUserId?: string;
+    zone_id?: string;
   }) =>
     opts.branches.filter((branch) => {
+      if (filter?.zone_id && !opts.branchIdsInZone.includes(branch.branch_id as BranchID))
+        return false;
       if (filter?.repo_id !== undefined && branch.repo_id !== filter.repo_id) return false;
       if (filter?.board_id !== undefined && branch.board_id !== filter.board_id) return false;
       if (filter?.archived !== undefined && Boolean(branch.archived) !== filter.archived)
@@ -1808,7 +1811,7 @@ describe('BranchesService.find zone filtering', () => {
       query: { zone_id: 'zone-review', $limit: 1 },
     })) as { data: Array<Record<string, unknown>>; total: number; limit: number; skip: number };
 
-    expect(branchRepo.findBranchIdsByZone).toHaveBeenCalledWith('zone-review');
+    expect(branchRepo.findBranchIdsByZone).not.toHaveBeenCalled();
     expect(result.total).toBe(2);
     expect(result.limit).toBe(1);
     expect(result.data).toHaveLength(1);
@@ -1860,6 +1863,7 @@ describe('BranchesService.find SQL pushdown', () => {
 
     // Read is SQL-bounded: the scoped repo read runs, the whole-table read does not.
     expect(branchRepo.findPage).toHaveBeenCalledWith({
+      zone_id: undefined,
       repo_id: undefined,
       board_id: 'board-1',
       archived: false,
@@ -1892,6 +1896,7 @@ describe('BranchesService.find SQL pushdown', () => {
     })) as { data: Array<Record<string, unknown>>; total: number };
 
     expect(branchRepo.findPage).toHaveBeenCalledWith({
+      zone_id: undefined,
       repo_id: undefined,
       board_id: 'board-1',
       archived: false,
@@ -1919,10 +1924,11 @@ describe('BranchesService.find SQL pushdown', () => {
     })) as { data: Array<Record<string, unknown>>; total: number };
 
     expect(branchRepo.findPage).toHaveBeenCalledWith({
+      zone_id: 'zone-review',
       repo_id: undefined,
       board_id: 'board-1',
       archived: undefined,
-      branchIds: ['b1', 'b2'],
+      branchIds: undefined,
       visibleToUserId: undefined,
       limit: 1,
       offset: 1,
@@ -1944,6 +1950,7 @@ describe('BranchesService.find SQL pushdown', () => {
     })) as { data: Array<Record<string, unknown>>; total: number };
 
     expect(branchRepo.findPage).toHaveBeenCalledWith({
+      zone_id: undefined,
       repo_id: undefined,
       board_id: undefined,
       archived: undefined,
@@ -1968,6 +1975,7 @@ describe('BranchesService.find SQL pushdown', () => {
     })) as { data: Array<Record<string, unknown>>; total: number };
 
     expect(branchRepo.findPage).toHaveBeenCalledWith({
+      zone_id: undefined,
       repo_id: undefined,
       board_id: undefined,
       archived: undefined,
@@ -1993,6 +2001,7 @@ describe('BranchesService.find SQL pushdown', () => {
     } as BranchParams);
 
     expect(branchRepo.findPage).toHaveBeenCalledWith({
+      zone_id: undefined,
       repo_id: undefined,
       board_id: 'board-1',
       archived: undefined,

--- a/apps/agor-daemon/src/services/branches.ts
+++ b/apps/agor-daemon/src/services/branches.ts
@@ -127,12 +127,16 @@ function shouldSqlPageBranchQuery(query?: Record<string, unknown>): boolean {
     'board_id',
     'repo_id',
     'branch_id',
+    'zone_id',
     '$limit',
     '$skip',
     '$sort',
   ]);
   if (Object.keys(query).some((key) => !allowed.has(key))) return false;
-  for (const key of ['archived', 'board_id', 'repo_id']) {
+  // An empty virtual filter historically goes through the generic adapter;
+  // do not turn it into an unrestricted SQL page.
+  if (query.zone_id === '') return false;
+  for (const key of ['archived', 'board_id', 'repo_id', 'zone_id']) {
     if (query[key] !== undefined && typeof query[key] !== 'boolean' && key === 'archived') {
       return false;
     }
@@ -1396,7 +1400,9 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
     const zoneId = params?.query?.zone_id;
     let findParams = params;
 
-    if (zoneId) {
+    // Simple inventory pages can correlate zone membership in SQL rather than
+    // materializing every matching ID. Preserve the generic adapter fallback.
+    if (zoneId && !shouldSqlPageBranchQuery(params?.query)) {
       const branchIdsInZone = await this.branchRepo.findBranchIdsByZone(zoneId);
       const existingBranchFilter = params?.query?.branch_id;
       let filteredBranchIds = branchIdsInZone;
@@ -1442,6 +1448,7 @@ export class BranchesService extends DrizzleService<Branch, Partial<Branch>, Bra
       const page = await this.branchRepo.findPage({
         repo_id: typeof query?.repo_id === 'string' ? (query.repo_id as UUID) : undefined,
         board_id: typeof query?.board_id === 'string' ? (query.board_id as BoardID) : undefined,
+        zone_id: typeof query?.zone_id === 'string' ? query.zone_id : undefined,
         archived: typeof query?.archived === 'boolean' ? query.archived : undefined,
         branchIds,
         visibleToUserId: findParams?._agorSqlBranchAccessUserId,

--- a/apps/agor-daemon/test/board-entity-fixture.ts
+++ b/apps/agor-daemon/test/board-entity-fixture.ts
@@ -1,0 +1,67 @@
+import {
+  BoardObjectRepository,
+  BoardRepository,
+  BranchRepository,
+  CardRepository,
+  type Database,
+  RepoRepository,
+  UsersRepository,
+} from '@agor/core/db';
+
+export async function seedBoardEntities(db: Database, role: 'member' | 'admin' = 'member') {
+  const owner = await new UsersRepository(db).create({ email: `owner-${role}@example.test`, role });
+  const other = await new UsersRepository(db).create({
+    email: `other-${role}@example.test`,
+    role: 'member',
+  });
+  const board = await new BoardRepository(db).create({
+    name: 'Entities',
+    created_by: owner.user_id,
+    access_mode: 'private',
+  });
+  const repo = await new RepoRepository(db).create({
+    repo_type: 'remote',
+    remote_url: 'https://example.test/entity-fixture.git',
+    slug: 'entity-fixture',
+    local_path: '/tmp/entity-fixture',
+    default_branch: 'main',
+  });
+  const objects = new BoardObjectRepository(db);
+  const branches = new BranchRepository(db);
+  const entities = [];
+  for (const [index, name] of ['archived', 'active-a', 'active-b', 'hidden', 'outside'].entries()) {
+    const createdBy = name === 'hidden' ? other.user_id : owner.user_id;
+    const branch = await branches.create({
+      repo_id: repo.repo_id,
+      board_id: board.board_id,
+      name,
+      ref: name,
+      branch_unique_id: index + 1,
+      created_by: createdBy,
+      primary_owner_user_id: createdBy,
+      permission_source: 'override',
+      others_can: 'none',
+      archived: name === 'archived',
+    });
+    entities.push(
+      await objects.create({
+        board_id: board.board_id,
+        branch_id: branch.branch_id,
+        position: { x: index, y: 0 },
+        zone_id: name === 'outside' ? 'zone-other' : 'zone-review',
+      })
+    );
+  }
+  const card = await new CardRepository(db).create({
+    board_id: board.board_id,
+    title: 'Card',
+    created_by: owner.user_id,
+  });
+  const cardObject = await objects.create({
+    board_id: board.board_id,
+    card_id: card.card_id,
+    position: { x: 5, y: 0 },
+    zone_id: 'zone-review',
+  });
+  return { owner, other, board, repo, entities, cardObject };
+}

--- a/apps/agor-daemon/test/board-metadata-app.ts
+++ b/apps/agor-daemon/test/board-metadata-app.ts
@@ -19,8 +19,11 @@ import type { HookContext, UserID } from '@agor/core/types';
 import express from 'express';
 import jwt from 'jsonwebtoken';
 import { RuntimeJWTStrategy } from '../src/auth/runtime-jwt-strategy.js';
+import { setupMCPRoutes } from '../src/mcp/server.js';
 import { type RegisterHooksContext, registerHooks } from '../src/register-hooks.js';
+import { BoardObjectsService } from '../src/services/board-objects.js';
 import { createBoardsService } from '../src/services/boards.js';
+import { BranchesService } from '../src/services/branches.js';
 import { setupCapabilityPolicyServices } from '../src/services/capability-policies.js';
 import { setupBoardEffectiveAccessService } from '../src/services/groups.js';
 import { createUsersService } from '../src/services/users.js';
@@ -32,7 +35,8 @@ const JWT_SECRET = 'board-metadata-disposable-test-secret';
 export async function boardMetadataTestApp(
   db: TenantScopeAwareDatabase,
   config: RegisterHooksContext['config'],
-  withSocketIO = false
+  withSocketIO = false,
+  withMcp = false
 ) {
   const app = feathersExpress(feathers());
   app.use(express.json());
@@ -53,15 +57,7 @@ export async function boardMetadataTestApp(
       expiresIn: '15m',
     },
   });
-  for (const path of [
-    'messages',
-    'repos',
-    'branches',
-    'sessions',
-    'leaderboard',
-    'schedules',
-    'tasks',
-  ]) {
+  for (const path of ['messages', 'repos', 'sessions', 'leaderboard', 'schedules', 'tasks']) {
     app.use(path, {
       async find() {
         return [];
@@ -69,6 +65,7 @@ export async function boardMetadataTestApp(
     });
   }
   app.use('users', createUsersService(db, app, config));
+  app.use('branches', new BranchesService(db, app));
   const authentication = new AuthenticationService(app);
   authentication.register(
     'jwt',
@@ -86,6 +83,7 @@ export async function boardMetadataTestApp(
   }
   const boardsService = createBoardsService(db);
   app.use('boards', boardsService);
+  app.use('board-objects', new BoardObjectsService(db, app));
   setupBoardEffectiveAccessService(app, new BoardRepository(db), { allowSuperadmin: false });
   setupCapabilityPolicyServices(app, db, { allowSuperadmin: false });
   registerHooks({
@@ -106,6 +104,7 @@ export async function boardMetadataTestApp(
     usersRepository: new UsersRepository(db),
     sessionsRepository: {} as RegisterHooksContext['sessionsRepository'],
   });
+  if (withMcp) setupMCPRoutes(app, db, true, config);
   app.use(errorHandler());
   const server = (await app.listen(0)) as Server;
   const address = server.address();

--- a/apps/agor-daemon/test/board-metadata-app.ts
+++ b/apps/agor-daemon/test/board-metadata-app.ts
@@ -13,6 +13,7 @@ import {
   feathers,
   feathersExpress,
   rest,
+  socketio,
 } from '@agor/core/feathers';
 import type { HookContext, UserID } from '@agor/core/types';
 import express from 'express';
@@ -23,18 +24,20 @@ import { createBoardsService } from '../src/services/boards.js';
 import { setupCapabilityPolicyServices } from '../src/services/capability-policies.js';
 import { setupBoardEffectiveAccessService } from '../src/services/groups.js';
 import { createUsersService } from '../src/services/users.js';
+import { configureChannels, createSocketIOConfig } from '../src/setup/socketio.js';
 
 const JWT_SECRET = 'board-metadata-disposable-test-secret';
 
 /** Real REST/auth/hooks/repositories; only unrelated daemon services are inert. */
 export async function boardMetadataTestApp(
   db: TenantScopeAwareDatabase,
-  config: RegisterHooksContext['config']
+  config: RegisterHooksContext['config'],
+  withSocketIO = false
 ) {
   const app = feathersExpress(feathers());
   app.use(express.json());
   app.configure(rest());
-  (app as unknown as { publish: () => void }).publish = () => undefined;
+  if (!withSocketIO) (app as unknown as { publish: () => void }).publish = () => undefined;
   app.set('config', config);
   app.set('authentication', {
     secret: JWT_SECRET,
@@ -72,6 +75,15 @@ export async function boardMetadataTestApp(
     new RuntimeJWTStrategy({ multiTenancy: resolveMultiTenancyConfig(config) })
   );
   app.use('authentication', authentication);
+  if (withSocketIO) {
+    const sockets = createSocketIOConfig(app, {
+      corsOrigin: '*',
+      credentialsAllowed: false,
+      multiTenancy: resolveMultiTenancyConfig(config),
+    });
+    app.configure(socketio(sockets.serverOptions, sockets.callback));
+    configureChannels(app);
+  }
   const boardsService = createBoardsService(db);
   app.use('boards', boardsService);
   setupBoardEffectiveAccessService(app, new BoardRepository(db), { allowSuperadmin: false });

--- a/apps/agor-docs/content/guide/internal-mcp.mdx
+++ b/apps/agor-docs/content/guide/internal-mcp.mdx
@@ -226,6 +226,24 @@ Ask the client to call `agor_search_tools` with no arguments, then
 `agor_boards_list` with `{ "limit": 1 }`. A successful response should show
 tool domains and one accessible board page.
 
+For positioned branches/cards, use `agor_boards_get` with `includeEntities: true`.
+Optional `entityZoneId`, `entityType`, `entitiesLimit`, and `entitiesSkip` filter
+and page the authorized entities. Archived branches are excluded before counting
+and paging unless `includeArchived: true`; card entities are preserved. Omitting
+the limit retains the existing all-matched-entities behavior, so prefer an explicit
+limit for large boards. `entities_pagination.total` counts the filtered visible
+entities, not just the returned page.
+
+The execution facade reports malformed target-tool arguments with
+`code: "invalid_tool_arguments"`, `validation_stage: "tool_input"`, and bounded
+field/code `issues`. Fetch `agor_get_tool_details`, correct the indicated fields,
+and retry. A `service_validation_failed` response instead identifies downstream
+service validation; it does not by itself mean the agent supplied a bad payload.
+If the payload matches the published tool schema, report the tool/service mismatch
+rather than retrying unchanged. These failures retain the `error`/`tool` fields
+and MCP `isError: true`; diagnostic issues omit input values. Direct tool calls
+retain the MCP SDK's native input-validation errors.
+
 - **401:** confirm `AGOR_API_KEY` exists in the environment that launched the
   client, the header is exactly `X-API-Key`, and the key has not been revoked.
   Re-register if the client stored a literal secret or an unexpanded shell

--- a/apps/agor-ui/src/hooks/useGlobalPresenceHeartbeat.test.tsx
+++ b/apps/agor-ui/src/hooks/useGlobalPresenceHeartbeat.test.tsx
@@ -213,45 +213,52 @@ describe('useGlobalPresenceHeartbeat', () => {
     });
   });
 
-  it('keeps periodic heartbeats boardless after a failed latest route generation', () => {
-    vi.useFakeTimers();
-    const { client, emit } = makeMockClient();
-    const acknowledgements: Array<
-      (error: Error | null, result?: PresenceSubscriptionAcknowledgement) => void
-    > = [];
-    emit.mockImplementation((event, _payload, callback) => {
-      if (event === PRESENCE_SOCKET_EVENTS.subscribeBoardAssociations && callback) {
-        acknowledgements.push(
-          callback as (error: Error | null, result?: PresenceSubscriptionAcknowledgement) => void
-        );
-      }
-    });
-    const { rerender } = renderHook(
-      ({ currentBoardId }: { currentBoardId: BoardID }) =>
-        useGlobalPresenceHeartbeat({
-          client,
-          currentBoardId,
-          visibleBoardIds: [boardId('board-a'), boardId('board-b')],
-        }),
-      { initialProps: { currentBoardId: boardId('board-a') } }
-    );
-    act(() => acknowledgements[0]?.(null, { ok: true }));
-    expect(emit).toHaveBeenLastCalledWith(PRESENCE_SOCKET_EVENTS.heartbeat, {
-      boardId: boardId('board-a'),
-    });
+  it.each(['timeout', 'validation-rejection'] as const)(
+    'keeps periodic heartbeats boardless after %s and recovers on focus',
+    (failure) => {
+      vi.useFakeTimers();
+      const { client, emit } = makeMockClient();
+      const acknowledgements: Array<
+        (error: Error | null, result?: PresenceSubscriptionAcknowledgement) => void
+      > = [];
+      emit.mockImplementation((event, _payload, callback) => {
+        if (event === PRESENCE_SOCKET_EVENTS.subscribeBoardAssociations && callback) {
+          acknowledgements.push(
+            callback as (error: Error | null, result?: PresenceSubscriptionAcknowledgement) => void
+          );
+        }
+      });
+      const { rerender } = renderHook(
+        ({ currentBoardId }: { currentBoardId: BoardID }) =>
+          useGlobalPresenceHeartbeat({
+            client,
+            currentBoardId,
+            visibleBoardIds: [boardId('board-a'), boardId('board-b')],
+          }),
+        { initialProps: { currentBoardId: boardId('board-a') } }
+      );
+      act(() => acknowledgements[0]?.(null, { ok: true }));
+      expect(emit).toHaveBeenLastCalledWith(PRESENCE_SOCKET_EVENTS.heartbeat, {
+        boardId: boardId('board-a'),
+      });
 
-    rerender({ currentBoardId: boardId('board-b') });
-    expect(
-      emit.mock.calls.filter(([event]) => event === PRESENCE_SOCKET_EVENTS.heartbeat).at(-1)?.[1]
-    ).toEqual({ boardId: null });
-    act(() => acknowledgements[1]?.(new Error('authorization timed out')));
-    act(() => vi.advanceTimersByTime(PRESENCE_CONFIG.HEARTBEAT_INTERVAL_MS));
-    expect(emit).toHaveBeenLastCalledWith(PRESENCE_SOCKET_EVENTS.heartbeat, { boardId: null });
+      rerender({ currentBoardId: boardId('board-b') });
+      expect(
+        emit.mock.calls.filter(([event]) => event === PRESENCE_SOCKET_EVENTS.heartbeat).at(-1)?.[1]
+      ).toEqual({ boardId: null });
+      act(() =>
+        failure === 'timeout'
+          ? acknowledgements[1]?.(new Error('authorization timed out'))
+          : acknowledgements[1]?.(null, { ok: false })
+      );
+      act(() => vi.advanceTimersByTime(PRESENCE_CONFIG.HEARTBEAT_INTERVAL_MS));
+      expect(emit).toHaveBeenLastCalledWith(PRESENCE_SOCKET_EVENTS.heartbeat, { boardId: null });
 
-    act(() => window.dispatchEvent(new Event('focus')));
-    act(() => acknowledgements[2]?.(null, { ok: true }));
-    expect(emit).toHaveBeenLastCalledWith(PRESENCE_SOCKET_EVENTS.heartbeat, {
-      boardId: boardId('board-b'),
-    });
-  });
+      act(() => window.dispatchEvent(new Event('focus')));
+      act(() => acknowledgements[2]?.(null, { ok: true }));
+      expect(emit).toHaveBeenLastCalledWith(PRESENCE_SOCKET_EVENTS.heartbeat, {
+        boardId: boardId('board-b'),
+      });
+    }
+  );
 });

--- a/packages/core/src/config/constants.ts
+++ b/packages/core/src/config/constants.ts
@@ -115,6 +115,9 @@ export const PAGINATION = {
    */
   MAX_LIMIT: 10_000,
 
+  /** Offset ceiling for services using the common Feathers query schema. */
+  MAX_SKIP: 10_000,
+
   /**
    * Default limit for CLI list commands - reasonable for terminal display
    */

--- a/packages/core/src/db/repositories/board-objects.ts
+++ b/packages/core/src/db/repositories/board-objects.ts
@@ -17,7 +17,14 @@ import { and, asc, eq, getTableColumns, isNotNull, isNull, or, type SQL, sql } f
 import { generateId } from '../../lib/ids';
 import { toAbsolutePosition } from '../../utils/board-placement.js';
 import type { Database } from '../client';
-import { deleteFrom, insert, jsonExtract, select, update } from '../database-wrapper';
+import {
+  deleteFrom,
+  insert,
+  isSQLiteDatabase,
+  jsonExtract,
+  select,
+  update,
+} from '../database-wrapper';
 import { type BoardObjectInsert, type BoardObjectRow, boardObjects, branches } from '../schema';
 import { EntityNotFoundError, RepositoryError } from './base';
 import {
@@ -31,6 +38,8 @@ export interface BoardObjectFindFilters {
   card_id?: CardID;
   zone_id?: string;
   entity_type?: BoardEntityType;
+  /** Exclude archived/missing branch references, preserving card entities. */
+  exclude_archived_branches?: boolean;
 }
 
 export interface BoardObjectFindOptions {
@@ -65,6 +74,18 @@ export class BoardObjectRepository {
       conditions.push(isNull(boardObjects.card_id));
     } else if (filters.entity_type === 'card') {
       conditions.push(isNotNull(boardObjects.card_id));
+    }
+    if (filters.exclude_archived_branches) {
+      // Keep archive filtering in the same query as visibility and pagination.
+      // EXISTS avoids hydrating branches or building an unbounded client ID set.
+      conditions.push(
+        or(
+          isNull(boardObjects.branch_id),
+          sql`exists (select 1 from ${branches}
+            where ${branches.branch_id} = ${boardObjects.branch_id}
+              and ${branches.archived} = false)`
+        )!
+      );
     }
 
     return conditions;
@@ -104,6 +125,9 @@ export class BoardObjectRepository {
       query = query.orderBy(asc(boardObjects.created_at), asc(boardObjects.object_id));
       if (options.limit !== undefined) {
         query = query.limit(options.limit);
+      } else if (options.offset !== undefined && isSQLiteDatabase(this.db)) {
+        // SQLite requires LIMIT with OFFSET; -1 preserves the unbounded contract.
+        query = query.limit(sql`-1`);
       }
       if (options.offset !== undefined) {
         query = query.offset(options.offset);
@@ -162,6 +186,8 @@ export class BoardObjectRepository {
       query = query.orderBy(asc(boardObjects.created_at), asc(boardObjects.object_id));
       if (options.limit !== undefined) {
         query = query.limit(options.limit);
+      } else if (options.offset !== undefined && isSQLiteDatabase(this.db)) {
+        query = query.limit(sql`-1`);
       }
       if (options.offset !== undefined) {
         query = query.offset(options.offset);

--- a/packages/core/src/db/repositories/branches.ts
+++ b/packages/core/src/db/repositories/branches.ts
@@ -35,6 +35,7 @@ import {
 import {
   type BranchInsert,
   type BranchRow,
+  boardObjects,
   branches,
   branchPermissionConfigs,
   branchPermissionEntries,
@@ -430,6 +431,7 @@ export class BranchRepository implements BaseRepository<Branch, Partial<Branch>>
   async findPage(opts: {
     repo_id?: UUID;
     board_id?: BoardID;
+    zone_id?: string;
     archived?: boolean;
     branchIds?: BranchID[];
     visibleToUserId?: UUID;
@@ -442,6 +444,13 @@ export class BranchRepository implements BaseRepository<Branch, Partial<Branch>>
     const conditions: SQL[] = [];
     if (opts.repo_id) conditions.push(eq(branches.repo_id, opts.repo_id));
     if (opts.board_id) conditions.push(eq(branches.board_id, opts.board_id));
+    if (opts.zone_id) {
+      conditions.push(
+        sql`exists (select 1 from ${boardObjects}
+          where ${boardObjects.branch_id} = ${branches.branch_id}
+            and ${jsonExtract(this.db, boardObjects.data, 'zone_id')} = ${opts.zone_id})`
+      );
+    }
     if (opts.archived !== undefined) conditions.push(eq(branches.archived, opts.archived));
     if (opts.branchIds) conditions.push(inArray(branches.branch_id, opts.branchIds));
     if (opts.visibleToUserId) {

--- a/packages/core/src/db/repositories/capability-policies.test.ts
+++ b/packages/core/src/db/repositories/capability-policies.test.ts
@@ -15,6 +15,7 @@ import type { Database } from '../client';
 import { update } from '../database-wrapper';
 import { branchPermissionConfigs } from '../schema';
 import { dbTest } from '../test-helpers';
+import { BoardObjectRepository } from './board-objects';
 import { BoardRepository } from './boards';
 import { BranchRepository } from './branches';
 import { CapabilityPolicyRepository } from './capability-policies';
@@ -206,6 +207,67 @@ describe('CapabilityPolicyRepository', () => {
       expect(
         (await policies.resolveBranchAccess(value.branchId, value.grouped)).capabilities
       ).toContain('branch.policy.manage');
+    }
+  );
+
+  dbTest(
+    'keeps direct-deny precedence, groups, Others and owner access in archive/zone SQL pages',
+    async ({ db }) => {
+      const value = await fixture(db);
+      const policies = new CapabilityPolicyRepository(db);
+      const boardPolicy = await policies.getBoardPolicies(value.boardId);
+      boardPolicy.board_access.sharing_mode = 'shared';
+      boardPolicy.board_access.others = {
+        preset: 'viewer',
+        capabilities: capabilityPolicyPresetCapabilities('board_access', 'viewer') ?? [],
+        fs_access: 'none',
+      };
+      await policies.replaceBoardPolicies(value.boardId, boardPolicy, value.owner);
+      const branchPolicy = await policies.getBranchPolicy(value.branchId);
+      const config = structuredClone(branchPolicy.override_config!);
+      config.access.sharing_mode = 'shared';
+      config.access.entries = [
+        userEntry(value.direct, 'none'),
+        groupEntry(value.readers, 'collaborator', 'read'),
+      ];
+      config.access.others = {
+        preset: 'viewer',
+        capabilities: capabilityPolicyPresetCapabilities('branch_access', 'viewer') ?? [],
+        fs_access: 'none',
+      };
+      await policies.replaceBranchPolicy(
+        value.branchId,
+        { ...branchPolicy, override_config: config },
+        value.owner
+      );
+      const objects = new BoardObjectRepository(db);
+      await objects.create({
+        board_id: value.boardId,
+        branch_id: value.branchId,
+        position: { x: 0, y: 0 },
+        zone_id: 'zone-review',
+      });
+      for (const userId of [value.owner, value.grouped, value.unmatched, value.direct]) {
+        const expected = userId === value.direct ? 0 : 1;
+        const filters = {
+          board_id: value.boardId,
+          zone_id: 'zone-review',
+          exclude_archived_branches: true,
+        };
+        expect(await objects.countVisibleToUser(userId, filters)).toBe(expected);
+        expect(await objects.findVisibleToUser(userId, filters, { limit: 1 })).toHaveLength(
+          expected
+        );
+        const page = await new BranchRepository(db).findPage({
+          board_id: value.boardId,
+          zone_id: 'zone-review',
+          archived: false,
+          visibleToUserId: userId,
+          limit: 1,
+        });
+        expect(page.total).toBe(expected);
+        expect(page.data).toHaveLength(expected);
+      }
     }
   );
 

--- a/packages/core/src/lib/feathers-validation.test.ts
+++ b/packages/core/src/lib/feathers-validation.test.ts
@@ -68,6 +68,7 @@ describe('boardObjectQueryValidator', () => {
           card_id: '019e8e1e',
           zone_id: 'zone-review',
           entity_type: 'branch',
+          exclude_archived_branches: 'true',
           $limit: 25,
           $skip: 5,
           unknown: 'removed',
@@ -83,6 +84,7 @@ describe('boardObjectQueryValidator', () => {
       card_id: '019e8e1e',
       zone_id: 'zone-review',
       entity_type: 'branch',
+      exclude_archived_branches: true,
       $limit: 25,
       $skip: 5,
     });

--- a/packages/core/src/lib/feathers-validation.test.ts
+++ b/packages/core/src/lib/feathers-validation.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
+import { MAX_PRESENCE_BOARD_SUBSCRIPTIONS } from '../types/presence';
 import {
   boardObjectQueryValidator,
+  boardQueryValidator,
   branchQueryValidator,
   mcpCatalogQueryValidator,
   mcpServerQueryValidator,
@@ -10,6 +12,51 @@ import {
   typedValidateQuery,
   userQueryValidator,
 } from './feathers-validation';
+
+describe('boardQueryValidator', () => {
+  const id = '019e8e1c-1234-7123-8123-123456789abc';
+
+  it.each([id, '019e8e1c', { $in: [id, '019e8e1d'] }, { $in: [] }])(
+    'preserves scalar and bounded set filters with REST coercion',
+    async (board_id) => {
+      const query = { board_id, lean: 'true', archived: 'false', $limit: '512', $skip: '0' };
+      expect(await boardQueryValidator(query)).toEqual({
+        board_id,
+        lean: true,
+        archived: false,
+        $limit: 512,
+        $skip: 0,
+      });
+    }
+  );
+
+  it('accepts the maximum presence set without dropping the ID restriction', async () => {
+    const query = { board_id: { $in: Array(MAX_PRESENCE_BOARD_SUBSCRIPTIONS).fill(id) } };
+    expect(await boardQueryValidator(structuredClone(query))).toEqual(query);
+  });
+
+  it.each([
+    { board_id: { $in: ['not-a-uuid'] } },
+    { board_id: { $in: [id, { $ne: id }] } },
+    { board_id: { $in: id } },
+    { board_id: { $in: Array(MAX_PRESENCE_BOARD_SUBSCRIPTIONS + 1).fill(id) } },
+    { board_id: { $ne: id } },
+    { board_id: {} },
+    { board_id: 'not-a-uuid' },
+    { $limit: 10001 },
+    { $skip: 10001 },
+    { $skip: -1 },
+    { lean: 'invalid' },
+  ])('rejects malformed or unbounded board queries: %j', async (query) => {
+    await expect(boardQueryValidator(query)).rejects.toThrow();
+  });
+
+  it('retains the existing unknown-property stripping contract without widening a set filter', async () => {
+    expect(
+      await boardQueryValidator({ board_id: { $in: [id], unexpected: true }, unexpected: true })
+    ).toEqual({ board_id: { $in: [id] } });
+  });
+});
 
 describe('boardObjectQueryValidator', () => {
   it('preserves supported board-object filters through Feathers query validation', async () => {

--- a/packages/core/src/lib/feathers-validation.ts
+++ b/packages/core/src/lib/feathers-validation.ts
@@ -8,6 +8,7 @@
 import { Ajv } from '@feathersjs/schema';
 import type { TObject, TProperties } from '@feathersjs/typebox';
 import { getValidator, Type } from '@feathersjs/typebox';
+import { PAGINATION } from '../config/constants';
 import { AGENTIC_TOOL_NAMES, PERSISTED_AGENTIC_TOOL_NAMES } from '../types/agentic-tool';
 import { MAX_PRESENCE_BOARD_SUBSCRIPTIONS } from '../types/presence';
 
@@ -91,8 +92,8 @@ export function createQuerySchema<T extends TProperties>(properties: TObject<T>)
     [
       properties,
       Type.Object({
-        $limit: Type.Optional(Type.Integer({ minimum: 0, maximum: 10000 })),
-        $skip: Type.Optional(Type.Integer({ minimum: 0, maximum: 10000 })),
+        $limit: Type.Optional(Type.Integer({ minimum: 0, maximum: PAGINATION.MAX_LIMIT })),
+        $skip: Type.Optional(Type.Integer({ minimum: 0, maximum: PAGINATION.MAX_SKIP })),
         $sort: Type.Optional(
           Type.Record(Type.String(), Type.Union([Type.Literal(1), Type.Literal(-1)]))
         ),
@@ -365,6 +366,7 @@ export const boardObjectQuerySchema = createQuerySchema(
     card_id: Type.Optional(CommonSchemas.uuid),
     zone_id: Type.Optional(Type.String()),
     entity_type: Type.Optional(Type.Union([Type.Literal('branch'), Type.Literal('card')])),
+    exclude_archived_branches: Type.Optional(CommonSchemas.boolean),
     created_at: Type.Optional(CommonSchemas.timestamp),
   })
 );

--- a/packages/core/src/lib/feathers-validation.ts
+++ b/packages/core/src/lib/feathers-validation.ts
@@ -9,6 +9,7 @@ import { Ajv } from '@feathersjs/schema';
 import type { TObject, TProperties } from '@feathersjs/typebox';
 import { getValidator, Type } from '@feathersjs/typebox';
 import { AGENTIC_TOOL_NAMES, PERSISTED_AGENTIC_TOOL_NAMES } from '../types/agentic-tool';
+import { MAX_PRESENCE_BOARD_SUBSCRIPTIONS } from '../types/presence';
 
 /**
  * Query validator with type coercion enabled
@@ -300,7 +301,19 @@ export const branchQuerySchema = createQuerySchema(
  */
 export const boardQuerySchema = createQuerySchema(
   Type.Object({
-    board_id: Type.Optional(CommonSchemas.uuid),
+    // Presence authorizes a bounded set through the same registered find hooks
+    // as REST/Socket.IO lists. Keep every ID validated and retain scalar queries.
+    board_id: Type.Optional(
+      Type.Union([
+        CommonSchemas.uuid,
+        Type.Object(
+          {
+            $in: Type.Array(CommonSchemas.uuid, { maxItems: MAX_PRESENCE_BOARD_SUBSCRIPTIONS }),
+          },
+          { additionalProperties: false }
+        ),
+      ])
+    ),
     name: Type.Optional(Type.String({ maxLength: 255 })),
     slug: Type.Optional(Type.String({ maxLength: 255 })),
     created_by: Type.Optional(CommonSchemas.uuid),


### PR DESCRIPTION
## Summary

User-approved expansion of the independent board-query reliability follow-up. Fix two reproduced query/schema mismatches and push related inventory filtering/pagination into SQL, without N+1 branch reads or authorization caches.

### Commits and baseline

- Starting clean HEAD and freshly fetched main: **33a428b95dc4a0f42a1ac8d551d533ce81ebd16d**. Original audit reference: `9326e8706a971fae6f45bc9ae38f998f10fe2d17`.
- **4b08bf74baf48f20a3bf8dbf40d572362d980fd1** — bounded board-ID set validation and real presence/transport/UI regressions.
- **cbd51df6ef4abb012f5bdd2434793e77102d3b24** — SQL entity/zone pushdown, schema-visible MCP bounds, and safe validation failures.
- Latest main recheck: **8f8b3ec764a9c28ee658b4f2d5cedf95265c5e47** (now includes independently merged #2686). This branch retains its original baseline: no cherry-picks, modifications, or dependency on clone diagnostics #2686. No session-list query changes; #2687 is separate.

## Evidence: distinguish the failures

Datadog was initially unavailable, then attached successfully during the expanded follow-up. The eligible-server catalog still returned empty, but the attached authenticated Datadog tools worked.

For `service:agor-daemon env:sandbox host:agor-2`, the fixed 24h window **2026-09-06 18:05 → 2026-09-07 18:05 UTC** returned **1,006 retained sampled `boards.find` error spans** and **9 retained sampled `branches.find` error spans**, all `BadRequest / validation failed`. These are **not full-traffic rates**.

- [Fresh board trace at 18:46:20](https://app.datadoghq.com/apm/trace/6a9f067c0000000039ef8dcaace6fad9): `boards.find`, Socket.IO, 10.581543ms, Feathers query-validator stack. The original [18:02:25 trace](https://app.datadoghq.com/apm/trace/6a9efc31000000001a885cb3314a12ab?spanID=3521439756310530545) fails before the board listing SQL.
- [Supplemental MCP trace at 18:14:05](https://app.datadoghq.com/apm/trace/6a9efeed000000007ef29f2819563bb4): HTTP MCP request with `boards.get`, `board-objects.find`, and a failing `branches.find` (11.679688ms, transport MCP). This is consistent with the separately reproduced board-entity archive-filter path, not the Socket.IO presence failure.
- Inspected spans do not expose the rejected query, detailed validation fields, or deployment SHA/version. The previously supplied application-log searches had no matching logs. Do not infer deployment identity, absence of errors, or that every retained sample shares one root cause.

## Before → after

| Path | Reproduced before | After / proof |
| --- | --- | --- |
| Native `presence:subscribe-boards` | Sends `board_id: {$in: requestedIds}` to the scalar-only board schema; real registered Socket.IO hooks reject `/board_id` type, acknowledgement `{ok:false}`. Introduced in `714ea498df84856a7e1f984fa4ff8bf96ebe5ce3` (#2567). | Accept the set up to existing `MAX_PRESENCE_BOARD_SUBSCRIPTIONS` (512), validating each member with the existing ID schema. Acknowledgement true; only authorized requested rooms joined. |
| `agor_boards_get(includeEntities:true)` | Metadata succeeds; positioned branch entities fail. Explicit `includeArchived:true` succeeds (51 entities in the read-only live control). Default archive filter hydrates all matching objects then sends unsupported `branch_id.$in` to `branches.find`. Introduced in `84e766dd5798c9e9d4105f58833a5aa6cdbae125` (#1408). | One board-object service call; archive exclusion, RBAC, count and requested page run in SQL. No second branch lookup and no per-entity gets. Real registered REST/Socket.IO/MCP tests preserve mixed cards/branches, archive options, totals, empty pages and offset-only results. |
| Ordinary branch-zone inventory | Materializes every zone branch ID before count/page/enrichment. | Correlated SQL `EXISTS` for the normal paged query path; no preliminary ID-list query. Existing batch zone enrichment and generic-query fallback remain. |
| Offset-only board-object reads | SQLite emits invalid `OFFSET` without `LIMIT` when paging is pushed down. | SQLite-only `LIMIT -1` preserves the unlimited tail; PostgreSQL keeps its native offset-only syntax. Both dialects tested. |
| Agent pagination errors / schema discovery | Board/branch MCP offsets advertise values the service rejects; entity maxima exist only in Zod refinements and are absent from published JSON Schema. | Existing ceilings are shared/published as `maximum:10000`. Oversized offsets fail at tool input, before service execution. No pagination ceiling raised. |
| MCP validation feedback | Facade returns only `validation failed` for downstream rejection; target Zod failures can serialize verbose raw details. | Add bounded schema-known top-level fields/codes, `invalid_tool_arguments` vs `service_validation_failed`, validation stage, `retryable:false`, and correction/reporting guidance. Preserve `error`/`tool` and `isError:true`. Direct SDK calls retain native input validation and share downstream diagnostics. No input values, arbitrary record keys, raw AJV messages, stacks, or new telemetry logging. |

## Security and compatibility

- Boards, branches, cards, associations, and their query results are tenant-owned/derived resources. Existing trusted tenant context, registered authentication hooks, SQL visibility predicates, and PostgreSQL RLS remain authoritative.
- No bypasses or global/process authorization caches. No changes to direct-user precedence, additive active groups, unmatched-member Others, immutable ownership, or admin/superadmin distinctions. Added negative count/page coverage for direct denial despite group/Others grants, plus owner/group/Others positives.
- Isolated PostgreSQL fixtures assert `NOSUPERUSER` and `NOBYPASSRLS`. A foreign tenant cannot retrieve positioned entities or zone-filtered branches, including as an administrator. Original presence cross-tenant room checks remain.
- Existing scalar IDs, ID-format rules, coercion, `additionalProperties:false`, and unknown-query-property stripping remain. Malformed standalone set operators/IDs, oversized sets, and invalid pagination still fail; recognized ID restrictions are never dropped.
- `board-objects.find` remains archive-inclusive by default; the new archive-exclusion flag is opt-in and MCP opts in unless `includeArchived:true`. Cards remain present. MCP omission of entity limit still returns all matching authorized entities with `limit:null`; explicit limits/offsets now apply before hydration. No extra response projection or ordering changes.
- Branch queries outside the existing SQL-page contract, including empty virtual zone filters, retain the generic adapter behavior. No unrelated cleanup inventory, filesystem, lifecycle, or session-pagination refactor.

## Validation

- `pnpm i` — passed; lockfile unchanged.
- `pnpm check` — final complete run passed: typechecks, lint, 330 frontend plugin fixtures, short-ID/tenant/filesystem/realtime boundaries and builds.
- Core schema/client/board/branch/object/capability-policy regressions — **304 passed / 6 files**.
- Daemon real registered REST/Socket.IO/native-presence/MCP, service, RBAC and MCP SDK regressions — **394 passed / 16 files**.
- UI `useAgorData` and presence heartbeat — **40 passed / 2 files**.
- `pnpm test:postgres:docker` — **260 passed, 0 failed, 0 skipped / 53 files**, twice during this expansion. Runner interruption cleanup passed for processes/databases/reports. The earlier first-phase unrelated knowledge timeout did not recur.
- Query-work assertions: board-object count + bounded page execute exactly **two SQL statements**, and branch-zone repository count + bounded page also execute exactly **two**, with no preliminary ID materialization. MCP entity retrieval asserts zero `branches.find` calls.
- Actual HTTP MCP direct and facade tests use disposable API-key authentication and real registered services: valid mixed-entity pages, published maximums, malformed arguments blocked before service work, and distinct bounded downstream failure output.
- Dedicated new/changed MCP/entity tests and fixtures pass targeted `tsc`. The existing large `services/branches.test.ts` has **51 pre-existing standalone type diagnostics**, unchanged against its pre-edit version after normalizing line numbers; these were not hidden or expanded into an unrelated test refactor. Normal hooks and `pnpm check` were not bypassed.
- `check:ci-test-coverage` and whitespace checks passed.
- **Managed Chromium smoke:** login, board navigation, focus, offline/reconnect and reload; **5 successful board finds and 6 successful nonempty presence acknowledgements**. Screenshot inspected.
- **Managed daemon MCP smoke:** direct and facade entity requests both return the seeded branch (`total:1`, one-row page); malformed entity limit and oversized branch offset produce tool-input guidance. Disposable smoke credential revoked.

## Operational caveats / rollout

- No migration, production data/config mutation, deployment, merge, or issue closure performed. Branch is now in the user-requested Codex review workflow.
- Ship core and daemon together and restart every daemon replica; old schemas continue failing closed. An intermediate watch-mode smoke still reached downstream offset validation; a clean managed restart aligned the schema and the final smoke passed. This is not a deployment assertion.
- Existing no-limit reads remain potentially large for compatibility; callers should request explicit entity limits. Existing 10,000-offset ceilings remain; narrow filters rather than retrying an invalid continuation unchanged. Counts/pages retain ordinary concurrent-update caveats, not a new snapshot guarantee.
- Existing large REST URLs can hit HTTP header limits before schema validation; the shared REST serializer omits empty arrays. Native presence uses Socket.IO and skips empty sets.


## AI review follow-up

Initial independent Codex review (`gpt-6-astra`, high) found no merge blockers at `cbd51df6ef4abb012f5bdd2434793e77102d3b24`. Both reasonably scoped optional improvements were addressed in **`a68f221d84398f3b97d5edbdd1e8aa27804faf8a`**:

- Publish schedule configuration source exclusivity in the shared create/patch schema description and the create timezone omission rule. Keep sanitized diagnostics unchanged; no raw Zod messages or generic hint framework. Real HTTP MCP discovery/facade regression confirms discoverable guidance and value-free rejection. This discovery assertion failed before the description change and passes after it.
- Extend the isolated registered-service entity fixture above the default page size: omitted limit returns **108 entities**, offset-only returns the full **105-entity tail**, with correct total and `limit:null` and zero extra branch finds.

Follow-up validation: `pnpm i`, `pnpm check`, **43 focused daemon tests across 8 files**, targeted new/changed test TypeScript checks, and normal commit hooks passed. No query, RBAC, tenant or database production logic changed in this follow-up; prior isolated PostgreSQL and managed browser evidence remains as documented above, not claimed as rerun for this description/test-only commit. The same independent Codex reviewer (`gpt-6-astra`, high) completed follow-up review at `a68f221d84398f3b97d5edbdd1e8aa27804faf8a`: **PASS — no remaining substantive findings**, independently rerunning all 43 targeted tests. GitHub checks were still running at review completion; this is a code-review pass, not a claim that pending CI has finished.

