### PR TITLE
fix(opencode): decouple model catalog from runtime binary

### DIFF
--- a/apps/agor-daemon/src/integrations/opencode/models-service.test.ts
+++ b/apps/agor-daemon/src/integrations/opencode/models-service.test.ts
@@ -3,11 +3,6 @@ import { runWithTenantContext, UsersRepository } from '@agor/core/db';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createOpenCodeModelsService } from './models-service';
 
-const resolveBinary = vi.hoisted(() => vi.fn());
-vi.mock('@agor/agentic-tool-opencode/runtime/binary', () => ({
-  resolvePackagedOpenCodeBinary: resolveBinary,
-}));
-
 vi.mock('@agor/core/config', async () => {
   const actual = await vi.importActual<typeof import('@agor/core/config')>('@agor/core/config');
   return {
@@ -79,7 +74,6 @@ beforeEach(() => {
     return { findById: vi.fn(async () => ({ unix_username: 'alice' })) };
   } as never);
   runCommand.mockResolvedValue({ success: true, data: catalog });
-  resolveBinary.mockResolvedValue('/packaged/opencode');
 });
 
 describe('OpenCode model catalog service', () => {
@@ -101,10 +95,6 @@ describe('OpenCode model catalog service', () => {
     const result = await runWithTenantContext('tenant-a', () => service().find(params));
 
     expect(result).toEqual(catalog);
-    expect(resolveBinary).toHaveBeenCalledOnce();
-    expect(resolveBinary.mock.invocationCallOrder[0]).toBeLessThan(
-      runCommand.mock.invocationCallOrder[0] ?? Infinity
-    );
     expect(runCommand).toHaveBeenCalledWith(
       expect.objectContaining({
         command: 'agentic-tool.invoke',
@@ -119,25 +109,46 @@ describe('OpenCode model catalog service', () => {
     );
   });
 
-  it.each(['missing', 'not executable'])(
-    'uses catalog readiness failure when the packaged binary is %s',
-    async () => {
-      resolveBinary.mockRejectedValueOnce(new Error('private binary detail'));
+  it('reads the server-free catalog without daemon runtime binary preflight', async () => {
+    await runWithTenantContext('tenant-a', async () => {
+      await expect(service().find(params)).resolves.toEqual(catalog);
+    });
 
-      await runWithTenantContext('tenant-a', async () => {
-        await expect(service().find(params)).rejects.toThrow(MODEL_CATALOG_ERROR);
-      });
-      expect(runCommand).not.toHaveBeenCalled();
-    }
-  );
+    expect(runCommand).toHaveBeenCalledOnce();
+  });
 
-  it('uses catalog readiness failure for an SDK/CLI version mismatch', async () => {
-    resolveBinary.mockRejectedValueOnce(new Error('private SDK/CLI versions'));
+  it.each([
+    undefined,
+    {},
+    { runtimeVersion: '1.14.33' },
+    { runtimeVersion: '1.14.33', providers: [{}] },
+    { runtimeVersion: '1.14.33', providers: [], suggestedSelection: { providerId: 'openai' } },
+    {
+      runtimeVersion: '1.14.33',
+      providers: [
+        {
+          id: 'openai',
+          name: 'OpenAI',
+          availableForSelection: true,
+          models: [{ id: 'gpt-test', name: 'GPT test', status: 'unknown' }],
+        },
+      ],
+    },
+  ])('rejects malformed executor catalog data without exposing details', async (data) => {
+    runCommand.mockResolvedValueOnce({ success: true, data });
 
     await runWithTenantContext('tenant-a', async () => {
       await expect(service().find(params)).rejects.toThrow(MODEL_CATALOG_ERROR);
     });
-    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  it('accepts an empty valid catalog so the UI can keep exact manual entry available', async () => {
+    const empty = { runtimeVersion: '1.14.33', providers: [] };
+    runCommand.mockResolvedValueOnce({ success: true, data: empty });
+
+    await runWithTenantContext('tenant-a', async () => {
+      await expect(service().find(params)).resolves.toEqual(empty);
+    });
   });
 
   it('routes identical user IDs in different tenants to isolated opaque namespaces', async () => {

--- a/apps/agor-daemon/src/integrations/opencode/models-service.test.ts
+++ b/apps/agor-daemon/src/integrations/opencode/models-service.test.ts
@@ -122,6 +122,10 @@ describe('OpenCode model catalog service', () => {
     {},
     { runtimeVersion: '1.14.33' },
     { runtimeVersion: '1.14.33', providers: [{}] },
+    ...[null, false, 1, 'invalid', []].map((suggestedSelection) => ({
+      ...catalog,
+      suggestedSelection,
+    })),
     { runtimeVersion: '1.14.33', providers: [], suggestedSelection: { providerId: 'openai' } },
     {
       runtimeVersion: '1.14.33',
@@ -138,7 +142,11 @@ describe('OpenCode model catalog service', () => {
     runCommand.mockResolvedValueOnce({ success: true, data });
 
     await runWithTenantContext('tenant-a', async () => {
-      await expect(service().find(params)).rejects.toThrow(MODEL_CATALOG_ERROR);
+      await expect(service().find(params)).rejects.toMatchObject({
+        name: 'BadRequest',
+        code: 400,
+        message: MODEL_CATALOG_ERROR,
+      });
     });
   });
 
@@ -148,6 +156,18 @@ describe('OpenCode model catalog service', () => {
 
     await runWithTenantContext('tenant-a', async () => {
       await expect(service().find(params)).resolves.toEqual(empty);
+    });
+  });
+
+  it('preserves a valid suggested provider/model selection', async () => {
+    const data = {
+      ...catalog,
+      suggestedSelection: { providerId: 'openai', modelId: 'gpt-5' },
+    };
+    runCommand.mockResolvedValueOnce({ success: true, data });
+
+    await runWithTenantContext('tenant-a', async () => {
+      await expect(service().find(params)).resolves.toEqual(data);
     });
   });
 

--- a/apps/agor-daemon/src/integrations/opencode/models-service.ts
+++ b/apps/agor-daemon/src/integrations/opencode/models-service.ts
@@ -20,7 +20,10 @@ function isOpenCodeModelCatalog(value: unknown): value is OpenCodeModelCatalog {
   if (!isString(catalog.runtimeVersion) || !Array.isArray(catalog.providers)) return false;
   if (
     catalog.suggestedSelection !== undefined &&
-    (!isString(catalog.suggestedSelection.providerId) ||
+    (!catalog.suggestedSelection ||
+      typeof catalog.suggestedSelection !== 'object' ||
+      Array.isArray(catalog.suggestedSelection) ||
+      !isString(catalog.suggestedSelection.providerId) ||
       !isString(catalog.suggestedSelection.modelId))
   ) {
     return false;

--- a/apps/agor-daemon/src/integrations/opencode/models-service.ts
+++ b/apps/agor-daemon/src/integrations/opencode/models-service.ts
@@ -1,4 +1,3 @@
-import { resolvePackagedOpenCodeBinary } from '@agor/agentic-tool-opencode/runtime/binary';
 import type { AgorConfig } from '@agor/core/config';
 import type { TenantScopeAwareDatabase } from '@agor/core/db';
 import { BadRequest } from '@agor/core/feathers';
@@ -9,6 +8,40 @@ import { startOpenCodeExecutorInvocation } from './executor-command.js';
 import { blockOpenCodeNativeStateNamespace } from './native-state-coordinator.js';
 
 const MODEL_CATALOG_FAILURE = 'OpenCode model catalog could not be loaded. Try again.';
+const OPEN_CODE_MODEL_STATUSES = new Set(['active', 'alpha', 'beta', 'deprecated']);
+
+function isString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function isOpenCodeModelCatalog(value: unknown): value is OpenCodeModelCatalog {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const catalog = value as Partial<OpenCodeModelCatalog>;
+  if (!isString(catalog.runtimeVersion) || !Array.isArray(catalog.providers)) return false;
+  if (
+    catalog.suggestedSelection !== undefined &&
+    (!isString(catalog.suggestedSelection.providerId) ||
+      !isString(catalog.suggestedSelection.modelId))
+  ) {
+    return false;
+  }
+  return catalog.providers.every(
+    (provider) =>
+      provider &&
+      isString(provider.id) &&
+      isString(provider.name) &&
+      typeof provider.availableForSelection === 'boolean' &&
+      (provider.suggestedModel === undefined || isString(provider.suggestedModel)) &&
+      Array.isArray(provider.models) &&
+      provider.models.every(
+        (model) =>
+          model &&
+          isString(model.id) &&
+          isString(model.name) &&
+          OPEN_CODE_MODEL_STATUSES.has(model.status)
+      )
+  );
+}
 
 async function readModelCatalog(
   db: TenantScopeAwareDatabase,
@@ -18,7 +51,6 @@ async function readModelCatalog(
   const context = await resolveAuthenticatedOpenCodeSubjectContext(db, config, params);
   let result: ExecutorCommandResult;
   try {
-    await resolvePackagedOpenCodeBinary();
     const handle = startOpenCodeExecutorInvocation(
       context.dataHome,
       { operation: 'read-model-catalog' },
@@ -34,10 +66,10 @@ async function readModelCatalog(
   } catch {
     throw new BadRequest(MODEL_CATALOG_FAILURE);
   }
-  if (!result.success || !result.data) {
+  if (!result.success || !isOpenCodeModelCatalog(result.data)) {
     throw new BadRequest(MODEL_CATALOG_FAILURE);
   }
-  return result.data as OpenCodeModelCatalog;
+  return result.data;
 }
 
 export class OpenCodeModelsService {

--- a/apps/agor-ui/src/hooks/useSessionActions.browser.test.tsx
+++ b/apps/agor-ui/src/hooks/useSessionActions.browser.test.tsx
@@ -1,0 +1,45 @@
+import type { AgorClient, Session } from '@agor-live/client';
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useSessionActions } from './useSessionActions';
+
+describe('OpenCode session creation (real browser)', () => {
+  it('submits one exact fictional provider/model pair to the sessions service', async () => {
+    const session = {
+      session_id: 'fictional-opencode-session',
+      branch_id: 'fictional-branch',
+      agentic_tool: 'opencode',
+      status: 'idle',
+    } as Session;
+    const create = vi.fn(async () => session);
+    const client = {
+      service: vi.fn((name: string) => {
+        if (name === 'sessions') return { create };
+        throw new Error(`Unexpected service: ${name}`);
+      }),
+    } as unknown as AgorClient;
+    const { result } = renderHook(() => useSessionActions(client));
+
+    await act(async () => {
+      await expect(
+        result.current.createSession({
+          branch_id: 'fictional-branch',
+          agent: 'opencode',
+          modelConfig: { mode: 'exact', provider: 'opencode', model: 'big-pickle' },
+        })
+      ).resolves.toBe(session);
+    });
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentic_tool: 'opencode',
+        branch_id: 'fictional-branch',
+        model_config: expect.objectContaining({
+          mode: 'exact',
+          provider: 'opencode',
+          model: 'big-pickle',
+        }),
+      })
+    );
+  });
+});

--- a/scripts/daemon-filesystem-exceptions.json
+++ b/scripts/daemon-filesystem-exceptions.json
@@ -1106,34 +1106,6 @@
     "reviewDate": null
   },
   {
-    "id": "DAEMON-FS-CAP-OPENCODE-014",
-    "class": "A",
-    "file": "packages/agentic-tool-opencode/src/runtime/binary.ts",
-    "import": "node:fs/promises",
-    "symbol": "access",
-    "local": "access",
-    "operation": "call:access@isExecutable#1",
-    "owner": "daemon OpenCode runtime readiness",
-    "boundary": "operator-controlled executable discovery",
-    "rationale": "Checks executability only for the operator-configured AGOR_OPENCODE_PATH or candidates derived from the daemon PATH; no tenant or request path is accepted.",
-    "reviewTarget": null,
-    "reviewDate": null
-  },
-  {
-    "id": "DAEMON-FS-CAP-OPENCODE-015",
-    "class": "A",
-    "file": "packages/agentic-tool-opencode/src/runtime/binary.ts",
-    "import": "node:child_process",
-    "symbol": "spawn",
-    "local": "spawn",
-    "operation": "call:spawn@readOpenCodeCommandVersion#1",
-    "owner": "daemon OpenCode runtime readiness",
-    "boundary": "operator-controlled executable discovery",
-    "rationale": "Runs only the resolved operator-installed OpenCode executable with the fixed --version argument to enforce compatibility with Agor's pinned SDK; no tenant-controlled command or arguments are accepted.",
-    "reviewTarget": null,
-    "reviewDate": null
-  },
-  {
     "id": "DAEMON-FS-CAP-170",
     "class": "A",
     "file": "packages/core/src/agentic-integrations.ts",


### PR DESCRIPTION
## Root cause
The daemon performed packaged OpenCode binary discovery/version validation before requesting the server-free model catalog. A runtime-resolution failure therefore prevented model selection and session creation even though catalog discovery itself does not need a running or locally resolved binary.

## Scope
- remove the daemon-side runtime-binary preflight from catalog discovery;
- validate the contained executor response structurally and retain the sanitized catalog error for malformed or failed results;
- retain per-user opaque namespace isolation and credential redaction coverage;
- add a Chromium session-creation smoke using fictional provider/model data;
- remove the now-unreachable daemon filesystem capability exceptions.

Actual OpenCode execution still validates the packaged binary and version at execution time. This does not add a paid-model fallback or change provider authentication behavior.

## Validation
- focused daemon catalog tests (12 passed)
- OpenCode runtime suite (18 files, 146 tests passed)
- Chromium browser smoke (4 browser instances passed)
- full UI suite (307 files, 2,265 tests passed)
- daemon/UI typechecks and production builds passed
- Biome/lint, multitenancy, daemon-filesystem, realtime, and short-ID boundary gates passed

The full daemon suite otherwise passed 330 files / 4,237 tests; three existing host-platform sandbox-path/containment tests fail before this change and are unrelated to the OpenCode paths modified here.

## Risk and rollback
Catalog discovery can now succeed when runtime validation would later reject execution; that validation remains intentionally enforced when a session runs. Revert this single commit to restore the previous behavior.
