### PR TITLE
fix(ui): let session-tree wheel gestures pan the canvas

### DIFF
--- a/apps/agor-docs/content/guide/sessions.mdx
+++ b/apps/agor-docs/content/guide/sessions.mdx
@@ -93,8 +93,12 @@ The tree is rendered on the branch card on the board, and in full detail in the 
 ### Large session lists
 
 Branch cards and the branch teammate panel keep manual and gateway genealogy
-trees in a virtual, scrollable viewport (up to 400 pixels high). Scroll inside
-the tree to reach older sessions; collapsing a parent still hides its descendants.
+trees in a virtual, scrollable viewport (up to 400 pixels high). On board cards,
+two-finger scrolling over a session tree pans the canvas, and pinching zooms it;
+drag the tree's scrollbar to reach older sessions. In the branch teammate panel,
+scroll inside the tree normally. Collapsing a parent still hides its descendants.
+Expanded, overflowing descriptions and task peeks retain ordinary inner scrolling
+on board cards, while pinching still zooms the canvas.
 Scheduled runs and panel search results show 20 sessions per page. Search matches
 the loaded collection, not just the current page. The branch settings Sessions
 tab also paginates its table.

--- a/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.tsx
@@ -113,21 +113,28 @@ const BranchCardComponent = ({
 
   const branchBoardId = (branch as { board_id?: string | null }).board_id;
   const cardRef = React.useRef<HTMLDivElement>(null);
+  const sessionSectionsRef = React.useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const card = cardRef.current;
     if (!card || inPopover || panelMode) return;
 
     const onWheel = (event: WheelEvent) => {
-      // Trackpad pinch is Ctrl+wheel, often without a Control keydown.
-      if (!(event.ctrlKey || event.metaKey) || !(event.target instanceof Element)) return;
+      if (!(event.target instanceof Element)) return;
       const scrollArea = event.target.closest(`.${REACT_FLOW_NO_WHEEL_CLASS}`);
       const renderer = card.closest('.react-flow__renderer');
       if (!scrollArea || !card.contains(scrollArea) || !renderer) return;
 
-      // nowheel excludes pinch as well as scrolling in React Flow 11. Capture
-      // before the virtual tree consumes it, then let React Flow own zoom,
-      // pointer anchoring and limits. Ordinary inner scrolling stays untouched.
+      // Session lists belong to the canvas gesture surface, even when virtual.
+      // Expanded descriptions/peeks retain ordinary scrolling only if they overflow.
+      const isSessionList = sessionSectionsRef.current?.contains(scrollArea);
+      const overflows =
+        scrollArea.scrollHeight > scrollArea.clientHeight ||
+        scrollArea.scrollWidth > scrollArea.clientWidth;
+      if (!event.ctrlKey && !event.metaKey && !isSessionList && overflows) return;
+
+      // Removing nowheel alone is insufficient: the virtual list still consumes
+      // wheel. Capture first, then let React Flow own pan/zoom and anchoring.
       event.preventDefault();
       event.stopPropagation();
       renderer.dispatchEvent(new WheelEvent(event.type, event));
@@ -567,6 +574,7 @@ const BranchCardComponent = ({
 
       {/* Sessions & Scheduled Runs - composable content shared with the teammate panel */}
       <div
+        ref={sessionSectionsRef}
         className={REACT_FLOW_NO_DRAG_CLASS}
         style={sectionsReady ? undefined : { minHeight: sessionShellMinHeight }}
       >

--- a/apps/agor-ui/src/components/BranchCard/BranchCard.wheel.browser.test.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchCard.wheel.browser.test.tsx
@@ -21,10 +21,10 @@ const onSessionClick = vi.fn();
 
 function CardNode({
   data,
-}: NodeProps<{ sessions: Session[]; panelMode?: boolean; inPopover?: boolean }>) {
+}: NodeProps<{ sessions: Session[]; panelMode?: boolean; inPopover?: boolean; notes?: string }>) {
   return (
     <BranchCard
-      branch={branch}
+      branch={{ ...branch, notes: data.notes }}
       repo={repo}
       sessions={data.sessions}
       userById={new Map()}
@@ -37,7 +37,7 @@ function CardNode({
 }
 const nodeTypes = { branch: CardNode };
 
-async function mount(count: number, scheduled = false) {
+async function mount(count: number, scheduled = false, notes?: string) {
   let flow: ReactFlowInstance | undefined;
   const sessions = Array.from(
     { length: count },
@@ -85,7 +85,7 @@ async function mount(count: number, scheduled = false) {
                 type: 'branch',
                 position: { x: 70, y: 70 },
                 dragHandle: REACT_FLOW_DRAG_HANDLE_SELECTOR,
-                data: { sessions },
+                data: { sessions, notes },
               },
             ]}
             nodeTypes={nodeTypes}
@@ -187,24 +187,26 @@ it.each([2, 100])(
   }
 );
 
-it('keeps trusted plain wheel scrolling inside an overflowing tree', async () => {
-  const { flow, scroller } = await mount(100);
+it.each([2, 100])('pans the canvas over a %s-session tree without scrolling it', async (count) => {
+  const { flow, scroller } = await mount(count);
   const before = flow.getViewport();
   await act(async () =>
     userEvent.wheel(screen.getByRole('button', { name: 'Open session Conversation 0' }), {
       delta: { y: 150 },
     })
   );
-  await waitFor(() => expect(scroller.scrollTop).toBeGreaterThan(0));
-  expect(flow.getViewport()).toEqual(before);
+  await waitFor(() => expect(flow.getViewport().y).not.toBe(before.y));
+  expect(flow.getZoom()).toBe(before.zoom);
+  expect(scroller.scrollTop).toBe(0);
 });
 
-it('preserves native scrolling and pagination in scheduled lists while routing pinch to the canvas', async () => {
+it('pans and zooms the canvas over scheduled lists while preserving pagination', async () => {
   const { flow, scroller } = await mount(100, true);
   const before = flow.getViewport();
   await act(async () => userEvent.wheel(scroller, { delta: { y: 150 } }));
-  await waitFor(() => expect(scroller.scrollTop).toBeGreaterThan(0));
-  expect(flow.getViewport()).toEqual(before);
+  await waitFor(() => expect(flow.getViewport().y).not.toBe(before.y));
+  expect(flow.getZoom()).toBe(before.zoom);
+  expect(scroller.scrollTop).toBe(0);
   const scrollTop = scroller.scrollTop;
   expect(wheel(scroller, { ctrlKey: true }).defaultPrevented).toBe(true);
   await settle();
@@ -218,6 +220,43 @@ it('preserves native scrolling and pagination in scheduled lists while routing p
   );
   expect(onSessionClick).toHaveBeenCalledWith('session-20');
 });
+
+it.each([6, 40])(
+  'scrolls a %s-paragraph description only when expanded and overflowing',
+  async (count) => {
+    const notes = Array.from(
+      { length: count },
+      (_, index) => `Description paragraph ${index}.`
+    ).join('\n\n');
+    const { flow } = await mount(2, false, notes);
+    const more = await screen.findByRole('button', { name: 'See more' });
+    const viewport = document.getElementById(more.getAttribute('aria-controls')!)!;
+    const initialViewport = flow.getViewport();
+    wheel(viewport, { deltaY: 30 });
+    expect(flow.getViewport().y).not.toBe(initialViewport.y);
+    expect(viewport.scrollTop).toBe(0);
+    await act(async () => flow.setViewport(initialViewport));
+    await act(async () => userEvent.click(more));
+    await settle();
+    expect(viewport.scrollHeight > viewport.clientHeight).toBe(count === 40);
+    const beforeScroll = flow.getViewport();
+    await act(async () => userEvent.wheel(viewport, { delta: { y: 60 } }));
+    await settle();
+    if (count === 40) {
+      expect(viewport.scrollTop).toBeGreaterThan(0);
+      expect(flow.getViewport()).toEqual(beforeScroll);
+    } else {
+      expect(viewport.scrollTop).toBe(0);
+      expect(flow.getViewport().y).not.toBe(beforeScroll.y);
+    }
+    const scrollTop = viewport.scrollTop;
+    const zoom = flow.getZoom();
+    expect(wheel(viewport, { ctrlKey: true }).defaultPrevented).toBe(true);
+    await settle();
+    expect(flow.getZoom()).toBeGreaterThan(zoom);
+    expect(viewport.scrollTop).toBe(scrollTop);
+  }
+);
 
 it.each(['Control', 'Meta'])(
   'cancels trusted %s+wheel and changes the rendered canvas transform, not inner scroll',
@@ -274,9 +313,12 @@ it('keeps pinch at both scroll edges and canvas zoom limits from escaping to bro
     await settle();
     expect(flow.getZoom()).toBe(zoom);
     expect(scroller.scrollTop).toBe(top);
-    // No modifier: retain inner-scroll ownership even at an edge.
+    // No modifier: pan the canvas even at a tree scroll edge.
+    const beforePan = flow.getViewport();
     wheel(scroller, { deltaY });
     await settle();
+    expect(flow.getViewport().y).not.toBe(beforePan.y);
+    expect(scroller.scrollTop).toBe(top);
     expect(flow.getZoom()).toBe(zoom);
   }
 });
@@ -317,8 +359,10 @@ it('leaves outside-canvas wheel and browser keyboard zoom shortcuts uncanceled',
     expect(
       wheel(screen.getByRole('button', { name: 'Open session Conversation 0' }), modifiers)
         .defaultPrevented
-    ).toBe(false);
+    ).toBe(true);
   }
+  expect(flow.getZoom()).toBe(before.zoom);
+  const afterPan = flow.getViewport();
   for (const modifiers of [{ ctrlKey: true }, { metaKey: true }]) {
     expect(wheel(outside, modifiers).defaultPrevented).toBe(false);
     for (const key of ['+', '-', '0']) {
@@ -334,7 +378,7 @@ it('leaves outside-canvas wheel and browser keyboard zoom shortcuts uncanceled',
       expect(event.defaultPrevented).toBe(false);
     }
   }
-  expect(flow.getViewport()).toEqual(before);
+  expect(flow.getViewport()).toEqual(afterPan);
 });
 
 it('opts panel/popover cards out, cleans up mode changes, and leaves standalone cards alone', async () => {

--- a/apps/agor-ui/src/components/BranchCard/SessionLatestTaskPeek.tsx
+++ b/apps/agor-ui/src/components/BranchCard/SessionLatestTaskPeek.tsx
@@ -6,6 +6,7 @@ import { useAppActions } from '../../contexts/AppActionsContext';
 import { useConnectionDisabled } from '../../contexts/ConnectionContext';
 import { useSharedReactiveSession } from '../../hooks/useSharedReactiveSession';
 import { useStreamingMessagesByTask } from '../../hooks/useStreamingMessagesByTask';
+import { REACT_FLOW_NO_WHEEL_CLASS } from '../../utils/reactFlowDragClasses';
 import { TaskBlock } from '../TaskBlock';
 import { chooseLatestSessionTask } from './latestSessionTask';
 
@@ -207,6 +208,7 @@ export const SessionLatestTaskPeek = React.memo<SessionLatestTaskPeekProps>(
       <div className="nodrag">
         <div
           ref={containerRef}
+          className={REACT_FLOW_NO_WHEEL_CLASS}
           style={{
             height: 360,
             overflowY: 'auto',


### PR DESCRIPTION
## Summary

Follow-up to #2692: let ordinary two-finger scroll/wheel over BranchCard session trees reach React Flow, not just pinch/Ctrl/Meta-wheel. Built on current `main` (`6cfcd66a5c1c366bb4872e12617839a58f4bad37`).

Max manually tried the trial changes in the managed dev environment and reported that the behavior worked perfectly. Those trial changes were made in the reviewer session and remained uncommitted when #2692 was merged; this PR publishes them separately.

## Cause and environment evidence

- #2687 added `nowheel` with session-list virtualization. React Flow skips these targets, and the virtual list can consume native wheel before it reaches the canvas.
- #2692 fixed modified wheel/pinch and deliberately retained ordinary inner scrolling. Its latest pushed commit (`bcb9fbe`) **was included in the merge**.
- The production `SessionCanvas-DkiDSEAs.js` bundle inspected during investigation contains the merged Ctrl/Meta-only handler. The managed dev server on port 10442 serves the additional uncommitted ordinary-wheel routing handler. This explains the observed difference; it is not a missing push of #2692.
- Independently, production `/health` reported backend SHA `7b301aa1a`, the parent of the merge, while its frontend already contained the fix. That backend/frontend discrepancy is not the explanation for ordinary wheel routing.

## Behavior and implementation

| Pointer location | Before (#2692) | After |
| --- | --- | --- |
| Short/overflowing session tree, scheduled list or pagination | Ordinary wheel blocked from canvas or consumed as list scroll | React Flow owns ordinary pan/zoom gestures |
| Expanded, overflowing description or task peek | Description scroll; peek lacked `nowheel` | Retain ordinary inner scroll; modified wheel zooms canvas |
| Collapsed/non-overflowing description or non-overflowing peek | Could block canvas gestures | React Flow owns gestures |
| Panel/popover and outside canvas | Existing behavior | Unchanged |

Keep routing inline in BranchCard; no new hook, file, global listener, or zoom algorithm. A section ref distinguishes session lists from scrollable reading surfaces. The native non-passive capture listener runs before the virtual list; React Flow still owns delta/modifier handling, anchoring, limits, and viewport notifications. `SessionLatestTaskPeek` marks its existing scroll viewport `nowheel`.

Intentional product choice: overflowing session trees no longer consume ordinary wheel on board cards. Their scrollbars, tree controls, and scheduled pagination remain available; panel/popover list behavior is unchanged. No tenant, authorization, persisted-data or realtime boundaries changed.

## Validation

- `pnpm i`: up to date; no lockfile change.
- `pnpm check`: passed (workspace typechecks, lint, boundary guards, and configured builds).
- 42 focused tests passed (BranchCard + SessionCanvas zoom).
- 84 Chromium browser cases passed across desktop, phone, tablet, and short-landscape viewport profiles (BranchCard gestures, bounded session sections, markdown cards).
- Strict no-emit typecheck of the changed browser test against built declarations passed.
- Coverage includes trusted ordinary wheel over short/overflowing trees, native scheduled lists/pagination, collapsed/expanded/non-overflowing/overflowing descriptions, Ctrl/Meta-wheel, pinch without keydown, scroll edges/zoom limits, pointer anchoring, clicks/keyboard activation/drag, panel/popover/standalone opt-out, and outside-canvas browser shortcuts.

Trusted CDP wheel plus real Chromium viewport transforms establishes event routing and cancellation, not physical-trackpad or browser-toolbar zoom behavior. The four profiles are viewport sizes, not four operating systems. Max's manual dev result is operator evidence, not an automated hardware claim; targeted physical-trackpad verification of descriptions/peeks remains worthwhile.

No merge or production deployment by this task. Review will reuse the existing Codex reviewer session and record its verdict here.
