### PR TITLE
fix(artifacts): report Sandpack compilation readiness accurately

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/artifacts.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/artifacts.test.ts
@@ -157,6 +157,42 @@ describe('artifact MCP tool input schemas', () => {
   });
 });
 
+describe('artifact publish runtime instructions', () => {
+  it.each([true, false])(
+    'keeps a timed-out wait inconclusive when observed=%s',
+    async (observed) => {
+      const artifactService = {
+        publishArtifact: vi.fn(async () => ({ artifact_id: 'artifact-1', files: {} })),
+        waitForRuntimeStatus: vi.fn(async () => ({ ok: false, observed, timed_out: true })),
+        buildStatusDiagnostic: vi.fn(() => null),
+      };
+      const ctx = {
+        app: {
+          service: (name: string) =>
+            name === 'branches'
+              ? { get: async () => ({ branch_id: 'branch-1' }) }
+              : artifactService,
+        },
+        userId: 'viewer-1',
+        baseServiceParams: { tenant: { tenant_id: 'tenant-a', source: 'auth_claim' } },
+      } as unknown as Parameters<typeof registerArtifactTools>[1];
+      const result = (await captureHandler(
+        'agor_artifacts_publish',
+        ctx
+      )({
+        branchId: 'branch-1',
+        subpath: 'synthetic-app',
+        waitForStatus: true,
+      })) as { content: Array<{ text: string }> };
+      const payload = JSON.parse(result.content[0].text);
+      expect(payload.instructions).toContain('inconclusive');
+      expect(payload.instructions).not.toContain('observed a failure');
+      expect(payload.instructions).not.toContain('fix and republish');
+      expect(payload.publish_validation).toMatchObject({ observed, timed_out: true, ok: false });
+    }
+  );
+});
+
 describe('artifact MCP list projection', () => {
   it('requests the legacy list shape without source files', async () => {
     const find = vi.fn(async () => ({

--- a/apps/agor-daemon/src/mcp/tools/artifacts.ts
+++ b/apps/agor-daemon/src/mcp/tools/artifacts.ts
@@ -253,10 +253,10 @@ IMPORTANT:
       const validationInstructions = publishValidation
         ? publishValidation.ok
           ? ' Browser runtime validation observed a successful Sandpack boot.'
-          : publishValidation.observed
-            ? ' Browser runtime validation observed a failure; inspect publish_validation.build_errors, sandpack_error, and console_logs, then fix and republish.'
-            : publishValidation.timed_out
-              ? ' Browser runtime validation was inconclusive because no current browser render reported status before the timeout. Open the artifact as this user and call agor_artifacts_status, or republish with waitForStatus once the board/fullscreen view is open.'
+          : publishValidation.timed_out
+            ? ' Browser runtime validation was inconclusive: compilation completion and settling were not confirmed before the timeout. Inspect publish_validation.note and the preview as this user, then call agor_artifacts_status. This is not evidence that the app is broken.'
+            : publishValidation.observed
+              ? ' Browser runtime validation observed a failure; inspect publish_validation.build_errors, sandpack_error, and console_logs, then fix and republish.'
               : ' Publish validation failed before browser boot; inspect publish_validation.build_errors, then fix and republish.'
         : '';
       return textResult({
@@ -374,7 +374,8 @@ Fields:
 - build_errors: array of error messages (includes Sandpack errors prefixed with [Sandpack])
 - diagnostic: compact deterministic diagnosis + suggested_fix when an error/no-observation pattern is recognized
 - sandpack_error: the raw Sandpack bundler/runtime error object (null if no error)
-- sandpack_status: Sandpack bundler status ('idle', 'running', 'timeout', etc.)
+- sandpack_status: Sandpack provider lifecycle ('idle', 'running', 'timeout', etc.), NOT compilation readiness
+- compilation_status: 'pending' | 'compiling' | 'success' | 'error'; explicit browser compilation progress (absent for older tabs). Compilation success is a boot smoke check, not proof of DOM correctness.
 - runtime_observed_at: when your browser last reported current-content status/logs
 - console_logs: console.log/warn/error output from the running app
 

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -1889,11 +1889,7 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       '/artifacts/:id/sandpack-error',
       {
         async create(
-          data: {
-            error: import('@agor/core/types').SandpackError | null;
-            status?: string;
-            content_hash?: string;
-          },
+          data: import('@agor/core/types').ArtifactSandpackReport,
           _params: RouteParams
         ) {
           const artifactId = _params.route?.id;
@@ -1910,7 +1906,8 @@ export function registerHooks(ctx: RegisterHooksContext): void {
             userId,
             data.error,
             data.status,
-            data.content_hash
+            data.content_hash,
+            data.compilation_status
           );
           return { success: true };
         },

--- a/apps/agor-daemon/src/services/artifacts.test.ts
+++ b/apps/agor-daemon/src/services/artifacts.test.ts
@@ -25,7 +25,14 @@ import {
   update,
 } from '@agor/core/db';
 import type { Application } from '@agor/core/feathers';
-import type { Artifact, BoardID, BranchID, SessionID, UUID } from '@agor/core/types';
+import type {
+  Artifact,
+  ArtifactStatus,
+  BoardID,
+  BranchID,
+  SessionID,
+  UUID,
+} from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
 import { dbTest } from '../../../../packages/core/src/db/test-helpers';
 import { requestExecutor } from '../utils/spawn-executor';
@@ -50,6 +57,31 @@ it('quotes dotenv values without permitting CR/LF record injection', () => {
   expect(escaped).toBe('"first\\rINJECTED=value\\nlast\\\\\\""');
   expect(escaped).not.toContain('\r');
   expect(escaped).not.toContain('\n');
+});
+
+describe('artifact status diagnosis', () => {
+  it.each([
+    [`Unexpected token '<', "<!doctype "... is not valid JSON`, 'html_instead_of_json'],
+    ['Unexpected token < in JSON at position 0', 'html_instead_of_json'],
+    [
+      'package.json: Expected property name in JSON at position 2',
+      'malformed_package_json_or_syntax',
+    ],
+    ["/App.tsx: Unexpected token '<'", 'malformed_package_json_or_syntax'],
+    ["Cannot use 'import.meta' outside a module", 'environment_variable_access'],
+    ["Cannot find module './missing'", 'missing_local_import_or_dependency'],
+  ])('classifies %s without inventing a failed endpoint', (message, diagnosis) => {
+    const status: ArtifactStatus = {
+      artifact_id: generateId(),
+      build_status: 'error',
+      sandpack_error: { message },
+      console_logs: [],
+    };
+    expect(ArtifactsService.prototype.buildStatusDiagnostic(status)).toMatchObject({
+      diagnosis,
+      primary_error: message,
+    });
+  });
 });
 
 /**
@@ -1152,6 +1184,173 @@ describe('ArtifactsService.grantTrust', () => {
 });
 
 describe('ArtifactsService.getStatus + console isolation', () => {
+  dbTest(
+    'explicit completion succeeds while the provider stays running, only for its viewer',
+    async ({ db }) => {
+      const service = new ArtifactsService(db, makeFakeApp());
+      const board = await seedBoard(db);
+      const artifact = await seedArtifact(db, board.board_id);
+      const payload = await service.getPayload(artifact.artifact_id, 'viewer-A' as never);
+      await service.setSandpackError(
+        artifact.artifact_id,
+        'viewer-A',
+        null,
+        'running',
+        payload.runtime_report_hash,
+        'success'
+      );
+
+      const result = await service.waitForRuntimeStatus(artifact.artifact_id, 'viewer-A' as never, {
+        settleMs: 0,
+      });
+      expect(result).toMatchObject({
+        ok: true,
+        observed: true,
+        timed_out: false,
+        sandpack_status: 'running',
+        compilation_status: 'success',
+      });
+      const other = await service.waitForRuntimeStatus(artifact.artifact_id, 'viewer-B' as never, {
+        timeoutMs: 500,
+        settleMs: 0,
+      });
+      expect(other).toMatchObject({ ok: false, observed: false, timed_out: true });
+      expect(other.compilation_status).toBeUndefined();
+    }
+  );
+
+  for (const status of ['idle', 'initial', 'running']) {
+    dbTest(
+      `legacy provider ${status} is observation, not successful compilation`,
+      async ({ db }) => {
+        const service = new ArtifactsService(db, makeFakeApp());
+        const artifact = await seedArtifact(db, (await seedBoard(db)).board_id);
+        await service.setSandpackError(artifact.artifact_id, 'viewer-A', null, status);
+        const result = await service.waitForRuntimeStatus(
+          artifact.artifact_id,
+          'viewer-A' as never,
+          { timeoutMs: 500, settleMs: 0 }
+        );
+        expect(result).toMatchObject({ ok: false, observed: true, timed_out: true });
+        expect(result.note).toContain('does not prove the app is broken');
+      }
+    );
+  }
+
+  dbTest(
+    'compilation failure without an error object is still an observed failure',
+    async ({ db }) => {
+      const service = new ArtifactsService(db, makeFakeApp());
+      const artifact = await seedArtifact(db, (await seedBoard(db)).board_id);
+      await service.setSandpackError(
+        artifact.artifact_id,
+        'viewer-A',
+        null,
+        'running',
+        undefined,
+        'error'
+      );
+      expect(
+        await service.waitForRuntimeStatus(artifact.artifact_id, 'viewer-A' as never)
+      ).toMatchObject({ ok: false, observed: true, timed_out: false, build_status: 'error' });
+    }
+  );
+
+  dbTest('a legacy report clears old completion rather than inheriting success', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const artifact = await seedArtifact(db, (await seedBoard(db)).board_id);
+    await service.setSandpackError(
+      artifact.artifact_id,
+      'viewer-A',
+      null,
+      'running',
+      undefined,
+      'success'
+    );
+    await service.setSandpackError(artifact.artifact_id, 'viewer-A', null, 'running');
+    expect(
+      (await service.getStatus(artifact.artifact_id, 'viewer-A' as never)).compilation_status
+    ).toBeUndefined();
+  });
+
+  dbTest(
+    'the settle window catches early runtime errors after successful compilation',
+    async ({ db }) => {
+      const service = new ArtifactsService(db, makeFakeApp());
+      const artifact = await seedArtifact(db, (await seedBoard(db)).board_id);
+      await service.setSandpackError(
+        artifact.artifact_id,
+        'viewer-A',
+        null,
+        'running',
+        undefined,
+        'success'
+      );
+      const waiting = service.waitForRuntimeStatus(artifact.artifact_id, 'viewer-A' as never, {
+        timeoutMs: 2000,
+        settleMs: 1000,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      await service.appendConsoleLogs(artifact.artifact_id, 'viewer-A', [
+        { timestamp: 1, level: 'error', message: 'boot failed' },
+      ]);
+      expect(await waiting).toMatchObject({ ok: false, observed: true, build_status: 'error' });
+    }
+  );
+
+  dbTest('HA still rejects process-local runtime waits', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp(), { runtimeIntrospectionEnabled: false });
+    await expect(
+      service.waitForRuntimeStatus('unobserved', 'viewer-A' as never)
+    ).rejects.toMatchObject({ data: { code: 'HA_FEATURE_UNSUPPORTED' } });
+  });
+
+  dbTest('completion must finish the settle window before the wait deadline', async ({ db }) => {
+    const service = new ArtifactsService(db, makeFakeApp());
+    const artifact = await seedArtifact(db, (await seedBoard(db)).board_id);
+    await service.setSandpackError(
+      artifact.artifact_id,
+      'viewer-A',
+      null,
+      'running',
+      undefined,
+      'success'
+    );
+    expect(
+      await service.waitForRuntimeStatus(artifact.artifact_id, 'viewer-A' as never, {
+        timeoutMs: 500,
+        settleMs: 25,
+      })
+    ).toMatchObject({ ok: true, observed: true, timed_out: false });
+    expect(
+      await service.waitForRuntimeStatus(artifact.artifact_id, 'viewer-A' as never, {
+        timeoutMs: 500,
+        settleMs: 1000,
+      })
+    ).toMatchObject({ ok: false, observed: true, timed_out: true });
+  });
+
+  dbTest(
+    'rejects invalid completion reports without recording browser activity',
+    async ({ db }) => {
+      const service = new ArtifactsService(db, makeFakeApp());
+      const artifact = await seedArtifact(db, (await seedBoard(db)).board_id);
+      await expect(
+        service.setSandpackError(
+          artifact.artifact_id,
+          'viewer-A',
+          null,
+          'running',
+          undefined,
+          'ready' as never
+        )
+      ).rejects.toMatchObject({ code: 400 });
+      const status = await service.getStatus(artifact.artifact_id, 'viewer-A' as never);
+      expect(status.compilation_status).toBeUndefined();
+      expect(status.runtime_observed_at).toBeUndefined();
+    }
+  );
+
   dbTest('console logs and sandpack errors are scoped per viewer', async ({ db }) => {
     const service = new ArtifactsService(db, makeFakeApp());
     const board = await seedBoard(db);
@@ -1246,7 +1445,14 @@ describe('ArtifactsService.getStatus + console isolation', () => {
           timeoutMs: 500,
           settleMs: 0,
         });
-        await service.setSandpackError(created.artifact_id, 'viewer-A', null, 'idle', 'old');
+        await service.setSandpackError(
+          created.artifact_id,
+          'viewer-A',
+          null,
+          'running',
+          'old',
+          'success'
+        );
         await vi.advanceTimersByTimeAsync(600);
 
         const result = await waitPromise;
@@ -1254,6 +1460,7 @@ describe('ArtifactsService.getStatus + console isolation', () => {
         expect(result.observed).toBe(false);
         expect(result.timed_out).toBe(true);
         expect(result.sandpack_status).toBeUndefined();
+        expect(result.compilation_status).toBeUndefined();
       } finally {
         vi.useRealTimers();
       }
@@ -1296,8 +1503,9 @@ describe('ArtifactsService.getStatus + console isolation', () => {
           created.artifact_id,
           'viewer-A',
           null,
-          'idle',
-          beforePayload.runtime_report_hash
+          'running',
+          beforePayload.runtime_report_hash,
+          'success'
         );
         await vi.advanceTimersByTimeAsync(600);
 

--- a/apps/agor-daemon/src/services/artifacts.ts
+++ b/apps/agor-daemon/src/services/artifacts.ts
@@ -28,12 +28,19 @@ import {
   type TenantScopeAwareDatabase,
   UsersRepository,
 } from '@agor/core/db';
-import { type Application, Forbidden, NotAuthenticated, Unavailable } from '@agor/core/feathers';
+import {
+  type Application,
+  BadRequest,
+  Forbidden,
+  NotAuthenticated,
+  Unavailable,
+} from '@agor/core/feathers';
 import type {
   AgorGrants,
   AgorRuntimeConfig,
   Artifact,
   ArtifactBuildStatus,
+  ArtifactCompilationStatus,
   ArtifactConsoleEntry,
   ArtifactPayload,
   ArtifactStatus,
@@ -52,6 +59,7 @@ import type {
   UUID,
 } from '@agor/core/types';
 import {
+  ARTIFACT_COMPILATION_STATUSES,
   ARTIFACT_LIST_FIELDS_WITHOUT_FILES,
   ARTIFACT_METADATA_LIST_FIELDS,
   canonicalizeAgorGrants,
@@ -239,6 +247,8 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
 
   /** In-memory Sandpack status, keyed by `${artifactId}:${userId}`. */
   private sandpackStatuses: Map<string, string> = new Map();
+
+  private compilationStatuses: Map<string, ArtifactCompilationStatus> = new Map();
 
   /** Latest browser runtime report time, keyed by `${artifactId}:${userId}`. */
   private runtimeObservedAt: Map<string, string> = new Map();
@@ -1932,6 +1942,9 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     for (const key of this.sandpackStatuses.keys()) {
       if (key.startsWith(prefix)) this.sandpackStatuses.delete(key);
     }
+    for (const key of this.compilationStatuses.keys()) {
+      if (key.startsWith(prefix)) this.compilationStatuses.delete(key);
+    }
     for (const key of this.runtimeObservedAt.keys()) {
       if (key.startsWith(prefix)) this.runtimeObservedAt.delete(key);
     }
@@ -1964,14 +1977,24 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     userId: string,
     error: SandpackError | null,
     status?: string,
-    contentHash?: string
+    contentHash?: string,
+    compilationStatus?: ArtifactCompilationStatus
   ): Promise<void> {
+    if (
+      compilationStatus !== undefined &&
+      !ARTIFACT_COMPILATION_STATUSES.includes(compilationStatus)
+    ) {
+      throw new BadRequest('Invalid artifact compilation status');
+    }
     if (!(await this.isCurrentRuntimeReportHash(artifactId, contentHash))) return;
     const key = this.viewerKey(artifactId, userId);
     this.sandpackErrors.set(key, error);
     if (status !== undefined) {
       this.sandpackStatuses.set(key, status);
     }
+    // A legacy report must not inherit readiness from a newer client's render.
+    if (compilationStatus === undefined) this.compilationStatuses.delete(key);
+    else this.compilationStatuses.set(key, compilationStatus);
     this.runtimeObservedAt.set(key, new Date().toISOString());
     this.notifyRuntimeStatusWaiters(key);
   }
@@ -2045,6 +2068,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     const key = userId ? this.viewerKey(artifactId, userId) : null;
     const sandpackError = key ? (this.sandpackErrors.get(key) ?? null) : null;
     const sandpackStatus = key ? this.sandpackStatuses.get(key) : undefined;
+    const compilationStatus = key ? this.compilationStatuses.get(key) : undefined;
     const runtimeObservedAt = key ? this.runtimeObservedAt.get(key) : undefined;
     const consoleLogs = key ? (this.consoleLogs.get(key) ?? []) : [];
 
@@ -2055,6 +2079,9 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       buildStatus = 'error';
       const sandpackMsg = `[Sandpack] ${sandpackError.message}`;
       buildErrors = [...(buildErrors ?? []), sandpackMsg];
+    } else if (compilationStatus === 'error') {
+      buildStatus = 'error';
+      buildErrors = [...(buildErrors ?? []), '[Sandpack] Compilation failed'];
     }
 
     return {
@@ -2063,6 +2090,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       build_errors: buildErrors ?? [],
       sandpack_error: sandpackError,
       sandpack_status: sandpackStatus,
+      compilation_status: compilationStatus,
       runtime_observed_at: runtimeObservedAt,
       console_logs: consoleLogs,
       content_hash: artifact.content_hash,
@@ -2101,6 +2129,14 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
           'If the missing specifier starts with ./ or ../, create that file or fix the import path. Otherwise add the package to package.json dependencies or sandpackConfig.customSetup.dependencies.',
       };
     }
+    if (/JSON/i.test(primary) && /<!doctype|<html|unexpected token\s+['"]?</i.test(primary)) {
+      return {
+        diagnosis: 'html_instead_of_json',
+        primary_error: primary,
+        suggested_fix:
+          "A JSON parser appears to have received HTML or other '<'-prefixed input. Inspect the first failing request in your browser Network panel (URL without credentials, status, content type, redirects, and CSP/CORS messages). This may be an app/API, ingress, proxy, or Sandpack/CDN response; the error alone does not identify the endpoint. Do not share tokens, cookies, env values, or an unredacted HAR.",
+      };
+    }
     if (/package\.json|JSON|Unexpected token/i.test(primary)) {
       return {
         diagnosis: 'malformed_package_json_or_syntax',
@@ -2131,10 +2167,10 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
    * contain secret-derived values.
    *
    * Resolution states:
-   * - observed + ok=true: Sandpack reached a non-running status and no quick
+   * - observed + ok=true: Sandpack explicitly completed compilation and no quick
    *   console.error arrived during the settle window.
-   * - observed + ok=false: Sandpack reported an error/timeout, or the app
-   *   emitted console.error.
+   * - observed + ok=false: Sandpack reported an error/timeout, the app emitted
+   *   console.error, or completion/settling was not confirmed before the deadline.
    * - observed=false: no browser for this user reported status before timeout.
    */
   async waitForRuntimeStatus(
@@ -2169,7 +2205,12 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
     > => {
       const status = await this.getStatus(artifactId, userId);
       const errorLogs = status.console_logs.filter((entry) => entry.level === 'error');
-      if (status.sandpack_error || status.sandpack_status === 'timeout' || errorLogs.length > 0) {
+      if (
+        status.sandpack_error ||
+        status.sandpack_status === 'timeout' ||
+        status.compilation_status === 'error' ||
+        errorLogs.length > 0
+      ) {
         return {
           ...status,
           build_status: 'error',
@@ -2182,7 +2223,11 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
           timed_out: false,
           note: status.sandpack_error
             ? 'Sandpack reported a bundler/runtime error in your browser render.'
-            : 'The artifact emitted console.error during boot/render.',
+            : status.sandpack_status === 'timeout'
+              ? 'Sandpack timed out in your browser render.'
+              : status.compilation_status === 'error'
+                ? 'Sandpack reported a compilation failure in your browser render.'
+                : 'The artifact emitted console.error during boot/render.',
         };
       }
       if (status.build_status === 'error' && (status.build_errors?.length ?? 0) > 0) {
@@ -2194,7 +2239,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
           note: 'Server-side file validation failed before browser runtime validation.',
         };
       }
-      if (status.sandpack_status && status.sandpack_status !== 'running') {
+      if (status.compilation_status === 'success') {
         return { ...status, ok: true, observed: true, timed_out: false };
       }
       return null;
@@ -2227,7 +2272,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
         resolve(result);
       };
 
-      const scheduleSuccess = (status: ArtifactStatus) => {
+      const scheduleSuccess = () => {
         if (settleTimer) return;
         settleTimer = setTimeout(async () => {
           settleTimer = null;
@@ -2239,7 +2284,11 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       const onUpdate = () => {
         void (async () => {
           const latest = await classify();
-          if (!latest) return;
+          if (!latest) {
+            if (settleTimer) clearTimeout(settleTimer);
+            settleTimer = null;
+            return;
+          }
           if (!latest.ok) {
             finish(latest);
             return;
@@ -2247,7 +2296,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
           if (settleMs === 0) {
             finish(latest);
           } else {
-            scheduleSuccess(latest);
+            scheduleSuccess();
           }
         })();
       };
@@ -2258,7 +2307,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
 
       timeoutTimer = setTimeout(async () => {
         const latest = await classify();
-        if (latest) {
+        if (latest && (!latest.ok || settleMs === 0)) {
           finish(latest);
           return;
         }
@@ -2266,9 +2315,11 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
         finish({
           ...status,
           ok: false,
-          observed: false,
+          observed: !!status.runtime_observed_at,
           timed_out: true,
-          note: `No Sandpack status was reported by your browser within ${timeoutMs}ms. Open the artifact on the board/fullscreen as this user and retry, or use agor_artifacts_status after viewing it. Server-side publish can only validate the file map; Sandpack boot happens in the browser.`,
+          note: status.runtime_observed_at
+            ? `Your browser reported activity, but compilation completion and its settle window were not confirmed within ${timeoutMs}ms. Inspect the preview and browser Network/Console panels; reload an older Agor tab to enable completion reporting. This timeout does not prove the app is broken.`
+            : `No Sandpack status was reported by your browser within ${timeoutMs}ms. Open the artifact on the board/fullscreen as this user and retry, or use agor_artifacts_status after viewing it. Server-side publish can only validate the file map; Sandpack boot happens in the browser.`,
         });
       }, timeoutMs);
 
@@ -2276,7 +2327,7 @@ export class ArtifactsService extends DrizzleService<Artifact, Partial<Artifact>
       // registration: a browser POST may have updated the in-memory status
       // just before we subscribed. Re-read once now that the waiter exists.
       onUpdate();
-      if (initial?.ok) scheduleSuccess(initial);
+      if (initial?.ok) scheduleSuccess();
     });
   }
 

--- a/apps/agor-docs/content/guide/artifacts.mdx
+++ b/apps/agor-docs/content/guide/artifacts.mdx
@@ -150,6 +150,25 @@ The typical agent workflow: **publish** the folder, **iterate** by editing files
 
 `agor_artifacts_publish({ waitForStatus: true })` is synchronous-ish, not a server-side build. Sandpack boots in the viewer's browser, and runtime logs are scoped per viewer because rendered code may include secret-derived values. If the publishing user has the artifact open on the board or fullscreen page, publish waits for that browser to report Sandpack status, bundler/runtime errors, and early `console.error` output. If no browser render reports before `waitTimeoutMs`, the tool returns `publish_validation.observed: false` with guidance instead of claiming the artifact rendered successfully. `agor_artifacts_validate_folder` / `agor_artifacts_check_build` are browserless smoke checks only: they catch obvious file/import/config mistakes, but they do not run Sandpack.
 
+Runtime status distinguishes the Sandpack **provider lifecycle** (`sandpack_status`)
+from **compilation progress** (`compilation_status`: `pending`, `compiling`,
+`success`, or `error`). A provider can stay `running` after an app appears;
+`idle` can mean it has not started. Neither alone confirms a successful build.
+`waitForStatus` requires explicit compilation completion and a short interval
+without reported errors. This is a boot smoke check, not proof of DOM correctness
+or all application behavior. An observed-but-incomplete wait returns
+`observed: true`, `ok: false`, and `timed_out: true`, without declaring the app
+broken. Older tabs may need a reload to send completion reports. Synchronous
+runtime observation remains unavailable in the constrained HA support profile.
+
+If an error says `Unexpected token '<' ... is not valid JSON`, do not assume the
+app's `package.json` is malformed. HTML may have come from an app API, Agor
+ingress, a proxy, or Sandpack's hosted dependency services. Inspect the first
+causal request in the **viewing browser's** Network panel: status, content type,
+redirects, and CSP/CORS messages. Share only sanitized URL/path and diagnostics,
+never cookies, authorization headers, env values, or an unredacted HAR. A daemon
+network check cannot establish what the viewer's browser can reach.
+
 ---
 
 ## Interacting with artifacts

--- a/apps/agor-ui/src/components/artifacts/ArtifactRenderSupport.tsx
+++ b/apps/agor-ui/src/components/artifacts/ArtifactRenderSupport.tsx
@@ -10,7 +10,6 @@ import { getAuthHeaders, getCurrentUserIdFromJwt } from '@/utils/authHeaders';
 /** Max console entries to send per batch, and minimum interval between sends. */
 const CONSOLE_BATCH_MAX = 50;
 const CONSOLE_THROTTLE_MS = 2000;
-const SANDPACK_ERROR_THROTTLE_MS = 1000;
 const RUNTIME_QUERY_DEFAULT_TIMEOUT_MS = 6000;
 
 /**
@@ -81,77 +80,7 @@ export function ArtifactConsoleReporter({
   return null;
 }
 
-/**
- * Captures Sandpack bundler/runtime errors and forwards them to the daemon.
- * Must be rendered inside a SandpackProvider.
- */
-export function ArtifactSandpackErrorReporter({
-  artifactId,
-  contentHash,
-}: {
-  artifactId: string;
-  contentHash?: string;
-}) {
-  const { sandpack } = useSandpack();
-  const lastSentRef = useRef<string | null>(null);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const pendingSendRef = useRef<(() => void) | null>(null);
-
-  useEffect(() => {
-    const stateKey = `${sandpack.error?.message ?? ''}\0${sandpack.status}`;
-    if (stateKey === lastSentRef.current) return;
-
-    const sendError = () => {
-      lastSentRef.current = stateKey;
-      pendingSendRef.current = null;
-
-      const payload: {
-        error: {
-          message: string;
-          title?: string;
-          path?: string;
-          line?: number;
-          column?: number;
-        } | null;
-        status: string;
-      } = {
-        error: sandpack.error
-          ? {
-              message: sandpack.error.message,
-              ...(sandpack.error.title ? { title: sandpack.error.title } : {}),
-              ...(sandpack.error.path ? { path: sandpack.error.path } : {}),
-              ...(sandpack.error.line != null ? { line: sandpack.error.line } : {}),
-              ...(sandpack.error.column != null ? { column: sandpack.error.column } : {}),
-            }
-          : null,
-        status: sandpack.status,
-      };
-
-      fetch(`${getDaemonUrl()}/artifacts/${artifactId}/sandpack-error`, {
-        method: 'POST',
-        headers: getAuthHeaders(),
-        body: JSON.stringify({ ...payload, content_hash: contentHash }),
-      }).catch(() => {});
-    };
-
-    if (timerRef.current) clearTimeout(timerRef.current);
-    pendingSendRef.current = sendError;
-    timerRef.current = setTimeout(() => {
-      timerRef.current = null;
-      sendError();
-    }, SANDPACK_ERROR_THROTTLE_MS);
-
-    return () => {
-      if (timerRef.current) {
-        clearTimeout(timerRef.current);
-        timerRef.current = null;
-        pendingSendRef.current?.();
-      }
-    };
-  }, [sandpack.error, sandpack.status, artifactId, contentHash]);
-
-  return null;
-}
+export { ArtifactSandpackErrorReporter } from './ArtifactSandpackErrorReporter';
 
 /**
  * Bridges agent-driven runtime queries: daemon WebSocket event → parent page →

--- a/apps/agor-ui/src/components/artifacts/ArtifactSandpackErrorReporter.test.tsx
+++ b/apps/agor-ui/src/components/artifacts/ArtifactSandpackErrorReporter.test.tsx
@@ -1,0 +1,157 @@
+import type { ArtifactSandpackReport } from '@agor/core/types';
+import type { SandpackClientListen, SandpackState } from '@codesandbox/sandpack-react';
+import { act, cleanup, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ArtifactSandpackErrorReporter } from './ArtifactSandpackErrorReporter';
+
+type Listener = Parameters<SandpackClientListen>[0];
+const mock = vi.hoisted(() => ({
+  sandpack: { status: 'running', error: null } as Pick<SandpackState, 'status' | 'error'>,
+  listen: vi.fn<SandpackClientListen>(),
+  listeners: new Set<Listener>(),
+  fetch: vi.fn<typeof fetch>(),
+}));
+
+vi.mock('@codesandbox/sandpack-react', () => ({
+  useSandpack: () => ({ sandpack: mock.sandpack, listen: mock.listen }),
+}));
+vi.mock('@/config/daemon', () => ({ getDaemonUrl: () => 'https://daemon.test' }));
+vi.mock('@/utils/authHeaders', () => ({ getAuthHeaders: () => ({ Authorization: 'test-only' }) }));
+
+function messages(): ArtifactSandpackReport[] {
+  return mock.fetch.mock.calls.map(([, options]) => JSON.parse(String(options?.body)));
+}
+function emit(message: Parameters<Listener>[0]) {
+  act(() => {
+    for (const listener of mock.listeners) listener(message);
+  });
+}
+async function flush() {
+  await act(() => vi.advanceTimersByTimeAsync(1000));
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mock.sandpack.status = 'running';
+  mock.sandpack.error = null;
+  mock.listeners.clear();
+  mock.listen.mockImplementation((listener) => {
+    mock.listeners.add(listener);
+    return () => {
+      mock.listeners.delete(listener);
+    };
+  });
+  mock.fetch.mockReset().mockResolvedValue(new Response(null, { status: 204 }));
+  vi.stubGlobal('fetch', mock.fetch);
+});
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('ArtifactSandpackErrorReporter', () => {
+  it('requires done, not provider running or connection, to report success', async () => {
+    render(<ArtifactSandpackErrorReporter artifactId="artifact-a" contentHash="revision-a" />);
+    await flush();
+    expect(messages().at(-1)).toMatchObject({ status: 'running', compilation_status: 'pending' });
+    emit({ type: 'connected' });
+    await flush();
+    expect(messages().at(-1)?.compilation_status).toBe('pending');
+    emit({ type: 'start', firstLoad: true });
+    await flush();
+    expect(messages().at(-1)?.compilation_status).toBe('compiling');
+    emit({ type: 'done', compilatonError: false });
+    await flush();
+    expect(messages().at(-1)).toMatchObject({
+      status: 'running',
+      compilation_status: 'success',
+      content_hash: 'revision-a',
+      error: null,
+    });
+  });
+
+  it('accepts static-client completion without a start event and resets on recompilation', async () => {
+    render(<ArtifactSandpackErrorReporter artifactId="artifact-a" contentHash="revision-a" />);
+    emit({ type: 'done', compilatonError: false });
+    await flush();
+    expect(messages().at(-1)?.compilation_status).toBe('success');
+    emit({ type: 'start', firstLoad: false });
+    await flush();
+    expect(messages().at(-1)?.compilation_status).toBe('compiling');
+    emit({ type: 'done', compilatonError: true });
+    await flush();
+    expect(messages().at(-1)?.compilation_status).toBe('error');
+  });
+
+  it('never attributes old completion to new content and unsubscribes on unmount', async () => {
+    const { rerender, unmount } = render(
+      <ArtifactSandpackErrorReporter artifactId="artifact-a" contentHash="revision-a" />
+    );
+    emit({ type: 'done', compilatonError: false });
+    await flush();
+    rerender(<ArtifactSandpackErrorReporter artifactId="artifact-a" contentHash="revision-b" />);
+    await flush();
+    const newReports = messages().filter((report) => report.content_hash === 'revision-b');
+    expect(newReports.length).toBeGreaterThan(0);
+    expect(newReports.every((report) => report.compilation_status === 'pending')).toBe(true);
+    expect(mock.listeners.size).toBe(1);
+    unmount();
+    expect(mock.listeners.size).toBe(0);
+  });
+
+  it('preserves completion when Sandpack replaces its listener registration function', async () => {
+    const { rerender } = render(
+      <ArtifactSandpackErrorReporter artifactId="artifact-a" contentHash="revision-a" />
+    );
+    emit({ type: 'done', compilatonError: false });
+    await flush();
+    mock.listen = vi.fn(mock.listen.getMockImplementation());
+    rerender(<ArtifactSandpackErrorReporter artifactId="artifact-a" contentHash="revision-a" />);
+    await flush();
+    expect(messages().at(-1)?.compilation_status).toBe('success');
+    expect(mock.listeners.size).toBe(1);
+    emit({ type: 'start', firstLoad: false });
+    await flush();
+    expect(messages().at(-1)?.compilation_status).toBe('compiling');
+  });
+
+  it('requires fresh completion when the provider restarts with the same content', async () => {
+    const { rerender } = render(
+      <ArtifactSandpackErrorReporter artifactId="artifact-a" contentHash="revision-a" />
+    );
+    emit({ type: 'done', compilatonError: false });
+    await flush();
+    mock.sandpack.status = 'idle';
+    rerender(<ArtifactSandpackErrorReporter artifactId="artifact-a" contentHash="revision-a" />);
+    await flush();
+    mock.sandpack.status = 'running';
+    rerender(<ArtifactSandpackErrorReporter artifactId="artifact-a" contentHash="revision-a" />);
+    await flush();
+    expect(messages().at(-1)?.compilation_status).toBe('pending');
+    emit({ type: 'done', compilatonError: false });
+    await flush();
+    expect(messages().at(-1)?.compilation_status).toBe('success');
+  });
+
+  it('reports runtime error details after completion instead of preserving success', async () => {
+    const { rerender } = render(
+      <ArtifactSandpackErrorReporter artifactId="artifact-a" contentHash="revision-a" />
+    );
+    emit({ type: 'done', compilatonError: false });
+    await flush();
+    mock.sandpack.error = {
+      message: 'boot failed',
+      title: 'Error',
+      path: '/App.js',
+      line: 1,
+      column: 0,
+    };
+    rerender(<ArtifactSandpackErrorReporter artifactId="artifact-a" contentHash="revision-a" />);
+    await flush();
+    expect(messages().at(-1)).toMatchObject({
+      compilation_status: 'error',
+      error: mock.sandpack.error,
+    });
+  });
+});

--- a/apps/agor-ui/src/components/artifacts/ArtifactSandpackErrorReporter.tsx
+++ b/apps/agor-ui/src/components/artifacts/ArtifactSandpackErrorReporter.tsx
@@ -1,0 +1,103 @@
+import type { ArtifactCompilationStatus, ArtifactSandpackReport } from '@agor/core/types';
+import { useSandpack } from '@codesandbox/sandpack-react';
+import { useEffect, useRef, useState } from 'react';
+import { getDaemonUrl } from '@/config/daemon';
+import { getAuthHeaders } from '@/utils/authHeaders';
+
+const SANDPACK_ERROR_THROTTLE_MS = 1000;
+
+/** Reports the existing preview's errors/completion, without creating another client/iframe. */
+export function ArtifactSandpackErrorReporter({
+  artifactId,
+  contentHash,
+}: {
+  artifactId: string;
+  contentHash?: string;
+}) {
+  const { sandpack, listen } = useSandpack();
+  const [compilation, setCompilation] = useState<{
+    contentHash?: string;
+    status: ArtifactCompilationStatus;
+  }>({ contentHash, status: 'pending' });
+  const lastSentRef = useRef<string | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingSendRef = useRef<(() => void) | null>(null);
+
+  useEffect(() => {
+    setCompilation({ contentHash, status: 'pending' });
+  }, [contentHash]);
+
+  useEffect(() => {
+    // Sandpack can replace `listen` during an ordinary provider update. Renew
+    // the subscription without discarding completion for the current render.
+    return listen((message) => {
+      if (message.type === 'start') {
+        setCompilation({ contentHash, status: 'compiling' });
+      } else if (message.type === 'done') {
+        // Sandpack's protocol spells this `compilatonError`. A connected client
+        // (or provider status `running`) alone says nothing about compilation.
+        setCompilation({
+          contentHash,
+          status: message.compilatonError === false ? 'success' : 'error',
+        });
+      }
+    });
+  }, [listen, contentHash]);
+
+  useEffect(() => {
+    if (sandpack.status !== 'running') {
+      setCompilation({ contentHash, status: 'pending' });
+    }
+  }, [sandpack.status, contentHash]);
+
+  const compilationStatus: ArtifactCompilationStatus = sandpack.error
+    ? 'error'
+    : sandpack.status !== 'running' || compilation.contentHash !== contentHash
+      ? 'pending'
+      : compilation.status;
+
+  useEffect(() => {
+    const payload: ArtifactSandpackReport = {
+      error: sandpack.error
+        ? {
+            message: sandpack.error.message,
+            ...(sandpack.error.title ? { title: sandpack.error.title } : {}),
+            ...(sandpack.error.path ? { path: sandpack.error.path } : {}),
+            ...(sandpack.error.line != null ? { line: sandpack.error.line } : {}),
+            ...(sandpack.error.column != null ? { column: sandpack.error.column } : {}),
+          }
+        : null,
+      status: sandpack.status,
+      compilation_status: compilationStatus,
+      content_hash: contentHash,
+    };
+    const stateKey = `${artifactId}\0${JSON.stringify(payload)}`;
+    if (stateKey === lastSentRef.current) return;
+
+    const sendReport = () => {
+      lastSentRef.current = stateKey;
+      pendingSendRef.current = null;
+      fetch(`${getDaemonUrl()}/artifacts/${artifactId}/sandpack-error`, {
+        method: 'POST',
+        headers: getAuthHeaders(),
+        body: JSON.stringify(payload),
+      }).catch(() => {});
+    };
+
+    pendingSendRef.current = sendReport;
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      sendReport();
+    }, SANDPACK_ERROR_THROTTLE_MS);
+
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+        pendingSendRef.current?.();
+      }
+    };
+  }, [sandpack.error, sandpack.status, compilationStatus, artifactId, contentHash]);
+
+  return null;
+}

--- a/context/explorations/artifact-runtime-direction.md
+++ b/context/explorations/artifact-runtime-direction.md
@@ -1,0 +1,524 @@
+# Artifact runtime direction: Sandpack compatibility and portable npm apps
+
+**Design proposal, not an approved migration or deprecation.** Investigated
+2026-09-08 for [#2640](https://github.com/preset-io/agor/issues/2640).
+Agor source revision: **`c3a2a1fd337cc285ab021961f831a5dc3d52370f`**.
+The initial investigation changed no production code, customer apps, deployment
+settings, or issue state. A subsequent user request authorized a narrow implementation:
+HTML-as-JSON diagnostics and explicit compilation-completion reporting/waits.
+The branch now includes those changes and tests, validated in its isolated
+managed environment; the updated [Artifacts guide](../../apps/agor-docs/content/guide/artifacts.mdx)
+describes the new status contract. The evidence below is the **pre-fix** snapshot.
+Template changes, native hosting, migrations and deprecation remain proposals.
+
+## Recommendation / decisions for Max
+
+1. **Retain working Sandpack apps. Repair specific defects, not the entire
+   population.** React, React-TS, React 18 CRA-layout apps, and several other
+   templates rendered in this investigation. Blanket deprecation is not justified.
+2. **Separate #2640 incident remediation from runtime strategy.** Its exact
+   HTML-as-JSON crash was **not reproduced** in this environment. Obtain the
+   failing browser's sanitized network evidence before prescribing a CDN,
+   CSP, template, or source-code fix. The original deployment remains unresolved.
+3. **Prefer a small, tested set of scaffolds, not embracing every upstream
+   template.** Today: dependency-free `static` for HTML-first work, and pinned,
+   explicit React/React-TS projects where browser bundling is appropriate.
+   Keep existing defaults/records until a separately reviewed change; do not
+   relabel an existing React app as static or silently update its dependencies.
+4. **Long-term direction: ordinary npm projects plus build-once/static-preview
+   publication**, with Sandpack as a compatibility/lightweight execution option.
+   Native full-stack services are a separate, provider-backed product, not a
+   prerequisite for replacing browser compilation. Do not make a native runtime
+   the universal default until Cloud can actually build and serve it safely.
+
+Max's short decision list:
+
+- Approve a narrow diagnostics/template-certification follow-up, without removal?
+- Is the first native deliverable **compiled frontend snapshots** (recommended),
+  or paid/externally hosted full-stack services with ongoing lifecycle costs?
+- Who owns the Cloud build/preview substrate, isolation review, quotas, and bill?
+  Is bring-your-own remote hosting acceptable before first-party hosting exists?
+- Should new-app guidance be capability-based, keeping Sandpack available when
+  native publication is unavailable? Recommended: yes; never a dead-end default.
+- Can we obtain the original browser capture and an authoritative vendor support
+  statement? Neither a sample failure nor a forwarded cessation notice warrants
+  deleting working applications.
+
+## Evidence boundaries and revisions
+
+### Original report and history
+
+`gh issue view 2640 --repo preset-io/agor --json
+title,body,comments,state,createdAt,updatedAt,url,author` returned an open issue by
+rusackas, created/last updated **2026-08-31T18:36:03Z**, **zero comments**.
+The paginated GitHub issue timeline returned no events. The report describes
+two publishes of one React app, not tests of every React/React-TS artifact.
+The dependency/CDN explanation and the family-wide impact are hypotheses, not
+established fleet observations. The issue does not identify the deployed Agor
+SHA, browser/version, effective `customSetup.environment`, or failed request.
+
+The sole existing-app access was the authorized, read-only
+`agor_artifacts_status` call for the issue's artifact
+`01a02563-9be6-78ce-8afd-d383b6f2e3c4`: **not found**. This does not distinguish
+absence from visibility/tenant filtering. No alternate-tenant lookup, database
+query, customer file read, listing of unrelated apps, mutation, or migration was
+attempted. Existing-app population and the original artifact's contents are
+**untested**. A sanitized capture/read-only access was requested from the user.
+
+The local checkout is shallow; history was read through GitHub's commits API,
+not inferred from the shallow log. Relevant prior changes:
+
+| Change | Exact merge revision                       | Relevance                                                   |
+| ------ | ------------------------------------------ | ----------------------------------------------------------- |
+| #914   | `47b470127bf7d087bde4338502bfdb1362cc65d7` | Earlier self-hosted bundler experiment                      |
+| #918   | `dfc168b81069b04d839bdf95b1fb2c42d02a90c8` | Artifacts decoupled from worktrees; DB file maps            |
+| #1147  | `be0dd98dda6e466a059a86ee6b390762f0006f3e` | Declarative format/consent; removed that local-bundler path |
+| #1161  | `7f88e817e9ab3b7f287599e5aa3ff7a1810ae88d` | CRA `REACT_APP_` injection correction                       |
+| #1432  | `3e738bd5c914323a87c1244885a1dfd104e783ec` | Browserless validation and browser-status diagnostics       |
+| #2269  | `be6f0ab1a2b7d280f4d2d693906719446064f33a` | Narrow HTML-first vanilla → static repair                   |
+| #2653  | `3f73029dc1239a4c9a866ae4dc4169a5b1d0bff9` | Artifact executor owner-home mounts, after the issue        |
+
+These are readable as `https://github.com/preset-io/agor/commit/<revision>`.
+The old [artifact-format design](../../docs/internal/artifacts-roadmap-2026-05-09.md)
+records why local bundler support was removed. Its historical willingness to
+break format compatibility is **not** authority to repeat that policy here.
+
+### Upstream maintenance: verified facts versus inference
+
+- [Sandpack releases](https://github.com/codesandbox/sandpack/releases/tag/v2.20.0):
+  latest `v2.20.0`, published **2025-02-14T13:14:41Z**; main commit
+  **`7d60a4334980eef304d53b1c3df371ed6dbcf491`**. GitHub API reports
+  `archived:false`, `disabled:false`, last push 2025-04-24. That is substantial
+  public release inactivity, not evidence every hosted runtime stopped working.
+- Authoritative npm registry metadata: [React package](https://registry.npmjs.org/@codesandbox%2fsandpack-react)
+  latest `2.20.0` (2025-02-14); [client](https://registry.npmjs.org/@codesandbox%2fsandpack-client)
+  latest `2.19.8` (2024-09-12); [Nodebox](https://registry.npmjs.org/@codesandbox%2fnodebox)
+  latest `0.1.9` (2023-11-29). These latest versions had no npm `deprecated`
+  field. Agor's lockfile uses React package `2.20.0`, client `2.19.8`, Nodebox
+  **`0.1.8`**, not `0.1.9`.
+- A [maintainer's 2025-11-04 statement](https://github.com/codesandbox/sandpack/issues/1243#issuecomment-3484814859)
+  reports a server repair and reduced attention, with occasional continued work.
+  A March 2026 comment forwards an alleged vendor cessation email, but its author
+  is not speaking for the vendor. No directly verifiable current vendor notice
+  was obtained; the CodeSandbox docs/blog root requests returned 403 here.
+  **Do not present that forwarded notice as independently verified official policy.**
+- The [classic bundler's repository](https://github.com/codesandbox/codesandbox-client)
+  is distinct from the Sandpack React wrapper. Its main revision was
+  `dcba8ebc49cd46838e298cfa1501811ac67fb0c9`, 2026-09-07; the sandbox subtree's
+  latest commit was `ddb9099a147e06728fe7ff5697b49c4eee489967`, 2025-11-12.
+  Repository activity does not establish which revision the hosted bundle runs.
+- The [experimental bundler](https://github.com/codesandbox/sandpack-bundler)
+  is another project: main `a323f46fd38442bb2dbc76fecd262e1435aca5bd`,
+  2024-08-14. Its [official compatibility page](https://sandpack.codesandbox.io/docs/advanced-usage/bundlers)
+  lists React/Solid support and limitations for other templates. It is **not**
+  a universal drop-in replacement, nor enabled by current Agor config.
+
+Conclusion: **maintenance/support risk is high enough to diversify new-app
+architecture; abandonment of all functional support is not proven.** Obtain a
+direct vendor statement about security fixes, hosted endpoint lifetime and SLA.
+React's separate [CRA sunset announcement](https://react.dev/blog/2025/02/14/sunsetting-create-react-app)
+supports avoiding new conventional CRA projects. Sandpack's CRA-compatible
+browser environment is not the same as executing a local CRA webpack server;
+that announcement does not demonstrate its present runtime is broken.
+
+## Current Agor contracts (source, not marketing promises)
+
+Paths below refer to the Agor revision above. Guides now live under
+`apps/agor-docs/content/guide/`, not the older `pages/guide/` path.
+
+| Concern         | Current owner and behavior                                                                                                                                                                                                                                                                                                                                                                               |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Board apps      | `packages/core/src/types/board.ts`: inline `AppBoardObject` stores files/deps/template in board data. `AppNode.tsx` renders Sandpack directly. It is **not a native npm server** and does not run the artifact payload/consent pipeline.                                                                                                                                                                 |
+| Artifacts       | `packages/core/src/types/artifact.ts`, schemas and artifact repository: board-owned DB file map + metadata; branch/path are provenance, nullable after branch deletion. Artifact lifetime is not dev-environment lifetime.                                                                                                                                                                               |
+| Publish/land    | `services/artifacts.ts`, `packages/executor/src/commands/artifacts.ts`: caller/branch-scoped executor reads staging files; publishes into DB. `.git`, `node_modules`, symlinks, root `.env`, metadata sidecar are omitted by the reader. Files are UTF-8 strings, **not** a binary build-output store. `land` reconstructs source plus `agor.artifact.json`.                                             |
+| Config          | `utils/sandpack-config.ts`: effective config template can override row template; `customSetup.environment` can override the bundler independently. No author-controlled `bundlerURL`, npm registry credentials, or external resource URL survives the options allowlist.                                                                                                                                 |
+| Render          | `ArtifactNode.tsx` and `ArtifactFullscreenPage.tsx` use `SandpackProvider`/`SandpackPreview`; `sandpackDefaults.ts` stabilizes inputs, prepends body reset, defaults to user-visible initialization. `entryFile` becomes editor `activeFile`; it is not a replacement for `customSetup.entry`.                                                                                                           |
+| Templates       | Sandpack merges implicit scaffold files with user files. A minimal stored map is not necessarily a runnable standalone npm checkout. `package.json` dependencies are canonical; config/cached dependencies participate in provider/export merging.                                                                                                                                                       |
+| Env/consent     | `getPayload` derives viewing-user values after trust resolution and emits a transient `.env`; persisted source is not mutated. Self/covered trust requests inject values; untrusted consent-gated values are empty. Session-scoped env vars are not resolved without a matching session. A frontend env value is visible to the viewer/app and potentially exfiltratable, **not a backend-only secret**. |
+| Runtime bridge  | `agor-runtime-source.ts` is inserted as a data-URL `externalResources` script. DOM requests traverse viewer browser → iframe, not daemon-side Chromium. Reports/logs are viewer-scoped and source/config revision checked.                                                                                                                                                                               |
+| Status          | Folder validation never executes Sandpack. Browser error reporter sends `sandpack.error` and provider `sandpack.status`, not a network trace. In-memory waits/logs/DOM query correlation are process-affine; HA explicitly blocks synchronous introspection/status/waits, not durable artifact metadata.                                                                                                 |
+| Security        | Tenant repository scopes/RLS + board/branch capabilities; public does not mean arbitrary cross-tenant access. `security-resolver.ts` allows `https://*.codesandbox.io` frames, blob workers; parent scripts do not require `unsafe-eval`. CORS to Agor and package CDN CORS are separate. Hosted iframe cookies must not become daemon authority.                                                        |
+| Defaults/legacy | New publish falls back to `react`; docs already prefer `static` for new HTML-first apps. Narrow vanilla empty/comment-only conventional-entry repair remains. Old Handlebars sidecars have existing safe-degraded behavior: retain it, do not batch migrate.                                                                                                                                             |
+
+Read together: [Artifacts guide](../../apps/agor-docs/content/guide/artifacts.mdx),
+[environment guide](../../apps/agor-docs/content/guide/environment-configuration.mdx),
+[HA support matrix](../../apps/agor-docs/content/guide/daemon-ha.mdx),
+[security](../concepts/security.md), [tenancy](../concepts/multitenancy.md).
+Some guide wording is stale: source need not still exist at a fixed branch path;
+the DB map is durable truth. The guide's broad Nodebox possibilities do not add
+Node/Vite/Next/Astro to the actual ten-member Agor template union.
+
+## Reproduction and compatibility matrix
+
+### Method and constraints
+
+The [probe](artifact-runtime-probe/probe.cjs) and
+[exact synthetic cases](artifact-runtime-probe/cases.json) are durable companions.
+They run the actual published **SandpackProvider + SandpackPreview**, not a mocked
+bundler. A small CommonJS loader wraps the npm distribution files without building
+Agor. Playwright intercepts only a synthetic HTTPS parent page (and explicitly
+named fault-injection requests). Real bundler/CDN requests use this machine's
+network. No server process or managed environment was needed.
+
+- Linux Google Chrome **146.0.7680.177**, headless, Playwright **1.58.2**;
+  new browser context per case, no saved user profile or credentials.
+  Chrome used `--no-sandbox` in this disposable test environment; this is **not**
+  a production isolation/security validation or a recommended app-hosting setup.
+- Host React/React DOM **19.2.8**; Sandpack React **2.20.0**, client **2.19.8**,
+  Nodebox **0.1.8**, static-browser-server **1.0.3**. Agor's primary Sandpack
+  lockfile versions match; this is not a full installation of its transitive UI tree.
+- `initMode: immediate` deliberately removes viewport/lazy-mount variability;
+  default observation 18 seconds; Nodebox 45 seconds. Real application text in
+  the preview is the success criterion, **not** `status === running`.
+- Current hosted classic URL: `https://2-19-8-sandpack.codesandbox.io/`;
+  observed assets include `sandbox.8a7d01a44.js`,
+  `sandbox-startup.a0ea8d1cb.js`, `babel-transpiler.dc3397b1.worker.js`.
+  These are served asset identifiers, not a verified upstream source SHA.
+- Successful React fetched JSON from `data.jsdelivr.com` and
+  `prod-packager-packages.codesandbox.io`, with files from `cdn.jsdelivr.net`.
+  React metadata failure also exercised an `unpkg.com` fallback.
+  `ERR_ABORTED` on an initial frame navigation occurred even in passing cases;
+  it is not, by itself, a failed build.
+- Observed resolved application packages: React/React DOM **19.2.8** for the
+  default pair, **18.3.1** for the issue's `^18.2.0` pair, Vue **3.5.42**, Svelte
+  **3.59.2**, Angular core **11.2.14**, Solid **1.3.15** (override **1.9.15**).
+  The Svelte compiler URL in the failing env probe was separately pinned to
+  `https://unpkg.com/svelte@3.0.0/compiler.js` by the hosted runtime.
+- Full Agor UI/API/consent flows, original deployment, private-network API calls,
+  Firefox/Safari/mobile, long-lived tabs, offline operation, binary assets, and
+  exports to live providers were **not tested**. Library-level success is not
+  production-deployment or fleet-wide certification.
+
+**W** = working for this synthetic case; **B** = broken for this case;
+**U** = untested / unavailable, not broken. Env tests use only
+`NON_SECRET_SENTINEL`; they test daemon-shaped payloads, not secret-store access.
+All **25** companion cases were observed. Eight of the ten allowed template
+names rendered their minimal app; Solid additionally rendered with the tested
+override. This is a template probe count, not an existing-app census.
+
+| Agor template | Actual pinned runtime / default entry              | Minimal rendering                                         | Current declared env path            | Env probe / interpretation                                                                      |
+| ------------- | -------------------------------------------------- | --------------------------------------------------------- | ------------------------------------ | ----------------------------------------------------------------------------------------------- |
+| `static`      | static-browser-server; `/index.html`               | **W**, `STATIC_OK`                                        | none                                 | Not supported by Agor; no injection test                                                        |
+| `react`       | `create-react-app`; `/index.js`, edits `/App.js`   | **W**, default React 19; **W** React 18 `/src` layout     | `REACT_APP_`, `process.env`          | **W**, `ENV_OK`; also **W** with actual Agor runtime script + body reset                        |
+| `react-ts`    | `create-react-app`; `/index.tsx`, edits `/App.tsx` | **W**, default React 19                                   | `REACT_APP_`, `process.env`          | **W**, `ENV_OK`                                                                                 |
+| `vanilla`     | `parcel`; `/index.js`                              | **W**                                                     | none                                 | Not supported by Agor; do not conflate with Parcel features generally                           |
+| `vanilla-ts`  | `parcel`; `/index.ts`                              | **W**                                                     | none                                 | Not supported by Agor                                                                           |
+| `vue`         | `vue-cli`, Vue 3 scaffold; `/src/main.js`          | **W**                                                     | unprefixed `process.env.PROBE`       | **B** for intended value: renders `ENV_MISSING`                                                 |
+| `vue3`        | no matching Sandpack 2.20.0 template               | **B**, invalid-template exception before iframe mount     | inherited `VITE_`                    | **U**, runtime cannot initialize; a row overridden to valid `vue` is a different effective case |
+| `svelte`      | `svelte`, Svelte 3 scaffold; `/index.js`           | **W**                                                     | inherited `VITE_`, `import.meta.env` | **B**, parser rejects `import.meta` in fixture; not HTML-as-JSON                                |
+| `solid`       | `solid`; `/index.tsx`; default `solid-js:1.3.15`   | **B** default; **W** with only `solid-js:1.9.15` override | inherited `VITE_`, `import.meta.env` | **B** on aligned runtime: `Cannot use 'import.meta' outside a module`                           |
+| `angular`     | `angular-cli`, Angular 11 scaffold; `/src/main.ts` | **W**                                                     | unprefixed `process.env.PROBE`       | **B** for intended value: renders `ENV_MISSING`                                                 |
+
+The Solid failure is `_tmpl$ is not a function` in `/App.tsx`. The network trace
+shows `solid-js/1.3.15` with `babel-preset-solid/1.9.15`; changing the synthetic
+runtime package to `1.9.15` renders `Hello world`. This strongly suggests a
+template/compiler version mismatch, **not proof all existing Solid apps fail**.
+Do not apply that dependency upgrade to customer source without testing/consent.
+
+Additional coverage:
+
+| Case                            | Result and meaning                                                                                                                                                                                                                                                                                                  |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Issue-shaped React 18           | `package.json` with `react`/`react-dom:^18.2.0`, `public/index.html`, `src/index.js`, `src/App.js`: **W** (`CRA18_OK`) both with explicit `/src/index.js` entry/main and without either. Original secret/API/application logic deliberately absent.                                                                 |
+| React + Agor payload additions  | **W** (`AGOR_ENV_OK`) with non-secret `.env`, body reset and exact `AGOR_RUNTIME_SOURCE` data URL. Does not certify the daemon consent/bridge round-trip.                                                                                                                                                           |
+| Relevant parent CSP allowlist   | **W** with `frame-src 'self' https://*.codesandbox.io`, self scripts, blob workers; **B**, explicit frame-block message with `frame-src 'self'`. These are controlled headers, not the affected deployment's headers.                                                                                               |
+| React metadata returns HTML     | One jsDelivr endpoint replaced with HTTP 200 HTML: **W**, fallback to unpkg. Replacing both React metadata paths: **B**, React 19.0.0 vs React DOM 19.2.8 version mismatch after fallback, **not the original error**. This cautions against diagnosing a specific dependency endpoint from the overlay text alone. |
+| Upstream `vite-react` / Nodebox | **W**, `Hello world`, runtime `node`, real `*.nodebox.codesandbox.io` preview. **Not an exposed Agor template**; no env/Cloud endorsement. Other Nodebox templates (Node, Next, Astro, other Vite variants) **U**.                                                                                                  |
+| Original artifact/deployment    | **U**; inaccessible from authorized context. Its exact crash is not reproduced or resolved.                                                                                                                                                                                                                         |
+
+### Distinguishing causes and immediate remediation
+
+The report's ErrorBoundary and guarded fetch narrow the possibilities, but do
+not prove no application code ran: boundaries do not catch import-time errors,
+all async failures, or failures outside their subtree. `Unexpected token '<'`
+means an HTML-like body reached a JSON parser; it does not identify that parser
+or the response producer. An upstream user reported a similar symptom for
+`/_sandpack_/manifest.json` in [July 2025](https://github.com/codesandbox/sandpack/issues/920#issuecomment-3086769114),
+but that is a **different incident**, not proof of #2640's cause.
+
+For the authorized failing browser, capture the **first causal failed request**:
+hostname/path (strip query credentials), initiator/frame, status, content type,
+redirect chain, CORS/CSP messages, and a manually redacted body classification
+(HTML login/challenge/error page versus JSON). Record timestamp, browser,
+effective template/environment, app revision, Agor SHA and deployment mode.
+Do not collect full source, `.env`, cookies, authorization headers, or raw HARs
+in shared logs. Browser extensions, corporate proxy, VPN, DNS, and service-worker
+state should be varied one at a time in a disposable browser context.
+
+| Observation                                       | Owner / next action                                                                                                                                                                                                  |
+| ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Artifact payload URL returns HTML                 | Agor ingress/auth/routing defect or deployment proxy; inspect before blaming npm.                                                                                                                                    |
+| Parent blocks iframe/worker                       | Compare actual effective CSP to resolver defaults. Correct the precise deployment directive; do not disable CSP or add blanket `unsafe-eval`/wildcard CORS.                                                          |
+| Public package/manifest URL returns HTML          | CDN/edge/proxy/redirect/service failure. Compare same synthetic case on another browser/network, retain sanitized request evidence, escalate upstream. Daemon `curl` success alone says nothing about viewer egress. |
+| No browser report / HA unsupported                | Observation unavailable, not broken application. Open correct viewer's frame if standalone; respect HA gate.                                                                                                         |
+| `vue3` invalid, Solid mismatch, env idiom failure | Specific Agor integration/template mismatch; test a render adapter/scaffold repair separately. Preserve persisted source and working effective overrides.                                                            |
+| API fetch fails only after app appears            | App API auth/CORS/mixed-content/Chrome local-network access. Different from compiler/dependency boot. Review browser network rules, not unrelated repo clone connectivity.                                           |
+
+Two concrete Agor diagnostics defects warrant a separately approved small patch:
+
+1. `buildStatusDiagnostic()` currently classifies `/JSON|Unexpected token/` as
+   `malformed_package_json_or_syntax`. Add an HTML-as-JSON/network-response branch
+   first, without pretending to know which endpoint failed; retain true syntax
+   diagnostics and recommend a redacted browser trace.
+2. Successful probes expose provider `sandpack.status: running` while bundler
+   messages say `status:idle` / `done` and the app is visible. The reporter sends
+   the former; `waitForRuntimeStatus()` accepts non-`running` as success and can
+   time out claiming no report despite an observed running app. Conversely,
+   `idle` alone can mean not yet started. This is a source-traced state-contract
+   mismatch, not an end-to-end daemon test. Distinguish provider lifecycle,
+   compilation completion, observed render, error and unavailable observation;
+   validate with actual library events and content/viewer revision fencing.
+
+Immediate issue follow-up should improve diagnosis and test these contracts;
+do not "fix" #2640 by dropping React, synthesizing secrets into static HTML,
+switching every bundler, or changing a customer's dependencies. A refresh/new
+context is a diagnostic comparison, not a demonstrated durable fix.
+
+## Options and what “native” means here
+
+Sandpack already consumes npm dependencies. The decision is **where installation,
+compilation and serving happen**, not “templates versus npm.” A Sandpack
+`vite-react` Nodebox instance is still an in-browser runtime, not native hosting.
+
+| Option                                                                                     | Benefits                                                                                            | Costs/constraints                                                                                                    | Recommendation                                                                             |
+| ------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| Retain and repair selected Sandpack templates                                              | Immediate board preview; no per-app server; preserves DB-backed apps                                | Hosted boot/dependency services, aging compilers, browser limits, viewer-time network failures                       | Yes, compatibility plus tested lightweight path                                            |
+| Self-host classic bundler and dependency service                                           | Operator controls availability/egress; potential warm offline use                                   | Own complex toolchain, CDN/mirror, updates, isolation, capacity and security response; previous Agor attempt removed | Consider only for a measured hosted-service failure/SLA requirement; not first remediation |
+| Switch to experimental bundler / Nodebox broadly                                           | Different compiler/runtime capabilities                                                             | Different compatibility, shared upstream support risk; Nodebox is still browser-constrained                          | Do not blanket switch; isolated opt-in evaluation only                                     |
+| New-app scaffolds are ordinary npm projects, still previewed with Sandpack when compatible | Better export, explicit entries/deps, no new server requirement                                     | Scaffold must also satisfy Sandpack; lockfile is not proof browser resolver obeys npm semantics                      | Useful incremental step                                                                    |
+| Native build → immutable static bundle → isolated preview                                  | Standard tools/lockfiles; build once per revision, cheap repeated views; no live app process needed | New build admission, binary assets, output storage, preview origin/auth and runtime config bridge                    | Preferred first native architecture                                                        |
+| Native persistent Node/backend service                                                     | Real Node, sockets, databases, backend-only secrets                                                 | Process/container/microVM runtime, ingress/WebSockets, state, quotas, idle shutdown, HA, billing/on-call             | Separate opt-in provider-backed capability, not default Cloud promise                      |
+
+[Upstream self-hosting instructions](https://sandpack.codesandbox.io/docs/guides/hosting-the-bundler)
+require the classic codesandbox-client build, separate serving and potentially a
+registry proxy. Hosting the iframe bundle alone does not remove package/CDN
+dependencies. Keep it on an untrusted origin, not Agor's authenticated UI origin.
+
+### Native contract proposal (not present implementation)
+
+“Native npm app” should mean a versioned source snapshot with ordinary
+`package.json`, package-manager lockfile, explicit entry and standard scripts,
+built by **real Node/npm on an admitted worker or external provider**. It is not
+executed in the daemon request handler or assumed to be a long-lived executor task.
+
+- **Build/install:** pin Node, package manager, registry policy and worker image;
+  verify lockfile/integrities. Use `npm ci`/equivalent frozen install, initially
+  lifecycle scripts disabled. Explicitly allow required install scripts only
+  inside the same untrusted-code isolation; disabling scripts is not a sandbox
+  and build/plugin code still executes. No inherited daemon environment, provider
+  login home, Docker socket, cloud metadata access or unrelated branch mounts.
+- **Storage:** source belongs to tenant + artifact/board, not just a disposable
+  branch directory. Keep immutable revisions and source digest. Store binary
+  build outputs in tenant-bound object storage, with output digest and manifest;
+  do not treat today's UTF-8 file map as an arbitrary `dist` upload mechanism.
+  Cache keys include ownership/registry policy, lockfile digest, image/toolchain
+  and architecture. Share only verified public immutable packages globally;
+  private packages, outputs and credentials remain tenant-scoped.
+- **Startup/serving:** static snapshots have no per-app startup. An authenticated
+  preview gateway serves immutable assets on a separate untrusted origin.
+  React routing/base paths, content types, CSP and frame permissions must be
+  tested. Do not serve arbitrary uploaded HTML on Agor's cookie-bearing origin.
+  [Vite documents](https://vite.dev/guide/static-deploy) deployment of build output;
+  `vite preview` is a local preview tool, not the production server.
+- **Development loop:** agents edit the branch staging project; a publish creates
+  a new admitted build and atomically replaces the preview only on success.
+  This trades Sandpack's immediate browser recompilation for build latency.
+  Optional `npm run dev`/HMR belongs in an operator-managed branch environment
+  or remote workspace with explicit app URL and WebSocket ingress, not a daemon
+  child or Cloud executor background process. Development source/workspace
+  lifetime and the published snapshot's lifetime must remain separate.
+- **Secrets:** public compile-time configuration is distinct from backend
+  credentials. Never bake viewing-user secrets into shared bundles/cache keys
+  or a shared server process. Preserve existing Sandpack consent behavior.
+  For new native apps, prefer a reviewed, narrow server-side capability broker
+  with caller/tenant/board/resource authorization on every use; no generic
+  secret-bearing arbitrary-URL proxy. If legacy-compatible viewer-side injection
+  is added, it needs explicit consent, private/no-store delivery, revision-bound
+  messages and tests; it still does not make secrets private from app JavaScript.
+  App-owned backend credentials and per-viewer credentials are different scopes.
+- **Preview bridge:** preserve board/fullscreen affordances and identity without
+  coupling them to Sandpack hooks. Validate message source, origin, schema,
+  viewer, request nonce and revision; bound DOM/log payloads. Do not broaden
+  legacy wildcard communication into universal daemon access. Live external URLs
+  must be independently authorized and tested for embedding; no cookie/token
+  appended to arbitrary provider URLs.
+- **Isolation/resources:** real npm executes untrusted package/build code.
+  Require a reviewed sandbox/container/microVM or external equivalent, fail
+  closed when unavailable, restricted egress and filesystem, hard memory/CPU/PID,
+  disk/output/log/time limits, cancellation and cleanup. Initial _pilot proposal_,
+  not current capacity: 2 vCPU, 2 GiB, 180 s per build, 25 MiB output and 1 MiB
+  logs; one active build/user, two/tenant plus a global admission cap. Measure
+  and revise limits; oversized apps should get a clear external-provider path.
+  Browser Sandpack CPU/memory remains browser-controlled, not covered by these
+  quotas. A task timeout alone is not containment or a resource quota.
+- **Tenant/HA:** new source, builds, revisions, preview tokens, private caches,
+  runtime logs, service instances and cleanup are tenant-owned or derived.
+  Carry trusted tenant identity through admission → worker → callback → storage
+  → ingress; IDs and authorization do not substitute for tenant scoping.
+  Persist job attempts with idempotency, leases/generation fencing and
+  compare-and-swap publication of the output pointer. Late/replayed callbacks
+  cannot publish a superseded or another tenant's build. Stateless asset delivery
+  must work on any replica. Keep secret-derived viewer telemetry isolated;
+  do not assume existing process-local Sandpack waits became HA-safe.
+- **Lifecycle:** last-known-good output remains available after a failed build
+  and after branch deletion, matching artifact durability. Deletion/revocation
+  must fence pending builds and preview capabilities, then clean outputs, private
+  caches, remote jobs and any service volumes. Tenant erasure/export/restore must
+  include these resources, not just database rows.
+- **Persistent-service extension:** provider owns process start/health/restart,
+  signed admission, stable authenticated ingress/WebSockets, writable volumes,
+  service secrets and a reconciler. Specify idle suspension, max lifetime,
+  reconnect behavior, server-side request limits, crash cleanup, per-tenant
+  budget and billing before enabling. No exposure of executor Pod ports.
+
+### Cloud feasibility is a gate, not an assumption
+
+The current [environment contract](../../apps/agor-docs/content/guide/environment-configuration.mdx)
+explicitly says executor Pod servers are **not exposed**, commands are bounded,
+and managed environments can launch a **remote** provider. HA external/delegated
+hybrid mode is an admitted lifecycle-command protocol (10 s launcher admission,
+60 s claim, command at most 300 s, bounded overall job), not app ingress/hosting.
+Webhook-only mode accepts public HTTP(S) GET lifecycle endpoints, no custom
+headers/body/signing, no redirects or URL credentials. That alone is not a
+secure arbitrary native-runtime control plane. Do not place secrets in queries.
+
+| Deployment                    | Sandpack                                                                          | Native npm build/static publication                                                                                                 | Long-lived native services                                                                  |
+| ----------------------------- | --------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| Standalone trusted local      | Present, browser/network-dependent                                                | Possible with separately admitted local worker/asset server; new integration required                                               | Operator-managed environment possible; not safe merely because `simple` can run a shell     |
+| Standalone sandbox/delegated  | Present                                                                           | Requires matching isolated worker/provider and storage/preview contract                                                             | Provider/OS isolation + explicit ingress and lifecycle required                             |
+| HA external / Agor Cloud      | Browser rendering/durable metadata present; synchronous runtime observation gated | Plausible future bounded build service + durable object store + preview gateway; **not currently supplied by managed environments** | External hosting only where provisioned; do not launch a background server in executor Pods |
+| Restricted/offline deployment | Existing cold-start hosted dependencies may fail                                  | Prebuilt, internally served assets reduce runtime external dependence, but new installs/builds still need mirrored packages         | Requires an operator-provided offline runtime, not a universal fallback                     |
+
+A capability response should distinguish browser rendering, static publication,
+external preview, native build and native service support. Offer only available
+new-app routes. Preserve legacy records when a capability is unavailable rather
+than silently converting them. Model runtimes separately from template names;
+an absent discriminator must continue to mean legacy Sandpack. Extend canonical
+core types, not duplicate frontend/MCP unions in the eventual implementation.
+
+## Portability, dependency security and operational cost
+
+**Export/migration is opt-in and reversible.** `land` recovers stored source and
+metadata; it does not necessarily materialize Sandpack's implicit scaffold.
+The UI export captures resolved provider files/environment and strips `.env`;
+the daemon CodeSandbox exporter reconstructs from stored files/dependencies and
+uses the define API. Those are not identical exports. Test both before promising
+round-trip fidelity; no live CodeSandbox export was performed here.
+
+A future portable export must include explicit entry/HTML, scripts, deps,
+lockfile and toolchain, source assets, licenses and a non-secret config manifest;
+exclude injected `.env`, tokens and generated Agor runtime resources. Resolve
+template-added files and dependencies intentionally. Convert CRA entry/JSX/TS,
+asset paths and env reads to Vite only in a **new copy**. Database/network drivers,
+Nodebox polyfills, source-path imports and private registries need a compatibility
+review. Rendering equal HTML once is insufficient: compare interactions,
+styles/assets, errors, configuration, API permissions and recovery. Keep the old
+artifact/runtime selectable until its owner accepts the new revision; test rollback.
+
+Offline: neither `static` nor Nodebox in today's Agor means a cold offline app.
+Static uses a hosted preview/relay; classic uses hosted scripts/workers/package
+resolution; Nodebox uses hosted runtime/preview/package services. Warm browser
+caches can help but are not a durable offline contract. Native **built** assets
+can avoid those services at view time; offline installation requires a complete
+verified registry/cache, and app APIs may still need network access.
+
+Dependency risk exists in both approaches. Pin new scaffold dependencies and
+record resolved runtime packages; floating ranges and hidden compiler packages
+can drift (the Solid probe is an example). Retaining a lockfile in Sandpack
+source does not establish npm lockfile enforcement by its resolver. Native npm
+improves reproducibility through [frozen installs](https://docs.npmjs.com/cli/v11/commands/npm-ci/)
+but introduces package lifecycle/build code on workers, native addons and image
+patching. Require provenance/integrity checks, vulnerability/license review,
+registry allowlists, bounded network access and ongoing rebuild policy. Do not
+auto-upgrade every existing app as a security “fix”; evaluate exposure and retain
+an explicit rollback. No vulnerability scan or full dependency security audit
+was performed in this investigation.
+
+Cost comparison: Sandpack shifts compilation/memory to each viewer and relies on
+vendor services; native static builds spend worker time once per source revision
+then storage/CDN bandwidth per view; native services add ongoing compute,
+volumes, ingress and on-call burden even when code is unchanged. Self-hosting
+Sandpack adds another compiler/CDN service to operate. Measure p50/p95 cold/warm
+first render, build success, worker seconds, image/install/cache size, artifact
+egress, idle-service hours, support incidents and per-tenant noisy-neighbor
+behavior before budgeting. No dollar pricing or production capacity estimate
+is established by these small browser probes.
+
+## Staged plan and exit criteria
+
+1. **Incident evidence + diagnostics (first follow-up PR):** reproduce in the
+   authorized reporting browser, correct HTML/JSON guidance and readiness
+   semantics, add negative tests for syntax errors, blocked iframe, HTML response,
+   stale revision, no viewer and HA unsupported. Do not expand logging of secrets.
+   Exit: known owner/cause or honestly classified unresolved deployment failure;
+   successful apps are not reported as failed merely because they are `running`.
+2. **Compatibility certification (independent PRs):** ten-template browser smoke
+   suite and env sentinels, board/fullscreen parity, actual Agor payload flow;
+   test `vue3` render alias/config validation and Solid scaffold alignment in
+   copies. Broaden docs only to demonstrated env conventions. Repair only the
+   proven shape; retain working source/config overrides. Test Chrome, Firefox,
+   Safari; HTTPS and supported local/private deployments; cold/warm/aged tabs.
+3. **New-app guidance/scaffold registry:** versioned explicit scaffolds with
+   declared runtime/entry/env/offline/export capabilities. Static HTML-first and
+   tested React paths remain usable now. Native instructions route to an
+   approved remote provider only where available. Changing a default must not
+   reinterpret persisted rows or inline board apps.
+4. **Native static pilot:** synthetic apps only, reviewed build admission,
+   isolated output origin/store, authenticated preview and normal npm export.
+   Prove cross-tenant read/write/token/cache/replay denial; cross-viewer secret
+   denial; branch deletion, tenant deletion, revocation, crash/cancel cleanup;
+   two replicas handling different job stages without stale publication.
+   Load-test quotas and measure cost. Cloud team signs off on substrate and
+   ingress, not just a local demo. Production rollout requires separate approval.
+5. **Optional owner-driven copy migration:** compare app behavior/config/export,
+   preserve original, show capability/cost differences, require acceptance and
+   retain rollback. No automated fleet migration in this proposal.
+
+### Evidence required before even recommending deprecation of existing support
+
+- Complete, **authorized metadata-only** inventory covering artifact rows **and
+  inline board apps**, effective template/config/environment overrides, legacy
+  shapes and deployment/browser classes. Use trusted tenant-scoped reads;
+  publish only approved aggregates. Inaccessible/unobserved apps remain unknown.
+- Strong, repeated evidence that **all affected apps/templates are effectively
+  broken** within the precisely proposed scope, not one scaffold or time window.
+  Account for working pinned/custom configurations. A working counterexample
+  prevents a family-wide claim; this investigation has several.
+- Exclude repairable integration, endpoint/network/CSP and version-specific
+  causes; get upstream endpoint/support clarity. A vendor EOL notice is risk
+  evidence but does not prove every app is broken.
+- Demonstrate a replacement in every supported affected deployment, especially
+  Cloud, with tenancy, secrets, export fidelity, costs and rollback proven.
+  Obtain explicit product/owner approval, notice and a preservation/access plan.
+
+Until those gates are met: **preserve support and working apps; unknown stays
+unknown.** No closure, merge, deployment, removal or deprecation is authorized
+by this investigation.
+
+## Running the synthetic reproduction again
+
+Use a disposable directory. The script writes result JSON beside itself; do not
+run it with customer file maps or real env values. It launches a bounded headless
+browser, not an app server, and has no Agor or GitHub mutation calls.
+
+```bash
+repo="$PWD"
+probe="$(mktemp -d /tmp/agor-2640-probe.XXXXXX)"
+cp context/explorations/artifact-runtime-probe/probe.cjs "$probe/probe.cjs"
+npm install --prefix "$probe" --ignore-scripts --no-audit --no-fund \
+  playwright@1.58.2 @codesandbox/sandpack-react@2.20.0 \
+  react@19.2.8 react-dom@19.2.8
+node "$probe/probe.cjs" \
+  "$repo/context/explorations/artifact-runtime-probe/cases.json" \
+  > "$probe/probe.log" 2>&1
+```
+
+Requires `/usr/bin/google-chrome` (adjust the explicit path on other machines).
+Baseline fixtures use upstream scaffolds from the exact Sandpack package; the
+case file includes issue-shaped overrides, sentinel env probes, fault injections
+and the Agor runtime source snapshot. Names identify JSON result files. Network
+and HTML excerpts are safe only because these fixtures are synthetic.
+Initial investigation outputs are at `/tmp/agor-2640-investigation/` (ephemeral,
+not a production evidence store); durable observations are summarized above.
+Hosted assets and floating application dependency ranges can change despite a
+pinned client, so a rerun is a new observation, not guaranteed byte-for-byte replay.

--- a/context/explorations/artifact-runtime-probe/cases.json
+++ b/context/explorations/artifact-runtime-probe/cases.json
@@ -1,0 +1,172 @@
+[
+  {
+    "name": "react-default",
+    "template": "react"
+  },
+  {
+    "name": "static-min",
+    "template": "static",
+    "files": {
+      "/index.html": "<!doctype html><html><body><h1>STATIC_OK</h1></body></html>"
+    }
+  },
+  {
+    "name": "react-ts-default",
+    "template": "react-ts"
+  },
+  {
+    "name": "vanilla-default",
+    "template": "vanilla"
+  },
+  {
+    "name": "vanilla-ts-default",
+    "template": "vanilla-ts"
+  },
+  {
+    "name": "vue-default",
+    "template": "vue"
+  },
+  {
+    "name": "vue3-default",
+    "template": "vue3"
+  },
+  {
+    "name": "svelte-default",
+    "template": "svelte"
+  },
+  {
+    "name": "solid-default",
+    "template": "solid"
+  },
+  {
+    "name": "angular-default",
+    "template": "angular"
+  },
+  {
+    "name": "cra18-src-explicit",
+    "template": "react",
+    "files": {
+      "/package.json": "{\"dependencies\":{\"react\":\"^18.2.0\",\"react-dom\":\"^18.2.0\"},\"main\":\"/src/index.js\"}",
+      "/public/index.html": "<!doctype html><div id=\"root\"></div>",
+      "/src/index.js": "import React from 'react';import {createRoot} from 'react-dom/client';import App from './App';createRoot(document.getElementById('root')).render(<App/>);",
+      "/src/App.js": "import React from 'react';export default function App(){return <h1>CRA18_OK</h1>}"
+    },
+    "customSetup": {
+      "entry": "/src/index.js"
+    }
+  },
+  {
+    "name": "cra18-src-implicit",
+    "template": "react",
+    "files": {
+      "/package.json": "{\"dependencies\":{\"react\":\"^18.2.0\",\"react-dom\":\"^18.2.0\"}}",
+      "/public/index.html": "<!doctype html><div id=\"root\"></div>",
+      "/src/index.js": "import React from 'react';import {createRoot} from 'react-dom/client';import App from './App';createRoot(document.getElementById('root')).render(<App/>);",
+      "/src/App.js": "import React from 'react';export default function App(){return <h1>CRA18_OK</h1>}"
+    }
+  },
+  {
+    "name": "react-env",
+    "template": "react",
+    "files": {
+      "/App.js": "export default function App(){return <h1>{process.env.REACT_APP_PROBE==='NON_SECRET_SENTINEL'?'ENV_OK':'ENV_MISSING'}</h1>}",
+      "/.env": "REACT_APP_PROBE=NON_SECRET_SENTINEL\n"
+    }
+  },
+  {
+    "name": "react-ts-env",
+    "template": "react-ts",
+    "files": {
+      "/App.tsx": "export default function App(){return <h1>{process.env.REACT_APP_PROBE==='NON_SECRET_SENTINEL'?'ENV_OK':'ENV_MISSING'}</h1>}",
+      "/.env": "REACT_APP_PROBE=NON_SECRET_SENTINEL\n"
+    }
+  },
+  {
+    "name": "react-agor-runtime",
+    "template": "react",
+    "files": {
+      "/App.js": "export default function App(){return <h1>{process.env.REACT_APP_PROBE==='NON_SECRET_SENTINEL'?'AGOR_ENV_OK':'ENV_MISSING'}</h1>}",
+      "/.env": "REACT_APP_PROBE=NON_SECRET_SENTINEL\n",
+      "/styles.css": "body{margin:0}"
+    },
+    "options": {
+      "externalResources": [
+        "data:text/javascript;base64,Ly8gYWdvci1ydW50aW1lLmpzIOKAlCBpbmplY3RlZCBieSBBZ29yIGF0IHJlbmRlciB0aW1lLiBEbyBub3QgZWRpdC4KLy8gU291cmNlOiBhcHBzL2Fnb3ItZGFlbW9uL3NyYy91dGlscy9hZ29yLXJ1bnRpbWUtc291cmNlLnRzCihmdW5jdGlvbiAoKSB7CiAgaWYgKHR5cGVvZiB3aW5kb3cgPT09ICd1bmRlZmluZWQnKSByZXR1cm47CiAgaWYgKHdpbmRvdy5fX2Fnb3JfcnVudGltZV9pbnN0YWxsZWRfXykgcmV0dXJuOwogIHdpbmRvdy5fX2Fnb3JfcnVudGltZV9pbnN0YWxsZWRfXyA9IHRydWU7CgogIHZhciBNQVhfTk9ERVMgPSA1MDsKICB2YXIgTUFYX0hUTUxfUEVSX05PREUgPSA1MDAwMDsKICB2YXIgTUFYX1RFWFRfUEVSX05PREUgPSA1MDAwOwogIHZhciBNQVhfRE9DX0hUTUwgPSAyMDAwMDA7CgogIGZ1bmN0aW9uIHNlcmlhbGl6ZUVsKGVsKSB7CiAgICB2YXIgYXR0cnMgPSB7fTsKICAgIGZvciAodmFyIGkgPSAwOyBpIDwgZWwuYXR0cmlidXRlcy5sZW5ndGg7IGkrKykgewogICAgICB2YXIgYSA9IGVsLmF0dHJpYnV0ZXNbaV07CiAgICAgIGF0dHJzW2EubmFtZV0gPSBhLnZhbHVlOwogICAgfQogICAgdmFyIGh0bWwgPSBlbC5vdXRlckhUTUwgfHwgJyc7CiAgICBpZiAoaHRtbC5sZW5ndGggPiBNQVhfSFRNTF9QRVJfTk9ERSkgewogICAgICBodG1sID0gaHRtbC5zbGljZSgwLCBNQVhfSFRNTF9QRVJfTk9ERSkgKyAnLi4uIFt0cnVuY2F0ZWRdJzsKICAgIH0KICAgIHZhciB0ZXh0ID0gKGVsLnRleHRDb250ZW50IHx8ICcnKTsKICAgIGlmICh0ZXh0Lmxlbmd0aCA+IE1BWF9URVhUX1BFUl9OT0RFKSB7CiAgICAgIHRleHQgPSB0ZXh0LnNsaWNlKDAsIE1BWF9URVhUX1BFUl9OT0RFKSArICcuLi4gW3RydW5jYXRlZF0nOwogICAgfQogICAgcmV0dXJuIHsKICAgICAgdGFnOiBlbC50YWdOYW1lID8gZWwudGFnTmFtZS50b0xvd2VyQ2FzZSgpIDogJycsCiAgICAgIGF0dHJpYnV0ZXM6IGF0dHJzLAogICAgICB0ZXh0Q29udGVudDogdGV4dCwKICAgICAgb3V0ZXJIVE1MOiBodG1sLAogICAgfTsKICB9CgogIHdpbmRvdy5hZGRFdmVudExpc3RlbmVyKCdtZXNzYWdlJywgZnVuY3Rpb24gKGV2ZW50KSB7CiAgICB2YXIgZGF0YSA9IGV2ZW50LmRhdGE7CiAgICBpZiAoIWRhdGEgfHwgdHlwZW9mIGRhdGEgIT09ICdvYmplY3QnIHx8IGRhdGEudHlwZSAhPT0gJ2Fnb3I6cXVlcnknKSByZXR1cm47CiAgICB2YXIgcmVxdWVzdElkID0gZGF0YS5yZXF1ZXN0SWQ7CiAgICB2YXIga2luZCA9IGRhdGEua2luZDsKICAgIHZhciBhcmdzID0gZGF0YS5hcmdzIHx8IHt9OwoKICAgIGZ1bmN0aW9uIHJlcGx5KHBheWxvYWQpIHsKICAgICAgdHJ5IHsKICAgICAgICB2YXIgbXNnID0geyB0eXBlOiAnYWdvcjpyZXN1bHQnLCByZXF1ZXN0SWQ6IHJlcXVlc3RJZCB9OwogICAgICAgIGZvciAodmFyIGsgaW4gcGF5bG9hZCkgewogICAgICAgICAgaWYgKE9iamVjdC5wcm90b3R5cGUuaGFzT3duUHJvcGVydHkuY2FsbChwYXlsb2FkLCBrKSkgbXNnW2tdID0gcGF5bG9hZFtrXTsKICAgICAgICB9CiAgICAgICAgbXNnLm9rID0gIXBheWxvYWQuZXJyb3I7CiAgICAgICAgLy8gZXZlbnQuc291cmNlIGlzIHRoZSBwYXJlbnQgd2luZG93LiAnKicgdGFyZ2V0T3JpZ2luIGJlY2F1c2UgdGhlCiAgICAgICAgLy8gaWZyYW1lIHJ1bnMgY3Jvc3Mtb3JpZ2luIGZyb20gYSBTYW5kcGFjayBidW5kbGVyIFVSTCB3ZSBkb24ndAogICAgICAgIC8vIGNvbnRyb2wuIFJlcGxpZXMgY2Fycnkgbm8gc2VjcmV0cyDigJQgb25seSB3aGF0ZXZlciB0aGUgaWZyYW1lJ3MKICAgICAgICAvLyBET00gYWxyZWFkeSBjb250YWlucywgd2hpY2ggdGhlIHBhcmVudCByZW5kZXJlZCBpdHNlbGYuCiAgICAgICAgaWYgKGV2ZW50LnNvdXJjZSAmJiB0eXBlb2YgZXZlbnQuc291cmNlLnBvc3RNZXNzYWdlID09PSAnZnVuY3Rpb24nKSB7CiAgICAgICAgICBldmVudC5zb3VyY2UucG9zdE1lc3NhZ2UobXNnLCAnKicpOwogICAgICAgIH0KICAgICAgfSBjYXRjaCAoZSkgewogICAgICAgIC8vIFNvdXJjZSBjbG9zZWQgb3IgdGhyb3dlZDsgbm90aGluZyB0byBkby4KICAgICAgfQogICAgfQoKICAgIHRyeSB7CiAgICAgIGlmIChraW5kID09PSAncXVlcnlfZG9tJykgewogICAgICAgIHZhciBzZWxlY3RvciA9IGFyZ3Muc2VsZWN0b3I7CiAgICAgICAgaWYgKHR5cGVvZiBzZWxlY3RvciAhPT0gJ3N0cmluZycgfHwgc2VsZWN0b3IubGVuZ3RoID09PSAwKSB7CiAgICAgICAgICByZXR1cm4gcmVwbHkoeyBlcnJvcjogJ3NlbGVjdG9yIHJlcXVpcmVkIChDU1Mgc2VsZWN0b3Igc3RyaW5nKScgfSk7CiAgICAgICAgfQogICAgICAgIHZhciBtdWx0aXBsZSA9IGFyZ3MubXVsdGlwbGUgPT09IHRydWU7CiAgICAgICAgdmFyIHJlcXVlc3RlZE1heCA9IHR5cGVvZiBhcmdzLm1heE5vZGVzID09PSAnbnVtYmVyJyA/IGFyZ3MubWF4Tm9kZXMgOiBNQVhfTk9ERVM7CiAgICAgICAgdmFyIG1heE5vZGVzID0gTWF0aC5tYXgoMSwgTWF0aC5taW4ocmVxdWVzdGVkTWF4LCBNQVhfTk9ERVMpKTsKCiAgICAgICAgdmFyIG5vZGVzOwogICAgICAgIGlmIChtdWx0aXBsZSkgewogICAgICAgICAgbm9kZXMgPSBBcnJheS5wcm90b3R5cGUuc2xpY2UuY2FsbChkb2N1bWVudC5xdWVyeVNlbGVjdG9yQWxsKHNlbGVjdG9yKSwgMCwgbWF4Tm9kZXMpOwogICAgICAgIH0gZWxzZSB7CiAgICAgICAgICB2YXIgc2luZ2xlID0gZG9jdW1lbnQucXVlcnlTZWxlY3RvcihzZWxlY3Rvcik7CiAgICAgICAgICBub2RlcyA9IHNpbmdsZSA/IFtzaW5nbGVdIDogW107CiAgICAgICAgfQogICAgICAgIHZhciBzZXJpYWxpemVkID0gW107CiAgICAgICAgZm9yICh2YXIgaSA9IDA7IGkgPCBub2Rlcy5sZW5ndGg7IGkrKykgc2VyaWFsaXplZC5wdXNoKHNlcmlhbGl6ZUVsKG5vZGVzW2ldKSk7CiAgICAgICAgcmV0dXJuIHJlcGx5KHsgcmVzdWx0OiB7IG1hdGNoZWQ6IHNlcmlhbGl6ZWQubGVuZ3RoLCBub2Rlczogc2VyaWFsaXplZCB9IH0pOwogICAgICB9CgogICAgICBpZiAoa2luZCA9PT0gJ2RvY3VtZW50X2h0bWwnKSB7CiAgICAgICAgdmFyIGh0bWwgPSAoZG9jdW1lbnQuZG9jdW1lbnRFbGVtZW50ICYmIGRvY3VtZW50LmRvY3VtZW50RWxlbWVudC5vdXRlckhUTUwpIHx8ICcnOwogICAgICAgIGlmIChodG1sLmxlbmd0aCA+IE1BWF9ET0NfSFRNTCkgewogICAgICAgICAgaHRtbCA9IGh0bWwuc2xpY2UoMCwgTUFYX0RPQ19IVE1MKSArICcuLi4gW3RydW5jYXRlZF0nOwogICAgICAgIH0KICAgICAgICByZXR1cm4gcmVwbHkoeyByZXN1bHQ6IHsgaHRtbDogaHRtbCwgbGVuZ3RoOiBodG1sLmxlbmd0aCB9IH0pOwogICAgICB9CgogICAgICByZXR1cm4gcmVwbHkoeyBlcnJvcjogJ3Vua25vd24gcXVlcnkga2luZDogJyArIFN0cmluZyhraW5kKSB9KTsKICAgIH0gY2F0Y2ggKGVycikgewogICAgICByZXR1cm4gcmVwbHkoeyBlcnJvcjogKGVyciAmJiBlcnIubWVzc2FnZSkgPyBlcnIubWVzc2FnZSA6IFN0cmluZyhlcnIpIH0pOwogICAgfQogIH0pOwoKICAvLyBBbm5vdW5jZSByZWFkaW5lc3MgdG8gdGhlIHBhcmVudCBzbyBpdCBrbm93cyB0aGUgaWZyYW1lIGlzIHdpcmVkIHVwCiAgLy8gYmVmb3JlIHNlbmRpbmcgYW55IHF1ZXJpZXMgKGF2b2lkcyBhIHJhY2Ugb24gZmlyc3QtcGFpbnQpLgogIHRyeSB7CiAgICBpZiAod2luZG93LnBhcmVudCAmJiB3aW5kb3cucGFyZW50ICE9PSB3aW5kb3cpIHsKICAgICAgd2luZG93LnBhcmVudC5wb3N0TWVzc2FnZSh7IHR5cGU6ICdhZ29yOnJlYWR5JyB9LCAnKicpOwogICAgfQogIH0gY2F0Y2ggKGUpIHsKICAgIC8qIHBhcmVudCBjbG9zZWQgKi8KICB9Cn0pKCk7Cg=="
+      ]
+    }
+  },
+  {
+    "name": "react-json-fault",
+    "template": "react",
+    "faultUrl": "https://data.jsdelivr.com/v1/package/npm/react"
+  },
+  {
+    "name": "react-csp-block",
+    "template": "react",
+    "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'self'; worker-src 'self' blob:"
+  },
+  {
+    "name": "react-csp-default",
+    "template": "react",
+    "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; frame-src 'self' https://*.codesandbox.io; worker-src 'self' blob:"
+  },
+  {
+    "name": "vite-react-nodebox",
+    "template": "vite-react",
+    "waitMs": 45000
+  },
+  {
+    "name": "react-json-all-metadata-fault",
+    "template": "react",
+    "faultUrls": [
+      "https://data.jsdelivr.com/v1/package/npm/react",
+      "https://unpkg.com/react@*/package.json"
+    ]
+  },
+  {
+    "name": "solid-aligned",
+    "template": "solid",
+    "customSetup": {
+      "dependencies": {
+        "solid-js": "1.9.15"
+      }
+    }
+  },
+  {
+    "name": "vue-env",
+    "template": "vue",
+    "files": {
+      "/.env": "PROBE=NON_SECRET_SENTINEL\n",
+      "/src/App.vue": "<template><h1>{{result}}</h1></template><script>export default { data(){return {result: process.env.PROBE==='NON_SECRET_SENTINEL'?'ENV_OK':'ENV_MISSING'}} }</script>"
+    }
+  },
+  {
+    "name": "svelte-env",
+    "template": "svelte",
+    "files": {
+      "/.env": "VITE_PROBE=NON_SECRET_SENTINEL\n",
+      "/App.svelte": "<script>let result;try {result=import.meta.env.VITE_PROBE==='NON_SECRET_SENTINEL'?'ENV_OK':'ENV_MISSING'}catch(e){result='ENV_ACCESS_ERROR'}</script><h1>{result}</h1>"
+    }
+  },
+  {
+    "name": "solid-env-aligned",
+    "template": "solid",
+    "customSetup": {
+      "dependencies": {
+        "solid-js": "1.9.15"
+      }
+    },
+    "files": {
+      "/.env": "VITE_PROBE=NON_SECRET_SENTINEL\n",
+      "/App.tsx": "export default function App(){let result;try {result=import.meta.env.VITE_PROBE==='NON_SECRET_SENTINEL'?'ENV_OK':'ENV_MISSING'}catch(e){result='ENV_ACCESS_ERROR'}return <h1>{result}</h1>}"
+    }
+  },
+  {
+    "name": "angular-env",
+    "template": "angular",
+    "files": {
+      "/.env": "PROBE=NON_SECRET_SENTINEL\n",
+      "/src/app/app.component.ts": "import { Component } from '@angular/core';@Component({selector:'app-root',template:'<h1>{{result}}</h1>'})export class AppComponent {result = process.env.PROBE==='NON_SECRET_SENTINEL'?'ENV_OK':'ENV_MISSING';}"
+    }
+  }
+]

--- a/context/explorations/artifact-runtime-probe/probe.cjs
+++ b/context/explorations/artifact-runtime-probe/probe.cjs
@@ -1,0 +1,129 @@
+// Design-only synthetic probe for #2640, NOT application/runtime implementation.
+// Copy to a disposable directory with the dependencies documented in the design note.
+// No HTTP server, Agor API, customer app, secret, or existing browser profile is used.
+// Wrap already-published CommonJS files for the browser; do not compile Agor.
+// Results contain network/body excerpts: use ONLY the checked-in synthetic cases.
+const fs = require('fs'),
+  path = require('path'),
+  { createRequire } = require('module');
+const { chromium } = require('playwright');
+const root = __dirname,
+  modules = {},
+  ids = new Map();
+function add(file) {
+  if (ids.has(file)) return ids.get(file);
+  const id = ids.size;
+  ids.set(file, id);
+  let code = fs.readFileSync(file, 'utf8');
+  if (file.endsWith('.json')) code = 'module.exports=' + code;
+  const req = createRequire(file),
+    deps = {};
+  modules[id] = { code, deps };
+  for (const m of code.matchAll(/\brequire\(["']([^"']+)["']\)/g)) {
+    try {
+      const f = req.resolve(m[1]);
+      if (path.isAbsolute(f)) deps[m[1]] = add(f);
+    } catch {}
+  }
+  return id;
+}
+const react = add(require.resolve('react')),
+  dom = add(require.resolve('react-dom/client')),
+  sand = add(require.resolve('@codesandbox/sandpack-react'));
+const bundle = `const process={env:{NODE_ENV:'production'}};const mods={${Object.entries(modules)
+  .map(
+    ([i, m]) => `${i}:[function(require,module,exports){\n${m.code}\n},${JSON.stringify(m.deps)}]`
+  )
+  .join(
+    ','
+  )}};const cache={};function R(id){if(cache[id])return cache[id].exports;const m=cache[id]={exports:{}};mods[id][0](n=>{if(!(n in mods[id][1]))throw Error('Missing require '+n);return R(mods[id][1][n])},m,m.exports);return m.exports;}window.React=R(${react});window.createRoot=R(${dom}).createRoot;window.SP=R(${sand});`;
+const init = `window.events=[];window.addEventListener('message',e=>{if(e.data?.type)window.events.push(e.data)});const h=React.createElement;window.run=(c)=>{window.config=c;function Report(){const {sandpack}=SP.useSandpack();window.state={status:sandpack.status,error:sandpack.error,environment:sandpack.environment,files:Object.keys(sandpack.files)};return null};createRoot(document.getElementById('root')).render(h(SP.SandpackProvider,{template:c.template,files:c.files||{},customSetup:c.customSetup,options:{initMode:'immediate',...c.options}},h(SP.SandpackPreview,{showOpenInCodeSandbox:false}),h(Report)));};`;
+(async () => {
+  const browser = await chromium.launch({
+    executablePath: '/usr/bin/google-chrome',
+    headless: true,
+    args: ['--no-sandbox'],
+  });
+  try {
+    console.log('browser', browser.version());
+    const configs = JSON.parse(fs.readFileSync(process.argv[2] || root + '/cases.json', 'utf8'));
+    for (const c of configs) {
+      const ctx = await browser.newContext();
+      const page = await ctx.newPage();
+      const network = [],
+        errors = [];
+      page.on('response', async (r) => {
+        if (!r.url().startsWith('https://probe.invalid')) {
+          const item = { url: r.url(), status: r.status(), type: r.headers()['content-type'] };
+          if (r.request().resourceType() === 'fetch' || r.status() >= 400) {
+            try {
+              item.prefix = (await r.text()).slice(0, 180);
+            } catch {}
+          }
+          network.push(item);
+        }
+      });
+      page.on('requestfailed', (r) =>
+        network.push({ url: r.url(), failure: r.failure()?.errorText })
+      );
+      page.on('pageerror', (e) => errors.push(e.message));
+      page.on('console', (m) => {
+        if (m.type() === 'error') errors.push(m.text().slice(0, 500));
+      });
+      for (const faultUrl of c.faultUrls || [c.faultUrl].filter(Boolean))
+        await page.route(faultUrl, (route) =>
+          route.fulfill({
+            status: 200,
+            contentType: 'text/html',
+            headers: { 'access-control-allow-origin': '*' },
+            body: '<!doctype html><html><body>SYNTHETIC_GATEWAY_ERROR</body></html>',
+          })
+        );
+      await page.route('https://probe.invalid/**', async (route) => {
+        const u = route.request().url();
+        await route.fulfill({
+          headers: !u.endsWith('.js') && c.csp ? { 'content-security-policy': c.csp } : {},
+          contentType: u.endsWith('.js') ? 'application/javascript' : 'text/html',
+          body: u.endsWith('bundle.js')
+            ? bundle
+            : u.endsWith('init.js')
+              ? init
+              : '<!doctype html><html><body><div id="root"></div><script src="/bundle.js"></script><script src="/init.js"></script></body></html>',
+        });
+      });
+      await page.goto('https://probe.invalid/');
+      await page.evaluate((c) => window.run(c), c);
+      await page.waitForTimeout(c.waitMs || 18000);
+      const state = await page.evaluate(() => ({
+        state: window.state,
+        events: window.events.filter((e) => /error|status|done|start/.test(e.type)).slice(-15),
+      }));
+      const frames = [];
+      for (const f of page.frames()) {
+        try {
+          frames.push({
+            url: f.url(),
+            text: (await f.locator('body').innerText({ timeout: 1000 })).slice(0, 1800),
+          });
+        } catch {}
+      }
+      const result = { name: c.name, config: c, ...state, frames, errors, network };
+      fs.writeFileSync(root + '/' + c.name + '.json', JSON.stringify(result, null, 2));
+      console.log(
+        JSON.stringify({
+          name: c.name,
+          ...state,
+          frames,
+          errors,
+          network: network.filter((n) => n.failure || n.status >= 400 || n.prefix),
+        })
+      );
+      await ctx.close();
+    }
+  } finally {
+    await browser.close();
+  }
+})().catch((e) => {
+  console.error(e);
+  process.exitCode = 1;
+});

--- a/packages/core/src/types/artifact.ts
+++ b/packages/core/src/types/artifact.ts
@@ -377,9 +377,19 @@ export interface SandpackError {
   column?: number;
 }
 
-/**
- * Full artifact status returned to agents via MCP
- */
+/** Compiler completion, independent of the Sandpack provider lifecycle. */
+export const ARTIFACT_COMPILATION_STATUSES = ['pending', 'compiling', 'success', 'error'] as const;
+export type ArtifactCompilationStatus = (typeof ARTIFACT_COMPILATION_STATUSES)[number];
+
+/** Viewer-scoped browser report; compilation completion is separate from provider lifecycle. */
+export interface ArtifactSandpackReport {
+  error: SandpackError | null;
+  status?: string;
+  compilation_status?: ArtifactCompilationStatus;
+  content_hash?: string;
+}
+
+/** Full artifact status returned to agents via MCP. */
 export interface ArtifactStatus {
   artifact_id: ArtifactID;
   /** Reflects file validation AND Sandpack runtime state.
@@ -389,8 +399,10 @@ export interface ArtifactStatus {
   build_errors?: string[];
   /** Sandpack bundler/runtime error from the browser iframe (null = no error) */
   sandpack_error?: SandpackError | null;
-  /** Sandpack bundler status: 'idle', 'running', 'timeout', etc. */
+  /** Sandpack provider lifecycle, NOT compilation readiness. */
   sandpack_status?: string;
+  /** Explicit compiler completion from this viewer; absent for older clients. Not DOM validation. */
+  compilation_status?: ArtifactCompilationStatus;
   /** ISO timestamp for the latest current-content browser runtime report from this viewer. */
   runtime_observed_at?: string;
   console_logs: ArtifactConsoleEntry[];


### PR DESCRIPTION
## Summary

Related to #2640. **Does not close the issue:** its original HTML-as-JSON/network incident has not been reproduced on the reported deployment.

- Report explicit Sandpack compilation progress separately from provider lifecycle. `running` is not completion; neither `idle` nor an initial connection proves readiness.
- Require successful compilation plus an error-free settle window for `waitForStatus`. Treat an observed-but-incomplete timeout as inconclusive, including the MCP publish instructions.
- Diagnose HTML-like input to a JSON parser without incorrectly prescribing a `package.json` repair or inventing the failing endpoint. Request sanitized browser Network evidence.
- Preserve completion across Sandpack listener-function changes; reset it for changed content, recompilation, and provider restarts.
- Document the runtime contract and retain the requested design proposal, compatibility matrix, authoritative upstream references, and reproducible synthetic template probes.

## Compatibility and security

- **No template removal, dependency upgrades, customer app changes, migration, or deprecation.** Native/npm hosting remains a design proposal, not an implemented replacement.
- Older tabs continue rendering. Their legacy status reports cannot prove compilation completion; reload enables the new reporting contract.
- Reports remain authenticated, viewer-scoped, and revision-checked through the existing tenant-scoped routes and repository lookups. Constrained HA runtime introspection remains disabled.
- No customer application files or credentials were accessed. The original issue artifact's authorized read-only lookup returned not found; that is not fleet-wide evidence.

## Validation

- [x] `pnpm i` — passed; lockfile unchanged.
- [x] `pnpm check` — passed, including full workspace typechecks, lint, short-ID/tenant/filesystem/realtime boundary checks, and non-docs builds. This resolves the earlier managed-environment limitation from missing generated client declarations.
- [x] `pnpm --filter @agor/daemon exec vitest run src/services/artifacts.test.ts src/mcp/tools/artifacts.test.ts src/register-hooks.artifact-routes.test.ts src/ha-support.test.ts` — **116 passed**.
- [x] `pnpm --filter agor-ui exec vitest run src/components/artifacts/ArtifactSandpackErrorReporter.test.tsx` — **6 passed**.
- [x] `node --check context/explorations/artifact-runtime-probe/probe.cjs` — passed.

Coverage includes explicit completion, legacy observations, compilation failure, settle deadlines/early errors, stale file/config revisions, viewer isolation, HA rejection, MCP timeout instructions, and guarded authenticated artifact routes. The route suite uses SQLite; this is not a new PostgreSQL RLS or multi-node HA integration run.

Prior browser investigation used Agor revision `c3a2a1fd337cc285ab021961f831a5dc3d52370f`, Sandpack React `2.20.0`, client `2.19.8`, and Chrome `146.0.7680.177`. The design note records all 25 pre-fix synthetic template/runtime probes and their limitations.

Post-fix browser checks used the managed branch's actual Vite-served reporter and installed Sandpack library with synthetic files and **mocked authentication/report transport**: React, React-TS, and static rendered and reported completion; malformed source reported an error; a CSP-blocked iframe stayed pending. These are not an end-to-end reproduction of the original deployment. Daemon behavior is tested separately.

## Remaining evidence / follow-up

Obtain the original viewing browser's sanitized failed-request URL/path, status, content type, redirects, and CSP/CORS diagnostics before claiming a network/CDN/ingress repair. Do not attach tokens, cookies, environment values, or an unredacted HAR. Representative failures and upstream release inactivity do not justify removing working Sandpack apps.
