### PR TITLE
fix(mcp): bound remote capability descriptions safely

### DIFF
--- a/apps/agor-daemon/src/mcp-egress/gateway.test.ts
+++ b/apps/agor-daemon/src/mcp-egress/gateway.test.ts
@@ -890,6 +890,73 @@ describe('authoritative MCP gateway real transport', () => {
     });
   });
 
+  it('does not reserialize non-metadata JSON responses', async () => {
+    const payload =
+      '{"jsonrpc":"2.0","id":79,"result":{"structuredContent":{"id":9007199254740993}}}';
+    const url = await listen((_request, response) => {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(payload);
+    });
+    const h = await harness({ server: { transport: 'http', url, auth: { type: 'none' } } });
+    const result = await h.request(
+      'POST',
+      JSON.stringify({ jsonrpc: '2.0', id: 79, method: 'tools/call', params: { name: 'search' } })
+    );
+    expect(await result.response.text()).toBe(payload);
+  });
+
+  it.each(['application/json', 'text/event-stream'])(
+    'scans reflected credentials before truncation in %s tools/list',
+    async (contentType) => {
+      const token = 'fictional-provider-credential-0123456789-ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+      const description =
+        'x'.repeat(
+          MAX_MCP_CAPABILITY_DESCRIPTION_LENGTH - MCP_DESCRIPTION_TRUNCATION_SUFFIX.length - 24
+        ) + token;
+      const url = await listen((_request, response) => {
+        const payload = JSON.stringify({
+          jsonrpc: '2.0',
+          id: 78,
+          result: {
+            tools: [{ name: 'search', description, inputSchema: { type: 'object' } }],
+          },
+        });
+        response.writeHead(200, { 'content-type': contentType });
+        response.end(contentType === 'application/json' ? payload : `data: ${payload}\n\n`);
+      });
+      const h = await harness({
+        server: { transport: 'http', url, auth: { type: 'bearer', token } },
+      });
+      await expect(
+        h.request('POST', JSON.stringify({ jsonrpc: '2.0', id: 78, method: 'tools/list' }))
+      ).rejects.toMatchObject({ code: 'credential_reflection_blocked' });
+    }
+  );
+
+  it('preserves multiline schema annotations and literal whitespace values on tools/list', async () => {
+    const tool = {
+      name: 'search',
+      description: 'Search mail',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          query: { type: 'string', description: 'First line\nSecond line\tformatted' },
+          separator: { type: 'string', enum: ['\n', '\t'], default: '\n' },
+        },
+      },
+    };
+    const url = await listen((_request, response) => {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ jsonrpc: '2.0', id: 77, result: { tools: [tool] } }));
+    });
+    const h = await harness({ server: { transport: 'http', url, auth: { type: 'none' } } });
+    const result = await h.request(
+      'POST',
+      JSON.stringify({ jsonrpc: '2.0', id: 77, method: 'tools/list' })
+    );
+    expect(await result.response.json()).toMatchObject({ result: { tools: [tool] } });
+  });
+
   it('rejects malformed tools/list metadata with a targeted provider diagnostic', async () => {
     const url = await listen((_request, response) => {
       response.writeHead(200, { 'content-type': 'application/json' });

--- a/apps/agor-daemon/src/mcp-egress/gateway.test.ts
+++ b/apps/agor-daemon/src/mcp-egress/gateway.test.ts
@@ -19,6 +19,10 @@ import {
   UsersRepository,
 } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
+import {
+  MAX_MCP_CAPABILITY_DESCRIPTION_LENGTH,
+  MCP_DESCRIPTION_TRUNCATION_SUFFIX,
+} from '@agor/core/mcp';
 import { refreshAndPersistToken } from '@agor/core/tools/mcp/oauth-refresh';
 import {
   capabilityPolicyPresetCapabilities,
@@ -842,6 +846,65 @@ describe('authoritative MCP gateway real transport', () => {
     ).resolves.toMatchObject({
       result: 'DEBUG=1 initialize',
     });
+  });
+
+  it('normalizes overlong tools/list metadata on the mediated agent path', async () => {
+    const longDescription = `fictional provider ${'📬'.repeat(40_000)}`;
+    const url = await listen((_request, response) => {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: 7,
+          result: {
+            tools: [
+              {
+                name: 'fictional_mail_search',
+                description: longDescription,
+                inputSchema: { type: 'object', properties: { query: { type: 'string' } } },
+                annotations: { readOnlyHint: true },
+              },
+            ],
+          },
+        })
+      );
+    });
+    const h = await harness({ server: { transport: 'http', url, auth: { type: 'none' } } });
+    const result = await h.request(
+      'POST',
+      JSON.stringify({ jsonrpc: '2.0', id: 7, method: 'tools/list' })
+    );
+    const payload = (await result.response.json()) as {
+      result: { tools: Array<Record<string, unknown>> };
+    };
+    expect(String(payload.result.tools[0]?.description).length).toBeLessThanOrEqual(
+      MAX_MCP_CAPABILITY_DESCRIPTION_LENGTH
+    );
+    expect(
+      String(payload.result.tools[0]?.description).endsWith(MCP_DESCRIPTION_TRUNCATION_SUFFIX)
+    ).toBe(true);
+    expect(payload.result.tools[0]).toMatchObject({
+      name: 'fictional_mail_search',
+      inputSchema: { type: 'object' },
+      annotations: { readOnlyHint: true },
+    });
+  });
+
+  it('rejects malformed tools/list metadata with a targeted provider diagnostic', async () => {
+    const url = await listen((_request, response) => {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: 8,
+          result: { tools: [{ name: 'fictional_mail_search', description: { private: true } }] },
+        })
+      );
+    });
+    const h = await harness({ server: { transport: 'http', url, auth: { type: 'none' } } });
+    await expect(
+      h.request('POST', JSON.stringify({ jsonrpc: '2.0', id: 8, method: 'tools/list' }))
+    ).rejects.toMatchObject({ code: 'invalid_mcp_tool_metadata' });
   });
 
   it('uses a second SQLite connection to prove a commit before final admission prevents provider observation', async () => {

--- a/apps/agor-daemon/src/mcp-egress/gateway.ts
+++ b/apps/agor-daemon/src/mcp-egress/gateway.ts
@@ -299,9 +299,16 @@ function validateBufferedMCPResponse(
   const text = Buffer.from(body).toString('utf8');
   if (contentType === 'application/json' || contentType?.endsWith('+json')) {
     try {
-      const parsed = normalizeToolsListResponse(JSON.parse(text), requestBody);
+      const parsed = JSON.parse(text);
+      // Check the original decoded payload: shortening a description can cut
+      // through a reflected credential and hide the full match from the scan.
       assertNoDecodedSecret(parsed, secrets);
-      return new TextEncoder().encode(JSON.stringify(parsed));
+      // Unrelated JSON-RPC results are not metadata. Preserve their wire bytes
+      // (including numbers that a non-JavaScript client can decode losslessly).
+      if (toolsListRequestIds(requestBody).size === 0) return body;
+      return new TextEncoder().encode(
+        JSON.stringify(normalizeToolsListResponse(parsed, requestBody))
+      );
     } catch (error) {
       if (error instanceof MCPEgressGatewayError) throw error;
       throw new MCPEgressGatewayError(
@@ -322,9 +329,11 @@ function validateBufferedMCPResponse(
         .join('\n');
       if (!data || data === '[DONE]') continue;
       try {
-        const parsed = normalizeToolsListResponse(JSON.parse(data), requestBody);
+        const parsed = JSON.parse(data);
         assertNoDecodedSecret(parsed, secrets);
-        released.push(`data: ${JSON.stringify(parsed)}\n\n`);
+        released.push(
+          `data: ${JSON.stringify(normalizeToolsListResponse(parsed, requestBody))}\n\n`
+        );
       } catch (error) {
         if (error instanceof MCPEgressGatewayError) throw error;
         throw new MCPEgressGatewayError(

--- a/apps/agor-daemon/src/mcp-egress/gateway.ts
+++ b/apps/agor-daemon/src/mcp-egress/gateway.ts
@@ -21,6 +21,7 @@ import {
   buildMCPTemplateContextFromEnv,
   extractMCPTemplateDependencies,
   isMCPServerUsableBy,
+  normalizeDiscoveredMCPCapabilities,
   resolveMcpServerTemplates,
 } from '@agor/core/mcp';
 import { mergeMCPRemoteHeaders } from '@agor/core/tools/mcp/http-headers';
@@ -290,15 +291,17 @@ function assertNoDecodedSecret(value: unknown, secrets: string[]): void {
 function validateBufferedMCPResponse(
   response: Response,
   body: Uint8Array,
-  secrets: string[]
+  secrets: string[],
+  requestBody?: Uint8Array
 ): Uint8Array {
   if (body.byteLength === 0) return body;
   const contentType = response.headers.get('content-type')?.split(';', 1)[0]?.trim().toLowerCase();
   const text = Buffer.from(body).toString('utf8');
   if (contentType === 'application/json' || contentType?.endsWith('+json')) {
     try {
-      assertNoDecodedSecret(JSON.parse(text), secrets);
-      return body;
+      const parsed = normalizeToolsListResponse(JSON.parse(text), requestBody);
+      assertNoDecodedSecret(parsed, secrets);
+      return new TextEncoder().encode(JSON.stringify(parsed));
     } catch (error) {
       if (error instanceof MCPEgressGatewayError) throw error;
       throw new MCPEgressGatewayError(
@@ -319,7 +322,7 @@ function validateBufferedMCPResponse(
         .join('\n');
       if (!data || data === '[DONE]') continue;
       try {
-        const parsed = JSON.parse(data);
+        const parsed = normalizeToolsListResponse(JSON.parse(data), requestBody);
         assertNoDecodedSecret(parsed, secrets);
         released.push(`data: ${JSON.stringify(parsed)}\n\n`);
       } catch (error) {
@@ -338,6 +341,72 @@ function validateBufferedMCPResponse(
     'unstructured_response_not_mediated',
     'Only bounded JSON or JSON SSE MCP responses are mediated'
   );
+}
+
+function toolsListRequestIds(body?: Uint8Array): Set<string> {
+  if (!body?.byteLength) return new Set();
+  try {
+    const parsed = JSON.parse(Buffer.from(body).toString('utf8')) as unknown;
+    const requests = Array.isArray(parsed) ? parsed : [parsed];
+    return new Set(
+      requests.flatMap((request) => {
+        if (!request || typeof request !== 'object') return [];
+        const record = request as { id?: unknown; method?: unknown };
+        return record.method === 'tools/list' && record.id !== undefined
+          ? [JSON.stringify(record.id)]
+          : [];
+      })
+    );
+  } catch {
+    return new Set();
+  }
+}
+
+/** Normalize tool metadata on the mediated agent path as well as discovery. */
+function normalizeToolsListResponse(value: unknown, requestBody?: Uint8Array): unknown {
+  const ids = toolsListRequestIds(requestBody);
+  if (ids.size === 0) return value;
+  const responses = Array.isArray(value) ? value : [value];
+  for (const response of responses) {
+    if (!response || typeof response !== 'object') continue;
+    const record = response as { id?: unknown; result?: { tools?: unknown } };
+    if (!ids.has(JSON.stringify(record.id)) || !Array.isArray(record.result?.tools)) continue;
+    try {
+      const normalized = normalizeDiscoveredMCPCapabilities({
+        tools: record.result.tools.map((tool, index) => {
+          if (!tool || typeof tool !== 'object' || Array.isArray(tool)) {
+            throw new Error(`tools[${index}] must be an object`);
+          }
+          const candidate = tool as {
+            name?: unknown;
+            description?: unknown;
+            inputSchema?: unknown;
+          };
+          return {
+            name: candidate.name,
+            ...(candidate.description === undefined ? {} : { description: candidate.description }),
+            ...(candidate.inputSchema === undefined ? {} : { input_schema: candidate.inputSchema }),
+          };
+        }),
+        resources: [],
+        prompts: [],
+      }).capabilities.tools;
+      record.result.tools = record.result.tools.map((tool, index) => {
+        const original = { ...(tool as Record<string, unknown>) };
+        const description = normalized[index]?.description;
+        if (description === undefined) delete original.description;
+        else original.description = description;
+        return original;
+      });
+    } catch {
+      throw new MCPEgressGatewayError(
+        502,
+        'invalid_mcp_tool_metadata',
+        'Provider returned invalid MCP tool metadata'
+      );
+    }
+  }
+  return value;
 }
 
 function requestedToolNames(body?: Uint8Array): string[] {
@@ -921,7 +990,7 @@ export class MCPEgressGateway {
         admitted.env,
         finalHeaders
       );
-      const releasedBody = validateBufferedMCPResponse(response, body, secrets);
+      const releasedBody = validateBufferedMCPResponse(response, body, secrets, input.body);
       timer({ outcome: 'complete' });
       return {
         response: new Response(releasedBody, {

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -68,6 +68,7 @@ import {
   hasTemplateMarker,
   isMCPServerUsableBy,
   type MCPExternalErrorStage,
+  normalizeDiscoveredMCPCapabilities,
   sanitizeMCPExternalError,
 } from '@agor/core/mcp';
 import type {
@@ -5766,35 +5767,38 @@ export async function registerMCPServices(
             listTimeout,
           ])) as PromptsResult;
 
+          const discovered = {
+            tools: toolsResult.tools.map((t) => ({
+              name: t.name,
+              description: t.description,
+              input_schema: t.inputSchema,
+            })),
+            resources: resourcesResult.resources.map((r) => ({
+              uri: r.uri,
+              name: r.name,
+              description: r.description,
+              mimeType: r.mimeType,
+            })),
+            prompts: promptsResult.prompts.map((p) => ({
+              name: p.name,
+              description: p.description,
+              arguments: p.arguments?.map((a) => ({
+                name: a.name,
+                description: a.description,
+                required: a.required,
+              })),
+            })),
+          };
+          let normalizedDiscovery = normalizeDiscoveredMCPCapabilities(discovered);
+
           if (serverId && discoveryAuthority) {
-            await runWithinOAuthAuthority(assertCurrentRequestAuthority, () =>
+            normalizedDiscovery = await runWithinOAuthAuthority(assertCurrentRequestAuthority, () =>
               runWithTenantDatabaseTransaction(db, tenantId, (scopedDb) =>
                 persistDiscoveredMCPCapabilities(
                   scopedDb,
                   tenantId,
                   discoveryAuthority as MCPDiscoveryAuthoritySnapshot,
-                  {
-                    tools: toolsResult.tools.map((t) => ({
-                      name: t.name,
-                      description: t.description,
-                      input_schema: t.inputSchema,
-                    })),
-                    resources: resourcesResult.resources.map((r) => ({
-                      uri: r.uri,
-                      name: r.name,
-                      description: r.description,
-                      mimeType: r.mimeType,
-                    })),
-                    prompts: promptsResult.prompts.map((p) => ({
-                      name: p.name,
-                      description: p.description,
-                      arguments: p.arguments?.map((a) => ({
-                        name: a.name,
-                        description: a.description,
-                        required: a.required,
-                      })),
-                    })),
-                  },
+                  discovered,
                   process.env.AGOR_MASTER_SECRET ?? ''
                 )
               )
@@ -5813,20 +5817,23 @@ export async function registerMCPServices(
           return {
             success: true,
             capabilities: {
-              tools: toolsResult.tools.length,
-              resources: resourcesResult.resources.length,
-              prompts: promptsResult.prompts.length,
+              tools: normalizedDiscovery.capabilities.tools.length,
+              resources: normalizedDiscovery.capabilities.resources.length,
+              prompts: normalizedDiscovery.capabilities.prompts.length,
             },
-            tools: toolsResult.tools.map((t) => ({
+            metadata: {
+              descriptions_truncated: normalizedDiscovery.truncatedDescriptions,
+            },
+            tools: normalizedDiscovery.capabilities.tools.map((t) => ({
               name: t.name,
               description: t.description || '',
             })),
-            resources: resourcesResult.resources.map((r) => ({
+            resources: normalizedDiscovery.capabilities.resources.map((r) => ({
               name: r.name,
               uri: r.uri,
               mimeType: r.mimeType,
             })),
-            prompts: promptsResult.prompts.map((p) => ({
+            prompts: normalizedDiscovery.capabilities.prompts.map((p) => ({
               name: p.name,
               description: p.description || '',
             })),

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -82,6 +82,8 @@ import type {
   AuthenticatedParams,
   HookContext,
   MCPAuth,
+  MCPDiscoveryRequest,
+  MCPDiscoveryResult,
   MCPOAuthAttemptID,
   MCPOAuthBrowserEventRequest,
   MCPOAuthBrowserOperation,
@@ -5190,30 +5192,9 @@ export async function registerMCPServices(
   // Discover endpoint
   app.use('/mcp-servers/discover', {
     async create(
-      data: {
-        mcp_server_id?: string;
-        url?: string;
-        transport?: 'http' | 'sse';
-        auth?: {
-          type: 'none' | 'bearer' | 'jwt' | 'oauth';
-          token?: string;
-          api_url?: string;
-          api_token?: string;
-          api_secret?: string;
-          oauth_token_url?: string;
-          oauth_client_id?: string;
-          oauth_client_secret?: string;
-          oauth_scope?: string;
-          oauth_grant_type?: string;
-          oauth_mode?: 'per_user' | 'shared';
-          oauth_compatibility_mode?: 'strict' | 'legacy';
-          oauth_dcr_mode?: MCPOAuthDCRMode;
-        };
-        headers?: Record<string, string>;
-        oauth_browser_event?: MCPOAuthBrowserEventRequest;
-      },
+      data: MCPDiscoveryRequest,
       params?: AuthenticatedParams
-    ) {
+    ): Promise<MCPDiscoveryResult> {
       try {
         const browserReservation = consumeOAuthBrowserReservation(
           data.oauth_browser_event,
@@ -5239,7 +5220,7 @@ export async function registerMCPServices(
         const { mergeMCPRemoteHeaders } = await import('@agor/core/tools/mcp/http-headers');
         const tenantId = tenantIdFromParams(params);
 
-        const validateUrl = (url: string): { valid: boolean; error?: string } => {
+        const validateUrl = (url: string): { valid: true } | { valid: false; error: string } => {
           try {
             const parsed = new URL(url);
             if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
@@ -5789,7 +5770,7 @@ export async function registerMCPServices(
               })),
             })),
           };
-          let normalizedDiscovery = normalizeDiscoveredMCPCapabilities(discovered);
+          let normalizedDiscovery: ReturnType<typeof normalizeDiscoveredMCPCapabilities>;
 
           if (serverId && discoveryAuthority) {
             normalizedDiscovery = await runWithinOAuthAuthority(assertCurrentRequestAuthority, () =>
@@ -5812,6 +5793,8 @@ export async function registerMCPServices(
               tenantId,
               [userId, authoritativeServer?.owner_user_id].filter(Boolean) as UserID[]
             );
+          } else {
+            normalizedDiscovery = normalizeDiscoveredMCPCapabilities(discovered);
           }
 
           return {

--- a/apps/agor-daemon/src/utils/mcp-discovered-capabilities.test.ts
+++ b/apps/agor-daemon/src/utils/mcp-discovered-capabilities.test.ts
@@ -17,6 +17,10 @@ import {
   users,
 } from '@agor/core/db';
 import { Conflict, Forbidden } from '@agor/core/feathers';
+import {
+  MAX_MCP_CAPABILITY_DESCRIPTION_LENGTH,
+  MCP_DESCRIPTION_TRUNCATION_SUFFIX,
+} from '@agor/core/mcp';
 import type { MCPServer, UserID } from '@agor/core/types';
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
@@ -136,6 +140,42 @@ describe('discovery authority/configuration CAS (SQLite)', () => {
     await expect(
       new MCPServerRepository(db).update(server.mcp_server_id, { display_name: 'Still editable' })
     ).resolves.toMatchObject({ display_name: 'Still editable', ...legal });
+  });
+
+  it('persists the same bounded representation returned to Test Authentication', async () => {
+    const snapshot = await captureSnapshot();
+    const providerDescription = `Fictional mail tool ${'📨'.repeat(40_000)}`;
+    const result = await runWithTenantDatabaseTransaction(db, undefined, (scopedDb) =>
+      persistDiscoveredMCPCapabilities(
+        scopedDb,
+        undefined,
+        snapshot,
+        {
+          tools: [
+            {
+              name: 'fictional_mail_search',
+              description: providerDescription,
+              input_schema: { type: 'object' },
+            },
+          ],
+          resources: [],
+          prompts: [],
+        },
+        masterSecret
+      )
+    );
+
+    expect(result.truncatedDescriptions).toBe(1);
+    const description = result.capabilities.tools[0]?.description ?? '';
+    expect(description.length).toBeLessThanOrEqual(MAX_MCP_CAPABILITY_DESCRIPTION_LENGTH);
+    expect(description.endsWith(MCP_DESCRIPTION_TRUNCATION_SUFFIX)).toBe(true);
+    await expect(new MCPServerRepository(db).findById(server.mcp_server_id)).resolves.toMatchObject(
+      {
+        tools: result.capabilities.tools,
+        resources: [],
+        prompts: [],
+      }
+    );
   });
 
   it('fails closed on oversized or malicious provider discovery before persistence', async () => {

--- a/apps/agor-daemon/src/utils/mcp-discovered-capabilities.ts
+++ b/apps/agor-daemon/src/utils/mcp-discovered-capabilities.ts
@@ -12,7 +12,7 @@ import {
   UsersRepository,
 } from '@agor/core/db';
 import { Conflict, Forbidden, NotAuthenticated, NotFound } from '@agor/core/feathers';
-import { assertValidDiscoveredMCPCapabilities } from '@agor/core/mcp';
+import { normalizeDiscoveredMCPCapabilities } from '@agor/core/mcp';
 import { isAtLeastMemberRole, mayMemberUseMCPTransport } from '@agor/core/mcp/member-policy';
 import type {
   MCPAuth,
@@ -233,11 +233,11 @@ export async function persistDiscoveredMCPCapabilities(
   snapshot: MCPDiscoveryAuthoritySnapshot,
   capabilities: DiscoveredMCPCapabilities,
   masterSecret: string
-): Promise<void> {
+): Promise<{ capabilities: DiscoveredMCPCapabilities; truncatedDescriptions: number }> {
   // Provider discovery output is untrusted input. Bound and close it before
   // any durable work so an oversized or extension-bearing response cannot be
   // persisted and later bypass API redaction/export assumptions.
-  assertValidDiscoveredMCPCapabilities(capabilities);
+  const normalized = normalizeDiscoveredMCPCapabilities(capabilities);
   assertTenantDiscoveryScope(db, true);
   if (tenantId) await assertTenantWritable(db, tenantId);
 
@@ -322,9 +322,10 @@ export async function persistDiscoveredMCPCapabilities(
   if (
     !(await repository.setDiscoveredCapabilitiesInCurrentTransaction(
       snapshot.serverId,
-      capabilities
+      normalized.capabilities
     ))
   ) {
     throw new NotFound('MCP server not found');
   }
+  return normalized;
 }

--- a/apps/agor-docs/content/guide/mcp-servers.mdx
+++ b/apps/agor-docs/content/guide/mcp-servers.mdx
@@ -15,7 +15,7 @@ For unsupported schemes, configure the server in **Settings → MCP Servers**. C
 
 ### Capability metadata
 
-Remote tool, resource, and prompt descriptions are untrusted optional free text. Agor keeps every valid capability name and schema, but deterministically shortens descriptions that exceed the per-field or aggregate safe metadata budget. **Test Authentication** reports when this happened. Malformed names, schemas, or non-string descriptions still fail with the affected capability path instead of being silently repaired. The same bounded tool descriptions are stored for display and applied by the mediated MCP egress path used in `compatibility` and `enforced` gateway modes.
+Remote tool, resource, and prompt descriptions are untrusted optional free text. Agor keeps every valid capability name and schema, but deterministically shortens descriptions that exceed the per-field or aggregate safe metadata budget. **Test Connection** (or **Save & Test Connection** for a saved/OAuth server) reports when this happened. Malformed names, schemas, or non-string descriptions still fail validation instead of being silently repaired. The same bounded tool descriptions are stored for display and applied by the mediated MCP egress path used in `compatibility` and `enforced` gateway modes.
 
 ### Local stdio servers
 
@@ -26,6 +26,8 @@ Upgrading Agor removes obsolete remote-auth, URL, and header fields from existin
 ## Safe edits, storage, and removal
 
 Bearer tokens and other MCP auth/header/env secrets are stored in MCP server JSON according to the deployment's storage security. Catalog installs are private to their owner, access controls restrict the row, and API, realtime, and UI projections redact secrets. Redaction is an output-boundary control, not application-level encryption; encryption at rest applies only when the deployment's documented database or storage configuration guarantees it. OAuth access and refresh tokens use Agor's per-user OAuth token store.
+
+**Test Authentication** on a new form checks authentication setup; **Test Connection** lists capabilities. Saved servers and new OAuth servers use **Save & Test Connection**: it saves the current form first, then probes only that durable server configuration. This preserves saved secrets and binds OAuth grants to the correct endpoint. A failed save prevents the probe. After OAuth creates a server, **Save** saves subsequent edits rather than simply dismissing the form. Results are cleared when the draft, server, or authenticated caller changes.
 
 Editing authentication is patch-safe: leaving a saved secret blank preserves it, while **Clear saved secret** explicitly removes it. Other omitted authentication fields are preserved; switching authentication type replaces the old mode. The edit form uses a configuration revision to detect another device's concurrent save. If that happens, **Reload latest** fetches the authoritative row and deliberately discards the local unsaved form before another save. OAuth shared/per-user mode changes remove credentials and grants that belong to the previous subject mode.
 

--- a/apps/agor-docs/content/guide/mcp-servers.mdx
+++ b/apps/agor-docs/content/guide/mcp-servers.mdx
@@ -13,6 +13,10 @@ Marketplace checks the live endpoint before installing it. An entry may be:
 
 For unsupported schemes, configure the server in **Settings → MCP Servers**. Custom headers support services such as Datadog API/application-key pairs; Marketplace's Datadog entry instead asks for the bearer PAT/SAT described in Datadog's MCP setup guide.
 
+### Capability metadata
+
+Remote tool, resource, and prompt descriptions are untrusted optional free text. Agor keeps every valid capability name and schema, but deterministically shortens descriptions that exceed the per-field or aggregate safe metadata budget. **Test Authentication** reports when this happened. Malformed names, schemas, or non-string descriptions still fail with the affected capability path instead of being silently repaired. The same bounded tool descriptions are stored for display and applied by the mediated MCP egress path used in `compatibility` and `enforced` gateway modes.
+
 ### Local stdio servers
 
 An stdio configuration uses only its command, arguments, and environment. HTTP/SSE authentication, URL, and custom-header fields do not apply. Agor does not download the command: it must already be available in the actual executor environment, which may differ from the daemon host. Store a per-user token in **Settings → Environment Variables**, then reference it from the server environment, for example `{"SHORTCUT_API_TOKEN":"{{ user.env.SHORTCUT_API_TOKEN }}"}`. The managed value is encrypted and resolved only for the authenticated user whose task is running; do not paste the token directly into the MCP server definition.

--- a/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.browser.test.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.browser.test.tsx
@@ -1,0 +1,82 @@
+import type { AgorClient, MCPServer } from '@agor-live/client';
+import { act, cleanup, render, screen } from '@testing-library/react';
+import { App, ConfigProvider, theme } from 'antd';
+import { afterEach, expect, it, vi } from 'vitest';
+import { userEvent } from 'vitest/browser';
+import { MCPServerEditModal } from './MCPServerEditModal';
+
+afterEach(cleanup);
+it('can edit, save, discover, inspect the notice, and save again at every viewport', async () => {
+  const server = {
+    mcp_server_id: '01900000-0000-7000-8000-000000000001',
+    name: 'fictional',
+    transport: 'http',
+    url: 'https://before.example/mcp',
+    scope: 'global',
+    enabled: true,
+    config_version: 7,
+    auth: { type: 'none' },
+  } as MCPServer;
+  const patch = vi.fn().mockResolvedValue({ ...server, config_version: 8 });
+  const discover = vi.fn().mockResolvedValue({
+    success: true,
+    capabilities: { tools: 1, resources: 0, prompts: 0 },
+    metadata: { descriptions_truncated: 1 },
+    tools: [{ name: 'search', description: 'Bounded description' }],
+    resources: [],
+    prompts: [],
+  });
+  const client = {
+    service: (path: string) => {
+      if (path === 'mcp-servers/discover') return { create: discover };
+      if (path === 'mcp-servers/oauth-browser-reservations')
+        return {
+          create: vi.fn().mockResolvedValue({
+            reservation_token: 'fictional-browser-reservation',
+            expires_at: Date.now() + 60_000,
+          }),
+        };
+      return { patch };
+    },
+    io: { on: vi.fn(), off: vi.fn() },
+  } as unknown as AgorClient;
+  const close = vi.fn();
+  render(
+    <ConfigProvider theme={{ algorithm: theme.darkAlgorithm, token: { motion: false } }}>
+      <App>
+        <MCPServerEditModal
+          server={server}
+          open
+          client={client}
+          identityKey="user-a"
+          authorityKey="user-a:admin:1"
+          authGeneration={1}
+          mutationAllowed
+          onClose={close}
+        />
+      </App>
+    </ConfigProvider>
+  );
+  const url = await screen.findByLabelText('URL');
+  await act(() => userEvent.fill(url, 'https://after.example/mcp'));
+  await act(() => userEvent.click(screen.getByRole('button', { name: /Save & Test Connection/ })));
+  const notice = await screen.findByText(
+    "1 provider description(s) shortened to Agor's safe metadata budget"
+  );
+  notice.scrollIntoView();
+  expect(notice).toBeVisible();
+  expect(patch.mock.calls[0]?.[1]).toMatchObject({
+    url: 'https://after.example/mcp',
+    expected_config_version: 7,
+  });
+  expect(discover).toHaveBeenCalledOnce();
+  expect(document.documentElement.scrollWidth).toBeLessThanOrEqual(window.innerWidth + 1);
+  await act(() => userEvent.fill(url, 'https://final.example/mcp'));
+  expect(screen.queryByText('Connected: 1 tools, 0 resources, 0 prompts')).not.toBeInTheDocument();
+  await act(() => userEvent.click(screen.getByRole('button', { name: 'Save' })));
+  await vi.waitFor(() => expect(close).toHaveBeenCalledOnce());
+  expect(patch.mock.calls[1]?.[1]).toMatchObject({
+    url: 'https://final.example/mcp',
+    expected_config_version: 8,
+  });
+});

--- a/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.connection.test.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.connection.test.tsx
@@ -1,0 +1,159 @@
+import type { MCPDiscoveryResult } from '@agor/core/types';
+import type { AgorClient, MCPServer } from '@agor-live/client';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MCPServerEditModal } from './MCPServerEditModal';
+
+const showError = vi.fn();
+vi.mock('@/utils/message', () => ({
+  useThemedMessage: () => ({
+    showSuccess: vi.fn(),
+    showError,
+    showInfo: vi.fn(),
+    showWarning: vi.fn(),
+  }),
+}));
+const result: MCPDiscoveryResult = {
+  success: true,
+  capabilities: { tools: 1, resources: 0, prompts: 0 },
+  metadata: { descriptions_truncated: 1 },
+  tools: [{ name: 'search', description: 'Bounded description' }],
+  resources: [],
+  prompts: [],
+};
+function harness(
+  options: { discover?: ReturnType<typeof vi.fn>; patch?: ReturnType<typeof vi.fn> } = {}
+) {
+  const server = {
+    mcp_server_id: '01900000-0000-7000-8000-000000000001' as MCPServer['mcp_server_id'],
+    name: 'fictional',
+    source: 'user',
+    created_at: new Date(),
+    updated_at: new Date(),
+    transport: 'http',
+    url: 'https://before.example/mcp',
+    scope: 'global',
+    enabled: true,
+    config_version: 7,
+    auth: { type: 'bearer', token: '••••••••' },
+    headers: { 'X-Key': '••••••••' },
+    env: { API_KEY: '••••••••' },
+  } as MCPServer;
+  const discover = options.discover ?? vi.fn().mockResolvedValue(result);
+  const patch = options.patch ?? vi.fn().mockResolvedValue({ ...server, config_version: 8 });
+  const client = {
+    service: vi.fn((path: string) => {
+      if (path === 'mcp-servers/discover') return { create: discover };
+      if (path === 'mcp-servers/oauth-browser-reservations')
+        return {
+          create: vi.fn().mockResolvedValue({
+            reservation_token: 'fictional-reservation-token-00001',
+            expires_at: Date.now() + 60_000,
+          }),
+        };
+      return { get: vi.fn().mockResolvedValue(server), patch };
+    }),
+    io: { on: vi.fn(), off: vi.fn() },
+  } as unknown as AgorClient;
+  render(
+    <MCPServerEditModal
+      server={server}
+      open
+      client={client}
+      identityKey="user-a"
+      authorityKey="user-a:admin:1"
+      authGeneration={1}
+      mutationAllowed
+      onClose={vi.fn()}
+    />
+  );
+  return { server, discover, patch };
+}
+const button = (label: string) => {
+  const element = screen.getByText(label).closest('button');
+  if (!element) throw new Error(`Button not found: ${label}`);
+  return element;
+};
+describe('saved MCP form connection flow', () => {
+  beforeEach(() => vi.clearAllMocks());
+  it('saves the visible draft and preserved secrets before discovery, then shows its metadata', async () => {
+    const h = harness();
+    fireEvent.change(await screen.findByLabelText('URL'), {
+      target: { value: 'https://after.example/mcp' },
+    });
+    fireEvent.click(button('Save & Test Connection'));
+    await screen.findByText('Connected: 1 tools, 0 resources, 0 prompts');
+    expect(h.patch).toHaveBeenCalledWith(
+      h.server.mcp_server_id,
+      expect.objectContaining({
+        expected_config_version: 7,
+        url: 'https://after.example/mcp',
+        auth: { type: 'bearer', token: '••••••••' },
+      })
+    );
+    expect(h.patch.mock.invocationCallOrder[0]).toBeLessThan(
+      h.discover.mock.invocationCallOrder[0]
+    );
+    expect(h.discover).toHaveBeenCalledWith({
+      mcp_server_id: h.server.mcp_server_id,
+      oauth_browser_event: { reservation_token: 'fictional-reservation-token-00001' },
+    });
+    expect(
+      screen.getByText("1 provider description(s) shortened to Agor's safe metadata budget")
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Test Authentication')).not.toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText('URL'), {
+      target: { value: 'https://next.example/mcp' },
+    });
+    expect(
+      screen.queryByText('Connected: 1 tools, 0 resources, 0 prompts')
+    ).not.toBeInTheDocument();
+  });
+  it('does not probe after a save conflict', async () => {
+    const h = harness({ patch: vi.fn().mockRejectedValue({ code: 409 }) });
+    fireEvent.click(button('Save & Test Connection'));
+    await screen.findByText('Newer MCP settings are available');
+    expect(h.discover).not.toHaveBeenCalled();
+    expect(button('Save')).toBeDisabled();
+    expect(button('Save & Test Connection')).toBeDisabled();
+  });
+  it('does not display an old draft result after editing during discovery', async () => {
+    let resolve!: (value: MCPDiscoveryResult) => void;
+    const h = harness({
+      discover: vi.fn(
+        () =>
+          new Promise<MCPDiscoveryResult>((done) => {
+            resolve = done;
+          })
+      ),
+    });
+    fireEvent.click(button('Save & Test Connection'));
+    await waitFor(() => expect(h.discover).toHaveBeenCalledOnce());
+    fireEvent.change(screen.getByLabelText('URL'), {
+      target: { value: 'https://next.example/mcp' },
+    });
+    await act(async () => resolve(result));
+    expect(
+      screen.queryByText('Connected: 1 tools, 0 resources, 0 prompts')
+    ).not.toBeInTheDocument();
+    expect(button('Save & Test Connection')).toBeEnabled();
+  });
+  it('validates environment JSON and explicitly clears emptied secret maps', async () => {
+    const h = harness();
+    fireEvent.change(await screen.findByLabelText('Environment Variables'), {
+      target: { value: '{invalid' },
+    });
+    fireEvent.click(button('Save'));
+    await screen.findByText('Environment variables must be valid JSON');
+    expect(h.patch).not.toHaveBeenCalled();
+    fireEvent.change(screen.getByLabelText('Environment Variables'), { target: { value: '' } });
+    fireEvent.change(screen.getByLabelText('Custom HTTP Headers'), { target: { value: '' } });
+    fireEvent.click(button('Save'));
+    await waitFor(() =>
+      expect(h.patch).toHaveBeenCalledWith(
+        h.server.mcp_server_id,
+        expect.objectContaining({ env: {}, headers: {} })
+      )
+    );
+  });
+});

--- a/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.test.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.test.tsx
@@ -388,7 +388,7 @@ describe('MCPServerEditModal legacy DCR compatibility', () => {
   it('drops a delayed saved-server discovery browser event across admin A -> admin B', async () => {
     let resolveDiscover: ((value: { success: boolean }) => void) | undefined;
     const discover = vi.fn(
-      () =>
+      (_request: { oauth_browser_event: { reservation_token: string } }) =>
         new Promise<{ success: boolean }>((resolve) => {
           resolveDiscover = resolve;
         })
@@ -402,7 +402,7 @@ describe('MCPServerEditModal legacy DCR compatibility', () => {
       service: vi.fn((path: string) => {
         if (path === 'mcp-servers/discover') return { create: discover };
         if (path === 'mcp-servers/oauth-browser-reservations') return { create: reserve };
-        return { patch: vi.fn() };
+        return { patch: vi.fn().mockResolvedValue({ config_version: 2 }) };
       }),
       io: {
         on: vi.fn((_event: string, listener: (event: Record<string, unknown>) => void) =>

--- a/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerEditModal.tsx
@@ -7,7 +7,10 @@ import type {
 } from '@agor-live/client';
 import { Alert, Button, Form, Modal, Space, Tooltip } from 'antd';
 import { useEffect, useRef, useState } from 'react';
-import { useAuthorityOperationGuard } from '@/hooks/useAuthorityOperationGuard';
+import {
+  type AuthorityOperationGuard,
+  useAuthorityOperationGuard,
+} from '@/hooks/useAuthorityOperationGuard';
 import { useThemedMessage } from '@/utils/message';
 import { MCPServerFormFields } from './MCPServerFormFields';
 import {
@@ -17,7 +20,7 @@ import {
   useFormRevision,
 } from './mcp-form-requirements';
 import { buildAuthFromValues, parseEnvJSON, parseHeadersJSON } from './mcp-oauth-utils';
-import { useOAuthBrowserEventAttempt } from './useOAuthBrowserEventAttempt';
+import { useMCPServerDiscovery } from './useMCPServerDiscovery';
 
 export interface MCPServerEditModalProps {
   /** The server being edited. Modal opens when this is non-null and `open` is true. */
@@ -48,17 +51,6 @@ export interface MCPServerEditModalProps {
   focusTriggerAfterClose?: boolean;
 }
 
-interface TestResult {
-  success: boolean;
-  toolCount: number;
-  resourceCount: number;
-  promptCount: number;
-  error?: string;
-  tools?: Array<{ name: string; description?: string }>;
-  resources?: Array<{ name: string; uri: string; mimeType?: string }>;
-  prompts?: Array<{ name: string; description?: string }>;
-}
-
 /**
  * Self-contained "Edit MCP Server" modal.
  *
@@ -86,8 +78,6 @@ const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
   const [form] = Form.useForm();
   const [transport, setTransport] = useState<MCPTransport>('stdio');
   const [authType, setAuthType] = useState<'none' | 'bearer' | 'jwt' | 'oauth'>('none');
-  const [testing, setTesting] = useState(false);
-  const [testResult, setTestResult] = useState<TestResult | null>(null);
   const [preserveAbsentDcrMode, setPreserveAbsentDcrMode] = useState(false);
   const [preserveAbsentCompatibilityMode, setPreserveAbsentCompatibilityMode] = useState(false);
   const [preserveAbsentGrantType, setPreserveAbsentGrantType] = useState(false);
@@ -96,19 +86,24 @@ const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
   // animates in.
   const [formHydrated, setFormHydrated] = useState(false);
   const [configConflict, setConfigConflict] = useState(false);
-  const [reloadingLatest, setReloadingLatest] = useState(false);
+  const [reloadScope, setReloadScope] = useState<AuthorityOperationGuard | null>(null);
   const [managedOAuthCompatibilityMode, setManagedOAuthCompatibilityMode] = useState<
     'strict' | 'marketplace' | undefined
   >();
   const [formRevision, bumpFormRevision] = useFormRevision();
   const operationGuard = useAuthorityOperationGuard(
-    authorityKey && mutationAllowed ? [authorityKey, client, mutationAllowed] : null
+    authorityKey && mutationAllowed
+      ? [authorityKey, client, mutationAllowed, open, server?.mcp_server_id]
+      : null
   );
-  const oauthBrowserEvents = useOAuthBrowserEventAttempt({
+  const reloadingLatest = reloadScope === operationGuard;
+  const { testing, testResult, testConnection } = useMCPServerDiscovery({
     client,
+    authorityKey: mutationAllowed ? authorityKey : null,
     currentUserId: identityKey,
     authGeneration,
-    authorityGuard: operationGuard,
+    formRevision,
+    contextKey: open ? (server?.mcp_server_id ?? null) : null,
   });
 
   // Only ask the form once it is rendered and filled — an unmounted instance
@@ -117,7 +112,13 @@ const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
     open && formHydrated
       ? missingMCPFieldLabels(form.getFieldsValue(true), { mode: 'edit', transport, authType })
       : [];
-  const saveBlocked = !mutationAllowed || missingRequiredFields.length > 0;
+  const saveBlocked =
+    !mutationAllowed ||
+    !authorityKey ||
+    configConflict ||
+    testing ||
+    reloadingLatest ||
+    missingRequiredFields.length > 0;
   const mutationStateRef = useRef({ allowed: mutationAllowed, reason: mutationBlockedReason });
   const configVersionRef = useRef(1);
   mutationStateRef.current = { allowed: mutationAllowed, reason: mutationBlockedReason };
@@ -130,7 +131,6 @@ const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
   useEffect(() => {
     if (!open || !server) return;
 
-    setTestResult(null);
     setConfigConflict(false);
     configVersionRef.current = server.config_version ?? 1;
     setPreserveAbsentDcrMode(false);
@@ -205,119 +205,28 @@ const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
     form.resetFields();
     setTransport('stdio');
     setAuthType('none');
-    setTestResult(null);
     setPreserveAbsentDcrMode(false);
     setPreserveAbsentCompatibilityMode(false);
     setPreserveAbsentGrantType(false);
     setFormHydrated(false);
     setConfigConflict(false);
-    setReloadingLatest(false);
+    setReloadScope(null);
     setManagedOAuthCompatibilityMode(undefined);
     onClose();
   };
 
-  const handleTestConnection = async () => {
-    const operation = operationGuard.begin();
-    if (!operation.isCurrent()) return;
-    if (!client || !server) {
-      // Pre-flight failure — no inline result UI yet, so a toast is the
-      // only signal we have. Result-bearing failures below set testResult
-      // and rely on the inline alert (no duplicate toast).
-      showError('Client not available');
-      return;
-    }
-
-    const values = form.getFieldsValue(true);
-
-    if (!values.url) {
-      showError('URL is required to test connection');
-      return;
-    }
-    if (values.transport === 'stdio') {
-      showError('Connection test is not available for stdio transport');
-      return;
-    }
-    let browserAttempt: Awaited<ReturnType<typeof oauthBrowserEvents.begin>> = null;
-    try {
-      await form.validateFields(['headers']);
-    } catch {
-      if (!operation.isCurrent()) return;
-      showError('Please fix custom HTTP headers before testing');
-      return;
-    }
-    if (!operation.isCurrent()) return;
-
-    try {
-      setTesting(true);
-      setTestResult(null);
-      browserAttempt = await oauthBrowserEvents.begin({
-        operation: 'discover',
-        mcpServerId: server.mcp_server_id,
-      });
-      if (!operation.isCurrent()) return;
-      const data = (await client.service('mcp-servers/discover').create({
-        mcp_server_id: server.mcp_server_id,
-        url: values.url,
-        transport: values.transport || 'http',
-        auth: buildAuthFromValues(values, {
-          preserveAbsentDcrMode,
-          preserveAbsentCompatibilityMode,
-          preserveAbsentGrantType,
-        }),
-        headers: parseHeadersJSON(values.headers),
-        ...(browserAttempt ? { oauth_browser_event: browserAttempt.request } : {}),
-      })) as {
-        success: boolean;
-        error?: string;
-        capabilities?: { tools: number; resources: number; prompts: number };
-        tools?: Array<{ name: string; description?: string }>;
-        resources?: Array<{ name: string; uri: string; mimeType?: string }>;
-        prompts?: Array<{ name: string; description?: string }>;
-      };
-
-      if (!operation.isCurrent()) return;
-
-      if (data.success && data.capabilities) {
-        const refreshed = await client.service('mcp-servers').get(server.mcp_server_id);
-        if (!operation.isCurrent()) return;
-        configVersionRef.current = refreshed.config_version ?? configVersionRef.current;
-        setTestResult({
-          success: true,
-          toolCount: data.capabilities.tools,
-          resourceCount: data.capabilities.resources,
-          promptCount: data.capabilities.prompts,
-          tools: data.tools,
-          resources: data.resources,
-          prompts: data.prompts,
-        });
-      } else {
-        setTestResult({
-          success: false,
-          toolCount: 0,
-          resourceCount: 0,
-          promptCount: 0,
-          error: data.error || 'Connection test failed',
-        });
-      }
-    } catch {
-      if (!operation.isCurrent()) return;
-      setTestResult({
-        success: false,
-        toolCount: 0,
-        resourceCount: 0,
-        promptCount: 0,
-        error: 'Connection test failed. Check the saved configuration and try again.',
-      });
-    } finally {
-      browserAttempt?.cleanup();
-      if (operation.isCurrent()) setTesting(false);
-    }
-  };
+  // A saved ID is authoritative at the daemon. Save the draft first rather
+  // than sending ignored inline credentials and claiming that they were tested.
+  const handleTestConnection = () =>
+    testConnection(async (operation) => {
+      if (!server || !(await saveFormValues(operation))) return null;
+      return { mcp_server_id: server.mcp_server_id };
+    });
 
   const saveFormValues = async (
     operation: ReturnType<typeof operationGuard.begin>
   ): Promise<boolean> => {
-    if (!server || !client || !operation.isCurrent()) return false;
+    if (!server || !client || configConflict || !operation.isCurrent()) return false;
     if (!mutationStateRef.current.allowed) {
       showError(mutationStateRef.current.reason);
       return false;
@@ -346,11 +255,10 @@ const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
         updates.args = values.args?.split(',').map((arg: string) => arg.trim()) || [];
       } else {
         updates.url = values.url;
-        updates.headers = parseHeadersJSON(values.headers);
+        updates.headers = parseHeadersJSON(values.headers) ?? {};
       }
 
-      const env = parseEnvJSON(values.env);
-      if (env) updates.env = env;
+      updates.env = parseEnvJSON(values.env) ?? {};
 
       updates.auth = buildAuthFromValues(values, {
         preserveAbsentDcrMode,
@@ -365,6 +273,7 @@ const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
         return false;
       }
       const updated = await client.service('mcp-servers').patch(server.mcp_server_id, updates);
+      if (!operation.isCurrent()) return false;
       configVersionRef.current = updated.config_version ?? configVersionRef.current + 1;
       return operation.isCurrent();
     } catch (error) {
@@ -398,10 +307,12 @@ const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
   };
 
   const reloadLatest = async () => {
-    if (!client || !server) return;
-    setReloadingLatest(true);
+    const operation = operationGuard.begin();
+    if (!client || !server || !operation.isCurrent()) return;
+    setReloadScope(operationGuard);
     try {
       const latest = await client.service('mcp-servers').get(server.mcp_server_id);
+      if (!operation.isCurrent()) return;
       configVersionRef.current = latest.config_version ?? 1;
       const latestAuthType = latest.auth?.type || 'none';
       const latestManagedMode = latest.oauth_compatibility_policy?.managed_by_catalog
@@ -451,9 +362,10 @@ const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
       setConfigConflict(false);
       bumpFormRevision();
     } catch (error) {
+      if (!operation.isCurrent()) return;
       showError(error instanceof Error ? error.message : 'Failed to reload the latest MCP server');
     } finally {
-      setReloadingLatest(false);
+      if (operation.isCurrent()) setReloadScope(null);
     }
   };
 
@@ -480,9 +392,15 @@ const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
             title={
               !mutationAllowed
                 ? mutationBlockedReason
-                : saveBlocked
-                  ? describeMissingForSave(missingRequiredFields)
-                  : undefined
+                : configConflict
+                  ? 'Reload the latest settings before saving again.'
+                  : testing || reloadingLatest
+                    ? 'Wait for the current connection operation to finish.'
+                    : !authorityKey
+                      ? 'Reconnect before saving.'
+                      : missingRequiredFields.length > 0
+                        ? describeMissingForSave(missingRequiredFields)
+                        : undefined
             }
           >
             <span>
@@ -546,8 +464,14 @@ const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
           testing={testing}
           testResult={testResult}
           onPrepareOAuthStart={prepareOAuthStart}
-          mutationAllowed={mutationAllowed}
-          mutationBlockedReason={mutationBlockedReason}
+          mutationAllowed={mutationAllowed && !configConflict && !reloadingLatest}
+          mutationBlockedReason={
+            configConflict
+              ? 'Reload the latest settings before trying again.'
+              : reloadingLatest
+                ? 'Wait for the latest settings to load.'
+                : mutationBlockedReason
+          }
           formRevision={formRevision}
           managedOAuthCompatibilityMode={managedOAuthCompatibilityMode}
         />
@@ -558,14 +482,14 @@ const MCPServerEditModalForIdentity: React.FC<MCPServerEditModalProps> = ({
 
 /**
  * The form can contain raw OAuth/JWT/bearer credentials. Remount its entire
- * state owner when the authenticated identity changes so another same-role
+ * state owner when the authenticated identity or selected server changes so another same-role
  * caller cannot inherit a selected row or any registered Ant Form value.
  * `authorityKey` remains a finer mutation gate; it intentionally does not key
  * this owner, preserving same-user reconnect and token-refresh edits.
  */
 export const MCPServerEditModal: React.FC<MCPServerEditModalProps> = (props) => (
   <MCPServerEditModalForIdentity
-    key={props.identityKey ?? '__no-authenticated-user__'}
+    key={`${props.identityKey ?? '__no-authenticated-user__'}:${props.server?.mcp_server_id ?? ''}`}
     {...props}
   />
 );

--- a/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.test.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.test.tsx
@@ -7,10 +7,11 @@ import { MCPServerFormFields } from './MCPServerFormFields';
 import { useFormRevision } from './mcp-form-requirements';
 
 const showError = vi.fn();
+const showSuccess = vi.fn();
 
 vi.mock('@/utils/message', () => ({
   useThemedMessage: () => ({
-    showSuccess: vi.fn(),
+    showSuccess,
     showError,
     showInfo: vi.fn(),
     showWarning: vi.fn(),
@@ -32,6 +33,48 @@ const oauthButton = (name = 'Start OAuth Flow') => buttonLabeled(name);
 
 describe('MCPServerFormFields OAuth start', () => {
   beforeEach(() => vi.clearAllMocks());
+
+  it('surfaces when valid provider descriptions were shortened safely', async () => {
+    const testOAuth = vi.fn().mockResolvedValue({
+      success: true,
+      oauthType: 'oauth',
+      metadata: { descriptions_truncated: 2 },
+    });
+    const client = {
+      service: vi.fn((path: string) =>
+        path === 'mcp-servers/test-oauth' ? { create: testOAuth } : {}
+      ),
+    } as unknown as AgorClient;
+    const Harness = () => {
+      const [form] = Form.useForm();
+      useEffect(() => {
+        form.setFieldsValue({ url: 'https://fictional.example/mcp', auth_type: 'oauth' });
+      }, [form]);
+      return (
+        <Form form={form}>
+          <MCPServerFormFields
+            mode="create"
+            transport="http"
+            authType="oauth"
+            form={form}
+            client={client}
+            authorityKey="fictional-user:member:1"
+            onPrepareOAuthStart={vi.fn().mockResolvedValue('fictional-server')}
+          />
+        </Form>
+      );
+    };
+
+    render(<Harness />);
+    fireEvent.click(buttonLabeled('Test Authentication'));
+    await waitFor(() =>
+      expect(showSuccess).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "2 provider description(s) shortened to Agor's safe metadata budget"
+        )
+      )
+    );
+  });
 
   it('uses an explicit visible control to clear a saved bearer secret', async () => {
     let capturedForm: FormInstance | undefined;

--- a/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.test.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.test.tsx
@@ -34,46 +34,35 @@ const oauthButton = (name = 'Start OAuth Flow') => buttonLabeled(name);
 describe('MCPServerFormFields OAuth start', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('surfaces when valid provider descriptions were shortened safely', async () => {
-    const testOAuth = vi.fn().mockResolvedValue({
-      success: true,
-      oauthType: 'oauth',
-      metadata: { descriptions_truncated: 2 },
-    });
-    const client = {
-      service: vi.fn((path: string) =>
-        path === 'mcp-servers/test-oauth' ? { create: testOAuth } : {}
-      ),
-    } as unknown as AgorClient;
+  it('shows truncation metadata in the discovery result, not the OAuth setup response', () => {
     const Harness = () => {
       const [form] = Form.useForm();
-      useEffect(() => {
-        form.setFieldsValue({ url: 'https://fictional.example/mcp', auth_type: 'oauth' });
-      }, [form]);
       return (
         <Form form={form}>
           <MCPServerFormFields
             mode="create"
             transport="http"
-            authType="oauth"
             form={form}
-            client={client}
-            authorityKey="fictional-user:member:1"
-            onPrepareOAuthStart={vi.fn().mockResolvedValue('fictional-server')}
+            client={null}
+            authorityKey="user-a:admin:1"
+            onPrepareOAuthStart={vi.fn()}
+            testResult={{
+              success: true,
+              capabilities: { tools: 1, resources: 0, prompts: 0 },
+              metadata: { descriptions_truncated: 2 },
+              tools: [{ name: 'search' }],
+              resources: [],
+              prompts: [],
+            }}
           />
         </Form>
       );
     };
-
     render(<Harness />);
-    fireEvent.click(buttonLabeled('Test Authentication'));
-    await waitFor(() =>
-      expect(showSuccess).toHaveBeenCalledWith(
-        expect.stringContaining(
-          "2 provider description(s) shortened to Agor's safe metadata budget"
-        )
-      )
-    );
+    expect(
+      screen.getByText("2 provider description(s) shortened to Agor's safe metadata budget")
+    ).toBeInTheDocument();
+    expect(showSuccess).not.toHaveBeenCalled();
   });
 
   it('uses an explicit visible control to clear a saved bearer secret', async () => {

--- a/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.tsx
@@ -302,6 +302,7 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
           responseHeaders?: Record<string, string>;
           hint?: string;
           debugInfo?: unknown;
+          metadata?: { descriptions_truncated?: number };
         };
         if (!operation.isCurrent()) return;
 
@@ -322,6 +323,9 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
             }
             if (data.mcpStatus !== undefined) {
               message += ` | MCP server responded with ${data.mcpStatus}`;
+            }
+            if ((data.metadata?.descriptions_truncated ?? 0) > 0) {
+              message += ` | ${data.metadata?.descriptions_truncated} provider description(s) shortened to Agor's safe metadata budget`;
             }
             showSuccess(message);
           }

--- a/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.tsx
+++ b/apps/agor-ui/src/components/MCPServer/MCPServerFormFields.tsx
@@ -1,3 +1,4 @@
+import type { MCPDiscoveryResult } from '@agor/core/types';
 import type { AgorClient, MCPScope, MCPTransport } from '@agor-live/client';
 import { MCP_SCOPES, MCP_TRANSPORTS } from '@agor-live/client';
 import { ApiOutlined, DownOutlined } from '@ant-design/icons';
@@ -25,7 +26,11 @@ import { useThemedMessage } from '@/utils/message';
 import { sanitizeSecretValue } from '@/utils/sanitizeSecret';
 import { MCPOAuthRecoveryAlert } from './MCPOAuthRecoveryAlert';
 import { describeMissingForOAuth, missingMCPFieldLabels } from './mcp-form-requirements';
-import { extractOAuthConfigForTesting, validateHeadersJSON } from './mcp-oauth-utils';
+import {
+  extractOAuthConfigForTesting,
+  validateEnvJSON,
+  validateHeadersJSON,
+} from './mcp-oauth-utils';
 import { useMCPServerOAuthStart } from './useMCPServerOAuthStart';
 
 const { TextArea } = Input;
@@ -70,16 +75,7 @@ export interface MCPServerFormFieldsProps {
   serverId?: string;
   onTestConnection?: () => Promise<void>;
   testing?: boolean;
-  testResult?: {
-    success: boolean;
-    toolCount: number;
-    resourceCount: number;
-    promptCount: number;
-    error?: string;
-    tools?: Array<{ name: string; description?: string }>;
-    resources?: Array<{ name: string; uri: string; mimeType?: string }>;
-    prompts?: Array<{ name: string; description?: string }>;
-  } | null;
+  testResult?: MCPDiscoveryResult | null;
   /** Persist current settings and return the authoritative server ID before every OAuth start. */
   onPrepareOAuthStart: () => Promise<string | null>;
   /** Whether persistent mutations/OAuth preparation remain authorized. */
@@ -302,7 +298,6 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
           responseHeaders?: Record<string, string>;
           hint?: string;
           debugInfo?: unknown;
-          metadata?: { descriptions_truncated?: number };
         };
         if (!operation.isCurrent()) return;
 
@@ -323,9 +318,6 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
             }
             if (data.mcpStatus !== undefined) {
               message += ` | MCP server responded with ${data.mcpStatus}`;
-            }
-            if ((data.metadata?.descriptions_truncated ?? 0) > 0) {
-              message += ` | ${data.metadata?.descriptions_truncated} provider description(s) shortened to Agor's safe metadata budget`;
             }
             showSuccess(message);
           }
@@ -624,16 +616,21 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
 
       {/* Connection action buttons — surfaced before secondary fields so they
           aren't buried under env vars or the OAuth advanced section. */}
-      {(authType !== 'none' || isRemoteTransport) && (
+      {isRemoteTransport && (
         <Form.Item label="Actions" style={{ marginBottom: 16 }}>
           <Space wrap>
-            {authType !== 'none' && (
-              <Button type="default" loading={testingAuth} onClick={handleTestAuth}>
+            {authType !== 'none' && !serverId && (
+              <Button
+                type="default"
+                loading={testingAuth}
+                disabled={!oauthStartAllowed || testing}
+                onClick={handleTestAuth}
+              >
                 Test Authentication
               </Button>
             )}
             {authType === 'oauth' &&
-              oauthBrowserFlowAvailable &&
+              (oauthBrowserFlowAvailable || !!serverId) &&
               (!oauthStartAllowed || missingRequiredFields.length > 0 ? (
                 // Disabled rather than hidden: the user has already earned this
                 // button with a successful auth test, so it has to say what is
@@ -673,8 +670,17 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
                 icon={<ApiOutlined />}
                 onClick={onTestConnection}
                 loading={testing}
+                disabled={
+                  !oauthStartAllowed ||
+                  !onTestConnection ||
+                  ((!!serverId || authType === 'oauth') && missingRequiredFields.length > 0)
+                }
               >
-                {testing ? 'Testing...' : 'Test Connection'}
+                {testing
+                  ? 'Testing...'
+                  : serverId || authType === 'oauth'
+                    ? 'Save & Test Connection'
+                    : 'Test Connection'}
               </Button>
             )}
           </Space>
@@ -686,10 +692,18 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
         <div style={{ marginBottom: 16 }}>
           <Alert
             type="success"
-            title={`Connected: ${testResult.toolCount} tools, ${testResult.resourceCount} resources, ${testResult.promptCount} prompts`}
+            title={`Connected: ${testResult.capabilities.tools} tools, ${testResult.capabilities.resources} resources, ${testResult.capabilities.prompts} prompts`}
             showIcon
             style={{ marginBottom: 8 }}
           />
+          {!!testResult.metadata?.descriptions_truncated && (
+            <Alert
+              type="info"
+              showIcon
+              title={`${testResult.metadata.descriptions_truncated} provider description(s) shortened to Agor's safe metadata budget`}
+              style={{ marginBottom: 8 }}
+            />
+          )}
           {testResult.tools && testResult.tools.length > 0 && (
             <div style={{ marginTop: 8 }}>
               <Typography.Text
@@ -974,6 +988,7 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
     },
     {
       key: 'advanced-config',
+      forceRender: true,
       label: (
         <Space size={8}>
           <Typography.Text strong>Advanced Configuration</Typography.Text>
@@ -1013,6 +1028,14 @@ export const MCPServerFormFields: React.FC<MCPServerFormFieldsProps> = ({
           <Form.Item
             label="Environment Variables"
             name="env"
+            rules={[
+              {
+                validator: async (_, value) => {
+                  const error = validateEnvJSON(value);
+                  if (error) throw new Error(error);
+                },
+              },
+            ]}
             tooltip="JSON object of environment variables. Values support templates like {{ user.env.VAR_NAME }}"
           >
             <TextArea

--- a/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.test.ts
+++ b/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.test.ts
@@ -5,6 +5,7 @@ import {
   extractOAuthConfigForTesting,
   isTemplateValue,
   parseEnvJSON,
+  validateEnvJSON,
   validateHeadersJSON,
 } from './mcp-oauth-utils';
 
@@ -434,4 +435,19 @@ describe('buildAuthFromValues PATCH semantics', () => {
       )
     ).toMatchObject({ type: 'jwt', api_token: null, api_secret: null });
   });
+});
+
+describe('environment form validation', () => {
+  it.each(['', '{}', '{"API_KEY":"••••••••"}', '{"API_KEY":"{{ user.env.API_KEY }}"}'])(
+    'accepts %s',
+    (value) => {
+      expect(validateEnvJSON(value)).toBeUndefined();
+    }
+  );
+  it.each(['{invalid', 'null', '[]', '{"API_KEY":123}', '{"bad name":"value"}'])(
+    'rejects %s rather than dropping the edit',
+    (value) => {
+      expect(validateEnvJSON(value)).toMatch(/Environment/);
+    }
+  );
 });

--- a/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.ts
+++ b/apps/agor-ui/src/components/MCPServer/mcp-oauth-utils.ts
@@ -358,3 +358,22 @@ export function validateHeadersJSON(headersValue: unknown): string | undefined {
 
   return undefined;
 }
+
+/** Environment edits must not silently disappear on malformed JSON. */
+export function validateEnvJSON(value: unknown): string | undefined {
+  if (typeof value !== 'string' || !value.trim()) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return 'Environment variables must be valid JSON';
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed))
+    return 'Environment variables must be a JSON object';
+  for (const [key, entry] of Object.entries(parsed)) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key))
+      return 'Environment variable names must be valid identifiers';
+    if (typeof entry !== 'string') return 'Environment variable values must be strings';
+  }
+  return undefined;
+}

--- a/apps/agor-ui/src/components/MCPServer/useMCPServerDiscovery.test.tsx
+++ b/apps/agor-ui/src/components/MCPServer/useMCPServerDiscovery.test.tsx
@@ -1,0 +1,100 @@
+import type { MCPDiscoveryResult } from '@agor/core/types';
+import type { AgorClient } from '@agor-live/client';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useMCPServerDiscovery } from './useMCPServerDiscovery';
+
+const discovered: MCPDiscoveryResult = {
+  success: true,
+  capabilities: { tools: 1, resources: 0, prompts: 0 },
+  metadata: { descriptions_truncated: 1 },
+  tools: [{ name: 'search' }],
+  resources: [],
+  prompts: [],
+};
+function harness(discover = vi.fn().mockResolvedValue(discovered)) {
+  const reserve = vi.fn().mockResolvedValue({
+    reservation_token: 'fictional-reservation',
+    expires_at: Date.now() + 60_000,
+  });
+  const client = {
+    service: vi.fn((path: string) => ({
+      create: path === 'mcp-servers/discover' ? discover : reserve,
+    })),
+    io: { on: vi.fn(), off: vi.fn() },
+  } as unknown as AgorClient;
+  const options = {
+    client,
+    authorityKey: 'user-a:admin:1' as string | null,
+    currentUserId: 'user-a',
+    authGeneration: 1,
+    formRevision: 0,
+    contextKey: 'server-a',
+  };
+  const hook = renderHook((props) => useMCPServerDiscovery(props), { initialProps: options });
+  return { ...hook, options, discover, reserve };
+}
+describe('MCP discovery form lifecycle', () => {
+  it('preserves the canonical metadata in the displayed result', async () => {
+    const h = harness();
+    await act(() => h.result.current.testConnection(async () => ({ mcp_server_id: 'server-a' })));
+    expect(h.result.current.testResult).toEqual(discovered);
+    expect(h.result.current.testing).toBe(false);
+    expect(h.reserve).toHaveBeenCalledWith({ operation: 'discover', mcp_server_id: 'server-a' });
+  });
+  it.each(['draft', 'server', 'identity', 'close'] as const)(
+    'drops a delayed response after %s changes',
+    async (change) => {
+      let resolve!: (value: MCPDiscoveryResult) => void;
+      const h = harness(
+        vi.fn(
+          () =>
+            new Promise<MCPDiscoveryResult>((done) => {
+              resolve = done;
+            })
+        )
+      );
+      let pending!: Promise<void>;
+      act(() => {
+        pending = h.result.current.testConnection(async () => ({ mcp_server_id: 'server-a' }));
+      });
+      await waitFor(() => expect(h.discover).toHaveBeenCalledOnce());
+      h.rerender({
+        ...h.options,
+        ...(change === 'draft'
+          ? { formRevision: 1 }
+          : change === 'server'
+            ? { contextKey: 'server-b' }
+            : change === 'identity'
+              ? { authorityKey: 'user-b:admin:2', currentUserId: 'user-b', authGeneration: 2 }
+              : { authorityKey: null }),
+      });
+      await act(async () => {
+        resolve(discovered);
+        await pending;
+      });
+      expect(h.result.current.testResult).toBeNull();
+      expect(h.result.current.testing).toBe(false);
+    }
+  );
+  it('does not dispatch without authority or after failed preparation', async () => {
+    const h = harness();
+    await act(() => h.result.current.testConnection(async () => null));
+    expect(h.reserve).not.toHaveBeenCalled();
+    h.rerender({ ...h.options, authorityKey: null });
+    const prepare = vi.fn();
+    await act(() => h.result.current.testConnection(prepare));
+    expect(prepare).not.toHaveBeenCalled();
+    expect(h.discover).not.toHaveBeenCalled();
+  });
+  it('does not expose raw transport errors', async () => {
+    const h = harness(vi.fn().mockRejectedValue(new Error('fictional-secret-response')));
+    await act(() =>
+      h.result.current.testConnection(async () => ({ url: 'https://example.test/mcp' }))
+    );
+    expect(h.result.current.testResult).toEqual({
+      success: false,
+      error: 'Connection test failed. Check the saved configuration and try again.',
+    });
+  });
+});

--- a/apps/agor-ui/src/components/MCPServer/useMCPServerDiscovery.ts
+++ b/apps/agor-ui/src/components/MCPServer/useMCPServerDiscovery.ts
@@ -1,0 +1,86 @@
+import type { MCPDiscoveryRequest, MCPDiscoveryResult } from '@agor/core/types';
+import type { AgorClient } from '@agor-live/client';
+import { useRef, useState } from 'react';
+import {
+  type AuthorityOperation,
+  useAuthorityOperationGuard,
+} from '@/hooks/useAuthorityOperationGuard';
+import { useOAuthBrowserEventAttempt } from './useOAuthBrowserEventAttempt';
+
+/** One discovery lifecycle for create/edit: bind results and browser events to the exact draft and caller. */
+export function useMCPServerDiscovery(options: {
+  client: AgorClient | null;
+  authorityKey: string | null;
+  currentUserId: string | null;
+  authGeneration: number;
+  formRevision: number;
+  contextKey: string | null;
+}) {
+  const { client, authorityKey, currentUserId, authGeneration, formRevision, contextKey } = options;
+  const guard = useAuthorityOperationGuard(
+    authorityKey && contextKey
+      ? [authorityKey, client, currentUserId, authGeneration, contextKey, formRevision]
+      : null
+  );
+  const browserEvents = useOAuthBrowserEventAttempt({
+    client,
+    currentUserId,
+    authGeneration,
+    authorityGuard: guard,
+  });
+  const active = useRef<AuthorityOperation | null>(null);
+  const [state, setState] = useState<{
+    scope: typeof guard;
+    testing: boolean;
+    result: MCPDiscoveryResult | null;
+  }>();
+
+  const testConnection = async (
+    prepare: (operation: AuthorityOperation) => Promise<MCPDiscoveryRequest | null>
+  ) => {
+    if (!client || !guard.isCurrent() || active.current?.isCurrent()) return;
+    const operation = guard.begin();
+    active.current = operation;
+    setState({ scope: guard, testing: true, result: null });
+    let browserAttempt: Awaited<ReturnType<typeof browserEvents.begin>> = null;
+    try {
+      const request = await prepare(operation);
+      if (!request || !operation.isCurrent()) return;
+      browserAttempt = await browserEvents.begin({
+        operation: 'discover',
+        mcpServerId: request.mcp_server_id,
+      });
+      if (!operation.isCurrent()) return;
+      const result = (await client.service('mcp-servers/discover').create({
+        ...request,
+        ...(browserAttempt ? { oauth_browser_event: browserAttempt.request } : {}),
+      })) as MCPDiscoveryResult;
+      if (!operation.isCurrent()) return;
+      setState({ scope: guard, testing: false, result });
+    } catch {
+      if (!operation.isCurrent()) return;
+      setState({
+        scope: guard,
+        testing: false,
+        result: {
+          success: false,
+          error: 'Connection test failed. Check the saved configuration and try again.',
+        },
+      });
+    } finally {
+      browserAttempt?.cleanup();
+      if (operation.isCurrent())
+        setState((current) =>
+          current?.scope === guard ? { ...current, testing: false } : current
+        );
+      operation.cancel();
+      if (active.current === operation) active.current = null;
+    }
+  };
+
+  return {
+    testing: state?.scope === guard && state.testing,
+    testResult: state?.scope === guard ? state.result : null,
+    testConnection,
+  };
+}

--- a/apps/agor-ui/src/components/SettingsModal/MCPServersTable.oauth.test.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPServersTable.oauth.test.tsx
@@ -15,11 +15,13 @@ vi.mock('../MCPServer', () => ({
   MCPServerFormFields: ({
     form,
     onAuthTypeChange,
+    onTransportChange,
     onPrepareOAuthStart,
     serverId,
   }: {
     form: { setFieldsValue: (values: Record<string, unknown>) => void };
     onAuthTypeChange?: (authType: 'oauth') => void;
+    onTransportChange?: (transport: 'http') => void;
     onPrepareOAuthStart: () => Promise<string | null>;
     serverId?: string;
   }) => (
@@ -39,6 +41,7 @@ vi.mock('../MCPServer', () => ({
             oauth_dcr_mode: 'advertised',
           });
           onAuthTypeChange?.('oauth');
+          onTransportChange?.('http');
         }}
       >
         Configure OAuth
@@ -115,7 +118,15 @@ describe('MCPServersTable OAuth creation', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Prepare OAuth' }));
     await waitFor(() => expect(patch).toHaveBeenCalledWith('server-1', expect.any(Object)));
 
-    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    // Once OAuth has created the row, the footer must save later edits, not
+    // merely dismiss them as the former Done button did.
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(patch).toHaveBeenCalledTimes(2));
+    expect(patch.mock.calls[0]?.[1]).toMatchObject({ expected_config_version: 1 });
+    expect(patch.mock.calls[1]?.[1]).toMatchObject({ expected_config_version: 2 });
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument()
+    );
     fireEvent.click(screen.getByRole('button', { name: /New MCP Server/ }));
     expect(await screen.findByTestId('prepared-server-id')).toHaveTextContent('none');
 
@@ -123,7 +134,7 @@ describe('MCPServersTable OAuth creation', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Prepare OAuth' }));
     await waitFor(() => expect(create).toHaveBeenCalledTimes(2));
     expect(screen.getByTestId('prepared-server-id')).toHaveTextContent('server-2');
-    expect(patch).toHaveBeenCalledTimes(1);
+    expect(patch).toHaveBeenCalledTimes(2);
     expect(showError).not.toHaveBeenCalled();
   }, 30_000);
 });

--- a/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
+++ b/apps/agor-ui/src/components/SettingsModal/MCPServersTable.tsx
@@ -63,7 +63,7 @@ import {
   type MCPServerCapabilityContext,
   policyPendingState,
 } from '../MCPServer/memberPolicy';
-import { useOAuthBrowserEventAttempt } from '../MCPServer/useOAuthBrowserEventAttempt';
+import { useMCPServerDiscovery } from '../MCPServer/useMCPServerDiscovery';
 import { AdaptiveSettingsModal } from './AdaptiveSettingsModal';
 import { MCPEgressGatewayStatus } from './MCPEgressGatewayStatus';
 import { MCPMemberPolicySetting } from './MCPMemberPolicySetting';
@@ -123,17 +123,6 @@ const getServerHealth = (
   };
 };
 
-interface TestResult {
-  success: boolean;
-  toolCount: number;
-  resourceCount: number;
-  promptCount: number;
-  error?: string;
-  tools?: Array<{ name: string; description: string }>;
-  resources?: Array<{ name: string; uri: string; mimeType?: string }>;
-  prompts?: Array<{ name: string; description: string }>;
-}
-
 const MCPServersTableForIdentity: React.FC<MCPServersTableProps> = ({
   mcpServerById,
   client,
@@ -184,12 +173,6 @@ const MCPServersTableForIdentity: React.FC<MCPServersTableProps> = ({
       ? [durableAuthorityKey, client, memberPolicy.policy, memberPolicy.canConfigure]
       : null
   );
-  const oauthBrowserEvents = useOAuthBrowserEventAttempt({
-    client,
-    currentUserId: currentUser?.user_id ?? null,
-    authGeneration,
-    authorityGuard: operationGuard,
-  });
   const capabilityRef = useRef({ capability, policyPending, addRestriction });
   capabilityRef.current = { capability, policyPending, addRestriction };
   const addIsCurrentlyAllowed = () => {
@@ -220,23 +203,33 @@ const MCPServersTableForIdentity: React.FC<MCPServersTableProps> = ({
   const [chosenTransport, setChosenTransport] = useState<MCPTransport | null>(null);
   const transport = chosenTransport ?? offeredTransports[0];
   const [authType, setAuthType] = useState<'none' | 'bearer' | 'jwt' | 'oauth'>('none');
-  const [testing, setTesting] = useState(false);
   const [createdServerId, setCreatedServerId] = useState<string | null>(null);
-  const [testResult, setTestResult] = useState<TestResult | null>(null);
+  const createdConfigVersion = useRef(1);
   const [searchTerm, setSearchTerm] = useState('');
 
   const [formRevision, bumpFormRevision] = useFormRevision();
+  const createOperationGuard = useAuthorityOperationGuard(
+    createModalOpen && canAdd && durableAuthorityKey
+      ? [durableAuthorityKey, client, createModalOpen]
+      : null
+  );
+  const { testing, testResult, testConnection } = useMCPServerDiscovery({
+    client,
+    authorityKey: canAdd ? durableAuthorityKey : null,
+    currentUserId: currentUser?.user_id ?? null,
+    authGeneration,
+    formRevision,
+    contextKey: createModalOpen ? 'create' : null,
+  });
   // Only ask the form once it is rendered — an unmounted instance warns.
   const missingRequiredFields = createModalOpen
     ? missingMCPFieldLabels(createForm.getFieldsValue(true), {
-        mode: 'create',
+        mode: createdServerId ? 'edit' : 'create',
         transport,
         authType,
       })
     : [];
-  // Once the row exists the button only dismisses the modal, so nothing about
-  // the form should be able to trap the user behind it.
-  const createBlocked = !createdServerId && (!canAdd || missingRequiredFields.length > 0);
+  const createBlocked = !canAdd || testing || missingRequiredFields.length > 0;
 
   // Sync modal records when mcpServerById updates (real-time WebSocket
   // updates). An absent row is authoritative too: retaining the previous
@@ -294,8 +287,9 @@ const MCPServersTableForIdentity: React.FC<MCPServersTableProps> = ({
 
   // Persist the current form before every OAuth start. The saved row is the
   // daemon's tenant-scoped authority for provider URL and client credentials.
-  const prepareOAuthStartForCreate = async (): Promise<string | null> => {
-    const operation = operationGuard.begin();
+  const prepareOAuthStartForCreate = async (
+    operation = createOperationGuard.begin()
+  ): Promise<string | null> => {
     if (!client || !operation.isCurrent()) return null;
     if (!addIsCurrentlyAllowed()) {
       showError(capabilityRef.current.addRestriction);
@@ -315,14 +309,24 @@ const MCPServersTableForIdentity: React.FC<MCPServersTableProps> = ({
         const result = await client.service('mcp-servers').create(data);
         if (!operation.isCurrent()) return null;
         const newServerId = (result as MCPServer).mcp_server_id || null;
+        createdConfigVersion.current = (result as MCPServer).config_version ?? 1;
         setCreatedServerId(newServerId);
         return newServerId;
       }
 
       const { name: _name, ...updates } = data;
       if (!operation.isCurrent() || !addIsCurrentlyAllowed()) return null;
-      await client.service('mcp-servers').patch(createdServerId, updates as UpdateMCPServerInput);
+      const updated = await client.service('mcp-servers').patch(createdServerId, {
+        ...updates,
+        auth: buildAuthFromValues(createForm.getFieldsValue(true), { forPatch: true }),
+        expected_config_version: createdConfigVersion.current,
+        env: parseEnvJSON(createForm.getFieldValue('env')) ?? {},
+        ...(data.transport === 'stdio'
+          ? {}
+          : { headers: parseHeadersJSON(createForm.getFieldValue('headers')) ?? {} }),
+      } as UpdateMCPServerInput);
       if (!operation.isCurrent()) return null;
+      createdConfigVersion.current = updated.config_version ?? createdConfigVersion.current + 1;
       return createdServerId;
     } catch (error) {
       if (!operation.isCurrent()) return null;
@@ -341,13 +345,13 @@ const MCPServersTableForIdentity: React.FC<MCPServersTableProps> = ({
     setCreateModalOpen(false);
     setChosenTransport(null);
     setAuthType('none');
-    setTestResult(null);
     setCreatedServerId(null);
+    bumpFormRevision();
   };
 
   const handleCreate = async () => {
     if (createdServerId) {
-      resetCreateModal();
+      if (await prepareOAuthStartForCreate()) resetCreateModal();
       return;
     }
 
@@ -356,7 +360,7 @@ const MCPServersTableForIdentity: React.FC<MCPServersTableProps> = ({
       return;
     }
 
-    const operation = operationGuard.begin();
+    const operation = createOperationGuard.begin();
     try {
       await createForm.validateFields();
       if (!operation.isCurrent()) return;
@@ -371,96 +375,34 @@ const MCPServersTableForIdentity: React.FC<MCPServersTableProps> = ({
       resetCreateModal();
     } catch (error) {
       if (!operation.isCurrent()) return;
-      console.error('Form validation failed:', error);
       showError(firstFormErrorMessage(error) || 'Please fill in required fields');
     }
   };
 
-  // Test connection from create modal (always inline config, no persistence).
-  const handleCreateTestConnection = async () => {
-    const operation = operationGuard.begin();
-    if (!operation.isCurrent()) return;
-    if (!client) {
-      showError('Client not available');
-      return;
-    }
-
-    const values = createForm.getFieldsValue(true);
-
-    if (!values.url) {
-      showError('URL is required to test connection');
-      return;
-    }
-    if (values.transport === 'stdio') {
-      showError('Connection test is not available for stdio transport');
-      return;
-    }
-    try {
-      await createForm.validateFields(['headers']);
-    } catch {
-      if (!operation.isCurrent()) return;
-      showError('Please fix custom HTTP headers before testing');
-      return;
-    }
-    if (!operation.isCurrent()) return;
-
-    let browserAttempt: Awaited<ReturnType<typeof oauthBrowserEvents.begin>> = null;
-    try {
-      setTesting(true);
-      setTestResult(null);
-      browserAttempt = await oauthBrowserEvents.begin({ operation: 'discover' });
-      if (!operation.isCurrent()) return;
-      const data = (await client.service('mcp-servers/discover').create({
+  const handleCreateTestConnection = () =>
+    testConnection(async (operation) => {
+      const values = createForm.getFieldsValue(true);
+      if (createdServerId || values.auth_type === 'oauth') {
+        const id = await prepareOAuthStartForCreate(operation);
+        return id ? { mcp_server_id: id } : null;
+      }
+      try {
+        await createForm.validateFields(['url', 'headers']);
+      } catch (error) {
+        if (operation.isCurrent())
+          showError(
+            firstFormErrorMessage(error) ?? 'Please fix connection settings before testing'
+          );
+        return null;
+      }
+      if (!values.url || values.transport === 'stdio') return null;
+      return {
         url: values.url,
         transport: values.transport || 'http',
         auth: buildAuthFromValues(values),
         headers: parseHeadersJSON(values.headers),
-        ...(browserAttempt ? { oauth_browser_event: browserAttempt.request } : {}),
-      })) as {
-        success: boolean;
-        error?: string;
-        capabilities?: { tools: number; resources: number; prompts: number };
-        tools?: Array<{ name: string; description: string }>;
-        resources?: Array<{ name: string; uri: string; mimeType?: string }>;
-        prompts?: Array<{ name: string; description: string }>;
       };
-
-      if (!operation.isCurrent()) return;
-
-      if (data.success && data.capabilities) {
-        setTestResult({
-          success: true,
-          toolCount: data.capabilities.tools,
-          resourceCount: data.capabilities.resources,
-          promptCount: data.capabilities.prompts,
-          tools: data.tools,
-          resources: data.resources,
-          prompts: data.prompts,
-        });
-      } else {
-        setTestResult({
-          success: false,
-          toolCount: 0,
-          resourceCount: 0,
-          promptCount: 0,
-          error: data.error || 'Connection test failed',
-        });
-      }
-    } catch (error) {
-      if (!operation.isCurrent()) return;
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      setTestResult({
-        success: false,
-        toolCount: 0,
-        resourceCount: 0,
-        promptCount: 0,
-        error: errorMessage,
-      });
-    } finally {
-      browserAttempt?.cleanup();
-      if (operation.isCurrent()) setTesting(false);
-    }
-  };
+    });
 
   const handleEdit = useCallback((server: MCPServer) => {
     setEditingServer(server);
@@ -778,16 +720,18 @@ const MCPServersTableForIdentity: React.FC<MCPServersTableProps> = ({
             {/* A disabled button can't host a tooltip of its own — hence the span. */}
             <Tooltip
               title={
-                !createdServerId && !canAdd
+                !canAdd
                   ? addRestriction
-                  : createBlocked
-                    ? describeMissingForSave(missingRequiredFields)
-                    : undefined
+                  : testing
+                    ? 'Wait for the connection test to finish.'
+                    : missingRequiredFields.length > 0
+                      ? describeMissingForSave(missingRequiredFields)
+                      : undefined
               }
             >
               <span>
                 <Button type="primary" disabled={createBlocked} onClick={handleCreate}>
-                  {createdServerId ? 'Done' : 'Create'}
+                  {createdServerId ? 'Save' : 'Create'}
                 </Button>
               </span>
             </Tooltip>
@@ -810,7 +754,7 @@ const MCPServersTableForIdentity: React.FC<MCPServersTableProps> = ({
           onValuesChange={bumpFormRevision}
         >
           <MCPServerFormFields
-            mode="create"
+            mode={createdServerId ? 'edit' : 'create'}
             transport={transport}
             onTransportChange={setChosenTransport}
             offeredTransports={offeredTransports}

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -22,7 +22,12 @@ export {
   assertValidDiscoveredMCPCapabilities,
   assertValidEffectiveMCPServer,
   assertValidMCPServerWrite,
+  MAX_MCP_CAPABILITY_DESCRIPTION_BUDGET,
+  MAX_MCP_CAPABILITY_DESCRIPTION_LENGTH,
+  MCP_DESCRIPTION_TRUNCATION_SUFFIX,
   MCPServerWriteValidationError,
+  type NormalizedDiscoveredMCPCapabilities,
+  normalizeDiscoveredMCPCapabilities,
 } from '../tools/mcp/server-validation';
 export {
   canConfigureMCPServers,

--- a/packages/core/src/tools/mcp/capability-normalization.test.ts
+++ b/packages/core/src/tools/mcp/capability-normalization.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MAX_MCP_CAPABILITY_DESCRIPTION_BUDGET,
+  MAX_MCP_CAPABILITY_DESCRIPTION_LENGTH,
+  MCP_DESCRIPTION_TRUNCATION_SUFFIX,
+  MCPServerWriteValidationError,
+  normalizeDiscoveredMCPCapabilities,
+} from './server-validation';
+
+const capabilities = (description?: unknown) => ({
+  tools: [
+    {
+      name: 'fictional_mail_search',
+      ...(description === undefined ? {} : { description }),
+      input_schema: { type: 'object', properties: { query: { type: 'string' } } },
+    },
+  ],
+  resources: [],
+  prompts: [],
+});
+
+describe('normalizeDiscoveredMCPCapabilities', () => {
+  it.each([
+    ['missing', undefined],
+    ['exactly at the limit', 'a'.repeat(MAX_MCP_CAPABILITY_DESCRIPTION_LENGTH)],
+  ])('preserves valid %s descriptions', (_label, description) => {
+    const result = normalizeDiscoveredMCPCapabilities(capabilities(description));
+    expect(result.truncatedDescriptions).toBe(0);
+    expect(result.capabilities.tools[0]?.description).toBe(description);
+    expect(result.capabilities.tools[0]).toMatchObject({
+      name: 'fictional_mail_search',
+      input_schema: { type: 'object' },
+    });
+  });
+
+  it.each([
+    ['limit plus one', 'a'.repeat(MAX_MCP_CAPABILITY_DESCRIPTION_LENGTH + 1)],
+    ['very long ASCII', 'mail metadata '.repeat(20_000)],
+    ['emoji and graphemes', `${'x'.repeat(MAX_MCP_CAPABILITY_DESCRIPTION_LENGTH - 3)}👩🏽‍💻é`],
+  ])('deterministically and Unicode-safely truncates %s', (_label, description) => {
+    const first = normalizeDiscoveredMCPCapabilities(capabilities(description));
+    const second = normalizeDiscoveredMCPCapabilities(capabilities(description));
+    const normalized = first.capabilities.tools[0]?.description;
+    expect(first).toEqual(second);
+    expect(first.truncatedDescriptions).toBe(1);
+    expect(normalized?.length).toBeLessThanOrEqual(MAX_MCP_CAPABILITY_DESCRIPTION_LENGTH);
+    expect(normalized?.endsWith(MCP_DESCRIPTION_TRUNCATION_SUFFIX)).toBe(true);
+    expect(normalized).not.toMatch(/[\uD800-\uDBFF]$/);
+  });
+
+  it('caps aggregate descriptions without dropping or reordering tools', () => {
+    const result = normalizeDiscoveredMCPCapabilities({
+      tools: Array.from({ length: 8 }, (_, index) => ({
+        name: `tool_${index}`,
+        description: String(index).repeat(MAX_MCP_CAPABILITY_DESCRIPTION_LENGTH),
+        input_schema: { type: 'object' },
+      })),
+      resources: [],
+      prompts: [],
+    });
+    expect(result.capabilities.tools.map((tool) => tool.name)).toEqual(
+      Array.from({ length: 8 }, (_, index) => `tool_${index}`)
+    );
+    expect(
+      result.capabilities.tools.reduce((sum, tool) => sum + (tool.description?.length ?? 0), 0)
+    ).toBeLessThanOrEqual(MAX_MCP_CAPABILITY_DESCRIPTION_BUDGET);
+    expect(result.truncatedDescriptions).toBeGreaterThan(0);
+  });
+
+  it.each([null, 1, {}, ['not text']])(
+    'rejects malformed description value %j with a per-tool diagnostic',
+    (description) => {
+      expect(() => normalizeDiscoveredMCPCapabilities(capabilities(description))).toThrowError(
+        new MCPServerWriteValidationError('tools[0].description must be a bounded string')
+      );
+    }
+  );
+
+  it('rejects malformed names and schemas instead of silently repairing them', () => {
+    expect(() =>
+      normalizeDiscoveredMCPCapabilities({
+        tools: [{ name: '', input_schema: 'not-an-object' }],
+        resources: [],
+        prompts: [],
+      })
+    ).toThrow(/tools\[0\]\.name/);
+  });
+
+  it('allows protocol free text line breaks but rejects unsafe control characters', () => {
+    expect(
+      normalizeDiscoveredMCPCapabilities(capabilities('line one\nline two\tformatted')).capabilities
+        .tools[0]?.description
+    ).toBe('line one\nline two\tformatted');
+    expect(() => normalizeDiscoveredMCPCapabilities(capabilities('bad\0text'))).toThrow(
+      /tools\[0\]\.description/
+    );
+  });
+});

--- a/packages/core/src/tools/mcp/capability-normalization.test.ts
+++ b/packages/core/src/tools/mcp/capability-normalization.test.ts
@@ -86,6 +86,33 @@ describe('normalizeDiscoveredMCPCapabilities', () => {
     ).toThrow(/tools\[0\]\.name/);
   });
 
+  it('preserves JSON schema text while retaining storage and structural bounds', () => {
+    const input_schema = {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'First line\nSecond line' },
+        separator: { type: 'string', enum: ['\n', '\t', '\b'], default: '\t' },
+      },
+    };
+    const discovered = { tools: [{ name: 'search', input_schema }], resources: [], prompts: [] };
+    expect(
+      normalizeDiscoveredMCPCapabilities(discovered).capabilities.tools[0]?.input_schema
+    ).toEqual(input_schema);
+    for (const invalid of [
+      null,
+      'not a schema',
+      { description: 'bad\0text' },
+      { enum: Array(257).fill('x') },
+    ]) {
+      expect(() =>
+        normalizeDiscoveredMCPCapabilities({
+          ...discovered,
+          tools: [{ name: 'search', input_schema: invalid }],
+        })
+      ).toThrow(/tools\[0\]\.input_schema/);
+    }
+  });
+
   it('allows protocol free text line breaks but rejects unsafe control characters', () => {
     expect(
       normalizeDiscoveredMCPCapabilities(capabilities('line one\nline two\tformatted')).capabilities

--- a/packages/core/src/tools/mcp/server-validation.ts
+++ b/packages/core/src/tools/mcp/server-validation.ts
@@ -91,10 +91,11 @@ function hasControlCharacter(value: string): boolean {
 }
 
 function hasUnsafeDescriptionControlCharacter(value: string): boolean {
-  return [...value].some((character) => {
+  for (const character of value) {
     const code = character.charCodeAt(0);
-    return (code <= 31 && code !== 9 && code !== 10 && code !== 13) || code === 127;
-  });
+    if ((code <= 31 && code !== 9 && code !== 10 && code !== 13) || code === 127) return true;
+  }
+  return false;
 }
 
 export interface MCPServerWriteValidationOptions {
@@ -291,7 +292,10 @@ function boundedJsonValue(value: unknown, label: string): void {
       return;
     }
     if (typeof nested === 'string') {
-      if (nested.length > MAX_VALUE_LENGTH || hasControlCharacter(nested)) {
+      // Schema annotations and literal enum/default values are JSON strings,
+      // not identifiers. Preserve whitespace and escaped control characters;
+      // only NUL is unrepresentable in PostgreSQL jsonb (keep SQLite parity).
+      if (nested.length > MAX_VALUE_LENGTH || nested.includes('\0')) {
         throw new Error(`${path} contains an invalid string`);
       }
       return;

--- a/packages/core/src/tools/mcp/server-validation.ts
+++ b/packages/core/src/tools/mcp/server-validation.ts
@@ -5,7 +5,14 @@ import {
   isValidMCPHttpUrlTemplate,
 } from '../../mcp/template-patterns';
 import { isCanonicalFullUuid } from '../../types/id';
-import { MCP_SCOPES, MCP_TRANSPORTS, type MCPServer } from '../../types/mcp';
+import {
+  MCP_SCOPES,
+  MCP_TRANSPORTS,
+  type MCPPrompt,
+  type MCPResource,
+  type MCPServer,
+  type MCPTool,
+} from '../../types/mcp';
 import { assertValidMCPAuthPatch } from './auth-patch';
 import {
   findDuplicateMCPCustomHeaderName,
@@ -69,12 +76,24 @@ const MAX_NAME_LENGTH = 255;
 const MAX_TEXT_LENGTH = 16_384;
 const MAX_COLLECTION_ENTRIES = 256;
 const MAX_VALUE_LENGTH = 65_536;
+/** Per-field persistence ceiling for provider-controlled capability descriptions. */
+export const MAX_MCP_CAPABILITY_DESCRIPTION_LENGTH = MAX_VALUE_LENGTH;
+/** Total persisted description budget for one discovered server. */
+export const MAX_MCP_CAPABILITY_DESCRIPTION_BUDGET = 256 * 1024;
+export const MCP_DESCRIPTION_TRUNCATION_SUFFIX = '\n\n[Description truncated by Agor]';
 const ENV_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 function hasControlCharacter(value: string): boolean {
   return [...value].some((character) => {
     const code = character.charCodeAt(0);
     return code <= 31 || code === 127;
+  });
+}
+
+function hasUnsafeDescriptionControlCharacter(value: string): boolean {
+  return [...value].some((character) => {
+    const code = character.charCodeAt(0);
+    return (code <= 31 && code !== 9 && code !== 10 && code !== 13) || code === 127;
   });
 }
 
@@ -244,11 +263,16 @@ function boundedRequiredString(
 function boundedOptionalString(
   record: Record<string, unknown>,
   field: string,
-  label: string
+  label: string,
+  options: { allowOverlongDescription?: boolean } = {}
 ): void {
   const value = record[field];
   if (value === undefined) return;
-  if (typeof value !== 'string' || value.length > MAX_VALUE_LENGTH || hasControlCharacter(value)) {
+  if (
+    typeof value !== 'string' ||
+    (!options.allowOverlongDescription && value.length > MAX_VALUE_LENGTH) ||
+    hasUnsafeDescriptionControlCharacter(value)
+  ) {
     throw new Error(`${label}.${field} must be a bounded string`);
   }
 }
@@ -292,7 +316,10 @@ function boundedJsonValue(value: unknown, label: string): void {
   visit(value, label, 0);
 }
 
-function capabilities(record: Record<string, unknown>): void {
+function capabilities(
+  record: Record<string, unknown>,
+  options: { allowOverlongDescriptions?: boolean } = {}
+): void {
   if (record.tools !== undefined) {
     if (!Array.isArray(record.tools) || record.tools.length > MAX_COLLECTION_ENTRIES) {
       throw new Error(`tools must be an array of at most ${MAX_COLLECTION_ENTRIES} entries`);
@@ -300,7 +327,9 @@ function capabilities(record: Record<string, unknown>): void {
     for (const [index, value] of record.tools.entries()) {
       const tool = closedObject(value, `tools[${index}]`, ['name', 'description', 'input_schema']);
       boundedRequiredString(tool, 'name', `tools[${index}]`);
-      boundedOptionalString(tool, 'description', `tools[${index}]`);
+      boundedOptionalString(tool, 'description', `tools[${index}]`, {
+        allowOverlongDescription: options.allowOverlongDescriptions,
+      });
       if (tool.input_schema !== undefined) {
         recordOf(tool.input_schema, `tools[${index}].input_schema`);
         boundedJsonValue(tool.input_schema, `tools[${index}].input_schema`);
@@ -320,7 +349,9 @@ function capabilities(record: Record<string, unknown>): void {
       ]);
       boundedRequiredString(resource, 'uri', `resources[${index}]`);
       boundedRequiredString(resource, 'name', `resources[${index}]`);
-      boundedOptionalString(resource, 'description', `resources[${index}]`);
+      boundedOptionalString(resource, 'description', `resources[${index}]`, {
+        allowOverlongDescription: options.allowOverlongDescriptions,
+      });
       if (resource.mimeType !== undefined) {
         boundedRequiredString(resource, 'mimeType', `resources[${index}]`);
       }
@@ -333,7 +364,9 @@ function capabilities(record: Record<string, unknown>): void {
     for (const [index, value] of record.prompts.entries()) {
       const prompt = closedObject(value, `prompts[${index}]`, ['name', 'description', 'arguments']);
       boundedRequiredString(prompt, 'name', `prompts[${index}]`);
-      boundedOptionalString(prompt, 'description', `prompts[${index}]`);
+      boundedOptionalString(prompt, 'description', `prompts[${index}]`, {
+        allowOverlongDescription: options.allowOverlongDescriptions,
+      });
       if (prompt.arguments === undefined) continue;
       if (!Array.isArray(prompt.arguments) || prompt.arguments.length > MAX_COLLECTION_ENTRIES) {
         throw new Error(
@@ -350,7 +383,8 @@ function capabilities(record: Record<string, unknown>): void {
         boundedOptionalString(
           argument,
           'description',
-          `prompts[${index}].arguments[${argumentIndex}]`
+          `prompts[${index}].arguments[${argumentIndex}]`,
+          { allowOverlongDescription: options.allowOverlongDescriptions }
         );
         if (argument.required !== undefined && typeof argument.required !== 'boolean') {
           throw new Error(`prompts[${index}].arguments[${argumentIndex}].required must be boolean`);
@@ -581,6 +615,116 @@ export function assertValidDiscoveredMCPCapabilities(value: unknown): void {
       }
     }
     capabilities(record);
+  } catch (error) {
+    if (error instanceof MCPServerWriteValidationError) throw error;
+    throw new MCPServerWriteValidationError(
+      error instanceof Error ? error.message : 'Invalid discovered MCP capabilities'
+    );
+  }
+}
+
+export interface NormalizedDiscoveredMCPCapabilities {
+  capabilities: {
+    tools: MCPTool[];
+    resources: MCPResource[];
+    prompts: MCPPrompt[];
+  };
+  /** Number of optional descriptions shortened or omitted to meet the budget. */
+  truncatedDescriptions: number;
+}
+
+function truncateDescription(value: string, limit: number): string | undefined {
+  if (value.length <= limit) return value;
+  if (limit < MCP_DESCRIPTION_TRUNCATION_SUFFIX.length) return undefined;
+  const prefixLimit = limit - MCP_DESCRIPTION_TRUNCATION_SUFFIX.length;
+  let prefix = '';
+  // Grapheme segmentation keeps emoji ZWJ sequences and combining marks intact;
+  // the explicit code-unit check also guarantees the persisted string ceiling.
+  const segments = new Intl.Segmenter('en', { granularity: 'grapheme' }).segment(value);
+  for (const { segment } of segments) {
+    if (prefix.length + segment.length > prefixLimit) break;
+    prefix += segment;
+  }
+  return `${prefix}${MCP_DESCRIPTION_TRUNCATION_SUFFIX}`;
+}
+
+/**
+ * Normalize provider-controlled MCP metadata once at discovery ingress.
+ *
+ * MCP descriptions are optional free text and the protocol does not impose a
+ * length limit. Agor does impose persistence/prompt budgets, so valid long
+ * descriptions are shortened deterministically instead of rejecting the
+ * entire provider. Names, schemas, collection sizes, and malformed description
+ * values remain fail-closed with their existing path-specific diagnostics.
+ */
+export function normalizeDiscoveredMCPCapabilities(
+  value: unknown
+): NormalizedDiscoveredMCPCapabilities {
+  try {
+    const record = recordOf(value, 'discovered MCP capabilities');
+    for (const key of Object.keys(record)) {
+      if (!['tools', 'resources', 'prompts'].includes(key)) {
+        throw new Error(`Unknown discovered MCP capabilities field: ${key}`);
+      }
+    }
+    capabilities(record, { allowOverlongDescriptions: true });
+
+    let remaining = MAX_MCP_CAPABILITY_DESCRIPTION_BUDGET;
+    let truncatedDescriptions = 0;
+    const normalizeDescription = (description: string | undefined): string | undefined => {
+      if (description === undefined) return undefined;
+      const limit = Math.min(MAX_MCP_CAPABILITY_DESCRIPTION_LENGTH, remaining);
+      const normalized = truncateDescription(description, limit);
+      if (normalized !== description) truncatedDescriptions += 1;
+      if (normalized !== undefined) remaining -= normalized.length;
+      return normalized;
+    };
+
+    const tools = (record.tools ?? []) as MCPTool[];
+    const resources = (record.resources ?? []) as MCPResource[];
+    const prompts = (record.prompts ?? []) as MCPPrompt[];
+    const normalized = {
+      tools: tools.map((tool) => {
+        const description = normalizeDescription(tool.description);
+        return {
+          name: tool.name,
+          ...(description === undefined ? {} : { description }),
+          ...(tool.input_schema === undefined ? {} : { input_schema: tool.input_schema }),
+        };
+      }),
+      resources: resources.map((resource) => {
+        const description = normalizeDescription(resource.description);
+        return {
+          uri: resource.uri,
+          name: resource.name,
+          ...(description === undefined ? {} : { description }),
+          ...(resource.mimeType === undefined ? {} : { mimeType: resource.mimeType }),
+        };
+      }),
+      prompts: prompts.map((prompt) => {
+        const description = normalizeDescription(prompt.description);
+        return {
+          name: prompt.name,
+          ...(description === undefined ? {} : { description }),
+          ...(prompt.arguments === undefined
+            ? {}
+            : {
+                arguments: prompt.arguments.map((argument) => {
+                  const argumentDescription = normalizeDescription(argument.description);
+                  return {
+                    name: argument.name,
+                    ...(argumentDescription === undefined
+                      ? {}
+                      : { description: argumentDescription }),
+                    ...(argument.required === undefined ? {} : { required: argument.required }),
+                  };
+                }),
+              }),
+        };
+      }),
+    };
+    assertValidDiscoveredMCPCapabilities(normalized);
+    return { capabilities: normalized, truncatedDescriptions };
   } catch (error) {
     if (error instanceof MCPServerWriteValidationError) throw error;
     throw new MCPServerWriteValidationError(

--- a/packages/core/src/types/mcp.ts
+++ b/packages/core/src/types/mcp.ts
@@ -427,6 +427,28 @@ export interface PromptArgument {
   required?: boolean;
 }
 
+/** Request for an authenticated, tenant-scoped capability probe. Saved IDs use the durable row. */
+export interface MCPDiscoveryRequest {
+  mcp_server_id?: string;
+  url?: string;
+  transport?: 'http' | 'sse';
+  auth?: MCPAuth;
+  headers?: Record<string, string>;
+  oauth_browser_event?: MCPOAuthBrowserEventRequest;
+}
+
+/** Bounded discovery response shared by the daemon and both MCP server forms. */
+export type MCPDiscoveryResult =
+  | {
+      success: true;
+      capabilities: { tools: number; resources: number; prompts: number };
+      metadata?: { descriptions_truncated: number };
+      tools: Pick<MCPTool, 'name' | 'description'>[];
+      resources: Pick<MCPResource, 'name' | 'uri' | 'mimeType'>[];
+      prompts: Pick<MCPPrompt, 'name' | 'description'>[];
+    }
+  | { success: false; error: string; recovery?: MCPAuthRecovery; category?: string };
+
 /**
  * MCP Server Capabilities
  * Discovered from server via MCP protocol


### PR DESCRIPTION
## Summary

- Normalize provider-controlled MCP capability descriptions at one shared ingress before persistence.
- Keep every valid tool name and input schema while deterministically, grapheme-safely shortening optional descriptions to the existing 65,536-code-unit field ceiling and a 256 KiB aggregate budget.
- Apply the same bounded tool representation to Test Authentication/discovery, persisted catalog display, and daemon-mediated agent `tools/list` responses.
- Continue to reject malformed names, schemas, and non-string descriptions with a targeted capability path.
- Surface a sanitized Test Authentication notice when descriptions were shortened.

## Root cause

The MCP schema defines `Tool.description` as optional free text without a protocol length limit: https://modelcontextprotocol.io/specification/2025-06-18/schema#tool. Agor's persistence validator instead rejected a protocol-valid description over its internal 65,536-code-unit ceiling. Because Test Authentication persists discovered capabilities, one long description rejected the whole otherwise valid server with `tools[0].description must be a bounded string`.

A fictional MCP returning one long mail-tool description reproduces this on current upstream `main`. This patch treats the internal ceiling as an ingestion budget rather than a remote protocol requirement. It is intentionally separate from provider-token refresh behavior: metadata normalization runs only after authentication and capability listing succeed, and it does not relabel metadata failures as OAuth failures.

## Security and isolation

Remote metadata remains untrusted. The normalizer preserves deterministic order, caps both individual and aggregate description text, never splits an emoji/grapheme cluster, and does not silently drop tools. Existing closed-object, schema-depth/node, collection-size, and control-character validation remains fail-closed. No provider payload, credential, token, or Authorization material is added to logs, UI, events, or snapshots.

## Tests

- Core normalization matrix: missing, exact limit, limit+1, very long ASCII, emoji/combining graphemes, line breaks, malformed description/name/schema, aggregate cap, deterministic output.
- Daemon discovery persistence: returned Test Authentication representation equals the stored representation.
- MCP egress: mediated `tools/list` normalization preserves name, input schema, and annotations; malformed metadata gets a targeted provider diagnostic.
- UI: Test Authentication surfaces the bounded-metadata notice.

Validated locally:

- `pnpm --filter @agor/git build` then `pnpm --filter @agor/core build`
- full workspace build and typecheck
- full core suite: 4,151 passed
- full UI suite: 2,196 passed
- browser suite: 140 passed
- focused OAuth/discovery/egress/UI suites: 253 passed
- Biome/lint and short-ID, multitenancy, filesystem, realtime, CI-matrix, image-publication, dependency, and package-alignment policy checks

The full daemon suite passed 4,162 tests; three unrelated pre-existing macOS path/sandbox harness cases fail because the platform resolves `/var` through `/private/var` (one dependent executor handoff case consequently sees no fixture payload). All changed daemon suites pass.
