### PR TITLE
perf(sessions): evaluate inventory visibility at branch cardinality

### DIFF
--- a/apps/agor-cli/src/lib/agentic-tool-integrations.lock.test.ts
+++ b/apps/agor-cli/src/lib/agentic-tool-integrations.lock.test.ts
@@ -1,0 +1,162 @@
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { stat as nodeStat, type PathLike, type Stats } from 'node:fs';
+import { access, mkdir, mkdtemp, rm, stat, utimes } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, expect, it, vi } from 'vitest';
+import { acquireAgenticToolInstallLock } from './agentic-tool-integrations.js';
+
+// Intercept the dependency's stale observation, not its mkdir/rmdir/lock logic.
+const require = createRequire(import.meta.url);
+const lockFs = createRequire(require.resolve('proper-lockfile'))('graceful-fs') as {
+  stat(path: PathLike, callback: (error: NodeJS.ErrnoException | null, stats: Stats) => void): void;
+};
+const originalRoot = process.env.AGOR_AGENTIC_TOOLS_DIR;
+const roots: string[] = [];
+afterEach(async () => {
+  vi.restoreAllMocks();
+  if (originalRoot === undefined) delete process.env.AGOR_AGENTIC_TOOLS_DIR;
+  else process.env.AGOR_AGENTIC_TOOLS_DIR = originalRoot;
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+it('does not admit a second reclaimer while the first holds a stale observation', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'agor-install-race-'));
+  roots.push(root);
+  process.env.AGOR_AGENTIC_TOOLS_DIR = root;
+  const lock = join(root, '.install.lock');
+  await mkdir(lock);
+  await utimes(lock, new Date(0), new Date(0));
+  let resume: (() => void) | undefined;
+  let observed!: () => void;
+  const staleObserved = new Promise<void>((resolve) => {
+    observed = resolve;
+  });
+  vi.spyOn(lockFs, 'stat').mockImplementation((path, callback) => {
+    nodeStat(path, (error, stats) => {
+      if (path === lock && !error && stats.mtimeMs === 0 && !resume) {
+        resume = () => callback(error, stats);
+        observed();
+      } else callback(error, stats);
+    });
+  });
+  const first = acquireAgenticToolInstallLock();
+  let secondRelease: (() => Promise<void>) | undefined;
+  try {
+    await staleObserved;
+    // Before the fix, this contender succeeds. Resuming the first then lets it
+    // remove that fresh directory using its previously captured stale stat.
+    await expect(
+      acquireAgenticToolInstallLock().then((release) => {
+        secondRelease = release;
+        return release;
+      })
+    ).rejects.toThrow('Another `agor install`');
+  } finally {
+    resume?.();
+    const result = await Promise.allSettled([first]);
+    // The old implementation may return two releases for one replaced lock.
+    // Always clean up both paths, including when this regression fails.
+    await Promise.allSettled([
+      ...(secondRelease ? [secondRelease()] : []),
+      ...(result[0].status === 'fulfilled' ? [result[0].value()] : []),
+    ]);
+  }
+});
+
+it('fails closed on an abandoned acquisition guard rather than racing to reclaim it', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'agor-install-guard-'));
+  roots.push(root);
+  process.env.AGOR_AGENTIC_TOOLS_DIR = root;
+  const guard = join(root, '.install.acquire.lock');
+  await mkdir(guard, { mode: 0o700 });
+  await utimes(guard, new Date(0), new Date(0));
+  await expect(acquireAgenticToolInstallLock()).rejects.toThrow(
+    'verify that no installer is running'
+  );
+  expect((await stat(guard)).mtimeMs).toBe(0);
+  await expect(access(join(root, '.install.lock'))).rejects.toMatchObject({ code: 'ENOENT' });
+});
+
+it('scopes acquisition and leases to the installation root', async () => {
+  const releases: (() => Promise<void>)[] = [];
+  try {
+    for (let i = 0; i < 2; i++) {
+      const root = await mkdtemp(join(tmpdir(), 'agor-install-root-'));
+      roots.push(root);
+      process.env.AGOR_AGENTIC_TOOLS_DIR = root;
+      releases.push(await acquireAgenticToolInstallLock());
+      await expect(access(join(root, '.install.acquire.lock'))).rejects.toMatchObject({
+        code: 'ENOENT',
+      });
+    }
+  } finally {
+    await Promise.all(releases.map((release) => release()));
+  }
+});
+
+it.each([false, true])(
+  'admits one independent installer process (stale=%s)',
+  async (stale) => {
+    const root = await mkdtemp(join(tmpdir(), 'agor-install-process-'));
+    roots.push(root);
+    if (stale) {
+      const lock = join(root, '.install.lock');
+      await mkdir(lock);
+      await utimes(lock, new Date(0), new Date(0));
+    }
+    const code = `
+    import { acquireAgenticToolInstallLock } from ${JSON.stringify(new URL('./agentic-tool-integrations.ts', import.meta.url).href)};
+    process.once('message', async () => {
+      try {
+        const release = await acquireAgenticToolInstallLock();
+        process.once('message', async () => { await release(); process.disconnect(); });
+        process.send({ status: 'held' });
+      } catch (error) {
+        process.send({ status: 'busy', message: error.message });
+        process.disconnect();
+      }
+    });
+    process.send('ready');
+  `;
+    const children = [0, 1].map(() =>
+      spawn(
+        process.execPath,
+        ['--import', 'tsx', '--conditions=source', '--input-type=module', '--eval', code],
+        {
+          env: { ...process.env, AGOR_AGENTIC_TOOLS_DIR: root },
+          stdio: ['ignore', 'ignore', 'pipe', 'ipc'],
+        }
+      )
+    );
+    const exits = children.map((child) => once(child, 'exit'));
+    try {
+      const signal = AbortSignal.timeout(15000);
+      await Promise.all(children.map((child) => once(child, 'message', { signal })));
+      const results = children.map((child) => once(child, 'message', { signal }));
+      children.forEach((child) => {
+        child.send('acquire');
+      });
+      const outcomes = (await Promise.all(results)).map(
+        ([result]) => result as { status: string; message?: string }
+      );
+      expect(outcomes.filter((result) => result.status === 'held')).toHaveLength(1);
+      expect(outcomes.filter((result) => result.status === 'busy')).toEqual([
+        { status: 'busy', message: expect.stringContaining('Another `agor install`') },
+      ]);
+      children[outcomes.findIndex((result) => result.status === 'held')].send('release');
+      expect(await Promise.all(exits)).toEqual([
+        [0, null],
+        [0, null],
+      ]);
+    } finally {
+      children.forEach((child) => {
+        if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+      });
+      await Promise.allSettled(exits);
+    }
+  },
+  20000
+);

--- a/apps/agor-cli/src/lib/agentic-tool-integrations.lock.test.ts
+++ b/apps/agor-cli/src/lib/agentic-tool-integrations.lock.test.ts
@@ -63,6 +63,7 @@ it('does not admit a second reclaimer while the first holds a stale observation'
       ...(secondRelease ? [secondRelease()] : []),
       ...(result[0].status === 'fulfilled' ? [result[0].value()] : []),
     ]);
+    expect(result[0].status, 'the paused installer recovers after resuming').toBe('fulfilled');
   }
 });
 

--- a/apps/agor-cli/src/lib/agentic-tool-integrations.ts
+++ b/apps/agor-cli/src/lib/agentic-tool-integrations.ts
@@ -8,6 +8,7 @@ import {
   readFile,
   rename,
   rm,
+  rmdir,
   stat,
   writeFile,
 } from 'node:fs/promises';
@@ -168,35 +169,40 @@ export async function writeAgenticToolSelectionManifest(
 export async function acquireAgenticToolInstallLock(): Promise<() => Promise<void>> {
   const root = getAgenticToolsRoot();
   const lock = join(root, '.install.lock');
+  const acquisitionGuard = join(root, '.install.acquire.lock');
   await ensureSharedManagedDirectory(root);
+  // Serialize stale inspection/removal across processes. Retrying the library's
+  // stat -> rmdir race cannot prevent one reclaimer deleting another's new lock.
+  // This short-lived guard must NOT expire: that would recreate the same race.
   try {
-    const release = await acquireFileLock(root, {
+    await mkdir(acquisitionGuard, { mode: PRIVATE_MANAGED_DIRECTORY_MODE });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+      throw new Error(
+        'Another `agor install` is acquiring the agentic-tools lock. ' +
+          `If a previous installer was interrupted, verify that no installer is running before removing the empty directory ${JSON.stringify(acquisitionGuard)}.`
+      );
+    }
+    throw error;
+  }
+  let release: (() => Promise<void>) | undefined;
+  try {
+    release = await acquireFileLock(root, {
       lockfilePath: lock,
       realpath: false,
       stale: 10_000,
       update: 5_000,
-      // Two contenders can observe the same stale directory and race while
-      // proper-lockfile removes it. One may briefly see ENOENT if the other
-      // contender replaces the directory during the stale-lock probe. A few
-      // short, randomized retries let that transient race settle; a genuinely
-      // live lock still fails quickly with ELOCKED and the user-facing message
-      // below.
-      retries: {
-        retries: 3,
-        factor: 1,
-        minTimeout: 10,
-        maxTimeout: 25,
-        randomize: true,
-      },
+      retries: 0,
     });
     try {
       await chmod(lock, PRIVATE_MANAGED_DIRECTORY_MODE);
-      return release;
     } catch (error) {
       await release();
+      release = undefined;
       throw error;
     }
   } catch (error) {
+    await rmdir(acquisitionGuard);
     if ((error as NodeJS.ErrnoException).code === 'ELOCKED') {
       throw new Error(
         'Another `agor install` is already updating agentic tools. Try again when it finishes.'
@@ -204,6 +210,14 @@ export async function acquireAgenticToolInstallLock(): Promise<() => Promise<voi
     }
     throw error;
   }
+  try {
+    await rmdir(acquisitionGuard);
+  } catch (error) {
+    // Do not strand the long-lived lease if guard cleanup prevents returning it.
+    await release();
+    throw error;
+  }
+  return release;
 }
 
 export function getAgenticToolInstallSlug(tool: InstallableAgenticTool): string {

--- a/apps/agor-daemon/src/services/sessions.find.test.ts
+++ b/apps/agor-daemon/src/services/sessions.find.test.ts
@@ -21,13 +21,14 @@ import {
 import type { Application } from '@agor/core/feathers';
 import type { Session, UUID } from '@agor/core/types';
 import { SessionStatus } from '@agor/core/types';
-import { describe, expect, vi } from 'vitest';
+import { afterEach, describe, expect, vi } from 'vitest';
 import { ownedDbTest as dbTest } from '../../../../packages/core/src/db/test-helpers';
 import { SessionsService } from './sessions';
 
 // The find() board_id path only touches the session repos built from `db`; the
 // stored `app` is never read. A bare cast keeps the harness minimal.
 const STUB_APP = {} as unknown as Application;
+afterEach(() => vi.restoreAllMocks());
 
 function createService(db: Database) {
   // Standalone SQLite query tests deliberately install no tenant around-hook.
@@ -217,6 +218,50 @@ describe('SessionsService.find — recency sort + pagination (SQL pushdown)', ()
       }
     }
   );
+
+  dbTest('caps the SQL page limit and preserves count-only requests', async ({ db }) => {
+    const service = createService(db);
+    const branch = await createBranchOnBoard(db, await createBoard(db));
+    await createSession(db, branch);
+    await createSession(db, branch);
+    const pageSpy = vi.spyOn(SessionRepository.prototype, 'findPage');
+    expect(await service.find({ query: { branch_id: branch, $limit: 10000 } })).toMatchObject({
+      limit: 10000,
+    });
+    service.paginate = { default: 100, max: 1000 };
+    expect(await service.find({ query: { branch_id: branch } })).toMatchObject({ limit: 100 });
+    const capped = await service.find({ query: { branch_id: branch, $limit: 10000 } });
+    expect(capped).toMatchObject({ total: 2, limit: 1000 });
+    expect(pageSpy).toHaveBeenLastCalledWith(expect.objectContaining({ limit: 1000 }));
+    expect(await service.find({ query: { branch_id: branch, $limit: 0 } })).toMatchObject({
+      total: 2,
+      limit: 0,
+      data: [],
+    });
+  });
+
+  dbTest('keeps residual operators and field selection before pagination', async ({ db }) => {
+    const service = createService(db);
+    const board = await createBoard(db);
+    const branch = await createBranchOnBoard(db, board);
+    await createSession(db, branch, { title: 'excluded', created_at: T_OLD });
+    const first = await createSession(db, branch, { title: 'first', created_at: T_MID });
+    const second = await createSession(db, branch, { title: 'second', created_at: T_NEW });
+    for (const scope of [{ board_id: board }, { branch_id: branch }]) {
+      const result = await service.find({
+        query: {
+          ...scope,
+          status: SessionStatus.IDLE,
+          session_id: { $in: [first, second] },
+          $select: ['title'],
+          $sort: { created_at: 1 },
+          $limit: 1,
+          $skip: 1,
+        },
+      });
+      expect(result).toEqual({ total: 2, limit: 1, skip: 1, data: [{ title: 'second' }] });
+    }
+  });
 
   dbTest('orders board-scoped sessions by updated_at desc', async ({ db }) => {
     const service = createService(db);

--- a/apps/agor-daemon/src/services/sessions.ts
+++ b/apps/agor-daemon/src/services/sessions.ts
@@ -195,7 +195,7 @@ export type SessionParams = QueryParams<{
  * (SQL board filter + recency sort + limit/offset) rather than the generic
  * in-memory path. We only divert the loader's bounded list queries — those that
  * sort by `updated_at` and/or scope to a `board_id`/`branch_id` — and only when the rest of
- * the query is a shape findPage fully models (archived + pagination). Anything
+ * the query is a shape findPage fully models (archived/status + pagination). Anything
  * with extra filters, operators, or `$select` falls through to the existing path
  * so we never silently drop semantics findPage doesn't implement.
  */
@@ -660,7 +660,9 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
   }
 
   async enrichRemoteRelationships(sessionList: Session[]): Promise<Session[]> {
-    const sessionIds = sessionList.map((session) => session.session_id);
+    // A generic $select can intentionally omit the ID. Do not send undefined
+    // SQL parameters or reintroduce fields the caller did not select.
+    const sessionIds = sessionList.map((session) => session.session_id).filter(Boolean);
     if (sessionIds.length === 0) return sessionList;
 
     const relationships = await this.sessionRelationshipRepo.findForSessions(sessionIds);
@@ -1697,7 +1699,10 @@ export class SessionsService extends DrizzleService<Session, SessionUpdate, Sess
         Array.isArray((branchFilter as { $in?: unknown }).$in)
           ? ((branchFilter as { $in: BranchID[] }).$in ?? [])
           : undefined;
-      const limit = (query?.$limit as number | undefined) ?? PAGINATION.DEFAULT_LIMIT;
+      const limit = Math.min(
+        (query?.$limit as number | undefined) ?? this.paginate?.default ?? PAGINATION.DEFAULT_LIMIT,
+        this.paginate?.max ?? 1000 // Same fallback as DrizzleService.paginateData.
+      );
       const skip = (query?.$skip as number | undefined) ?? 0;
       const { data, total } = await this.sessionRepo.findPage({
         status: query?.status as SessionStatus | undefined,

--- a/apps/agor-docs/content/guide/extended-install.mdx
+++ b/apps/agor-docs/content/guide/extended-install.mdx
@@ -97,6 +97,17 @@ but installs into Agor's private runtime directory rather than changing global n
 is staged and swapped into place only after the exact Agor package version is verified. It does not
 replace Claude, Codex, or other tools you may already use from your terminal.
 
+Run only one installer at a time, including across Agor versions. Installation uses a
+heartbeat lease and a short-lived `.install.acquire.lock` directory under the managed
+agentic-tools root to serialize acquisition and stale-lease recovery across processes.
+The acquisition guard never expires automatically: deleting it based on age could let
+two installers proceed together. If an installer is killed during acquisition, the next
+attempt reports the exact guard path. First verify that **no installer is running**,
+then remove only that empty directory with `rmdir` and retry. Do not remove an active
+guard or recursively delete the managed tools directory. Normal completion removes the
+guard before package installation starts; an expired installation lease is still
+recovered automatically.
+
 Inspect the managed integrations at any time:
 
 ```bash

--- a/context/guides/rbac-and-unix-isolation.md
+++ b/context/guides/rbac-and-unix-isolation.md
@@ -146,6 +146,11 @@ The inventory primitives require an already authenticated, existing same-tenant
 principal; none implements tenant-admin bypass or replaces trusted tenant scope.
 PostgreSQL RLS and tenant-qualified foreign keys remain an additional
 boundary, not a substitute for application authorization.
+Message/task inventories already reuse `visibleSessionReferenceAccessExists`:
+its INNER JOIN permits branch-first filtering for broad queries and a selective
+parent lookup for exact IDs. Their isolated PostgreSQL plan tests cover both
+shapes at multiple session/child ratios. Do not mechanically replace this with
+a fenced global inventory merely because both helpers answer visibility.
 
 Realtime delivery materializes the exact current set of viewers with that same
 SQL predicate. A permissive `Others` role is never represented as a tenant-wide

--- a/context/guides/rbac-and-unix-isolation.md
+++ b/context/guides/rbac-and-unix-isolation.md
@@ -133,6 +133,18 @@ same normalized policies through `CapabilityPolicyRepository`:
 - `resolveBranchAccess(branchId, userId)`
 - `resolveSessionPromptAuthority({ branch_id, caller_user_id, session_owner_user_id, session_sdk_home_scope })`
 
+For capability-specific SQL, `boardCapabilityCondition` and
+`branchCapabilityCondition` are typed row predicates (their resource table must
+be in the outer query). Existing visibility/admission wrappers delegate to them.
+Their role allow-lists derive from the canonical
+`capabilityPolicyPresetCapabilities` expansion, via its inverse
+`capabilityPolicyPresetsGrantingCapability`; do not add independent SQL role maps.
+Terminal still requires actual filesystem access, possibly contributed by a
+different active group. SQL and rich point resolution retain different execution
+models; the cross-dialect `branch-access` parity matrix checks every capability,
+role and valid filesystem dimension, including precedence and revocation.
+These predicates do not replace the richer foreign-session prompt check above.
+
 `BranchRepository.resolveUserAccess` is the compatibility projection used by
 existing hooks; it is backed exclusively by the normalized resolver. SQL list
 queries mirror direct-user shadowing, additive active groups, and unmatched

--- a/context/guides/rbac-and-unix-isolation.md
+++ b/context/guides/rbac-and-unix-isolation.md
@@ -136,7 +136,15 @@ same normalized policies through `CapabilityPolicyRepository`:
 `BranchRepository.resolveUserAccess` is the compatibility projection used by
 existing hooks; it is backed exclusively by the normalized resolver. SQL list
 queries mirror direct-user shadowing, additive active groups, and unmatched
-`Others`. PostgreSQL RLS and tenant-qualified foreign keys remain an additional
+`Others`. For many child rows referring to branches, `inVisibleBranchSet` composes
+that predicate into a statement-local branch-ID set, with optional intersecting
+branch/branch-set/board scopes. Session inventory uses it to avoid evaluating
+policy per Session. Use `visibleBranchReferenceAccessExists` for selective
+exact-branch references or outer-user audience enumeration; use the rich point
+resolver when effective capabilities or principal existence must be resolved.
+The inventory primitives require an already authenticated, existing same-tenant
+principal; none implements tenant-admin bypass or replaces trusted tenant scope.
+PostgreSQL RLS and tenant-qualified foreign keys remain an additional
 boundary, not a substitute for application authorization.
 
 Realtime delivery materializes the exact current set of viewers with that same

--- a/docs/internal/session-inventory-sql-2026-09-07.md
+++ b/docs/internal/session-inventory-sql-2026-09-07.md
@@ -267,3 +267,51 @@ an already efficient shared primitive, documenting why, and adding repeatable
 regressions is the evidence-backed extension here. This does not establish
 optimal plans for every possible filter, data distribution or database version.
 Full validation and managed message/task smoke results are in the PR body.
+
+## Canonical capability definitions and broader predicate parity (2026-09-08)
+
+The next user-approved follow-up started at
+`b2e6dce995af8591ea1bdfd695a8ad13268d5989`. A fresh fetch confirmed main
+was still `8f8b3ec764a9c28ee658b4f2d5cedf95265c5e47`; no rebase or
+clone-diagnostics edits were needed.
+
+Review found a concrete maintainability hazard, not a reproduced authorization
+bug: SQL kept independent board/branch capability-to-role tables alongside the
+canonical role expansion used by policy writes and rich point resolution.
+`capabilityPolicyPresetsGrantingCapability` now inverts that canonical expansion;
+SQL derives its static allow-lists once from it. These are product definitions,
+not cached user/resource decisions. Terminal's SQL still requires actual
+filesystem grants, including role/file contributions from different groups.
+
+`branchCapabilityCondition` is now a typed reusable row predicate, and
+`boardCapabilityCondition` generalizes the existing board visibility predicate.
+The existing visibility/admission wrappers use them without changing their SQL
+policy precedence. Unsupported capability values fail closed, even for owners.
+Both predicates require the resource table in the outer query and an existing
+authenticated same-tenant principal in trusted tenant DB scope. They neither
+implement admin bypass nor replace principal-existence checks or foreign-session
+prompt authority. No new public service method, query operator or permission
+was introduced.
+
+The new persisted-policy matrix compares SQL against rich point resolution for
+all four board and eight branch capabilities, all roles and valid filesystem
+dimensions, across direct/group/Others grants. It exercises an owner, a member,
+and an admin-ID principal; direct entries shadow stronger group grants and
+matched groups suppress stronger Others grants. Both inherited and overridden
+branches are checked. Split group role/filesystem grants, group archive and
+membership removal cover terminal derivation and immediate revocation.
+PostgreSQL repeats the matrix in isolated tenant scopes and checks foreign
+board/branch IDs for every capability, including an attempted foreign-owner-ID
+bypass. Existing inventory/count and cross-tenant regressions remain intact.
+
+Before replacing the role tables, the initial SQLite matrix and capability tests
+passed with the historical tables temporarily restored (13 tests). The expanded
+matrix passes with canonical-derived tables. Explicit role-expansion assertions
+preserve the historical allow-lists independently of the differential checks.
+No authorization mismatch reproduced; this follow-up removes drift risk rather
+than claiming a new access fix or speedup. Production inventory SQL composition,
+query counts, pagination, residual filters, RLS and HA boundaries are unchanged.
+The plan regressions remain the performance guardrail; nested-predicate rewrites
+or a universal fenced query are not justified by this change.
+
+Final validation totals and managed smoke results are recorded in the PR body.

--- a/docs/internal/session-inventory-sql-2026-09-07.md
+++ b/docs/internal/session-inventory-sql-2026-09-07.md
@@ -1,0 +1,136 @@
+# Session inventory SQL: count cost, not just page size
+
+## Baselines and scope
+
+- Initial clean branch and fetched `origin/main`:
+  `33a428b95dc4a0f42a1ac8d551d533ce81ebd16d` (2026-09-07).
+- The audit named `9326e8706a971fae6f45bc9ae38f998f10fe2d17`; that object
+  was not present in this independent clone. No commit from clone-diagnostics
+  PR #2686 was fetched, cherry-picked, or modified.
+- Both prior fixes are ancestors of the initial baseline:
+  `5ff672d98646f97226bf14284dace87c672fff9b` (#2555) and
+  `ac0861269cc40811b521e6c6765e59d363309665` (#2669).
+- Main advanced during this work to
+  `74e96187b663cd533a1925a46d3ba5db72047890` (#2687), following
+  `7a5bbc95b905b73fe74c87f20ed71b0d07b85708` (#2682). This branch was
+  rebased onto that exact main. #2687 independently fixed exact-status SQL
+  paging; its implementation, validation and regression were retained rather
+  than duplicated here. The count/projection issue remained.
+
+Read the canonical session guide under `apps/agor-docs/content/guide/`
+(the older `pages/guide/` pointer is stale), multitenancy, testing, and the
+normalized-policy implementation guidance. Sessions, branches and policies are
+tenant-owned; visibility/counts are derived tenant-owned information. Existing
+trusted service markers and PostgreSQL tenant scopes/RLS remain authoritative.
+
+## Supplied telemetry, with its limits
+
+[The 17:12:20 UTC trace](https://app.datadoghq.com/apm/trace/6a9ef074000000007d3ed6f31f3dec4e?spanID=7779615651796564656)
+records `sessions.find` at 6379.933594 ms, with an authorization-filtered count
+at 3139.570801 ms. The next SQL span is labelled non-parsable (3038.710205 ms):
+its query text, plan and row count are **unknown**, not established as a page
+query. Another supplied Socket.IO find took 6495 ms; an MCP find took 31 ms.
+These demonstrate access/query-shape sensitivity, not full-traffic rates.
+
+This session's attached MCP server list and eligible-server catalog were both
+empty. Datadog was not independently queried here. Retained spans are sampled;
+their counts/p95 are not traffic-wide statistics. Inspected audit traces had
+no deployment version/SHA, and the audit's log searches had no matching
+service/host/trace logs. Neither deployment identity nor absence of errors can
+be inferred from that.
+
+## Reproduction and change
+
+`sessions.inventory.postgres.test.ts` builds isolated synthetic tenant data:
+200 branches, 100 sessions per branch, half private and half granting the
+unmatched viewer access. Separate small policy fixtures in two other tenants
+exercise negative isolation. Connections use the non-superuser, non-BYPASSRLS
+application role. Statistics are analyzed **only in the disposable database**.
+
+The baseline count joins sessions to branches, then applies the existing
+owner/direct-user/group/Others predicate. PostgreSQL leaves that predicate on
+the join: each of its six policy SubPlans executes 20,000 times. The query
+returns 10,000 visible sessions.
+
+The changed query applies the **same predicate** inside an uncorrelated
+branch-ID set. `OFFSET 0` prevents flattening that set back into the outer
+join; SQLite uses its equivalent unbounded `LIMIT -1 OFFSET 0` syntax. Board
+and branch scopes also constrain the inner set. The set is statement-local,
+not an application cache or persisted authorization snapshot. Both count and
+page independently consult current authority inside their existing scope.
+
+Representative rebased production-query captures (not production traffic):
+
+| Query                    | Visible total / page rows | Max policy SubPlan loops | Shared buffer hits | Execution ms |
+| ------------------------ | ------------------------: | -----------------------: | -----------------: | -----------: |
+| Baseline count           |                10,000 / — |                   20,000 |            850,569 |   11,801.383 |
+| Changed repository count |                10,000 / — |                      200 |              9,466 |      129.028 |
+| Changed repository page  |               10,000 / 20 |                      200 |              9,485 |      154.571 |
+
+Timings are illustrative observations, **not assertions or production speedup
+estimates**. Tests capture the actual repository count/page SQL and run
+`EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)` against it. Assertions cover equal
+authorized counts, returned cardinality, policy-loop bounds and query count,
+not wall-clock thresholds. `INVENTORY_PLAN` output retains repeatable full plans.
+
+Other changes:
+
+- Page projection retains every Session column (including hidden tenant
+  mapping) but selects only `branches.board_id`, not the repeated branch blob.
+- `$limit:0` executes just the count, not a second data query. A normal page
+  still uses two queries; relationship enrichment remains separate.
+- SQL pagination now respects the adapter's configured default and maximum.
+  **Audit correction:** sessions explicitly configure **10,000**, not 1,000.
+  The latter is the generic adapter's fallback. Valid `$limit:10000` remains
+  supported. A regression configures a smaller adapter cap to prove it cannot
+  be bypassed by SQL paging.
+- Extra filters/operators and `$select` still take the full residual-filter
+  path; no residual predicate is discarded to force a SQL page. Testing found
+  that `$select:['title']` previously sent undefined IDs to relationship SQL.
+  ID-less selections now skip that enrichment without adding unselected fields.
+
+## Repeatable validation
+
+```sh
+pnpm i
+pnpm check
+pnpm --filter @agor/core exec vitest run \
+  src/db/repositories/sessions.inventory.test.ts \
+  src/db/repositories/sessions.test.ts \
+  src/db/repositories/capability-policies.test.ts
+pnpm --filter @agor/daemon exec vitest run \
+  src/services/sessions.find.test.ts \
+  src/utils/rbac-find-scoping.test.ts \
+  src/utils/branch-authorization.test.ts \
+  src/mcp/tools/sessions.test.ts
+pnpm test:postgres:docker
+```
+
+The PostgreSQL runner provisions the reviewed pgvector image, verifies role
+flags, creates a separate database per test file, and removes it afterward.
+Do not point performance/ANALYZE tests at a live deployment database.
+
+Coverage includes private/shared boards and independent branch visibility,
+owner versus explicit admin-ID predicates, direct-user denial shadowing a
+granting group, group denial suppressing Others, group-only grants, inherited
+templates, archived groups and removed membership, archive/status filters,
+branch/board/set scopes, stable continuation pages, skip/limit/count and
+Session mapping. Cross-tenant requests include explicit foreign branch IDs and
+foreign-board count-only requests, including the no-RBAC-marker path. Existing
+service-hook suites cover trusted administrator/internal bypass distinctions.
+
+Validation results and managed browser smoke are recorded in the PR body.
+
+## Operational limits
+
+No schema/index migration, policy rewrite, authorization cache, transaction
+lifetime change, telemetry change, or deployment is required by this patch.
+Large branch inventories still have policy-resolution costs, and exact counts
+still inspect matching sessions. Unsupported query shapes still materialize
+candidates. This is not a claim that all historical latency is fixed.
+
+In particular, the supplied 09:03:43 trace
+`6a9e7def0000000079cfe8b709b9bfe7` records a separate 49.49-second
+`branches.get` failure with PostgreSQL `CONNECT_TIMEOUT`. Connection capacity
+and timeout investigation remains distinct. Health-monitor outer transactions,
+OAuth/gateway changes and board-query validation are outside this change.

--- a/docs/internal/session-inventory-sql-2026-09-07.md
+++ b/docs/internal/session-inventory-sql-2026-09-07.md
@@ -5,8 +5,8 @@
 - Initial clean branch and fetched `origin/main`:
   `33a428b95dc4a0f42a1ac8d551d533ce81ebd16d` (2026-09-07).
 - The audit named `9326e8706a971fae6f45bc9ae38f998f10fe2d17`; that object
-  was not present in this independent clone. No commit from clone-diagnostics
-  PR #2686 was fetched, cherry-picked, or modified.
+  was not present in this independent clone. No clone-diagnostics PR #2686 ref was fetched, cherry-picked, or modified.
+  Its later arrival through merged main is recorded below.
 - Both prior fixes are ancestors of the initial baseline:
   `5ff672d98646f97226bf14284dace87c672fff9b` (#2555) and
   `ac0861269cc40811b521e6c6765e59d363309665` (#2669).
@@ -218,3 +218,52 @@ remains observational, not a test threshold or a production estimate. The
 expanded isolated fixture's two tests passed; cross-tenant negative checks now
 exercise the additional readers as well. Full follow-up validation and managed
 smoke outcomes are recorded in the PR body.
+
+## Message/task inventory review and guardrails
+
+The next follow-up rebased normally onto current main
+`8f8b3ec764a9c28ee658b4f2d5cedf95265c5e47`, which now contains the
+merged #2686. No clone-diagnostics source was modified and no PR commit was
+cherry-picked. The earlier PR commits became `a10a2fcf310fa53b5f9407f0dfd4133109d66e9d`
+(implementation), `a71716eaaac5e6b03e36396e6d8c561efb44a8bd` (evidence), and
+`1470af728e53400bf776307408ef6fe59926472d` (shared branch-set composition).
+
+The message/task reproduction found **no analogous per-child policy scan**.
+Their shared `visibleSessionReferenceAccessExists` uses an INNER JOIN, unlike
+the expensive LEFT JOIN in the session reproduction. The inspected PostgreSQL
+plans can filter branches first, join their sessions, and semi-join the child
+inventory. For exact session/task/message IDs, the planner instead uses the
+selective parent lookup. This difference is evidence against mechanically
+replacing this helper with a fenced full-inventory set.
+
+An initial isolated fixture with 200 branches, 2,000 sessions, and 20,000 rows
+**in each** of tasks/messages returned 10,000 visible children per table.
+Observed policy-loop bounds were already 200 for broad count/page queries,
+1 for exact session/task/message queries, and 2 for a two-session scope
+containing one denied and one visible session. Representative broad count
+observations were 144.951 ms (tasks) and 146.700 ms (messages); exact-session
+counts were 0.673/0.691 ms. These are existing-query fixture measurements, not
+a before/after speedup or a production estimate.
+
+`session-children.inventory.postgres.test.ts` now guards broad and selective
+query shapes at three ratios: 1, 10, and 100 sessions per branch, respectively
+100, 10, and 1 children per session. Every case has 200 branches and 20,000
+rows in each child table. It captures actual `findAll` and `findPage` SQL,
+checks query counts and returned cardinality/projection, and explains the
+count/data statements. Assertions bound policy work at branches for broad
+inventories and at 1/2 for selective scopes, without timing thresholds.
+Session and child plan tests share small test-only capture/inspection helpers.
+
+The existing cross-dialect policy fixture now also seeds a task and message
+per session. It compares all/page/count/select/skip/status/role and mixed,
+empty or contradictory session scopes against the same visible-session set,
+including direct-user shadowing, groups/Others, owner/admin-ID distinctions,
+archive/removal revocation and independent board/branch visibility. PostgreSQL
+negative checks cover foreign session, task and message IDs and unmarked
+count-only requests; a foreign tenant cannot contribute to totals.
+
+**No message/task runtime SQL or authorization behavior was changed.** Keeping
+an already efficient shared primitive, documenting why, and adding repeatable
+regressions is the evidence-backed extension here. This does not establish
+optimal plans for every possible filter, data distribution or database version.
+Full validation and managed message/task smoke results are in the PR body.

--- a/docs/internal/session-inventory-sql-2026-09-07.md
+++ b/docs/internal/session-inventory-sql-2026-09-07.md
@@ -134,3 +134,87 @@ In particular, the supplied 09:03:43 trace
 `branches.get` failure with PostgreSQL `CONNECT_TIMEOUT`. Connection capacity
 and timeout investigation remains distinct. Health-monitor outer transactions,
 OAuth/gateway changes and board-query validation are outside this change.
+
+## Shared-primitives review (follow-up)
+
+The normalized policy predicate was already centralized before this PR. There
+are deliberately different query shapes, not one universal authorization API:
+
+| Use                                        | Existing owner                                                                                                   | Contract                                                                                                                                      |
+| ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| Branch/board inventory                     | `visibleBranchAccessCondition` / `visibleBoardAccessCondition`                                                   | Predicate on the current branch/board row; already at resource cardinality.                                                                   |
+| Many rows referring to branches            | `inVisibleBranchSet`                                                                                             | Statement-local branch-ID membership, with optional exact branch, branch-set and board scopes. Holds policy evaluation at branch cardinality. |
+| Exact branch reference / realtime audience | `visibleBranchReferenceAccessExists`                                                                             | Correlated exact-ID existence check; also accepts an outer user expression for viewer enumeration.                                            |
+| Session/task/message references            | `visibleSessionReferenceAccessExists` and its task/message wrappers                                              | Follow the tenant-owned parent to its branch; do not confuse board visibility with branch visibility.                                         |
+| Rich point authorization                   | `CapabilityPolicyRepository.resolveBranchAccess` (`BranchRepository.resolveUserAccess` compatibility projection) | Effective capabilities, filesystem access, owner/source/group explanation; checks principal existence.                                        |
+| Task launch/heartbeat                      | `resolveSessionRuntimeBranchAccess`                                                                              | Bounded exact-session projection including prompting, filesystem access and session-sharing rules. Not an inventory visibility check.         |
+
+The reusable branch-set primitive centralizes the optimization fence and scope
+composition formerly embedded in `SessionRepository.findPage`. All four
+session inventory readers now use it: `findPage`, `findAll`, `findByBoard` and
+`findAccessibleSessions`. Residual service filters still run after authorized
+candidate selection; this does not broaden SQL pushdown or discard predicates.
+
+### Important usage boundaries
+
+- These inventory SQL predicates take an **already authenticated, existing
+  same-tenant principal** and run in the caller's existing trusted tenant DB
+  scope. They are not authentication or a complete `canUserDoAnything` API.
+  In particular the low-level list predicate does not independently check that
+  an arbitrary supplied user ID exists; the rich point resolver does. Do not
+  expose a caller-selected user ID as authority or use the list predicate as a
+  replacement for that resolver.
+- Tenant administrator bypass belongs to trusted service hooks, not to these
+  user-ID predicates. Owner rights, view rights, prompting another user's
+  session and filesystem access are different questions.
+- Scope IDs only intersect the allowed branch set. Empty branch sets deny;
+  branch and board filters combine, never override one another. The board
+  scope is a location filter, **not** a grant from `board_access`.
+- `inVisibleBranchSet` requires a fixed principal ID. Do not use it to enumerate
+  principals; the existing correlated point/reference predicate owns that case.
+- No allowed-ID array is cached or fetched into application memory. Each SQL
+  statement reads current policy and membership under its existing DB scope.
+
+### Other consumers reviewed, not mechanically rewritten
+
+Branches and boards already apply their respective shared policy at their own
+row cardinality. Replacing their predicates with another membership join adds
+no demonstrated benefit. Messages/tasks use shared session-reference checks;
+board comments, marketplace attachments and nested references reuse those
+same helpers. Artifacts/board objects use branch-reference checks; cards and
+board objects separately enforce board visibility. Schedules join branches
+and could benefit from the new primitive if a many-schedules-per-branch
+fixture establishes the same problem.
+
+For messages/tasks, a branch-set rewrite must be measured separately for both
+broad inventory and selective exact-session history. Forcing a full allowed
+branch set for one exact session can do unnecessary work. This follow-up does
+not claim their current plans are optimal, nor change all reference helpers
+without reproductions. The remaining nested policy EXISTS clauses and the
+separate rich/SQL role projections are unchanged; consolidation of those
+semantics needs broader capability/terminal/owner parity evidence, not merely
+similar-looking SQL. The new differential coverage compares visibility from
+row predicates, exact-ID predicates, branch-set predicates, rich point checks,
+and all session inventory readers on the same SQLite/PostgreSQL policies.
+
+Follow-up started from `ff32e0dae72450723f97a5240cc05cb4293fb5d7`;
+fetched main was still `74e96187b663cd533a1925a46d3ba5db72047890`.
+A new regression failed before the extraction: actual `findAll` policy
+SubPlans each ran 20,000 times, with 850,569 shared buffer hits and an observed
+14,730.310 ms execution. The page path was already at 200 loops.
+
+After extraction, the same isolated 200-branch/20,000-session fixture captured:
+
+| Actual repository query       | Returned rows | Max policy loops | Shared hits | Execution ms |
+| ----------------------------- | ------------: | ---------------: | ----------: | -----------: |
+| `findAll`                     |        10,000 |              200 |       9,479 |      190.928 |
+| `findByBoard`                 |        10,000 |              200 |       9,480 |      172.433 |
+| `findAccessibleSessions`      |        10,000 |              200 |       9,480 |      287.931 |
+| `findAll`, one visible branch |           100 |                1 |          58 |        1.490 |
+
+Each reader executes one query. The new plan assertions enforce the 200/1
+policy-loop bounds, one-query contract and exact returned cardinality. Timing
+remains observational, not a test threshold or a production estimate. The
+expanded isolated fixture's two tests passed; cross-tenant negative checks now
+exercise the additional readers as well. Full follow-up validation and managed
+smoke outcomes are recorded in the PR body.

--- a/packages/core/src/db/repositories/branch-access.parity-test-helpers.ts
+++ b/packages/core/src/db/repositories/branch-access.parity-test-helpers.ts
@@ -1,0 +1,247 @@
+import { eq, sql } from 'drizzle-orm';
+import { expect } from 'vitest';
+import { generateId } from '../../lib/ids';
+import type {
+  BoardPolicyCapability,
+  BranchID,
+  BranchPolicyCapability,
+  CapabilityPolicyEntry,
+  CapabilityPolicyFsAccess,
+  CapabilityPolicyKind,
+  CapabilityPolicyPresetId,
+} from '../../types';
+import {
+  BOARD_POLICY_CAPABILITIES,
+  BRANCH_POLICY_CAPABILITIES,
+  capabilityPolicyPresetCapabilities,
+} from '../../types/capability-policy';
+import type { Database } from '../client';
+import { select } from '../database-wrapper';
+import { boards, branches } from '../schema';
+import { BoardRepository } from './boards';
+import { boardCapabilityCondition, branchCapabilityCondition } from './branch-access';
+import { BranchRepository } from './branches';
+import { CapabilityPolicyRepository } from './capability-policies';
+import { GroupRepository } from './groups';
+import { RepoRepository } from './repos';
+import { UsersRepository } from './users';
+
+/** Same persisted-policy matrix on SQLite and PostgreSQL under tenant RLS. */
+export async function exerciseCapabilityPredicateParity(db: Database) {
+  const userRepo = new UsersRepository(db);
+  const owner = (
+    await userRepo.create({ email: `${generateId()}@example.invalid`, role: 'member' })
+  ).user_id;
+  const member = (
+    await userRepo.create({ email: `${generateId()}@example.invalid`, role: 'member' })
+  ).user_id;
+  const admin = (await userRepo.create({ email: `${generateId()}@example.invalid`, role: 'admin' }))
+    .user_id;
+  const groupRepo = new GroupRepository(db);
+  const work = await groupRepo.create({ name: `Work-${generateId()}`, created_by: owner });
+  const files = await groupRepo.create({ name: `Files-${generateId()}`, created_by: owner });
+  for (const group of [work, files]) await groupRepo.addMember(group.group_id, member, owner);
+  const board = await new BoardRepository(db).create({
+    name: 'Capability parity',
+    created_by: owner,
+    access_mode: 'private',
+  });
+  const repo = await new RepoRepository(db).create({
+    slug: `capability-parity-${generateId()}`,
+    name: 'Parity',
+    repo_type: 'remote',
+    remote_url: 'https://example.invalid/parity.git',
+    local_path: '/tmp/capability-parity',
+    default_branch: 'main',
+  });
+  const branchRepo = new BranchRepository(db);
+  const branchIds: BranchID[] = [];
+  for (const [i, binding] of (['inherit', 'override'] as const).entries()) {
+    branchIds.push(
+      (
+        await branchRepo.create({
+          repo_id: repo.repo_id,
+          board_id: board.board_id,
+          created_by: owner,
+          name: binding,
+          ref: binding,
+          path: `/tmp/capability-parity/${binding}`,
+          branch_unique_id: i,
+          permission_binding: binding,
+        })
+      ).branch_id
+    );
+  }
+  const policyRepo = new CapabilityPolicyRepository(db);
+  const grant = (
+    kind: CapabilityPolicyKind,
+    preset: CapabilityPolicyPresetId,
+    fs_access: CapabilityPolicyFsAccess = 'none'
+  ) => {
+    const capabilities = capabilityPolicyPresetCapabilities(kind, preset, fs_access);
+    if (!capabilities) throw new Error('Invalid test role');
+    return { preset, capabilities, fs_access };
+  };
+  const entry = (
+    principal: CapabilityPolicyEntry['principal'],
+    value: ReturnType<typeof grant>
+  ): CapabilityPolicyEntry => ({
+    entry_id: generateId(),
+    principal,
+    ...value,
+  });
+  const direct = { principal_type: 'user', user_id: member } as const;
+  const workGroup = { principal_type: 'group', group_id: work.group_id } as const;
+  const fileGroup = { principal_type: 'group', group_id: files.group_id } as const;
+
+  async function verify(label: string) {
+    for (const userId of [owner, member, admin]) {
+      // Admin is intentionally just a principal here: bypass belongs to the
+      // trusted service boundary, never to these reusable SQL predicates.
+      const boardPoint = await policyRepo.resolveBoardAccess(board.board_id, userId);
+      const boardSql = await select(
+        db,
+        Object.fromEntries(
+          BOARD_POLICY_CAPABILITIES.map((capability) => [
+            capability,
+            sql`CASE WHEN ${boardCapabilityCondition(db, userId, capability)} THEN 1 ELSE 0 END`,
+          ])
+        )
+      )
+        .from(boards)
+        .where(eq(boards.board_id, board.board_id))
+        .one();
+      for (const capability of BOARD_POLICY_CAPABILITIES) {
+        expect(Boolean(boardSql[capability]), `${label}: board ${capability}`).toBe(
+          boardPoint.capabilities.includes(capability)
+        );
+      }
+      for (const branchId of branchIds) {
+        const point = await policyRepo.resolveBranchAccess(branchId, userId);
+        const row = await select(
+          db,
+          Object.fromEntries(
+            BRANCH_POLICY_CAPABILITIES.map((capability) => [
+              capability,
+              sql`CASE WHEN ${branchCapabilityCondition(db, userId, capability)} THEN 1 ELSE 0 END`,
+            ])
+          )
+        )
+          .from(branches)
+          .where(eq(branches.branch_id, branchId))
+          .one();
+        for (const capability of BRANCH_POLICY_CAPABILITIES) {
+          expect(Boolean(row[capability]), `${label}: branch ${capability}`).toBe(
+            point.capabilities.includes(capability)
+          );
+        }
+      }
+    }
+  }
+
+  async function replaceBranch(
+    entries: CapabilityPolicyEntry[],
+    others = grant('branch_access', 'manager', 'write')
+  ) {
+    const config = {
+      access: {
+        schema_version: 1 as const,
+        policy_kind: 'branch_access' as const,
+        sharing_mode: 'shared' as const,
+        entries,
+        others,
+      },
+      allow_shared_session_prompts: false,
+    };
+    const currentBoard = await policyRepo.getBoardPolicies(board.board_id);
+    await policyRepo.replaceBoardPolicies(
+      board.board_id,
+      { ...currentBoard, branch_template: config },
+      owner
+    );
+    const currentBranch = await policyRepo.getBranchPolicy(branchIds[1]);
+    await policyRepo.replaceBranchPolicy(
+      branchIds[1],
+      { ...currentBranch, override_config: config },
+      owner
+    );
+  }
+
+  await verify('private');
+  // Runtime callers cannot turn an unknown capability into an owner bypass.
+  expect(
+    await select(db)
+      .from(boards)
+      .where(boardCapabilityCondition(db, owner, 'invalid' as BoardPolicyCapability))
+      .all()
+  ).toEqual([]);
+  expect(
+    await select(db)
+      .from(branches)
+      .where(branchCapabilityCondition(db, owner, 'invalid' as BranchPolicyCapability))
+      .all()
+  ).toEqual([]);
+  for (const preset of ['none', 'viewer', 'editor', 'manager'] as const) {
+    for (const source of ['direct', 'group', 'others'] as const) {
+      const current = await policyRepo.getBoardPolicies(board.board_id);
+      current.board_access.sharing_mode = 'shared';
+      current.board_access.others = grant('board_access', source === 'others' ? preset : 'manager');
+      current.board_access.entries =
+        source === 'others'
+          ? []
+          : [entry(source === 'direct' ? direct : workGroup, grant('board_access', preset))];
+      if (source === 'direct')
+        current.board_access.entries.push(entry(workGroup, grant('board_access', 'manager')));
+      await policyRepo.replaceBoardPolicies(board.board_id, current, owner);
+      await verify(`board ${source} ${preset}`);
+    }
+  }
+  for (const preset of ['none', 'viewer', 'collaborator', 'manager'] as const) {
+    for (const fs of ['none', 'read', 'write'] as const) {
+      if (preset === 'none' && fs !== 'none') continue; // Invalid persisted policy, not an authorization case.
+      for (const source of ['direct', 'group', 'others'] as const) {
+        const value = grant('branch_access', preset, fs);
+        const entries =
+          source === 'others' ? [] : [entry(source === 'direct' ? direct : workGroup, value)];
+        if (source === 'direct')
+          entries.push(entry(workGroup, grant('branch_access', 'manager', 'write')));
+        await replaceBranch(entries, source === 'others' ? value : undefined);
+        await verify(`branch ${source} ${preset}/${fs}`);
+      }
+    }
+  }
+  // Role and filesystem dimensions may come from DIFFERENT active groups.
+  const currentBoard = await policyRepo.getBoardPolicies(board.board_id);
+  currentBoard.board_access.entries = [
+    entry(workGroup, grant('board_access', 'editor')),
+    entry(fileGroup, grant('board_access', 'viewer')),
+  ];
+  currentBoard.board_access.others = grant('board_access', 'none');
+  await policyRepo.replaceBoardPolicies(board.board_id, currentBoard, owner);
+  await replaceBranch(
+    [
+      entry(workGroup, grant('branch_access', 'collaborator')),
+      entry(fileGroup, grant('branch_access', 'viewer', 'read')),
+    ],
+    grant('branch_access', 'none')
+  );
+  await verify('split group dimensions');
+  expect((await policyRepo.resolveBranchAccess(branchIds[0], member)).capabilities).toContain(
+    'terminal.open'
+  );
+  await groupRepo.update(files.group_id, { archived: true });
+  await verify('archived filesystem group');
+  expect((await policyRepo.resolveBranchAccess(branchIds[0], member)).capabilities).not.toContain(
+    'terminal.open'
+  );
+  await groupRepo.update(files.group_id, { archived: false });
+  await groupRepo.removeMember(work.group_id, member);
+  await verify('removed role membership');
+  expect((await policyRepo.resolveBranchAccess(branchIds[0], member)).capabilities).toEqual([
+    'branch.view',
+  ]);
+  await groupRepo.removeMember(files.group_id, member);
+  await verify('no matching groups');
+  expect((await policyRepo.resolveBranchAccess(branchIds[0], member)).capabilities).toEqual([]);
+  return { owner, member, admin, boardId: board.board_id, branchId: branchIds[0] };
+}

--- a/packages/core/src/db/repositories/branch-access.parity.postgres.test.ts
+++ b/packages/core/src/db/repositories/branch-access.parity.postgres.test.ts
@@ -1,0 +1,67 @@
+import { and, eq } from 'drizzle-orm';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { generateId } from '../../lib/ids';
+import {
+  BOARD_POLICY_CAPABILITIES,
+  BRANCH_POLICY_CAPABILITIES,
+} from '../../types/capability-policy';
+import { createDatabase, type Database } from '../client';
+import { select } from '../database-wrapper';
+import { initializeDatabase } from '../migrate';
+import { boards, branches } from '../schema';
+import { runWithTenantDatabaseScope } from '../tenant-scope';
+import { boardCapabilityCondition, branchCapabilityCondition } from './branch-access';
+import { exerciseCapabilityPredicateParity } from './branch-access.parity-test-helpers';
+
+const url = process.env.AGOR_TEST_POSTGRES_URL;
+describe.skipIf(!url || process.env.AGOR_DB_DIALECT !== 'postgresql')(
+  'capability predicate parity (PostgreSQL/RLS)',
+  () => {
+    let db: Database;
+    beforeAll(async () => {
+      db = createDatabase({ dialect: 'postgresql', url: url! });
+      await initializeDatabase(db);
+    });
+    afterAll(async () => {
+      await (db as Database & { $client: { end(): Promise<void> } }).$client.end();
+    });
+    it('matches point checks and cannot authorize foreign board/branch IDs, even with their owner ID', async () => {
+      const foreign = await runWithTenantDatabaseScope(
+        db,
+        `foreign-${generateId()}`,
+        exerciseCapabilityPredicateParity
+      );
+      await runWithTenantDatabaseScope(db, `local-${generateId()}`, async (scoped) => {
+        const local = await exerciseCapabilityPredicateParity(scoped);
+        for (const userId of [local.owner, local.member, local.admin, foreign.owner]) {
+          for (const capability of BOARD_POLICY_CAPABILITIES) {
+            expect(
+              await select(scoped)
+                .from(boards)
+                .where(
+                  and(
+                    eq(boards.board_id, foreign.boardId),
+                    boardCapabilityCondition(scoped, userId, capability)
+                  )
+                )
+                .all()
+            ).toEqual([]);
+          }
+          for (const capability of BRANCH_POLICY_CAPABILITIES) {
+            expect(
+              await select(scoped)
+                .from(branches)
+                .where(
+                  and(
+                    eq(branches.branch_id, foreign.branchId),
+                    branchCapabilityCondition(scoped, userId, capability)
+                  )
+                )
+                .all()
+            ).toEqual([]);
+          }
+        }
+      });
+    }, 60000);
+  }
+);

--- a/packages/core/src/db/repositories/branch-access.test.ts
+++ b/packages/core/src/db/repositories/branch-access.test.ts
@@ -1,0 +1,10 @@
+import { dbTest } from '../test-helpers';
+import { exerciseCapabilityPredicateParity } from './branch-access.parity-test-helpers';
+
+dbTest(
+  'SQL capability predicates match point resolution for every role and filesystem dimension (SQLite)',
+  async ({ db }) => {
+    await exerciseCapabilityPredicateParity(db);
+  },
+  30000
+);

--- a/packages/core/src/db/repositories/branch-access.ts
+++ b/packages/core/src/db/repositories/branch-access.ts
@@ -544,6 +544,13 @@ export function visibleBranchReferenceAccessExists(
   );
 }
 
+/**
+ * Shared visibility for session references, including message/task inventories.
+ * The INNER JOIN lets PostgreSQL filter branches before joining their Sessions;
+ * exact session IDs can instead become a bounded parent probe. Do not replace
+ * this with a fenced full inventory indiscriminately: the child-inventory plan
+ * regressions cover both broad and selective shapes across session/child ratios.
+ */
 export function visibleSessionReferenceAccessExists(
   db: Database,
   userId: UserIdExpression,

--- a/packages/core/src/db/repositories/branch-access.ts
+++ b/packages/core/src/db/repositories/branch-access.ts
@@ -1,13 +1,13 @@
 /** Shared SQL predicates for normalized board/branch capability policies. */
 
-import type { CapabilityPolicyFsAccess, SessionID, UserID, UUID } from '@agor/core/types';
+import type { BranchID, CapabilityPolicyFsAccess, SessionID, UserID, UUID } from '@agor/core/types';
 import { and, eq, exists, inArray, or, type SQL, type SQLWrapper, sql } from 'drizzle-orm';
 import {
   CAPABILITY_POLICY_SESSION_SHARING_KEY,
   CAPABILITY_POLICY_WORKSPACE_PREFERENCES_NAMESPACE,
 } from '../../types/capability-policy';
 import type { Database } from '../client';
-import { select } from '../database-wrapper';
+import { isPostgresDatabase, select } from '../database-wrapper';
 import {
   appVariables,
   boardAccessEntries,
@@ -391,6 +391,37 @@ function branchCapabilityCondition(
 
 export function visibleBranchAccessCondition(db: Database, userId: UserIdExpression): SQL {
   return branchCapabilityCondition(db, userId, 'branch.view');
+}
+
+/**
+ * Inventory membership for many rows referring to branches, for one already
+ * authenticated same-tenant principal. Scope filters only intersect visibility.
+ *
+ * Keep policy evaluation at branch cardinality: OFFSET 0 prevents PostgreSQL
+ * flattening this set into the outer query and repeating policy per child row.
+ * SQLite requires an unbounded LIMIT with OFFSET. This is statement-local, not
+ * an authorization cache, and must use the caller's existing tenant DB scope.
+ *
+ * For a selective exact-ID probe or outer-user enumeration use
+ * visibleBranchReferenceAccessExists instead; for effective capabilities and
+ * principal existence checks use CapabilityPolicyRepository.resolveBranchAccess.
+ */
+export function inVisibleBranchSet(
+  db: Database,
+  userId: UUID,
+  branchId: SQLWrapper,
+  scope: { branchId?: BranchID; branchIds?: BranchID[]; boardId?: string } = {}
+): SQL {
+  if (scope.branchIds?.length === 0) return sql`false`;
+  const conditions = [visibleBranchAccessCondition(db, userId)];
+  if (scope.branchId !== undefined) conditions.push(eq(branches.branch_id, scope.branchId));
+  if (scope.branchIds !== undefined) conditions.push(inArray(branches.branch_id, scope.branchIds));
+  if (scope.boardId !== undefined) conditions.push(eq(branches.board_id, scope.boardId));
+  return sql`${branchId} IN (
+    SELECT ${branches.branch_id} FROM ${branches}
+    WHERE ${and(...conditions)}
+    ${isPostgresDatabase(db) ? sql`OFFSET 0` : sql`LIMIT -1 OFFSET 0`}
+  )`;
 }
 
 export function sessionBranchAccessCondition(db: Database, userId: UserIdExpression): SQL {

--- a/packages/core/src/db/repositories/branch-access.ts
+++ b/packages/core/src/db/repositories/branch-access.ts
@@ -1,10 +1,21 @@
 /** Shared SQL predicates for normalized board/branch capability policies. */
 
-import type { BranchID, CapabilityPolicyFsAccess, SessionID, UserID, UUID } from '@agor/core/types';
+import type {
+  BoardPolicyCapability,
+  BranchID,
+  BranchPolicyCapability,
+  CapabilityPolicyFsAccess,
+  SessionID,
+  UserID,
+  UUID,
+} from '@agor/core/types';
 import { and, eq, exists, inArray, or, type SQL, type SQLWrapper, sql } from 'drizzle-orm';
 import {
+  BOARD_POLICY_CAPABILITIES,
+  BRANCH_POLICY_CAPABILITIES,
   CAPABILITY_POLICY_SESSION_SHARING_KEY,
   CAPABILITY_POLICY_WORKSPACE_PREFERENCES_NAMESPACE,
+  capabilityPolicyPresetsGrantingCapability,
 } from '../../types/capability-policy';
 import type { Database } from '../client';
 import { isPostgresDatabase, select } from '../database-wrapper';
@@ -26,23 +37,21 @@ import {
 
 type UserIdExpression = UUID | SQLWrapper;
 
-const BOARD_ROLES_BY_CAPABILITY = {
-  'board.view': ['viewer', 'editor', 'manager'],
-  'board.edit': ['editor', 'manager'],
-  'board.attach_branch': ['editor', 'manager'],
-  'board.policy.manage': ['manager'],
-} as const;
-
-const BRANCH_ROLES_BY_CAPABILITY = {
-  'branch.view': ['viewer', 'collaborator', 'manager'],
-  'sessions.create': ['collaborator', 'manager'],
-  'sessions.prompt_own': ['collaborator', 'manager'],
-  'sessions.manage_others': ['manager'],
-  'branch.manage': ['manager'],
-  'environment.control': ['manager'],
-  'terminal.open': ['collaborator', 'manager'],
-  'branch.policy.manage': ['manager'],
-} as const;
+// Static product definitions only, never principal/resource authorization state.
+// Expand with filesystem access so terminal's role half is included; SQL below
+// still checks actual filesystem grants (including additive group dimensions).
+const BOARD_ROLES_BY_CAPABILITY = Object.fromEntries(
+  BOARD_POLICY_CAPABILITIES.map((capability) => [
+    capability,
+    capabilityPolicyPresetsGrantingCapability('board_access', capability),
+  ])
+);
+const BRANCH_ROLES_BY_CAPABILITY = Object.fromEntries(
+  BRANCH_POLICY_CAPABILITIES.map((capability) => [
+    capability,
+    capabilityPolicyPresetsGrantingCapability('branch_access', capability, 'read'),
+  ])
+);
 
 function roleGrantsCapability(
   column: SQLWrapper,
@@ -368,11 +377,17 @@ function selectRaw(db: Database): any {
   return (db as any).select({ _: sql`1` });
 }
 
-function branchCapabilityCondition(
+/**
+ * Row predicate for an authenticated, existing same-tenant principal. Requires
+ * branches in the outer query and the caller's tenant DB scope; no admin bypass.
+ * This is not a principal-existence check or foreign-session prompt authority.
+ */
+export function branchCapabilityCondition(
   db: Database,
   userId: UserIdExpression,
-  capability: string
+  capability: BranchPolicyCapability
 ): SQL {
+  if (!BRANCH_POLICY_CAPABILITIES.includes(capability)) return sql`false`;
   const directMatch = directBranchEntryExists(db, userId);
   const groupMatch = activeBranchGroupEntryExists(db, userId);
   return (
@@ -493,14 +508,20 @@ function activeBoardGroupEntryExists(
   );
 }
 
-export function visibleBoardAccessCondition(db: Database, userId: UserIdExpression): SQL {
+/** Same authenticated-principal contract as branchCapabilityCondition; outer table is boards. */
+export function boardCapabilityCondition(
+  db: Database,
+  userId: UserIdExpression,
+  capability: BoardPolicyCapability
+): SQL {
+  if (!BOARD_POLICY_CAPABILITIES.includes(capability)) return sql`false`;
   const directMatch = directBoardEntryExists(db, userId);
   const groupMatch = activeBoardGroupEntryExists(db, userId);
   return (
     or(
       eq(boards.primary_owner_user_id, userId),
-      directBoardEntryExists(db, userId, 'board.view'),
-      and(sql`NOT ${directMatch}`, activeBoardGroupEntryExists(db, userId, 'board.view')),
+      directBoardEntryExists(db, userId, capability),
+      and(sql`NOT ${directMatch}`, activeBoardGroupEntryExists(db, userId, capability)),
       and(
         sql`NOT ${directMatch}`,
         sql`NOT ${groupMatch}`,
@@ -511,13 +532,17 @@ export function visibleBoardAccessCondition(db: Database, userId: UserIdExpressi
               and(
                 eq(boardAccessPolicies.board_id, boards.board_id),
                 eq(boardAccessPolicies.sharing_mode, 'shared'),
-                roleGrantsCapability(boardAccessPolicies.others_role, 'board', 'board.view')
+                roleGrantsCapability(boardAccessPolicies.others_role, 'board', capability)
               )
             )
         )
       )
     ) ?? sql`false`
   );
+}
+
+export function visibleBoardAccessCondition(db: Database, userId: UserIdExpression): SQL {
+  return boardCapabilityCondition(db, userId, 'board.view');
 }
 
 export function visibleBoardReferenceAccessExists(

--- a/packages/core/src/db/repositories/inventory-plan-test-helpers.ts
+++ b/packages/core/src/db/repositories/inventory-plan-test-helpers.ts
@@ -1,0 +1,21 @@
+import { type SQL, sql } from 'drizzle-orm';
+
+export function bindQuery(query: string, params: unknown[]): SQL {
+  return sql.join(
+    query
+      .split(/(\$\d+)/)
+      .map((part) =>
+        /^\$\d+$/.test(part) ? sql`${params[Number(part.slice(1)) - 1]}` : sql.raw(part)
+      ),
+    sql``
+  );
+}
+
+export function policyLoops(value: unknown): number[] {
+  if (!value || typeof value !== 'object') return [];
+  const node = value as Record<string, unknown>;
+  return [
+    ...(node['Parent Relationship'] === 'SubPlan' ? [Number(node['Actual Loops'])] : []),
+    ...Object.values(node).flatMap(policyLoops),
+  ];
+}

--- a/packages/core/src/db/repositories/session-children.inventory.postgres.test.ts
+++ b/packages/core/src/db/repositories/session-children.inventory.postgres.test.ts
@@ -275,7 +275,10 @@ describe.skipIf(!url || process.env.AGOR_DB_DIALECT !== 'postgresql')(
               process.stdout.write(
                 `INVENTORY_PLAN s${sessionsPerBranch}-${name}-${queryCount === 1 ? 'all' : i === 0 ? 'count' : 'page'} branches=${branchCount} sessions=${branchCount * sessionsPerBranch} ${JSON.stringify(plan)}\n`
               );
-              expect(Math.max(...policyLoops(plan))).toBeLessThanOrEqual(bound);
+              const loops = policyLoops(plan);
+              // A changed plan/extractor must not silently turn this bound into -Infinity.
+              expect(loops.length).toBeGreaterThan(0);
+              expect(Math.max(...loops)).toBeLessThanOrEqual(bound);
             }
           }
         });

--- a/packages/core/src/db/repositories/session-children.inventory.postgres.test.ts
+++ b/packages/core/src/db/repositories/session-children.inventory.postgres.test.ts
@@ -1,0 +1,286 @@
+import { sql } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import type postgres from 'postgres';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { generateId } from '../../lib/ids';
+import type { MessageID, SessionID, TaskID } from '../../types';
+import { createDatabase, type Database } from '../client';
+import { executeRaw, insert } from '../database-wrapper';
+import { initializeDatabase } from '../migrate';
+import { branches, branchPermissionConfigs, messages, sessions, tasks } from '../schema';
+import * as schema from '../schema.postgres';
+import { runWithTenantDatabaseScope } from '../tenant-scope';
+import { BoardRepository } from './boards';
+import { BranchRepository } from './branches';
+import { bindQuery, policyLoops } from './inventory-plan-test-helpers';
+import { MessagesRepository } from './messages';
+import { RepoRepository } from './repos';
+import { TaskRepository } from './tasks';
+import { UsersRepository } from './users';
+
+const url = process.env.AGOR_TEST_POSTGRES_URL;
+
+describe.skipIf(!url || process.env.AGOR_DB_DIALECT !== 'postgresql')(
+  'message/task inventory query cardinality (isolated PostgreSQL)',
+  () => {
+    let db: Database;
+    const captured: { query: string; params: unknown[] }[] = [];
+    let capture = false;
+    beforeAll(async () => {
+      const raw = createDatabase({ dialect: 'postgresql', url: url! });
+      const client = (raw as unknown as { $client: ReturnType<typeof postgres> }).$client;
+      db = drizzle(client, {
+        schema,
+        logger: {
+          logQuery(query, params) {
+            if (capture) captured.push({ query, params });
+          },
+        },
+      });
+      await initializeDatabase(db);
+    });
+
+    afterAll(async () => {
+      await (db as unknown as { $client: { end(): Promise<void> } }).$client.end();
+    });
+    it.each([1, 10, 100])(
+      'bounds broad and scoped policy work with %i sessions per branch',
+      async (sessionsPerBranch) => {
+        await runWithTenantDatabaseScope(db, `children-${generateId()}`, async (scoped) => {
+          const users = new UsersRepository(scoped);
+          const owner = await users.create({
+            email: `${generateId()}@example.invalid`,
+            role: 'member',
+          });
+          const viewer = await users.create({
+            email: `${generateId()}@example.invalid`,
+            role: 'member',
+          });
+          const board = await new BoardRepository(scoped).create({
+            name: 'Inventory',
+            created_by: owner.user_id,
+          });
+          const repo = await new RepoRepository(scoped).create({
+            slug: `children-${generateId()}`,
+            name: 'Inventory',
+            repo_type: 'remote',
+            remote_url: 'https://example.invalid/fixture.git',
+            local_path: '/tmp/inventory',
+            default_branch: 'main',
+          });
+          const ids: { sessionId: SessionID; taskId: TaskID; messageId: MessageID }[] = [];
+          const branchCount = 200;
+          const childrenPerSession = 100 / sessionsPerBranch;
+          const childrenPerBranch = sessionsPerBranch * childrenPerSession;
+          for (let b = 0; b < branchCount; b++) {
+            const branch = await new BranchRepository(scoped).create({
+              repo_id: repo.repo_id,
+              board_id: board.board_id,
+              created_by: owner.user_id,
+              name: `branch-${b}`,
+              ref: `branch-${b}`,
+              path: `/tmp/inventory/${b}`,
+              branch_unique_id: b,
+              permission_binding: 'override',
+              others_can: b % 2 ? 'view' : 'none',
+            });
+            const sessionIds = Array.from(
+              { length: sessionsPerBranch },
+              () => generateId() as SessionID
+            );
+            await insert(scoped, sessions)
+              .values(
+                sessionIds.map((session_id) => ({
+                  session_id,
+                  branch_id: branch.branch_id,
+                  created_by: owner.user_id,
+                  created_at: new Date(1700000000000),
+                  updated_at: new Date(1700000000000),
+                  status: 'idle',
+                  agentic_tool: 'claude-code',
+                  archived: false,
+                  data: { tasks: [], contextFiles: [], genealogy: { children: [] } },
+                }))
+              )
+              .run();
+            const taskIds = Array.from({ length: childrenPerBranch }, () => generateId() as TaskID);
+            const messageIds = Array.from(
+              { length: childrenPerBranch },
+              () => generateId() as MessageID
+            );
+            ids.push({ sessionId: sessionIds[0], taskId: taskIds[0], messageId: messageIds[0] });
+            await insert(scoped, tasks)
+              .values(
+                taskIds.map((task_id, index) => ({
+                  task_id,
+                  session_id: sessionIds[Math.floor(index / childrenPerSession)],
+                  created_by: owner.user_id,
+                  created_at: new Date(1700000000000),
+                  status: 'completed',
+                  data: {
+                    full_prompt: 'fixture',
+                    message_range: {
+                      start_index: 0,
+                      end_index: 0,
+                      start_timestamp: '2023-11-14T22:13:20.000Z',
+                    },
+                    git_state: { ref_at_start: 'main', sha_at_start: 'fixture' },
+                    tool_use_count: 0,
+                  },
+                }))
+              )
+              .run();
+            await insert(scoped, messages)
+              .values(
+                messageIds.map((message_id, index) => ({
+                  message_id,
+                  session_id: sessionIds[Math.floor(index / childrenPerSession)],
+                  task_id: taskIds[Math.floor(index / childrenPerSession) * childrenPerSession],
+                  created_at: new Date(1700000000000 + index),
+                  timestamp: new Date(1700000000000 + index),
+                  type: 'user',
+                  role: 'user',
+                  index,
+                  data: { content: 'fixture' },
+                }))
+              )
+              .run();
+          }
+          for (const table of [sessions, branches, tasks, messages, branchPermissionConfigs])
+            await executeRaw(scoped, sql`ANALYZE ${table}`);
+          const taskRepo = new TaskRepository(scoped);
+          const messageRepo = new MessagesRepository(scoped);
+          for (const [name, read, total, bound, queryCount = 2] of [
+            [
+              'tasksAll',
+              async () => {
+                const data = await taskRepo.findAll({ visibleToUserId: viewer.user_id });
+                return { data, total: data.length };
+              },
+              10000,
+              branchCount,
+              1,
+            ],
+            [
+              'messagesAll',
+              async () => {
+                const data = await messageRepo.findAll({ visibleToUserId: viewer.user_id });
+                return { data, total: data.length };
+              },
+              10000,
+              branchCount,
+              1,
+            ],
+            [
+              'tasksBroad',
+              () =>
+                taskRepo.findPage({
+                  visibleToUserId: viewer.user_id,
+                  limit: 20,
+                  selectTaskIdOnly: true,
+                }),
+              10000,
+              branchCount,
+            ],
+            [
+              'messagesBroad',
+              () =>
+                messageRepo.findPage({
+                  visibleToUserId: viewer.user_id,
+                  limit: 20,
+                  select: ['message_id'],
+                }),
+              10000,
+              branchCount,
+            ],
+            [
+              'tasksSession',
+              () =>
+                taskRepo.findPage({
+                  visibleToUserId: viewer.user_id,
+                  sessionId: ids[1].sessionId,
+                  limit: 20,
+                }),
+              childrenPerSession,
+              1,
+            ],
+            [
+              'messagesSession',
+              () =>
+                messageRepo.findPage({
+                  visibleToUserId: viewer.user_id,
+                  sessionId: ids[1].sessionId,
+                  limit: 20,
+                }),
+              childrenPerSession,
+              1,
+            ],
+            [
+              'tasksMixed',
+              () =>
+                taskRepo.findPage({
+                  visibleToUserId: viewer.user_id,
+                  sessionIds: [ids[0].sessionId, ids[1].sessionId],
+                  limit: 20,
+                }),
+              childrenPerSession,
+              2,
+            ],
+            [
+              'messagesTask',
+              () =>
+                messageRepo.findPage({
+                  visibleToUserId: viewer.user_id,
+                  taskId: ids[1].taskId,
+                  limit: 20,
+                }),
+              childrenPerSession,
+              1,
+            ],
+            [
+              'tasksExact',
+              () =>
+                taskRepo.findPage({
+                  visibleToUserId: viewer.user_id,
+                  taskId: ids[1].taskId,
+                  limit: 20,
+                }),
+              1,
+              1,
+            ],
+            [
+              'messagesExact',
+              () =>
+                messageRepo.findPage({
+                  visibleToUserId: viewer.user_id,
+                  messageId: ids[1].messageId,
+                  limit: 20,
+                }),
+              1,
+              1,
+            ],
+          ] as const) {
+            captured.length = 0;
+            capture = true;
+            const page = await read();
+            capture = false;
+            expect(page.total).toBe(total);
+            expect(page.data).toHaveLength(queryCount === 1 ? total : Math.min(20, total));
+            expect(captured).toHaveLength(queryCount);
+            for (const [i, query] of captured.entries()) {
+              const plan = await executeRaw(
+                scoped,
+                sql`EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) ${bindQuery(query.query, query.params)}`
+              );
+              process.stdout.write(
+                `INVENTORY_PLAN s${sessionsPerBranch}-${name}-${queryCount === 1 ? 'all' : i === 0 ? 'count' : 'page'} branches=${branchCount} sessions=${branchCount * sessionsPerBranch} ${JSON.stringify(plan)}\n`
+              );
+              expect(Math.max(...policyLoops(plan))).toBeLessThanOrEqual(bound);
+            }
+          }
+        });
+      },
+      180000
+    );
+  }
+);

--- a/packages/core/src/db/repositories/sessions.inventory-test-helpers.ts
+++ b/packages/core/src/db/repositories/sessions.inventory-test-helpers.ts
@@ -1,7 +1,15 @@
 import { eq, sql } from 'drizzle-orm';
 import { expect } from 'vitest';
 import { generateId } from '../../lib/ids';
-import type { BranchID, CapabilityPolicyEntry, UserID } from '../../types';
+import {
+  type BranchID,
+  type CapabilityPolicyEntry,
+  type Message,
+  MessageRole,
+  type Task,
+  TaskStatus,
+  type UserID,
+} from '../../types';
 import type { Database } from '../client';
 import { select } from '../database-wrapper';
 import { branches as branchTable, users as userTable } from '../schema';
@@ -14,8 +22,10 @@ import {
 import { BranchRepository } from './branches';
 import { CapabilityPolicyRepository } from './capability-policies';
 import { GroupRepository } from './groups';
+import { MessagesRepository } from './messages';
 import { RepoRepository } from './repos';
 import { SessionRepository } from './sessions';
+import { TaskRepository } from './tasks';
 import { UsersRepository } from './users';
 
 /** Same inventory authorization contract exercised on SQLite and PostgreSQL/RLS. */
@@ -66,6 +76,10 @@ export async function exerciseSessionInventory(db: Database) {
   const policies = new CapabilityPolicyRepository(db);
   const branches = new BranchRepository(db);
   const sessions = new SessionRepository(db);
+  const taskRepo = new TaskRepository(db);
+  const messageRepo = new MessagesRepository(db);
+  const childTasks: Task[] = [];
+  const childMessages: Message[] = [];
   const visible = new Set<string>();
   const all = new Set<string>();
   const branchIds: BranchID[] = [];
@@ -138,6 +152,25 @@ export async function exerciseSessionInventory(db: Database) {
         custom_context: { inventory: true },
         sdk_home_scope: 'branch',
       });
+      const task = await taskRepo.create({
+        session_id: session.session_id,
+        created_by: owner,
+        status: n % 2 ? TaskStatus.COMPLETED : TaskStatus.CREATED,
+        full_prompt: 'Inventory child',
+      });
+      childTasks.push(task);
+      childMessages.push(
+        await messageRepo.create({
+          session_id: session.session_id,
+          task_id: task.task_id,
+          type: n % 2 ? 'assistant' : 'user',
+          role: n % 2 ? MessageRole.ASSISTANT : MessageRole.USER,
+          index: 0,
+          timestamp: session.created_at,
+          content: 'Inventory child',
+          content_preview: 'Inventory child',
+        })
+      );
       all.add(session.session_id);
       if (!['private', 'shadow', 'group-deny'].includes(kind)) visible.add(session.session_id);
     }
@@ -175,6 +208,93 @@ export async function exerciseSessionInventory(db: Database) {
     expect(
       new Set((await sessions.findAccessibleSessions(userId)).map((row) => row.session_id))
     ).toEqual(expectedIds);
+    // Child inventories reuse the session-reference predicate. Keep all/page/
+    // count/projection semantics aligned with the same currently visible set.
+    const expectedTasks = childTasks
+      .filter((row) => expectedIds.has(row.session_id))
+      .sort((a, b) => a.task_id.localeCompare(b.task_id));
+    const expectedMessages = childMessages
+      .filter((row) => expectedIds.has(row.session_id))
+      .sort((a, b) => a.message_id.localeCompare(b.message_id));
+    expect(
+      new Set((await taskRepo.findAll({ visibleToUserId: userId })).map((row) => row.task_id))
+    ).toEqual(new Set(expectedTasks.map((row) => row.task_id)));
+    expect(
+      new Set((await messageRepo.findAll({ visibleToUserId: userId })).map((row) => row.message_id))
+    ).toEqual(new Set(expectedMessages.map((row) => row.message_id)));
+    expect(
+      await taskRepo.findPage({
+        visibleToUserId: userId,
+        limit: 2,
+        skip: 1,
+        sort: { task_id: 1 },
+        selectTaskIdOnly: true,
+      })
+    ).toEqual({
+      total: expectedTasks.length,
+      data: expectedTasks.slice(1, 3).map((row) => ({ task_id: row.task_id })),
+    });
+    expect(
+      await messageRepo.findPage({
+        visibleToUserId: userId,
+        limit: 2,
+        skip: 1,
+        sort: { message_id: 1 },
+        select: ['message_id'],
+      })
+    ).toEqual({
+      total: expectedMessages.length,
+      data: expectedMessages.slice(1, 3).map((row) => ({ message_id: row.message_id })),
+    });
+    expect(
+      await taskRepo.findPage({ visibleToUserId: userId, limit: 0, status: TaskStatus.COMPLETED })
+    ).toEqual({
+      total: expectedTasks.filter((row) => row.status === TaskStatus.COMPLETED).length,
+      data: [],
+    });
+    expect(
+      await messageRepo.findPage({ visibleToUserId: userId, limit: 0, role: MessageRole.ASSISTANT })
+    ).toEqual({
+      total: expectedMessages.filter((row) => row.role === MessageRole.ASSISTANT).length,
+      data: [],
+    });
+    const visibleChild = expectedTasks[0];
+    const hiddenChild = childTasks.find((row) => !expectedIds.has(row.session_id));
+    if (hiddenChild) {
+      for (const repository of [taskRepo, messageRepo]) {
+        expect(
+          await repository.findPage({
+            visibleToUserId: userId,
+            sessionId: hiddenChild.session_id,
+            limit: 1,
+          })
+        ).toEqual({ total: 0, data: [] });
+        const mixed = await repository.findPage({
+          visibleToUserId: userId,
+          sessionIds: [hiddenChild.session_id, visibleChild.session_id],
+          limit: 1,
+        });
+        expect(mixed.total).toBe(1);
+        expect(mixed.data[0].session_id).toBe(visibleChild.session_id);
+        expect(
+          await repository.findPage({
+            visibleToUserId: userId,
+            sessionId: hiddenChild.session_id,
+            taskId: visibleChild.task_id,
+            limit: 1,
+          })
+        ).toEqual({ total: 0, data: [] });
+      }
+    }
+    for (const repository of [taskRepo, messageRepo]) {
+      expect(await repository.findAll({ visibleToUserId: userId, sessionIds: [] })).toEqual([]);
+      expect(
+        await repository.findPage({ visibleToUserId: userId, sessionIds: [], limit: 1 })
+      ).toEqual({ total: 0, data: [] });
+      expect(
+        (await repository.findPage({ visibleToUserId: userId, skip: 100, limit: 1 })).data
+      ).toEqual([]);
+    }
     for (const boardId of [board.board_id, sharedBoard.board_id]) {
       const expected = new Set(
         paged.data.filter((row) => row.branch_board_id === boardId).map((row) => row.session_id)
@@ -286,5 +406,7 @@ export async function exerciseSessionInventory(db: Database) {
     branchId: groupedBranch,
     sessionId: expected[0].session_id,
     total: all.size,
+    childTaskId: childTasks[0].task_id,
+    childMessageId: childMessages[0].message_id,
   };
 }

--- a/packages/core/src/db/repositories/sessions.inventory-test-helpers.ts
+++ b/packages/core/src/db/repositories/sessions.inventory-test-helpers.ts
@@ -1,8 +1,16 @@
+import { eq, sql } from 'drizzle-orm';
 import { expect } from 'vitest';
 import { generateId } from '../../lib/ids';
 import type { BranchID, CapabilityPolicyEntry, UserID } from '../../types';
 import type { Database } from '../client';
+import { select } from '../database-wrapper';
+import { branches as branchTable, users as userTable } from '../schema';
 import { BoardRepository } from './boards';
+import {
+  inVisibleBranchSet,
+  visibleBranchAccessCondition,
+  visibleBranchReferenceAccessExists,
+} from './branch-access';
 import { BranchRepository } from './branches';
 import { CapabilityPolicyRepository } from './capability-policies';
 import { GroupRepository } from './groups';
@@ -60,6 +68,7 @@ export async function exerciseSessionInventory(db: Database) {
   const sessions = new SessionRepository(db);
   const visible = new Set<string>();
   const all = new Set<string>();
+  const branchIds: BranchID[] = [];
   let groupedBranch!: BranchID;
   let hiddenBranch!: BranchID;
   let shadowBranch!: BranchID;
@@ -82,6 +91,7 @@ export async function exerciseSessionInventory(db: Database) {
       branch_unique_id: i,
       permission_binding: kind === 'inherit' ? 'inherit' : 'override',
     });
+    branchIds.push(branch.branch_id);
     if (kind === 'group') groupedBranch = branch.branch_id;
     if (kind === 'private') hiddenBranch = branch.branch_id;
     if (kind === 'shadow') shadowBranch = branch.branch_id;
@@ -132,6 +142,81 @@ export async function exerciseSessionInventory(db: Database) {
       if (!['private', 'shadow', 'group-deny'].includes(kind)) visible.add(session.session_id);
     }
   }
+  // Differential proof: SQL inventory, exact reference, and rich point checks
+  // answer the same visibility question for an existing authenticated principal.
+  async function verifyPrimitiveParity(userId: UserID) {
+    const rowIds: { id: BranchID }[] = await select(db, { id: branchTable.branch_id })
+      .from(branchTable)
+      .where(visibleBranchAccessCondition(db, userId))
+      .all();
+    const setIds: { id: BranchID }[] = await select(db, { id: branchTable.branch_id })
+      .from(branchTable)
+      .where(inVisibleBranchSet(db, userId, branchTable.branch_id))
+      .all();
+    expect(new Set(setIds.map((row) => row.id))).toEqual(new Set(rowIds.map((row) => row.id)));
+    for (const branchId of branchIds) {
+      const visible = setIds.some((row) => row.id === branchId);
+      const exact = await select(db, {
+        allowed: visibleBranchReferenceAccessExists(db, userId, sql`${branchId}`),
+      })
+        .from(userTable)
+        .where(eq(userTable.user_id, userId))
+        .one();
+      expect(Boolean(exact?.allowed)).toBe(visible);
+      expect(
+        (await policies.resolveBranchAccess(branchId, userId)).capabilities.includes('branch.view')
+      ).toBe(visible);
+    }
+    const paged = await sessions.findPage({ visibleToUserId: userId, limit: 100 });
+    const expectedIds = new Set(paged.data.map((row) => row.session_id));
+    expect(
+      new Set((await sessions.findAll({ visibleToUserId: userId })).map((row) => row.session_id))
+    ).toEqual(expectedIds);
+    expect(
+      new Set((await sessions.findAccessibleSessions(userId)).map((row) => row.session_id))
+    ).toEqual(expectedIds);
+    for (const boardId of [board.board_id, sharedBoard.board_id]) {
+      const expected = new Set(
+        paged.data.filter((row) => row.branch_board_id === boardId).map((row) => row.session_id)
+      );
+      expect(
+        new Set(
+          (await sessions.findByBoard(boardId, { visibleToUserId: userId })).map(
+            (row) => row.session_id
+          )
+        )
+      ).toEqual(expected);
+    }
+    // Exact IDs and intersecting scopes remain filters, not grants.
+    const contradiction = await select(db, { id: branchTable.branch_id })
+      .from(branchTable)
+      .where(
+        inVisibleBranchSet(db, userId, branchTable.branch_id, {
+          branchId: groupedBranch,
+          boardId: sharedBoard.board_id,
+        })
+      )
+      .all();
+    expect(contradiction).toEqual([]);
+    expect(
+      await select(db, { id: branchTable.branch_id })
+        .from(branchTable)
+        .where(inVisibleBranchSet(db, userId, branchTable.branch_id, { branchIds: [] }))
+        .all()
+    ).toEqual([]);
+    const exactSet = await select(db, { id: branchTable.branch_id })
+      .from(branchTable)
+      .where(
+        inVisibleBranchSet(db, userId, branchTable.branch_id, {
+          branchId: groupedBranch,
+          boardId: board.board_id,
+          branchIds: [groupedBranch, hiddenBranch],
+        })
+      )
+      .all();
+    expect(exactSet).toEqual(rowIds.filter((row) => row.id === groupedBranch));
+  }
+  for (const userId of [owner, viewer, admin]) await verifyPrimitiveParity(userId);
   // Board visibility neither grants nor vetoes independent branch visibility.
   expect(await boards.findVisibleBoardIds(viewer)).not.toContain(board.board_id);
   expect(await boards.findVisibleBoardIds(viewer)).toContain(sharedBoard.board_id);
@@ -181,6 +266,7 @@ export async function exerciseSessionInventory(db: Database) {
   });
   // Revocation/fallback is read anew; no process-local allowed-branch cache.
   await groups.update(group.group_id, { archived: true });
+  await verifyPrimitiveParity(viewer);
   expect((await sessions.findPage({ visibleToUserId: viewer, limit: 100 })).total).toBe(16);
   expect(
     (await sessions.findPage({ visibleToUserId: viewer, branchId: groupedBranch, limit: 100 }))
@@ -191,6 +277,7 @@ export async function exerciseSessionInventory(db: Database) {
   ).toBe(0);
   await groups.update(group.group_id, { archived: false });
   await groups.removeMember(group.group_id, viewer);
+  await verifyPrimitiveParity(viewer);
   expect((await sessions.findPage({ visibleToUserId: viewer, limit: 100 })).total).toBe(16);
   return {
     owner,

--- a/packages/core/src/db/repositories/sessions.inventory-test-helpers.ts
+++ b/packages/core/src/db/repositories/sessions.inventory-test-helpers.ts
@@ -1,0 +1,203 @@
+import { expect } from 'vitest';
+import { generateId } from '../../lib/ids';
+import type { BranchID, CapabilityPolicyEntry, UserID } from '../../types';
+import type { Database } from '../client';
+import { BoardRepository } from './boards';
+import { BranchRepository } from './branches';
+import { CapabilityPolicyRepository } from './capability-policies';
+import { GroupRepository } from './groups';
+import { RepoRepository } from './repos';
+import { SessionRepository } from './sessions';
+import { UsersRepository } from './users';
+
+/** Same inventory authorization contract exercised on SQLite and PostgreSQL/RLS. */
+export async function exerciseSessionInventory(db: Database) {
+  const users = new UsersRepository(db);
+  const owner = (await users.create({ email: `${generateId()}@example.invalid`, role: 'member' }))
+    .user_id as UserID;
+  const viewer = (await users.create({ email: `${generateId()}@example.invalid`, role: 'member' }))
+    .user_id as UserID;
+  const admin = (await users.create({ email: `${generateId()}@example.invalid`, role: 'admin' }))
+    .user_id as UserID;
+  const boards = new BoardRepository(db);
+  const board = await boards.create({
+    name: 'Private canvas',
+    created_by: owner,
+    access_mode: 'private',
+  });
+  const sharedBoard = await boards.create({
+    name: 'Shared canvas',
+    created_by: owner,
+    access_mode: 'shared',
+  });
+  const repo = await new RepoRepository(db).create({
+    slug: `inventory-${generateId()}`,
+    name: 'Inventory',
+    repo_type: 'remote',
+    remote_url: 'https://example.invalid/inventory.git',
+    local_path: '/tmp/inventory',
+    default_branch: 'main',
+  });
+  const groups = new GroupRepository(db);
+  const group = await groups.create({ name: 'Readers', created_by: owner });
+  await groups.addMember(group.group_id, viewer, owner);
+  const groupEntry: CapabilityPolicyEntry = {
+    entry_id: generateId(),
+    principal: { principal_type: 'group', group_id: group.group_id },
+    preset: 'viewer',
+    capabilities: ['branch.view'],
+    fs_access: 'none',
+  };
+  const deniedEntry: CapabilityPolicyEntry = {
+    entry_id: generateId(),
+    principal: { principal_type: 'user', user_id: viewer },
+    preset: 'none',
+    capabilities: [],
+    fs_access: 'none',
+  };
+  const policies = new CapabilityPolicyRepository(db);
+  const branches = new BranchRepository(db);
+  const sessions = new SessionRepository(db);
+  const visible = new Set<string>();
+  const all = new Set<string>();
+  let groupedBranch!: BranchID;
+  let hiddenBranch!: BranchID;
+  let shadowBranch!: BranchID;
+  for (const [i, kind] of [
+    'private',
+    'others',
+    'group',
+    'shadow',
+    'group-deny',
+    'direct',
+    'inherit',
+  ].entries()) {
+    const branch = await branches.create({
+      repo_id: repo.repo_id,
+      board_id: kind === 'private' ? sharedBoard.board_id : board.board_id,
+      created_by: owner,
+      name: kind,
+      ref: kind,
+      path: `/tmp/inventory/${kind}`,
+      branch_unique_id: i,
+      permission_binding: kind === 'inherit' ? 'inherit' : 'override',
+    });
+    if (kind === 'group') groupedBranch = branch.branch_id;
+    if (kind === 'private') hiddenBranch = branch.branch_id;
+    if (kind === 'shadow') shadowBranch = branch.branch_id;
+    const policy = await policies.getBranchPolicy(branch.branch_id);
+    const config = policy.override_config ?? policy.inherited_config!;
+    config.access.sharing_mode = kind === 'private' ? 'private' : 'shared';
+    config.access.others = {
+      preset: ['private', 'group'].includes(kind) ? 'none' : 'viewer',
+      capabilities: ['private', 'group'].includes(kind) ? [] : ['branch.view'],
+      fs_access: 'none',
+    };
+    config.access.entries =
+      kind === 'group'
+        ? [groupEntry]
+        : kind === 'shadow'
+          ? [groupEntry, deniedEntry]
+          : kind === 'group-deny'
+            ? [{ ...groupEntry, preset: 'none', capabilities: [] }]
+            : kind === 'direct'
+              ? [{ ...deniedEntry, preset: 'viewer', capabilities: ['branch.view'] }]
+              : [];
+    if (kind === 'inherit') {
+      const boardPolicy = await policies.getBoardPolicies(board.board_id);
+      await policies.replaceBoardPolicies(
+        board.board_id,
+        { ...boardPolicy, branch_template: config },
+        owner
+      );
+    } else {
+      await policies.replaceBranchPolicy(
+        branch.branch_id,
+        { ...policy, override_config: config },
+        owner
+      );
+    }
+    for (let n = 0; n < 4; n++) {
+      const session = await sessions.create({
+        branch_id: branch.branch_id,
+        created_by: owner,
+        status: n === 2 ? 'running' : 'idle',
+        archived: n === 3,
+        created_at: new Date(1700000000000 + n).toISOString(),
+        title: `${kind}-${n}`,
+        custom_context: { inventory: true },
+        sdk_home_scope: 'branch',
+      });
+      all.add(session.session_id);
+      if (!['private', 'shadow', 'group-deny'].includes(kind)) visible.add(session.session_id);
+    }
+  }
+  // Board visibility neither grants nor vetoes independent branch visibility.
+  expect(await boards.findVisibleBoardIds(viewer)).not.toContain(board.board_id);
+  expect(await boards.findVisibleBoardIds(viewer)).toContain(sharedBoard.board_id);
+  const page = await sessions.findPage({ visibleToUserId: viewer, limit: 100 });
+  expect(new Set(page.data.map((s) => s.session_id))).toEqual(visible);
+  expect(page.total).toBe(16);
+  expect((await sessions.findPage({ visibleToUserId: owner, limit: 100 })).total).toBe(all.size);
+  // Admin bypass belongs to the trusted service hook, not to this user-id predicate.
+  expect((await sessions.findPage({ visibleToUserId: admin, limit: 100 })).total).toBe(20);
+  expect((await sessions.findPage({ limit: 100 })).total).toBe(all.size);
+  expect(
+    await sessions.findPage({ visibleToUserId: viewer, branchId: hiddenBranch, limit: 1 })
+  ).toEqual({ total: 0, data: [] });
+  expect(
+    await sessions.findPage({ visibleToUserId: viewer, boardId: sharedBoard.board_id, limit: 1 })
+  ).toEqual({ total: 0, data: [] });
+  expect(await sessions.findPage({ visibleToUserId: viewer, branchIds: [], limit: 1 })).toEqual({
+    total: 0,
+    data: [],
+  });
+  const opts = {
+    visibleToUserId: viewer,
+    archived: false,
+    status: 'idle' as const,
+    sortCreatedAt: -1 as const,
+  };
+  const expected = (await sessions.findPage({ ...opts, limit: 100 })).data;
+  expect(expected).toHaveLength(8);
+  for (let skip = 0; skip <= expected.length; skip += 2) {
+    const slice = await sessions.findPage({ ...opts, limit: 2, skip });
+    expect(slice.total).toBe(8);
+    expect(slice.data).toEqual(expected.slice(skip, skip + 2));
+  }
+  expect(await sessions.findPage({ ...opts, limit: 0 })).toEqual({ total: 8, data: [] });
+  const scoped = await sessions.findPage({
+    visibleToUserId: viewer,
+    branchIds: [groupedBranch, shadowBranch],
+    archived: true,
+    limit: 100,
+  });
+  expect(scoped.total).toBe(1);
+  expect(scoped.data[0]).toMatchObject({
+    branch_id: groupedBranch,
+    branch_board_id: board.board_id,
+    sdk_home_scope: 'branch',
+    custom_context: { inventory: true },
+  });
+  // Revocation/fallback is read anew; no process-local allowed-branch cache.
+  await groups.update(group.group_id, { archived: true });
+  expect((await sessions.findPage({ visibleToUserId: viewer, limit: 100 })).total).toBe(16);
+  expect(
+    (await sessions.findPage({ visibleToUserId: viewer, branchId: groupedBranch, limit: 100 }))
+      .total
+  ).toBe(0);
+  expect(
+    (await sessions.findPage({ visibleToUserId: viewer, branchId: shadowBranch, limit: 100 })).total
+  ).toBe(0);
+  await groups.update(group.group_id, { archived: false });
+  await groups.removeMember(group.group_id, viewer);
+  expect((await sessions.findPage({ visibleToUserId: viewer, limit: 100 })).total).toBe(16);
+  return {
+    owner,
+    viewer,
+    boardId: board.board_id,
+    branchId: groupedBranch,
+    sessionId: expected[0].session_id,
+    total: all.size,
+  };
+}

--- a/packages/core/src/db/repositories/sessions.inventory.postgres.test.ts
+++ b/packages/core/src/db/repositories/sessions.inventory.postgres.test.ts
@@ -1,4 +1,4 @@
-import { type SQL, sql } from 'drizzle-orm';
+import { sql } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/postgres-js';
 import type postgres from 'postgres';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
@@ -13,32 +13,15 @@ import { runWithTenantDatabaseScope } from '../tenant-scope';
 import { BoardRepository } from './boards';
 import { visibleBranchAccessCondition } from './branch-access';
 import { BranchRepository } from './branches';
+import { bindQuery, policyLoops } from './inventory-plan-test-helpers';
+import { MessagesRepository } from './messages';
 import { RepoRepository } from './repos';
 import { SessionRepository } from './sessions';
 import { exerciseSessionInventory } from './sessions.inventory-test-helpers';
+import { TaskRepository } from './tasks';
 import { UsersRepository } from './users';
 
 const url = process.env.AGOR_TEST_POSTGRES_URL;
-
-function bindQuery(query: string, params: unknown[]): SQL {
-  return sql.join(
-    query
-      .split(/(\$\d+)/)
-      .map((part) =>
-        /^\$\d+$/.test(part) ? sql`${params[Number(part.slice(1)) - 1]}` : sql.raw(part)
-      ),
-    sql``
-  );
-}
-
-function policyLoops(value: unknown): number[] {
-  if (!value || typeof value !== 'object') return [];
-  const node = value as Record<string, unknown>;
-  return [
-    ...(node['Parent Relationship'] === 'SubPlan' ? [Number(node['Actual Loops'])] : []),
-    ...Object.values(node).flatMap(policyLoops),
-  ];
-}
 
 describe.skipIf(!url || process.env.AGOR_DB_DIALECT !== 'postgresql')(
   'session inventory query cardinality (isolated PostgreSQL)',
@@ -78,11 +61,34 @@ describe.skipIf(!url || process.env.AGOR_DB_DIALECT !== 'postgresql')(
             []
           );
           expect(await repository.findByBoard(foreign.boardId, { visibleToUserId })).toEqual([]);
+          const taskRepo = new TaskRepository(scoped);
+          const messageRepo = new MessagesRepository(scoped);
+          for (const childRepo of [taskRepo, messageRepo]) {
+            expect(
+              await childRepo.findAll({ visibleToUserId, sessionId: foreign.sessionId })
+            ).toEqual([]);
+            expect(
+              await childRepo.findPage({ visibleToUserId, sessionId: foreign.sessionId, limit: 1 })
+            ).toEqual({ total: 0, data: [] });
+            expect(
+              await childRepo.findPage({ visibleToUserId, taskId: foreign.childTaskId, limit: 0 })
+            ).toEqual({ total: 0, data: [] });
+          }
+          expect(
+            await messageRepo.findPage({
+              visibleToUserId,
+              messageId: foreign.childMessageId,
+              limit: 1,
+            })
+          ).toEqual({ total: 0, data: [] });
           if (visibleToUserId) {
             expect(
               await repository.findAccessibleSessions(visibleToUserId, foreign.boardId)
             ).toEqual([]);
           }
+        }
+        for (const childRepo of [new TaskRepository(scoped), new MessagesRepository(scoped)]) {
+          expect(await childRepo.findPage({ limit: 0 })).toEqual({ total: local.total, data: [] });
         }
         expect((await repository.findPage({ limit: 100 })).total).toBe(local.total);
         expect(

--- a/packages/core/src/db/repositories/sessions.inventory.postgres.test.ts
+++ b/packages/core/src/db/repositories/sessions.inventory.postgres.test.ts
@@ -1,0 +1,201 @@
+import { type SQL, sql } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import type postgres from 'postgres';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { generateId } from '../../lib/ids';
+import type { UUID } from '../../types';
+import { createDatabase, type Database } from '../client';
+import { executeRaw, insert } from '../database-wrapper';
+import { initializeDatabase } from '../migrate';
+import { branches, sessions } from '../schema';
+import * as schema from '../schema.postgres';
+import { runWithTenantDatabaseScope } from '../tenant-scope';
+import { BoardRepository } from './boards';
+import { visibleBranchAccessCondition } from './branch-access';
+import { BranchRepository } from './branches';
+import { RepoRepository } from './repos';
+import { SessionRepository } from './sessions';
+import { exerciseSessionInventory } from './sessions.inventory-test-helpers';
+import { UsersRepository } from './users';
+
+const url = process.env.AGOR_TEST_POSTGRES_URL;
+
+function bindQuery(query: string, params: unknown[]): SQL {
+  return sql.join(
+    query
+      .split(/(\$\d+)/)
+      .map((part) =>
+        /^\$\d+$/.test(part) ? sql`${params[Number(part.slice(1)) - 1]}` : sql.raw(part)
+      ),
+    sql``
+  );
+}
+
+function policyLoops(value: unknown): number[] {
+  if (!value || typeof value !== 'object') return [];
+  const node = value as Record<string, unknown>;
+  return [
+    ...(node['Parent Relationship'] === 'SubPlan' ? [Number(node['Actual Loops'])] : []),
+    ...Object.values(node).flatMap(policyLoops),
+  ];
+}
+
+describe.skipIf(!url || process.env.AGOR_DB_DIALECT !== 'postgresql')(
+  'session inventory query cardinality (isolated PostgreSQL)',
+  () => {
+    let db: Database;
+    const captured: { query: string; params: unknown[] }[] = [];
+    let capture = false;
+    beforeAll(async () => {
+      const raw = createDatabase({ dialect: 'postgresql', url: url! });
+      const client = (raw as unknown as { $client: ReturnType<typeof postgres> }).$client;
+      db = drizzle(client, {
+        schema,
+        logger: {
+          logQuery(query, params) {
+            if (capture) captured.push({ query, params });
+          },
+        },
+      });
+      await initializeDatabase(db);
+    });
+
+    it('preserves policy precedence and prevents cross-tenant inventory/count inference', async () => {
+      const tenantA = `inventory-a-${generateId()}`;
+      const tenantB = `inventory-b-${generateId()}`;
+      const foreign = await runWithTenantDatabaseScope(db, tenantB, exerciseSessionInventory);
+      await runWithTenantDatabaseScope(db, tenantA, async (scoped) => {
+        const local = await exerciseSessionInventory(scoped);
+        const repository = new SessionRepository(scoped);
+        for (const visibleToUserId of [undefined, local.owner, local.viewer]) {
+          expect(
+            await repository.findPage({ visibleToUserId, branchId: foreign.branchId, limit: 1 })
+          ).toEqual({ total: 0, data: [] });
+          expect(
+            await repository.findPage({ visibleToUserId, boardId: foreign.boardId, limit: 0 })
+          ).toEqual({ total: 0, data: [] });
+        }
+        expect((await repository.findPage({ limit: 100 })).total).toBe(local.total);
+        expect(
+          (await repository.findPage({ limit: 100 })).data.map((s) => s.session_id)
+        ).not.toContain(foreign.sessionId);
+      });
+    }, 30000);
+    afterAll(async () => {
+      await (db as unknown as { $client: { end(): Promise<void> } }).$client.end();
+    });
+
+    it('compares session-correlated and branch-set counts under RLS', async () => {
+      await runWithTenantDatabaseScope(db, `inventory-${generateId()}`, async (scoped) => {
+        const users = new UsersRepository(scoped);
+        const owner = await users.create({
+          email: `${generateId()}@example.invalid`,
+          role: 'member',
+        });
+        const viewer = await users.create({
+          email: `${generateId()}@example.invalid`,
+          role: 'member',
+        });
+        const board = await new BoardRepository(scoped).create({
+          name: 'Inventory',
+          created_by: owner.user_id,
+        });
+        const repo = await new RepoRepository(scoped).create({
+          slug: `inventory-${generateId()}`,
+          name: 'Inventory',
+          repo_type: 'remote',
+          remote_url: 'https://example.invalid/inventory.git',
+          local_path: '/tmp/inventory',
+          default_branch: 'main',
+        });
+        const branchRepo = new BranchRepository(scoped);
+        const branchCount = 200;
+        const sessionsPerBranch = 100;
+        for (let b = 0; b < branchCount; b++) {
+          const branch = await branchRepo.create({
+            repo_id: repo.repo_id,
+            board_id: board.board_id,
+            created_by: owner.user_id,
+            name: `branch-${b}`,
+            ref: `branch-${b}`,
+            path: `/tmp/inventory/${b}`,
+            branch_unique_id: b,
+            permission_binding: 'override',
+            others_can: b % 2 ? 'view' : 'none',
+          });
+          await insert(scoped, sessions)
+            .values(
+              Array.from({ length: sessionsPerBranch }, (_, s) => ({
+                session_id: generateId(),
+                branch_id: branch.branch_id,
+                created_by: owner.user_id,
+                created_at: new Date(1700000000000 + s),
+                updated_at: new Date(1700000000000 + s),
+                status: 'idle',
+                agentic_tool: 'claude-code',
+                archived: false,
+                data: {
+                  tasks: [],
+                  contextFiles: [],
+                  genealogy: { children: [] },
+                  title: `Session ${s}`,
+                },
+              }))
+            )
+            .run();
+        }
+        await executeRaw(scoped, sql`ANALYZE sessions`);
+        await executeRaw(scoped, sql`ANALYZE branches`);
+        await executeRaw(scoped, sql`ANALYZE branch_permission_configs`);
+        const predicate = visibleBranchAccessCondition(scoped, viewer.user_id as UUID);
+        const legacy = sql`SELECT count(*) FROM ${sessions}
+          LEFT JOIN ${branches} ON ${sessions.branch_id} = ${branches.branch_id}
+          WHERE ${sessions.archived} = false AND ${predicate}`;
+        const legacyCount = await executeRaw(scoped, legacy);
+        const repository = new SessionRepository(scoped);
+        const opts = {
+          archived: false,
+          visibleToUserId: viewer.user_id as UUID,
+          limit: 20,
+          sortUpdatedAt: -1 as const,
+        };
+        captured.length = 0;
+        capture = true;
+        const page = await repository.findPage(opts);
+        capture = false;
+        expect(page.total).toBe((branchCount * sessionsPerBranch) / 2);
+        expect(Number((legacyCount as { count: string }[])[0].count)).toBe(page.total);
+        expect(page.data).toHaveLength(20);
+        expect(captured).toHaveLength(2);
+        expect(captured[1].query).not.toContain('"branches"."data"');
+        const actualQueries = captured.map(({ query, params }) => bindQuery(query, params));
+        for (const [name, query] of [
+          ['legacy', legacy],
+          ['count', actualQueries[0]],
+          ['page', actualQueries[1]],
+        ] as const) {
+          const plan = await executeRaw(
+            scoped,
+            sql`EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) ${query}`
+          );
+          if (name !== 'legacy') {
+            const loops = policyLoops(plan);
+            expect(loops.length).toBeGreaterThan(0);
+            expect(Math.max(...loops)).toBeLessThanOrEqual(branchCount);
+          }
+          process.stdout.write(
+            `INVENTORY_PLAN ${name} branches=${branchCount} sessions=${branchCount * sessionsPerBranch} ${JSON.stringify(plan)}\n`
+          );
+        }
+        captured.length = 0;
+        capture = true;
+        expect(await repository.findPage({ ...opts, limit: 0 })).toEqual({
+          total: page.total,
+          data: [],
+        });
+        capture = false;
+        expect(captured).toHaveLength(1);
+      });
+    }, 120000);
+  }
+);

--- a/packages/core/src/db/repositories/sessions.inventory.postgres.test.ts
+++ b/packages/core/src/db/repositories/sessions.inventory.postgres.test.ts
@@ -3,7 +3,7 @@ import { drizzle } from 'drizzle-orm/postgres-js';
 import type postgres from 'postgres';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { generateId } from '../../lib/ids';
-import type { UUID } from '../../types';
+import type { BranchID, UUID } from '../../types';
 import { createDatabase, type Database } from '../client';
 import { executeRaw, insert } from '../database-wrapper';
 import { initializeDatabase } from '../migrate';
@@ -74,6 +74,15 @@ describe.skipIf(!url || process.env.AGOR_DB_DIALECT !== 'postgresql')(
           expect(
             await repository.findPage({ visibleToUserId, boardId: foreign.boardId, limit: 0 })
           ).toEqual({ total: 0, data: [] });
+          expect(await repository.findAll({ visibleToUserId, branchId: foreign.branchId })).toEqual(
+            []
+          );
+          expect(await repository.findByBoard(foreign.boardId, { visibleToUserId })).toEqual([]);
+          if (visibleToUserId) {
+            expect(
+              await repository.findAccessibleSessions(visibleToUserId, foreign.boardId)
+            ).toEqual([]);
+          }
         }
         expect((await repository.findPage({ limit: 100 })).total).toBe(local.total);
         expect(
@@ -111,6 +120,7 @@ describe.skipIf(!url || process.env.AGOR_DB_DIALECT !== 'postgresql')(
         const branchRepo = new BranchRepository(scoped);
         const branchCount = 200;
         const sessionsPerBranch = 100;
+        let visibleBranchId!: BranchID;
         for (let b = 0; b < branchCount; b++) {
           const branch = await branchRepo.create({
             repo_id: repo.repo_id,
@@ -123,6 +133,7 @@ describe.skipIf(!url || process.env.AGOR_DB_DIALECT !== 'postgresql')(
             permission_binding: 'override',
             others_can: b % 2 ? 'view' : 'none',
           });
+          if (b === 1) visibleBranchId = branch.branch_id;
           await insert(scoped, sessions)
             .values(
               Array.from({ length: sessionsPerBranch }, (_, s) => ({
@@ -186,6 +197,50 @@ describe.skipIf(!url || process.env.AGOR_DB_DIALECT !== 'postgresql')(
           process.stdout.write(
             `INVENTORY_PLAN ${name} branches=${branchCount} sessions=${branchCount * sessionsPerBranch} ${JSON.stringify(plan)}\n`
           );
+        }
+        // The residual and compatibility inventories must use the same bounded
+        // branch-set composition as paging, not re-evaluate policy per Session.
+        for (const [name, read, expectedRows, policyBound] of [
+          [
+            'findAll',
+            () => repository.findAll({ visibleToUserId: viewer.user_id }),
+            page.total,
+            branchCount,
+          ],
+          [
+            'findByBoard',
+            () => repository.findByBoard(board.board_id, { visibleToUserId: viewer.user_id }),
+            page.total,
+            branchCount,
+          ],
+          [
+            'findAccessibleSessions',
+            () => repository.findAccessibleSessions(viewer.user_id, board.board_id),
+            page.total,
+            branchCount,
+          ],
+          [
+            'findAllExactBranch',
+            () =>
+              repository.findAll({ visibleToUserId: viewer.user_id, branchId: visibleBranchId }),
+            sessionsPerBranch,
+            1,
+          ],
+        ] as const) {
+          captured.length = 0;
+          capture = true;
+          const inventory = await read();
+          capture = false;
+          expect(inventory).toHaveLength(expectedRows);
+          expect(captured).toHaveLength(1);
+          const plan = await executeRaw(
+            scoped,
+            sql`EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON) ${bindQuery(captured[0].query, captured[0].params)}`
+          );
+          process.stdout.write(
+            `INVENTORY_PLAN ${name} branches=${branchCount} sessions=${branchCount * sessionsPerBranch} ${JSON.stringify(plan)}\n`
+          );
+          expect(Math.max(...policyLoops(plan))).toBeLessThanOrEqual(policyBound);
         }
         captured.length = 0;
         capture = true;

--- a/packages/core/src/db/repositories/sessions.inventory.postgres.test.ts
+++ b/packages/core/src/db/repositories/sessions.inventory.postgres.test.ts
@@ -246,7 +246,10 @@ describe.skipIf(!url || process.env.AGOR_DB_DIALECT !== 'postgresql')(
           process.stdout.write(
             `INVENTORY_PLAN ${name} branches=${branchCount} sessions=${branchCount * sessionsPerBranch} ${JSON.stringify(plan)}\n`
           );
-          expect(Math.max(...policyLoops(plan))).toBeLessThanOrEqual(policyBound);
+          const loops = policyLoops(plan);
+          // A changed plan/extractor must not silently turn this bound into -Infinity.
+          expect(loops.length).toBeGreaterThan(0);
+          expect(Math.max(...loops)).toBeLessThanOrEqual(policyBound);
         }
         captured.length = 0;
         capture = true;

--- a/packages/core/src/db/repositories/sessions.inventory.test.ts
+++ b/packages/core/src/db/repositories/sessions.inventory.test.ts
@@ -1,0 +1,9 @@
+import { dbTest } from '../test-helpers';
+import { exerciseSessionInventory } from './sessions.inventory-test-helpers';
+
+dbTest(
+  'session inventory preserves policy precedence, filtering, mapping and pages (SQLite)',
+  async ({ db }) => {
+    await exerciseSessionInventory(db);
+  }
+);

--- a/packages/core/src/db/repositories/sessions.ts
+++ b/packages/core/src/db/repositories/sessions.ts
@@ -582,7 +582,22 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
         conditions.push(inArray(sessions.branch_id, opts.branchIds));
       if (opts.archived !== undefined) conditions.push(eq(sessions.archived, opts.archived));
       if (opts.visibleToUserId) {
-        conditions.push(visibleBranchAccessCondition(this.db, opts.visibleToUserId));
+        // Keep policy evaluation at branch cardinality, not session cardinality.
+        // OFFSET 0 prevents PostgreSQL from flattening this into the outer join
+        // and repeating the correlated policy subplans for every Session. SQLite
+        // requires LIMIT with OFFSET; -1 means unbounded. This set exists only
+        // within each statement and keeps the same tenant/RLS scope and predicate.
+        const branchConditions = [visibleBranchAccessCondition(this.db, opts.visibleToUserId)];
+        if (opts.boardId !== undefined) branchConditions.push(eq(branches.board_id, opts.boardId));
+        if (opts.branchId !== undefined)
+          branchConditions.push(eq(branches.branch_id, opts.branchId));
+        if (opts.branchIds !== undefined)
+          branchConditions.push(inArray(branches.branch_id, opts.branchIds));
+        conditions.push(sql`${sessions.branch_id} IN (
+          SELECT ${branches.branch_id} FROM ${branches}
+          WHERE ${and(...branchConditions)}
+          ${isPostgresDatabase(this.db) ? sql`OFFSET 0` : sql`LIMIT -1 OFFSET 0`}
+        )`);
       }
       const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
 
@@ -593,10 +608,11 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
         .leftJoin(branches, eq(sessions.branch_id, branches.branch_id));
       const countRow = await (whereClause ? countQuery.where(whereClause) : countQuery).one();
       const total = Number(countRow?.count ?? 0);
+      if (opts.limit === 0) return { data: [], total };
 
       // Page of rows, recency-sorted in SQL on the real `updated_at` column.
       // biome-ignore lint/suspicious/noExplicitAny: Conditional query builder shape differs with the RBAC join
-      let dataQuery: any = select(this.db)
+      let dataQuery: any = select(this.db, { sessions, branches: { board_id: branches.board_id } })
         .from(sessions)
         .leftJoin(branches, eq(sessions.branch_id, branches.branch_id));
       if (whereClause) dataQuery = dataQuery.where(whereClause);

--- a/packages/core/src/db/repositories/sessions.ts
+++ b/packages/core/src/db/repositories/sessions.ts
@@ -60,7 +60,7 @@ import {
   RepositoryError,
   resolveByShortIdPrefix,
 } from './base';
-import { visibleBranchAccessCondition } from './branch-access';
+import { inVisibleBranchSet } from './branch-access';
 import { deepMerge } from './merge-utils';
 import {
   extractMessageText,
@@ -434,7 +434,9 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
         conditions.push(eq(sessions.archived, filter.archived));
       }
       if (filter?.visibleToUserId) {
-        conditions.push(visibleBranchAccessCondition(this.db, filter.visibleToUserId));
+        conditions.push(
+          inVisibleBranchSet(this.db, filter.visibleToUserId, sessions.branch_id, filter)
+        );
       }
 
       // biome-ignore lint/suspicious/noExplicitAny: Conditional query builder shape differs with the RBAC join
@@ -518,7 +520,9 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
 
       const conditions = [eq(branches.board_id, boardId)];
       if (filter?.visibleToUserId) {
-        conditions.push(visibleBranchAccessCondition(this.db, filter.visibleToUserId));
+        conditions.push(
+          inVisibleBranchSet(this.db, filter.visibleToUserId, sessions.branch_id, { boardId })
+        );
       }
 
       // Filter on the branch's board_id via the JOIN (sessions.board_id is dead).
@@ -582,22 +586,9 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
         conditions.push(inArray(sessions.branch_id, opts.branchIds));
       if (opts.archived !== undefined) conditions.push(eq(sessions.archived, opts.archived));
       if (opts.visibleToUserId) {
-        // Keep policy evaluation at branch cardinality, not session cardinality.
-        // OFFSET 0 prevents PostgreSQL from flattening this into the outer join
-        // and repeating the correlated policy subplans for every Session. SQLite
-        // requires LIMIT with OFFSET; -1 means unbounded. This set exists only
-        // within each statement and keeps the same tenant/RLS scope and predicate.
-        const branchConditions = [visibleBranchAccessCondition(this.db, opts.visibleToUserId)];
-        if (opts.boardId !== undefined) branchConditions.push(eq(branches.board_id, opts.boardId));
-        if (opts.branchId !== undefined)
-          branchConditions.push(eq(branches.branch_id, opts.branchId));
-        if (opts.branchIds !== undefined)
-          branchConditions.push(inArray(branches.branch_id, opts.branchIds));
-        conditions.push(sql`${sessions.branch_id} IN (
-          SELECT ${branches.branch_id} FROM ${branches}
-          WHERE ${and(...branchConditions)}
-          ${isPostgresDatabase(this.db) ? sql`OFFSET 0` : sql`LIMIT -1 OFFSET 0`}
-        )`);
+        conditions.push(
+          inVisibleBranchSet(this.db, opts.visibleToUserId, sessions.branch_id, opts)
+        );
       }
       const whereClause = conditions.length > 0 ? and(...conditions) : undefined;
 
@@ -1481,7 +1472,7 @@ export class SessionRepository implements BaseRepository<Session, Partial<Sessio
 
     // Join branches for board_id (exposed as Session.branch_board_id).
     // No boards join needed — flat `/s/<short>/` URLs don't carry a slug.
-    const accessCondition = visibleBranchAccessCondition(this.db, userId);
+    const accessCondition = inVisibleBranchSet(this.db, userId, sessions.branch_id, { boardId });
     const whereCondition = boardId
       ? and(accessCondition, eq(branches.board_id, boardId))
       : accessCondition;

--- a/packages/core/src/types/capability-policy.test.ts
+++ b/packages/core/src/types/capability-policy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   CAPABILITY_POLICY_SCHEMA_VERSION,
+  capabilityPolicyPresetsGrantingCapability,
   normalizeCapabilityPolicyCapabilities,
   removeCapabilityPolicyCapability,
   resolveCapabilityPolicyAccess,
@@ -10,6 +11,57 @@ import type { CapabilityPolicyDraft, GroupID, UserID, UUID } from './index';
 
 const groupId = '00000000-0000-0000-0000-000000000101' as GroupID;
 const entryId = '00000000-0000-0000-0000-000000000201' as UUID;
+
+describe('canonical capability-to-role expansion', () => {
+  it('preserves board role ordering and excludes branch-only roles', () => {
+    expect(capabilityPolicyPresetsGrantingCapability('board_access', 'board.view')).toEqual([
+      'viewer',
+      'editor',
+      'manager',
+    ]);
+    for (const capability of ['board.edit', 'board.attach_branch'] as const) {
+      expect(capabilityPolicyPresetsGrantingCapability('board_access', capability)).toEqual([
+        'editor',
+        'manager',
+      ]);
+    }
+    expect(
+      capabilityPolicyPresetsGrantingCapability('board_access', 'board.policy.manage')
+    ).toEqual(['manager']);
+    expect(capabilityPolicyPresetsGrantingCapability('board_access', 'branch.view')).toEqual([]);
+  });
+
+  it('keeps branch management separate from terminal filesystem requirements', () => {
+    expect(capabilityPolicyPresetsGrantingCapability('branch_access', 'branch.view')).toEqual([
+      'viewer',
+      'collaborator',
+      'manager',
+    ]);
+    for (const capability of ['sessions.create', 'sessions.prompt_own'] as const) {
+      expect(capabilityPolicyPresetsGrantingCapability('branch_access', capability)).toEqual([
+        'collaborator',
+        'manager',
+      ]);
+    }
+    for (const capability of [
+      'sessions.manage_others',
+      'branch.manage',
+      'environment.control',
+      'branch.policy.manage',
+    ] as const) {
+      expect(capabilityPolicyPresetsGrantingCapability('branch_access', capability)).toEqual([
+        'manager',
+      ]);
+    }
+    expect(capabilityPolicyPresetsGrantingCapability('branch_access', 'terminal.open')).toEqual([]);
+    for (const fs of ['read', 'write'] as const) {
+      expect(
+        capabilityPolicyPresetsGrantingCapability('branch_access', 'terminal.open', fs)
+      ).toEqual(['collaborator', 'manager']);
+    }
+    expect(capabilityPolicyPresetsGrantingCapability('branch_access', 'board.view')).toEqual([]);
+  });
+});
 
 function branchPolicy(overrides: Partial<CapabilityPolicyDraft> = {}): CapabilityPolicyDraft {
   return {

--- a/packages/core/src/types/capability-policy.ts
+++ b/packages/core/src/types/capability-policy.ts
@@ -254,6 +254,17 @@ export function capabilityPolicyPresetCapabilities(
   return normalizeCapabilityPolicyCapabilities(kind, capabilities);
 }
 
+/** Inverse of canonical role expansion, including the supplied filesystem dimension. */
+export function capabilityPolicyPresetsGrantingCapability(
+  kind: CapabilityPolicyKind,
+  capability: CapabilityPolicyCapability,
+  fsAccess: CapabilityPolicyFsAccess = 'none'
+): CapabilityPolicyPresetId[] {
+  return (Object.keys(PRESET_CAPABILITIES[kind]) as CapabilityPolicyPresetId[]).filter((preset) =>
+    capabilityPolicyPresetCapabilities(kind, preset, fsAccess)?.includes(capability)
+  );
+}
+
 export function capabilityPolicyPrincipalKey(principal: CapabilityPolicyPrincipalRef): string {
   return principal.principal_type === 'user'
     ? `user:${principal.user_id}`


### PR DESCRIPTION
## Summary

Fix the reproduced expensive session-inventory SQL by evaluating the **unchanged** normalized owner/direct-user/group/Others predicate at branch cardinality, not once per Session.

- Shared `inVisibleBranchSet(db, userId, branchIdExpression, { branchId?, branchIds?, boardId? })` owns the statement-local membership set, intersecting scopes, and dialect-compatible optimization fence. All four session inventory readers reuse it: `findPage`, `findAll`, `findByBoard`, `findAccessibleSessions`.
- Page projection selects every Session column plus only `branches.board_id`, avoiding repeated branch blobs.
- `$limit:0` is count-only on the session SQL-page path; SQL paging respects the adapter's configured default/max.
- Residual filters and `$select` retain their existing path. ID-less selection skips relationship enrichment instead of sending undefined SQL parameters or reintroducing unselected fields.

**Audit corrections:** sessions explicitly configure a maximum of **10,000**, not the generic adapter's 1,000 fallback; valid `$limit:10000` remains supported. Exact-status SQL paging was independently fixed by main #2687 during this work and was retained rather than duplicated.

## Shared RBAC primitives and the message/task follow-up

Policy SQL was already centralized in `branch-access.ts`; this PR does not rewrite its nested authorization rules or role maps.

| Question | Owner |
| --- | --- |
| Filter many rows referring to branches | `inVisibleBranchSet` |
| Check an exact branch reference / enumerate its current viewers | `visibleBranchReferenceAccessExists` |
| Resolve effective capabilities, filesystem access, ownership/source and principal existence | `CapabilityPolicyRepository.resolveBranchAccess` / `BranchRepository.resolveUserAccess` |
| Authorize task launch/heartbeat including shared-session prompting | Existing `resolveSessionRuntimeBranchAccess` |
| Filter task/message inventories through their session | Existing `visibleSessionReferenceAccessExists` |

Inventory SQL takes an **already authenticated, existing same-tenant principal** in a trusted tenant DB scope. It is not an arbitrary-user authentication API, does not implement tenant-admin bypass, and does not equate view rights with foreign-session prompting or filesystem access. Existing trusted service hooks and PostgreSQL RLS remain authoritative.

The user-requested message/task investigation found an important difference: their existing `EXISTS` uses an **INNER JOIN**. Inspected PostgreSQL plans already filter branches first for broad inventory and use a selective parent lookup for exact IDs. **No message/task runtime SQL rewrite was justified or shipped.** Instead this PR adds repeatable plan, authorization, pagination and isolation guardrails for those endpoints, plus shared test-only plan inspection helpers and a primitive-selection guide.

## Follow-up: shared capability definitions and auditable SQL primitives

- SQL role allow-lists now derive from the canonical policy role expansion via `capabilityPolicyPresetsGrantingCapability`; no independent board/branch role maps to drift.
- Typed `boardCapabilityCondition` / `branchCapabilityCondition` expose the existing row-policy composition for capability-specific consumers. Visibility/admission wrappers keep using the same precedence and query shapes. Unknown capabilities fail closed, including for owners.
- New persisted-policy SQL-versus-point-resolver matrix covers all 12 board/branch capabilities, every role/valid filesystem dimension, direct-user shadowing, groups/Others, owner/admin distinctions, inherited/override configurations, split-group terminal grants and archive/membership revocation on both dialects. PostgreSQL checks foreign board/branch IDs for every capability, including a foreign-owner-ID bypass attempt.
- The initial matrix passed against the historical role tables before replacing them (13 SQLite/type tests). Canonical expansion assertions preserve the old allow-lists. No authorization discrepancy reproduced: this removes drift risk, not a newly discovered access bug. Static role definitions are not an authorization cache.
- No additional inventory query rewrite, new public query operator, or claimed performance speedup in this follow-up; existing branch-cardinality and selective-reference plan regressions remain authoritative.

## Exact baseline, commits and independence

- Initial clean/fetched main: `33a428b95dc4a0f42a1ac8d551d533ce81ebd16d`.
- Intermediate tested main: `74e96187b663cd533a1925a46d3ba5db72047890` (#2687).
- **Current tested base:** `8f8b3ec764a9c28ee658b4f2d5cedf95265c5e47`.
- Current PR commits:
  - `a10a2fcf310fa53b5f9407f0dfd4133109d66e9d` — session count/page optimization and regressions.
  - `a71716eaaac5e6b03e36396e6d8c561efb44a8bd` — audit evidence.
  - `1470af728e53400bf776307408ef6fe59926472d` — shared branch-set composition across session inventories.
  - `b2e6dce995af8591ea1bdfd695a8ad13268d5989` — message/task plan and authorization guardrails.
  - `7dab01e2b8f6f4df0a913dd9ad2edb2ab3bf8734` — canonical role expansion and capability-wide SQL/point parity.
- Prior #2555 (`5ff672d98646f97226bf14284dace87c672fff9b`) and #2669 (`ac0861269cc40811b521e6c6765e59d363309665`) were verified as ancestors.
- Clone-diagnostics #2686 later merged into main. This branch received it only through the normal rebase onto current main; no PR ref was fetched/cherry-picked and none of its source is modified in this PR's delta. Earlier reported PR commit hashes were rewritten by that rebase; the evidence document records the chronology.
- The audit's `9326e8706a971fae6f45bc9ae38f998f10fe2d17` was not the implementation baseline.

## Reproduction: sessions

Disposable PostgreSQL 16/pgvector, verified NOSUPERUSER/NOBYPASSRLS application role, separate tenant fixtures. The test captures actual repository SQL and runs `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)` only against isolated fixtures.

200 branches × 100 sessions = 20,000 sessions; half the branches permit the unmatched viewer. Authorized count remains **10,000**.

| Query | Max policy SubPlan loops | Shared buffer hits | Observed execution ms |
| --- | ---: | ---: | ---: |
| Baseline session count | 20,000 | 850,569 | 11,801.383 |
| Changed count | 200 | 9,466 | 129.028 |
| Changed page (20 rows) | 200 | 9,485 | 154.571 |
| Baseline `findAll` in the shared-primitives follow-up | 20,000 | 850,569 | 14,730.310 |
| Changed `findAll` | 200 | 9,479 | 190.928 |
| Changed `findByBoard` | 200 | 9,480 | 172.433 |
| Changed `findAccessibleSessions` | 200 | 9,480 | 287.931 |
| Changed `findAll`, exact branch (100 rows) | 1 | 58 | 1.490 |

These are representative fixture observations from documented runs, **not production speedup estimates**. Assertions cover equal authorized counts, returned cardinality, policy-loop bounds, projection and query counts—not timing. A normal session page remains two queries, count-only one; relationship enrichment is separate.

## Reproduction: existing message/task SQL

The new child-inventory suite fixes cardinality at 200 branches and 20,000 rows **in each** of tasks/messages, with 1/10/100 sessions per branch and respectively 100/10/1 children per session.

It captures actual `findAll`, count and page SQL. Broad policy work is bounded at **200**, exact-session/task/message work at **1**, and a two-session mixed denied/visible scope at **2**. The initial 2,000-session run already met those bounds without production changes: task/message broad counts observed 144.951/146.700 ms; exact-session counts 0.673/0.691 ms. This is evidence for retaining the existing shared INNER JOIN shape, not a claimed speedup.

Shared SQLite/PostgreSQL fixtures compare branch-row SQL, branch-set SQL, exact-reference SQL, rich point resolution, session readers and message/task inventories. They cover owner/admin distinctions, direct-user shadowing, active groups, Others, inherited policies, private/shared boards, group archive/removal, branch/board/session scopes, empty/contradictory/mixed scopes, status/role, select, count, skip and stable pagination. Foreign session/task/message IDs and unmarked count-only requests cannot leak another tenant's rows or totals.

[Detailed evidence, operational limits and repeatable commands](https://github.com/preset-io/agor/blob/7dab01e2b8f6f4df0a913dd9ad2edb2ab3bf8734/docs/internal/session-inventory-sql-2026-09-07.md).

## Validation on current base

- [x] `pnpm i`.
- [x] `pnpm check`: type/build checks, lint, 330 frontend fixtures, short-ID, multitenancy, daemon-filesystem and realtime boundaries.
- [x] Core focused: **256 passed / 7 files** — capability types, capability SQL/point parity, session inventory, session repository, capability policies, messages, tasks.
- [x] Daemon focused: **187 passed / 6 files** — sessions.find, RBAC find scoping, branch authorization, MCP sessions, messages, task pagination.
- [x] `AGOR_POSTGRES_TEST_CONCURRENCY=1 pnpm test:postgres:docker`: **268 passed / 0 failed / 0 skipped across 55 files**, plus runner interruption cleanup (processes, databases, reports). All three message/task cardinality ratios met the 200 broad and 1/2 selective policy-loop bounds.
- [x] Rebuilt managed HA: both replicas passed REST/Socket.IO session/task/message exact/selected/count inventory and same/cross-tenant member/admin denial. Mixed message-session scopes returned only authorized rows; the public Task validator still rejected unsupported `session_id.$in` (repository-level mixed scopes remain tested). Invalid session-status operators also remained rejected. Chromium rendered member inventory, canvas, the seeded task/message and Sessions sidebar; screenshot inspected. The existing constrained-HA MCP OAuth unsupported-flow page error remains (not a clean-console smoke). Managed environment stopped afterward.
- Normal pre-commit hooks passed; all git operations used simple-git. Branch remains attached to this PR and pinned in Agor Coding Tasks.

Earlier stages also passed their focused/full suites. One intermediate pre-follow-up PostgreSQL run hit an unrelated existing 10-second knowledge-embedding HA timeout; that entire file and later full runs passed without weakening its timeout or tests. Temporary new-test authoring errors were fixed before the final validation above. This follow-up also stopped an early PostgreSQL run with SIGTERM to rediscover the final test-file set; cleanup removed its disposable container/databases before the complete rerun.

## Telemetry and operational caveats

The supplied [17:12:20 trace](https://app.datadoghq.com/apm/trace/6a9ef074000000007d3ed6f31f3dec4e?spanID=7779615651796564656) shows a 6,379.933594 ms find and 3,139.570801 ms authorization-filtered count. The following 3,038.710205 ms SQL span is non-parsable: its text, plan and row count remain **unknown**, not established as the page query.

This session had no attached Datadog MCP and the eligible catalog was empty. Supplied evidence was used without asking for secrets. Retained spans are sampled, not traffic-wide rates/p95. Missing deployment SHA and no matching application logs do not establish deployment identity or absence of errors.

Counts still inspect matching rows, large branch inventories still incur policy costs, and unsupported session query shapes still materialize authorized residual candidates. Plans are not claimed optimal for every distribution/filter/PostgreSQL version. The separate 49.49-second `branches.get` PostgreSQL `CONNECT_TIMEOUT` (trace `6a9e7def0000000079cfe8b709b9bfe7`) is not explained by this fix.

No schema/index migration, RBAC/RLS/validation weakening, global authorization cache, telemetry change, production mutation, deploy, merge or issue closure. Health-monitor transactions, OAuth/gateway changes and sibling board-query validation remain out of scope.


## Independent review follow-up

Codex reviewer `gpt-6-astra` approved `7dab01e2b8f6f4df0a913dd9ad2edb2ab3bf8734` with no substantive issues and one optional test-hardening suggestion. Commit `b7da7ec860804583c18d9c5883a545e80cb9dd96` addresses that suggestion: both additional inventory-plan assertions now require nonempty extracted SubPlans before applying the maximum-loop bound, preventing `Math.max(...[]) === -Infinity` from passing vacuously. A future fully decorrelated plan will require explicit inspection, not a silent pass.

This is test-only; no production semantics changed. Core typecheck, Biome for the two changed files, normal commit hooks, and the complete isolated PostgreSQL lane passed again: **268 passed, zero failed/skipped across 55 suites**, plus interruption cleanup. Previous installation/full check/core/daemon/HA-browser results remain recorded above; no new build or HA smoke was needed for these assertion-only edits. The same `gpt-6-astra` reviewer approved follow-up HEAD `b7da7ec860804583c18d9c5883a545e80cb9dd96`: no substantive issues or outstanding suggestions remain. Prior full-PR approval still applies. Review session: https://agor.sandbox.preset.zone/ui/s/01a07e80f262712190c3e409/.



## User-approved CI follow-up: installer stale-lock race

CI job [101904763688](https://github.com/preset-io/agor/actions/runs/34175779031/job/101904763688) failed the CLI assertion that only one of two stale-lock reclaimers acquires. The installer source, test, and dependency lockfile were identical to the tested base; the installer files also remain unchanged in newer main `4510b163e32ce8b7920996c2c09de7d20af97d21`. An unchanged-code CI retry passed. The user explicitly requested investigating and fixing the underlying intermittent behavior rather than treating that retry as a fix.

Commit `241989a741efc940a2f9d2fb32551c8e97fa8b4e` adds a filesystem acquisition guard around the existing heartbeat lease. Atomic `mkdir` serializes stale inspection/removal across processes; randomized retries alone could not prevent one contender deleting another's replacement lock. The new deterministic regression intercepts only the dependency's first stale `stat` callback while retaining real filesystem/locking logic: it **fails on the original code** because a second contender acquires, and passes with the guard. Independent-process tests cover fresh/stale contention; separate-root and abandoned-guard tests cover scope and fail-closed recovery. Existing race and permission tests remain enabled.

This resource is deployment-owned, host-local managed package state—not a tenant database or tenant-owned cache. No tenant/RLS/session SQL changes, new dependency, kernel helper, package install/download, or production mutation. Root and lock permissions remain unchanged. The guard is removed before reconciliation begins; the existing 10-second stale/5-second heartbeat lease remains unchanged. The guard itself never expires: interruption during acquisition requires verifying that no installer is running, then removing only the empty path identified in the error. This deliberate fail-closed availability tradeoff, and the prohibition on concurrent mixed-version installers, are documented in the installation guide.

Validation: `pnpm i`, `pnpm check`, **185 CLI tests across 30 files**, and a built-CLI lock smoke on a disposable root (stale recovery, live contention, guard cleanup, release/reacquire) all passed. Normal hooks passed. Existing SQL/HA/browser evidence is unchanged; those suites were not rerun for this installer-only fix. The review label was removed pending follow-up from the same reviewer; new-head CI and renewed review remain pending.


The same reviewer approved installer fix `241989a741efc940a2f9d2fb32551c8e97fa8b4e` with no substantive issues, suggesting an explicit assertion that the paused first installer succeeds after resumption. Test-only follow-up `69f908ef422f20a06234742e97bd5638f634e68c` adds that assertion **after cleanup**; no feedback was skipped. Biome, CLI typecheck, and all 26 focused installer tests passed; normal hooks passed. The same `gpt-6-astra` reviewer approved final HEAD `69f908ef422f20a06234742e97bd5638f634e68c`: no substantive issues or outstanding suggestions remain; prior SQL/RBAC and installer approvals apply. The `ai-reviewed-gpt-6-astra` label records completed code review, not CI success. Final-head CI is still running. No additional production changes.

