### PR TITLE
chore: bump release from 0.26.2 to 0.26.3

### DIFF
--- a/apps/agor-cli/package.json
+++ b/apps/agor-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor/cli",
-  "version": "0.26.2",
+  "version": "0.26.3",
   "private": true,
   "type": "module",
   "bin": {

--- a/packages/agor-claude/package.json
+++ b/packages/agor-claude/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/claude",
-  "version": "0.26.2",
+  "version": "0.26.3",
   "description": "Version-aligned claude agentic tool integration for Agor",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agor-claude/src/index.ts
+++ b/packages/agor-claude/src/index.ts
@@ -1,4 +1,4 @@
 /** Agor-managed, release-aligned claude integration. */
-export const AGOR_INTEGRATION_VERSION = '0.26.2';
+export const AGOR_INTEGRATION_VERSION = '0.26.3';
 export const VENDOR_PACKAGE = '@anthropic-ai/claude-agent-sdk';
 export * as sdk from '@anthropic-ai/claude-agent-sdk';

--- a/packages/agor-codex/package.json
+++ b/packages/agor-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/codex",
-  "version": "0.26.2",
+  "version": "0.26.3",
   "description": "Version-aligned codex agentic tool integration for Agor",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agor-codex/src/index.ts
+++ b/packages/agor-codex/src/index.ts
@@ -1,4 +1,4 @@
 /** Agor-managed, release-aligned codex integration. */
-export const AGOR_INTEGRATION_VERSION = '0.26.2';
+export const AGOR_INTEGRATION_VERSION = '0.26.3';
 export const VENDOR_PACKAGE = '@openai/codex-sdk';
 export * as sdk from '@openai/codex-sdk';

--- a/packages/agor-copilot/package.json
+++ b/packages/agor-copilot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/copilot",
-  "version": "0.26.2",
+  "version": "0.26.3",
   "description": "Version-aligned copilot agentic tool integration for Agor",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agor-copilot/src/index.ts
+++ b/packages/agor-copilot/src/index.ts
@@ -1,4 +1,4 @@
 /** Agor-managed, release-aligned copilot integration. */
-export const AGOR_INTEGRATION_VERSION = '0.26.2';
+export const AGOR_INTEGRATION_VERSION = '0.26.3';
 export const VENDOR_PACKAGE = '@github/copilot-sdk';
 export * as sdk from '@github/copilot-sdk';

--- a/packages/agor-cursor/package.json
+++ b/packages/agor-cursor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/cursor",
-  "version": "0.26.2",
+  "version": "0.26.3",
   "description": "Version-aligned cursor agentic tool integration for Agor",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agor-cursor/src/index.ts
+++ b/packages/agor-cursor/src/index.ts
@@ -1,4 +1,4 @@
 /** Agor-managed, release-aligned cursor integration. */
-export const AGOR_INTEGRATION_VERSION = '0.26.2';
+export const AGOR_INTEGRATION_VERSION = '0.26.3';
 export const VENDOR_PACKAGE = '@cursor/sdk';
 export * as sdk from '@cursor/sdk';

--- a/packages/agor-gemini/package.json
+++ b/packages/agor-gemini/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/gemini",
-  "version": "0.26.2",
+  "version": "0.26.3",
   "description": "Version-aligned gemini agentic tool integration for Agor",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agor-gemini/src/index.ts
+++ b/packages/agor-gemini/src/index.ts
@@ -1,4 +1,4 @@
 /** Agor-managed, release-aligned gemini integration. */
-export const AGOR_INTEGRATION_VERSION = '0.26.2';
+export const AGOR_INTEGRATION_VERSION = '0.26.3';
 export const VENDOR_PACKAGE = '@google/gemini-cli-core';
 export * as sdk from '@google/gemini-cli-core';

--- a/packages/agor-live/package.json
+++ b/packages/agor-live/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agor-live",
-  "version": "0.26.2",
+  "version": "0.26.3",
   "description": "Team command center for all things agentic — shared canvas for coding agents and assistants on isolated git branches, with real-time multiplayer and an MCP surface agents drive themselves.",
   "type": "module",
   "bin": {

--- a/packages/agor-opencode/package.json
+++ b/packages/agor-opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/opencode",
-  "version": "0.26.2",
+  "version": "0.26.3",
   "description": "Version-aligned opencode agentic tool integration for Agor",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agor-opencode/src/index.ts
+++ b/packages/agor-opencode/src/index.ts
@@ -1,5 +1,5 @@
 /** Agor-managed, release-aligned opencode integration. */
-export const AGOR_INTEGRATION_VERSION = '0.26.2';
+export const AGOR_INTEGRATION_VERSION = '0.26.3';
 export const VENDOR_PACKAGE = '@opencode-ai/sdk';
 export * as sdk from '@opencode-ai/sdk';
 export * as sdkV2 from '@opencode-ai/sdk/v2';

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agor-live/client",
-  "version": "0.26.2",
+  "version": "0.26.3",
   "description": "TypeScript client for connecting to the Agor daemon",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Bump **0.26.2 → 0.26.3** from fresh `origin/main` (`dcd3a645`) using exactly `packages/agor-live/build.sh --bump patch`, once; completed without retry.
- Align `agor-live`, client, CLI, six integration manifests, and six integration constants: 15 version-only edits. Dependency ranges and lockfile unchanged; no generated artifacts committed.
- Release metadata only; no tenant-data, authorization, or isolation behavior changes.

## Validation
- `pnpm install --frozen-lockfile` before and after the bump.
- Bump script: all 15 workspace builds, client `check:pack`, internal-package contract, eight aligned tarballs, and package-content budget passed (2,124 files; 23.65 MiB packed / 97.82 MiB unpacked).
- CI artifact-contract inspection: all eight packages at 0.26.3, exact client dependency, materialized internal packages, no install lifecycle hooks or workspace protocol in the release manifest.
- `pnpm typecheck`; `pnpm lint` (including 330 design-system fixtures); CI coverage, dependency/integration alignment, short-ID, multitenancy, daemon-filesystem, and realtime boundary checks passed.
- Packaging tests: 4 passed; client tests: 45 passed; CLI version tests: 4 passed. Shell syntax and diff whitespace checks passed; commit hooks enabled.
- Local tooling: Node 22.22.2, pnpm 11.17.0, CI-pinned npm 11.16.0 for packing. Full packaged-install OS matrix remains CI-owned.
- Initial commit hook backup hit a dual-mount `PWD`/Git path mismatch; aligning `PWD` fixed it and the normal hook-enabled commit passed (no bypass or tracked fix).

No npm publish, tag, merge, deployment, or global application install performed.
