### PR TITLE
refactor(daemon): one MCP caller-trust prelude, failing closed

### DIFF
--- a/apps/agor-daemon/src/register-hooks.mcp-caller-trust.test.ts
+++ b/apps/agor-daemon/src/register-hooks.mcp-caller-trust.test.ts
@@ -1,0 +1,151 @@
+/**
+ * The MCP caller-trust prelude, driven through the chains `registerHooks`
+ * actually installs.
+ *
+ * Seven MCP authorization sites open with the same prelude — skip internal
+ * calls, read `params.user`, exempt service accounts — but they disagreed on
+ * what "authenticated with no `params.user`" means: the authorizer utilities
+ * denied, while these two hooks passed the request straight through. On `find`
+ * that meant the query was left unscoped, so the caller would have received
+ * every MCP server in the tenant.
+ *
+ * `requireAuth` populates `params.user` ahead of both hooks today, so the
+ * divergence was latent rather than live. These assert it is now closed at the
+ * hook itself, and — the part that matters — that closing it did not take the
+ * genuine service-account exemption down with it, since both cases used to
+ * share one `||` branch.
+ */
+
+import type { HookContext } from '@agor/core/types';
+import { describe, expect, it } from 'vitest';
+import { type RegisterHooksContext, registerHooks } from './register-hooks';
+
+type RegisteredHook = (context: HookContext) => unknown;
+
+const captureChains = (): Map<string, RegisteredHook[]> => {
+  const chains = new Map<string, RegisteredHook[]>();
+  const app = {
+    service(path: string) {
+      return {
+        on() {},
+        hooks(hooks: {
+          before?: Record<string, RegisteredHook[]>;
+          after?: Record<string, RegisteredHook[]>;
+        }) {
+          const key = path.replace(/^\//, '');
+          for (const [phase, methods] of [
+            ['before', hooks?.before ?? {}],
+            ['after', hooks?.after ?? {}],
+          ] as const) {
+            for (const [method, chain] of Object.entries(methods)) {
+              const mapKey = `${key}.${phase}.${method}`;
+              chains.set(mapKey, [...(chains.get(mapKey) ?? []), ...(chain ?? [])]);
+            }
+          }
+        },
+      };
+    },
+    use() {},
+    publish() {},
+  };
+
+  registerHooks({
+    db: {} as RegisterHooksContext['db'],
+    app: app as unknown as RegisterHooksContext['app'],
+    config: {
+      database: { dialect: 'postgresql' },
+      multi_tenancy: { mode: 'static', static_tenant_id: 'mcp-caller-trust-test' },
+    } as RegisterHooksContext['config'],
+    jwtSecret: 'mcp-caller-trust-test-secret',
+    deployment: { mode: 'standalone' },
+    requireAuth: async (context) => context,
+    superadminOpts: { allowSuperadmin: true },
+    sessionsService: {} as RegisterHooksContext['sessionsService'],
+    messagesService: {} as RegisterHooksContext['messagesService'],
+    boardsService: undefined,
+    branchRepository: {} as RegisterHooksContext['branchRepository'],
+    usersRepository: {} as RegisterHooksContext['usersRepository'],
+    sessionsRepository: {} as RegisterHooksContext['sessionsRepository'],
+  });
+
+  return chains;
+};
+
+const chainFor = (key: string): RegisteredHook[] => {
+  const chain = captureChains().get(key);
+  if (!chain?.length) throw new Error(`no hooks captured for ${key}`);
+  return chain;
+};
+
+const runChain = async (chain: RegisteredHook[], context: HookContext): Promise<HookContext> => {
+  let current = context;
+  for (const hook of chain) {
+    current = ((await hook(current)) as HookContext) ?? current;
+  }
+  return current;
+};
+
+/** Authenticated transport, but no resolved user — the divergent case. */
+const anonymousFind = (): HookContext =>
+  ({
+    path: 'mcp-servers',
+    method: 'find',
+    params: { provider: 'rest', query: {} },
+  }) as unknown as HookContext;
+
+const serviceAccountFind = (): HookContext =>
+  ({
+    path: 'mcp-servers',
+    method: 'find',
+    params: {
+      provider: 'rest',
+      user: { user_id: 'svc-1', role: 'member', _isServiceAccount: true },
+      query: {},
+    },
+  }) as unknown as HookContext;
+
+const anonymousGet = (): HookContext =>
+  ({
+    path: 'mcp-servers',
+    method: 'get',
+    id: 'server-1',
+    result: { mcp_server_id: 'server-1', owner_user_id: 'someone-else' },
+    params: { provider: 'rest', query: {} },
+  }) as unknown as HookContext;
+
+const serviceAccountGet = (): HookContext =>
+  ({
+    path: 'mcp-servers',
+    method: 'get',
+    id: 'server-1',
+    result: { mcp_server_id: 'server-1', owner_user_id: 'someone-else' },
+    params: {
+      provider: 'rest',
+      user: { user_id: 'svc-1', role: 'member', _isServiceAccount: true },
+      query: {},
+    },
+  }) as unknown as HookContext;
+
+describe('MCP caller-trust prelude', () => {
+  it('refuses a find carrying no user instead of leaving the query unscoped', async () => {
+    await expect(runChain(chainFor('mcp-servers.before.find'), anonymousFind())).rejects.toThrow(
+      /authentication required/i
+    );
+  });
+
+  it('refuses a get carrying no user instead of returning the row', async () => {
+    await expect(runChain(chainFor('mcp-servers.after.get'), anonymousGet())).rejects.toThrow(
+      /authentication required/i
+    );
+  });
+
+  it('still exempts a genuine service account on find', async () => {
+    const context = await runChain(chainFor('mcp-servers.before.find'), serviceAccountFind());
+    expect(context.params.query?.usableByUserId).toBeUndefined();
+  });
+
+  it('still exempts a genuine service account on get', async () => {
+    const context = await runChain(chainFor('mcp-servers.after.get'), serviceAccountGet());
+    expect(context.result).toMatchObject({ mcp_server_id: 'server-1' });
+  });
+});

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -177,7 +177,10 @@ import {
   redactMCPServerSecrets,
   shouldExposeMCPServerSecrets,
 } from './utils/mcp-header-secrets.js';
-import { createMcpServerWriteAuthorizationHook } from './utils/mcp-server-authorization.js';
+import {
+  createMcpServerWriteAuthorizationHook,
+  resolveMcpCaller,
+} from './utils/mcp-server-authorization.js';
 import { realignRepoOriginAfterPatchHook } from './utils/realign-repo-origin.js';
 import {
   bindRealtimeAccessCacheInvalidation,
@@ -2320,9 +2323,10 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   };
 
   const scopeMcpServerFindToUsable = async (context: HookContext): Promise<HookContext> => {
-    if (!context.params.provider) return context;
-    const user = context.params.user;
-    if (!user || (user as { _isServiceAccount?: boolean })._isServiceAccount) return context;
+    const caller = resolveMcpCaller(context.params);
+    if (caller.kind === 'internal' || caller.kind === 'service-account') return context;
+    if (caller.kind === 'anonymous') throw new NotAuthenticated('Authentication required');
+    const user = caller.user;
     if (!hasMinimumRole(user.role, ROLES.ADMIN)) {
       // Do not trust a caller-supplied usableByUserId; it is an internal
       // authorization filter, not a public query capability.
@@ -2337,15 +2341,11 @@ export function registerHooks(ctx: RegisterHooksContext): void {
   const denyMcpServerGetOfAnotherUsersPrivate = async (
     context: HookContext
   ): Promise<HookContext> => {
-    if (!context.params.provider) return context;
-    const user = context.params.user;
-    if (
-      !user ||
-      (user as { _isServiceAccount?: boolean })._isServiceAccount ||
-      hasMinimumRole(user.role, ROLES.ADMIN)
-    ) {
-      return context;
-    }
+    const caller = resolveMcpCaller(context.params);
+    if (caller.kind === 'internal' || caller.kind === 'service-account') return context;
+    if (caller.kind === 'anonymous') throw new NotAuthenticated('Authentication required');
+    const user = caller.user;
+    if (hasMinimumRole(user.role, ROLES.ADMIN)) return context;
     if (!isMCPServerUsableBy(context.result as MCPServer, user.user_id)) {
       throw new NotFound(`MCP server not found: ${String(context.id)}`);
     }

--- a/apps/agor-daemon/src/register-services.mcp-discover-caller.test.ts
+++ b/apps/agor-daemon/src/register-services.mcp-discover-caller.test.ts
@@ -1,0 +1,204 @@
+import {
+  createDatabaseAsync,
+  createTenantScopedDatabaseProxy,
+  MCPServerRepository,
+  runMigrations,
+  runWithTenantContext,
+  runWithTenantDatabaseScope,
+  UsersRepository,
+} from '@agor/core/db';
+import { type Application, feathers } from '@agor/core/feathers';
+import type { AuthenticatedParams, MCPDiscoveryRequest, TenantID, UserID } from '@agor/core/types';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type RegisterServicesContext, registerMCPServices } from './register-services.js';
+
+// Exercise the registered service, real authorization and persistence; only
+// replace the remote capability client. Denials must precede provider work.
+const connect = vi.hoisted(() => vi.fn());
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
+  Client: class {
+    connect = connect;
+    async close() {}
+    async listTools() {
+      return { tools: [{ name: 'discovered', inputSchema: { type: 'object' } }] };
+    }
+    async listResources() {
+      return { resources: [] };
+    }
+    async listPrompts() {
+      return { prompts: [] };
+    }
+  },
+}));
+vi.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
+  StreamableHTTPClientTransport: class {},
+}));
+
+const TENANT = 'discovery-tenant-a' as TenantID;
+const denial = {
+  success: false,
+  error: 'Access denied: only an admin or the server owner can discover this MCP server',
+};
+
+async function createHarness() {
+  const rawDb = await createDatabaseAsync({ dialect: 'sqlite', url: ':memory:' });
+  await runMigrations(rawDb);
+  const db = createTenantScopedDatabaseProxy(rawDb);
+  const users = new UsersRepository(rawDb);
+  const owner = await users.create({ email: 'owner@example.test', role: 'member' });
+  const admin = await users.create({ email: 'admin@example.test', role: 'admin' });
+  const unrelated = await users.create({ email: 'unrelated@example.test', role: 'member' });
+  const repository = new MCPServerRepository(rawDb);
+  const saved = await repository.create({
+    name: 'private-discovery',
+    url: 'https://mcp.example.test/mcp',
+    transport: 'http',
+    scope: 'session',
+    owner_user_id: owner.user_id as UserID,
+  });
+  const shared = await repository.create({
+    name: 'shared-discovery',
+    url: 'https://mcp.example.test/shared',
+    transport: 'http',
+    scope: 'global',
+  });
+  const app = feathers() as Application;
+  await runWithTenantDatabaseScope(db, TENANT, () =>
+    registerMCPServices({
+      db,
+      app,
+      config: {} as RegisterServicesContext['config'],
+      jwtSecret: 'discovery-test-jwt',
+      daemonUrl: 'http://127.0.0.1:3030',
+      bundledUiAvailable: false,
+      DAEMON_PORT: 3030,
+      UI_PORT: 5173,
+      allowSuperadmin: false,
+      // Intentionally leave userless external calls intact: the authorization
+      // boundary must fail closed even without the upstream authentication hook.
+      requireAuth: async (context) => context,
+      deployment: {} as RegisterServicesContext['deployment'],
+    })
+  );
+  const params = (user?: AuthenticatedParams['user']): AuthenticatedParams => ({
+    provider: 'rest',
+    user,
+    tenant: { tenant_id: TENANT, source: 'auth_claim' },
+  });
+  const discover = (data: MCPDiscoveryRequest, caller: AuthenticatedParams) =>
+    app.service('mcp-servers/discover').create(data, caller);
+  return { rawDb, repository, owner, admin, unrelated, saved, shared, params, discover };
+}
+
+describe('saved MCP discovery caller authority', () => {
+  let h: Awaited<ReturnType<typeof createHarness>>;
+
+  beforeEach(async () => {
+    vi.stubEnv('AGOR_MASTER_SECRET', 'discovery-caller-test-master-secret');
+    connect.mockClear();
+    h = await createHarness();
+  });
+
+  afterEach(() => {
+    (h?.rawDb as unknown as { $client: { close(): void } })?.$client.close();
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  // Both paths must apply discovery authorization, including a submitted
+  // form snapshot accompanying a saved ID.
+  describe.each([false, true])('inline configuration: %s', (inline) => {
+    const request = (id: string): MCPDiscoveryRequest => ({
+      mcp_server_id: id,
+      ...(inline ? { url: 'https://untrusted.example.test/mcp', transport: 'http' } : {}),
+    });
+
+    it('denies a service account before capability capture or provider work', async () => {
+      const capture = vi.spyOn(UsersRepository.prototype, 'getDiscoveryAuthorityProjection');
+      const caller = h.params({
+        user_id: 'executor-service',
+        role: 'service',
+        _isServiceAccount: true,
+      } as unknown as NonNullable<AuthenticatedParams['user']>);
+      for (const server of [h.saved, h.shared]) {
+        await expect(h.discover(request(server.mcp_server_id), caller)).resolves.toEqual(denial);
+        expect(await h.repository.findById(server.mcp_server_id)).toEqual(server);
+      }
+      expect(capture).not.toHaveBeenCalled();
+      expect(connect).not.toHaveBeenCalled();
+    });
+
+    it.each(['owner', 'admin'] as const)(
+      'allows the %s and persists discovered capabilities',
+      async (kind) => {
+        const target = kind === 'owner' ? h.saved : h.shared;
+        await expect(
+          h.discover(request(target.mcp_server_id), h.params(h[kind]))
+        ).resolves.toMatchObject({ success: true, capabilities: { tools: 1 } });
+        expect(connect).toHaveBeenCalledOnce();
+        expect(await h.repository.findById(target.mcp_server_id)).toMatchObject({
+          tools: [{ name: 'discovered' }],
+        });
+      }
+    );
+
+    it('denies an unrelated member even when the row is visible', async () => {
+      await expect(
+        h.discover(request(h.shared.mcp_server_id), h.params(h.unrelated))
+      ).resolves.toEqual(denial);
+      await expect(
+        h.discover(request(h.saved.mcp_server_id), h.params(h.unrelated))
+      ).resolves.toMatchObject({ success: false });
+      expect(connect).not.toHaveBeenCalled();
+    });
+
+    it.each(['rest', 'socketio'])('fails closed for a userless %s caller', async (provider) => {
+      await expect(
+        h.discover(request(h.saved.mcp_server_id), { ...h.params(), provider })
+      ).rejects.toThrow(/authentication required/i);
+      expect(connect).not.toHaveBeenCalled();
+    });
+  });
+
+  it('does not read caller authority from query or body fields', async () => {
+    const spoof = {
+      provider: undefined,
+      user: { ...h.admin, _isServiceAccount: true },
+      owner_user_id: h.unrelated.user_id,
+      tenant: { tenant_id: 'spoofed-tenant', source: 'auth_claim' },
+    };
+    const data = { mcp_server_id: h.shared.mcp_server_id, ...spoof };
+    await expect(h.discover(data, { ...h.params(h.unrelated), query: spoof })).resolves.toEqual(
+      denial
+    );
+    await expect(h.discover(data, { ...h.params(), query: spoof })).rejects.toThrow(
+      /authentication required/i
+    );
+    expect(connect).not.toHaveBeenCalled();
+  });
+
+  it('rejects conflicting tenant authority before loading even an admin-visible saved ID', async () => {
+    // SQLite does not prove PostgreSQL RLS. This pins the changed endpoint's
+    // short-scope boundary: tenant B cannot enter A's scope using A's ID/params.
+    const lookup = vi.spyOn(MCPServerRepository.prototype, 'findById');
+    await expect(
+      runWithTenantContext('discovery-tenant-b', () =>
+        h.discover({ mcp_server_id: h.saved.mcp_server_id }, h.params(h.admin))
+      )
+    ).resolves.toMatchObject({ success: false });
+    expect(lookup).not.toHaveBeenCalled();
+    expect(connect).not.toHaveBeenCalled();
+  });
+
+  it('does not substitute a query/body tenant for missing trusted tenant context', async () => {
+    const spoof = { tenant: { tenant_id: TENANT, source: 'auth_claim' }, tenant_id: TENANT };
+    await expect(
+      h.discover(
+        { mcp_server_id: h.saved.mcp_server_id, ...spoof },
+        { ...h.params(h.admin), tenant: undefined, query: spoof }
+      )
+    ).resolves.toMatchObject({ success: false });
+    expect(connect).not.toHaveBeenCalled();
+    expect(await h.repository.findById(h.saved.mcp_server_id)).toEqual(h.saved);
+  });
+});

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -313,6 +313,7 @@ import {
   isSessionMcpServerLinkVisibleToCaller,
   loadMcpServerForCaller,
   registerMcpCapabilityRoleFloor,
+  resolveMcpCaller,
 } from './utils/mcp-server-authorization.js';
 import { resolveOwnerHomeStore, resolveSandboxStoragePaths } from './utils/sandbox-context.js';
 import {
@@ -5180,13 +5181,17 @@ export async function registerMCPServices(
     server: MCPServer,
     params?: AuthenticatedParams
   ): { success: false; error: string } | null => {
-    if (!params?.provider || !params.user) return null;
-    if (hasMinimumRole(params.user.role?.toLowerCase(), ROLES.ADMIN)) return null;
-    if (server.owner_user_id && server.owner_user_id === params.user.user_id) return null;
-    return {
-      success: false,
+    const caller = resolveMcpCaller(params);
+    if (caller.kind === 'internal' || caller.kind === 'service-account') return null;
+    const denial = {
+      success: false as const,
       error: 'Access denied: only an admin or the server owner can discover this MCP server',
     };
+    if (caller.kind === 'anonymous') return denial;
+    const user = caller.user;
+    if (hasMinimumRole(user.role?.toLowerCase(), ROLES.ADMIN)) return null;
+    if (server.owner_user_id && server.owner_user_id === user.user_id) return null;
+    return denial;
   };
 
   // Discover endpoint

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -5182,12 +5182,14 @@ export async function registerMCPServices(
     params?: AuthenticatedParams
   ): { success: false; error: string } | null => {
     const caller = resolveMcpCaller(params);
-    if (caller.kind === 'internal' || caller.kind === 'service-account') return null;
+    if (caller.kind === 'internal') return null;
     const denial = {
       success: false as const,
       error: 'Access denied: only an admin or the server owner can discover this MCP server',
     };
-    if (caller.kind === 'anonymous') return denial;
+    // Read visibility is not discovery authority: service accounts carry no
+    // membership or ownership and must not exercise a saved credential here.
+    if (caller.kind === 'anonymous' || caller.kind === 'service-account') return denial;
     const user = caller.user;
     if (hasMinimumRole(user.role?.toLowerCase(), ROLES.ADMIN)) return null;
     if (server.owner_user_id && server.owner_user_id === user.user_id) return null;

--- a/apps/agor-daemon/src/utils/mcp-server-authorization.test.ts
+++ b/apps/agor-daemon/src/utils/mcp-server-authorization.test.ts
@@ -10,6 +10,7 @@ import {
   isMcpServerUsableByCaller,
   isSessionMcpServerLinkVisibleToCaller,
   loadMcpServerForCaller,
+  resolveMcpCaller,
 } from './mcp-server-authorization.js';
 
 const { resolveMcpMemberPolicy, findById } = vi.hoisted(() => ({
@@ -641,5 +642,32 @@ describe('isSessionMcpServerLinkVisibleToCaller', () => {
         undefined
       )
     ).toBe(true);
+  });
+});
+
+describe('resolveMcpCaller', () => {
+  it('reads an absent provider as a daemon-internal call', () => {
+    expect(resolveMcpCaller(undefined)).toEqual({ kind: 'internal' });
+    expect(resolveMcpCaller({} as AuthenticatedParams)).toEqual({ kind: 'internal' });
+  });
+
+  it('reads an authenticated request carrying no user as anonymous, not as a service account', () => {
+    expect(resolveMcpCaller({ provider: 'rest' } as AuthenticatedParams)).toEqual({
+      kind: 'anonymous',
+    });
+  });
+
+  it('separates a service account from an ordinary user', () => {
+    const serviceAccount = {
+      provider: 'rest',
+      user: { user_id: 'svc-1', role: 'member', _isServiceAccount: true },
+    } as unknown as AuthenticatedParams;
+    expect(resolveMcpCaller(serviceAccount)).toEqual({ kind: 'service-account' });
+
+    const member = {
+      provider: 'rest',
+      user: { user_id: 'user-1', role: 'member' },
+    } as unknown as AuthenticatedParams;
+    expect(resolveMcpCaller(member)).toMatchObject({ kind: 'user', user: { user_id: 'user-1' } });
   });
 });

--- a/apps/agor-daemon/src/utils/mcp-server-authorization.ts
+++ b/apps/agor-daemon/src/utils/mcp-server-authorization.ts
@@ -53,6 +53,42 @@ import { runInOAuthTenantScope } from '../oauth-auth-helpers.js';
 
 export type McpServerWriteMethod = 'create' | 'update' | 'patch' | 'remove';
 
+/**
+ * Who is calling an MCP authorization boundary.
+ *
+ * `anonymous` is authenticated-but-userless. Every site must treat it as
+ * fail-closed; it is deliberately a separate case from `service-account` so
+ * neither can be reached by accident when only one was intended.
+ */
+export type McpCaller =
+  | { kind: 'internal' }
+  | { kind: 'service-account' }
+  | { kind: 'user'; user: NonNullable<AuthenticatedParams['user']> }
+  | { kind: 'anonymous' };
+
+/**
+ * Resolve the caller behind an MCP request.
+ *
+ * Feathers leaves `params.provider` undefined for internal, server-side calls
+ * and populates it for external transports, so its absence is what marks a
+ * daemon-internal caller — the same test each MCP site applied before this was
+ * consolidated. Service accounts are authenticated but carry no membership.
+ *
+ * Reading `params.user` before the service-account flag is what keeps
+ * "no user" and "service account" apart. Sites that folded them into one
+ * `||` branch could not tell them apart, and so let an authenticated caller
+ * with no user through on the service-account exemption.
+ */
+export function resolveMcpCaller(params: AuthenticatedParams | undefined): McpCaller {
+  if (!params?.provider) return { kind: 'internal' };
+  const user = params.user;
+  if (!user) return { kind: 'anonymous' };
+  if ((user as { _isServiceAccount?: boolean })._isServiceAccount === true) {
+    return { kind: 'service-account' };
+  }
+  return { kind: 'user', user };
+}
+
 export interface McpServerWriteRequest {
   method: McpServerWriteMethod;
   /** The row being changed or deleted; absent on create. */
@@ -460,10 +496,10 @@ async function decidePolicyAndOwnership(
 ): Promise<McpServerWriteDecision> {
   // Internal daemon calls and explicit daemon service accounts are not members;
   // they carry no policy and no ownership, matching `ensureMinimumRole`.
-  if (!params?.provider) return {};
-  const user = params.user;
-  if (!user) throw new NotAuthenticated('Authentication required');
-  if ((user as { _isServiceAccount?: boolean })._isServiceAccount === true) return {};
+  const caller = resolveMcpCaller(params);
+  if (caller.kind === 'internal' || caller.kind === 'service-account') return {};
+  if (caller.kind === 'anonymous') throw new NotAuthenticated('Authentication required');
+  const user = caller.user;
 
   // Keep the role floor ahead of identity validation and all policy/database
   // work. Authentication supplies the users-table key; short IDs are public
@@ -494,11 +530,12 @@ async function decidePolicyAndOwnership(
   // use one they do not own — that is the session-side rule, not this one.
   if (isAdmin) return {};
 
-  const policy = await resolveMcpMemberPolicy(db, userId, params.tenant?.tenant_id);
+  const policy = await resolveMcpMemberPolicy(db, userId, params?.tenant?.tenant_id);
   // Only the marketplace connect service sets this, and it cannot arrive on a
   // request — see `McpCatalogInstallParams`. So it is a safe way to tell the
   // caller which of the two things they were refused.
-  const isCatalogInstall = (params as McpCatalogInstallParams).mcpCatalogInstall !== undefined;
+  const isCatalogInstall =
+    (params as McpCatalogInstallParams | undefined)?.mcpCatalogInstall !== undefined;
   assertPolicyAllowsWrite(policy, isCatalogInstall);
 
   if (request.method === 'create') {
@@ -636,10 +673,10 @@ export function isSessionMcpServerLinkVisibleToCaller(
   row: SessionMcpServerVisibilityRow,
   params: AuthenticatedParams | undefined
 ): boolean {
-  if (!params?.provider) return true;
-  const user = params.user;
-  if (!user) return false;
-  if ((user as { _isServiceAccount?: boolean })._isServiceAccount) return true;
+  const caller = resolveMcpCaller(params);
+  if (caller.kind === 'internal' || caller.kind === 'service-account') return true;
+  if (caller.kind === 'anonymous') return false;
+  const user = caller.user;
   if (hasMinimumRole(user.role, ROLES.ADMIN)) return true;
   return isMCPServerUsableBy(row, row.session_created_by) && isMCPServerUsableBy(row, user.user_id);
 }
@@ -648,10 +685,10 @@ export function isMcpServerUsableByCaller(
   server: MCPServer,
   params: AuthenticatedParams | undefined
 ): boolean {
-  if (!params?.provider) return true;
-  const user = params.user;
-  if (!user) return false;
-  if ((user as { _isServiceAccount?: boolean })._isServiceAccount) return true;
+  const caller = resolveMcpCaller(params);
+  if (caller.kind === 'internal' || caller.kind === 'service-account') return true;
+  if (caller.kind === 'anonymous') return false;
+  const user = caller.user;
   return hasMinimumRole(user.role, ROLES.ADMIN) || isMCPServerUsableBy(server, user.user_id);
 }
 
@@ -668,8 +705,9 @@ export async function loadMcpServerForCaller(
   const server = await new MCPServerRepository(db).findById(serverId);
   if (!server) throw new NotFound(`MCP server not found: ${serverId}`);
 
-  if (!params?.provider) return server;
-  if (!params.user) throw new NotAuthenticated('Authentication required');
+  const caller = resolveMcpCaller(params);
+  if (caller.kind === 'internal') return server;
+  if (caller.kind === 'anonymous') throw new NotAuthenticated('Authentication required');
   if (isMcpServerUsableByCaller(server, params)) return server;
 
   // Avoid an existence oracle for private server definitions.


### PR DESCRIPTION
## What

Consolidates the caller-trust prelude that seven MCP authorization sites each wrote for themselves,
into one `resolveMcpCaller()` returning a discriminated union. Every site switches on it, and
"authenticated with no `params.user`" now fails closed everywhere.

## Why

The seven sites disagreed about that one case:

| Site | `params.user` absent → |
|---|---|
| `decidePolicyAndOwnership` | `throw NotAuthenticated` |
| `loadMcpServerForCaller` | `throw NotAuthenticated` |
| `isSessionMcpServerLinkVisibleToCaller` | `return false` |
| `isMcpServerUsableByCaller` | `return false` |
| `scopeMcpServerFindToUsable` | `return context` — **allow, unscoped** |
| `denyMcpServerGetOfAnotherUsersPrivate` | `return context` — **allow** |
| `denyDiscoverOfAnotherUsersServer` | `return null` — **allow** |

**The cause is ordering.** The four utilities read the user first and only then exempt service
accounts, so a missing user is its own case:

```ts
if (!user) throw new NotAuthenticated('Authentication required');
if (user._isServiceAccount) return {};
```

The other three folded both into one condition, which structurally cannot tell them apart:

```ts
if (!user || user._isServiceAccount) return context;
```

So an authenticated caller with no user was admitted on the service account's exemption. On `find`
that left the query unscoped — the caller would have received every MCP server in the tenant rather
than the ones they may use.

**This is latent, not a live hole.** `requireAuth` populates `params.user` ahead of every one of
these paths (`register-hooks.ts`, `all: [requireAuth, …]`), and `denyDiscoverOfAnotherUsersServer`
additionally runs *after* `loadMcpServerForCaller`, which already denies. Worth stating plainly: the
issue says the same, and this PR should not be read as fixing an exploitable bug. It removes a
safety property that depends on something outside the file staying true.

## How

`resolveMcpCaller(params)` returns `internal | service-account | user | anonymous`. Making
`anonymous` a distinct member is the point — a site can no longer reach the service-account branch
by accident when only that was intended.

The `!params?.provider` test for "internal" is lifted unchanged: it is already the convention at all
seven sites and elsewhere in the same files, and is Feathers' own (`provider` is set for external
transports, undefined for server-side calls). The helper carries a doc comment explaining it, since
the check now lives in one place rather than seven.

**Three sites change behaviour** — `scopeMcpServerFindToUsable`, `denyMcpServerGetOfAnotherUsersPrivate`,
and `denyDiscoverOfAnotherUsersServer` now deny an anonymous caller instead of passing it through.

### Scope

`_isServiceAccount` appears ~80 times across ~21 files in `apps/agor-daemon/src`. This PR touches
**only the seven MCP sites the issue names**. Generalising the helper across branches, boards,
schedules and users is a much larger change, and I'd rather it be asked for than assumed — happy to
follow up with it.

Line numbers moved since the issue was written (`b1f14837` → `0fb3643`); each site was re-verified
against current `main`.

## Testing

New `register-hooks.mcp-caller-trust.test.ts` drives the hooks through the chains `registerHooks`
actually installs, following the harness in `register-hooks.viewer-mcp-floor.test.ts`:

- a `find` with no user is refused instead of running unscoped — **fails before this change**
- a `get` with no user is refused instead of returning the row — **fails before this change**
- a genuine service account is **still** exempt on `find` (query left unscoped) — passed before and
  after

That last pair is the one that matters: `anonymous` and `service-account` used to share a single
`||` branch, so the risk in closing one was taking the other down with it. Both directions are
pinned.

Also added three `resolveMcpCaller` unit tests covering the four caller kinds.

- `@agor/daemon`: 4206 passed.
- `pnpm typecheck` 21/21, `pnpm lint` clean.

Three pre-existing failures in `sandbox-context.test.ts` and `spawn-executor.configured.test.ts`
(symlink canonicalization / bubblewrap) reproduce identically on a clean `main` on this machine and
are unrelated to this change.

Closes #2297
