### PR TITLE
fix(ui): make disabled MCP chips removable and stabilize picker popups

### DIFF
--- a/apps/agor-ui/src/components/MCPServerSelect/MCPServerSelect.browser.test.tsx
+++ b/apps/agor-ui/src/components/MCPServerSelect/MCPServerSelect.browser.test.tsx
@@ -1,20 +1,23 @@
-import type { Branch, MCPServer, Repo } from '@agor-live/client';
-import { act, cleanup, render, screen } from '@testing-library/react';
-import { App, ConfigProvider, Modal, theme } from 'antd';
+import type { Branch, MCPServer, Repo, User } from '@agor-live/client';
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import { App, Button, ConfigProvider, Drawer, Grid, Modal, Tabs, theme } from 'antd';
 import { useState } from 'react';
 import { afterEach, expect, it, vi } from 'vitest';
 import { userEvent } from 'vitest/browser';
+import { ConnectionProvider } from '../../contexts/ConnectionContext';
+import { __resetAuthConfigForTests, __setAuthConfigForTests } from '../../hooks/useAuthConfig';
 import { agorStore } from '../../store/agorStore';
 import { GeneralTab } from '../BranchModal/tabs/GeneralTab';
 import type { GeneralFormState } from '../BranchModal/useBranchModalForm';
 import { NewSessionModal } from '../NewSessionModal/NewSessionModal';
+import { UserSettingsModal } from '../SettingsModal/UserSettingsModal';
 
 const enabledId = '01900000-0000-7000-8000-000000000001';
 const disabledId = '01900000-0000-7000-8000-000000000002';
 const unavailableId = '01900000-0000-7000-8000-000000000003';
 const servers = [
   { mcp_server_id: enabledId, name: 'Enabled', enabled: true, transport: 'http' },
-  { mcp_server_id: disabledId, name: 'Disabled', enabled: false, transport: 'http' },
+  { mcp_server_id: disabledId, name: 'Paused integration', enabled: false, transport: 'http' },
   ...Array.from({ length: 10 }, (_, index) => ({
     mcp_server_id: `extra-${index}`,
     name: `Extra ${index}`,
@@ -42,10 +45,12 @@ const branch: Branch = {
 
 afterEach(() => {
   cleanup();
-  agorStore.setState({ mcpServerById: new Map() });
+  agorStore.setState({ mcpServerById: new Map(), agenticToolSettingsHydrated: false });
+  __resetAuthConfigForTests();
 });
 
 function GeneralSurface({ canEdit = true }: { canEdit?: boolean }) {
+  const compact = !Grid.useBreakpoint().md;
   const [state, setState] = useState<GeneralFormState>({
     boardId: undefined,
     issueUrl: '',
@@ -53,23 +58,84 @@ function GeneralSurface({ canEdit = true }: { canEdit?: boolean }) {
     notes: '',
     mcpServerIds: branch.mcp_server_ids ?? [],
   });
-  return (
+  // BranchModal's real responsive shell: bottom 94dvh drawer on phones,
+  // header/tabs/footer plus a separately scrolling body on both presentations.
+  const contents = (
+    <Tabs
+      items={[
+        {
+          key: 'general',
+          label: 'General',
+          children: (
+            <GeneralTab
+              branch={branch}
+              repo={{ name: 'Fixture' } as Repo}
+              sessions={[]}
+              mcpServers={servers}
+              canEdit={canEdit}
+              state={state}
+              setField={(key, value) => setState((prev) => ({ ...prev, [key]: value }))}
+            />
+          ),
+        },
+      ]}
+    />
+  );
+  const footer = <Button>Save</Button>;
+  return compact ? (
+    <Drawer
+      open
+      title="Teammate / General"
+      placement="bottom"
+      size="94dvh"
+      footer={footer}
+      styles={{ body: { padding: '12px 16px', overflowY: 'auto' } }}
+    >
+      {contents}
+    </Drawer>
+  ) : (
     <Modal
       open
       title="Teammate / General"
-      footer={null}
-      styles={{ body: { maxHeight: '80vh', overflowY: 'auto' } }}
+      width={900}
+      footer={footer}
+      styles={{ body: { padding: 0, maxHeight: '80vh', overflowY: 'auto' } }}
     >
-      <GeneralTab
-        branch={branch}
-        repo={{ name: 'Fixture' } as Repo}
-        sessions={[]}
-        mcpServers={servers}
-        canEdit={canEdit}
-        state={state}
-        setField={(key, value) => setState((prev) => ({ ...prev, [key]: value }))}
-      />
+      {contents}
     </Modal>
+  );
+}
+
+const user = {
+  user_id: 'fixture-user',
+  name: 'Fixture member',
+  email: 'fixture@example.test',
+  role: 'member',
+  default_mcp_server_ids: branch.mcp_server_ids,
+  default_agentic_config: {},
+} as User;
+
+function SettingsSurface() {
+  return (
+    <ConnectionProvider
+      value={{
+        connected: true,
+        connecting: false,
+        authGeneration: 1,
+        outOfSync: false,
+        capturedSha: null,
+        currentSha: null,
+      }}
+    >
+      <UserSettingsModal
+        open
+        user={user}
+        currentUser={user}
+        client={null}
+        initialTab="claude-code"
+        onClose={vi.fn()}
+      />
+    </ConnectionProvider>
   );
 }
 
@@ -77,18 +143,24 @@ function expectAnchoredAndUnclipped(input: HTMLElement) {
   const trigger = input.closest('.ant-select')!;
   const popup = document.querySelector('.ant-select-dropdown:not(.ant-select-dropdown-hidden)')!;
   expect(popup).not.toBeNull();
-  expect(
-    (
-      trigger.closest('.ant-popover, .ant-modal-container, .ant-drawer-content') ??
-      trigger.parentElement
-    )?.contains(popup)
-  ).toBe(true);
+  expect(popup.parentElement).toBe(document.body);
   const box = popup.getBoundingClientRect();
   const anchor = trigger.getBoundingClientRect();
-  if (Math.max(anchor.top, window.innerHeight - anchor.bottom) >= box.height + 4) {
-    expect(
-      Math.min(Math.abs(box.top - anchor.bottom), Math.abs(box.bottom - anchor.top))
-    ).toBeLessThan(12);
+  // Never excuse overlap just because a viewport is short. Shrink the list.
+  expect(box.bottom <= anchor.top + 1 || box.top >= anchor.bottom - 1).toBe(true);
+  expect(
+    Math.min(Math.abs(box.top - anchor.bottom), Math.abs(box.bottom - anchor.top)),
+    JSON.stringify({
+      anchor: anchor.toJSON(),
+      box: box.toJSON(),
+      style: popup.getAttribute('style'),
+    })
+  ).toBeLessThan(12);
+  // Every remove control AND the input must still win hit testing while open.
+  for (const control of [input, ...trigger.querySelectorAll('.ant-select-selection-item-remove')]) {
+    const rect = control.getBoundingClientRect();
+    const hit = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
+    expect(control.contains(hit), control.outerHTML).toBe(true);
   }
   expect(box.left).toBeGreaterThanOrEqual(-1);
   expect(box.right).toBeLessThanOrEqual(window.innerWidth + 1);
@@ -106,10 +178,12 @@ function expectAnchoredAndUnclipped(input: HTMLElement) {
   }
 }
 
-it.each(['New Session', 'Teammate / General'] as const)(
+it.each(['New Session', 'Teammate / General', 'User Settings'] as const)(
   '%s keeps removal, focus, and popup anchoring through scrolling',
   async (surface) => {
+    __setAuthConfigForTests({ requireAuth: false });
     agorStore.setState({
+      agenticToolSettingsHydrated: true,
       mcpServerById: new Map(servers.map((server) => [server.mcp_server_id, server])),
     });
     render(
@@ -125,6 +199,8 @@ it.each(['New Session', 'Teammate / General'] as const)(
               onClose={vi.fn()}
               onCreate={vi.fn(async () => null)}
             />
+          ) : surface === 'User Settings' ? (
+            <SettingsSurface />
           ) : (
             <GeneralSurface />
           )}
@@ -134,21 +210,47 @@ it.each(['New Session', 'Teammate / General'] as const)(
     if (surface === 'New Session') {
       await act(() => userEvent.click(screen.getByTestId('mcp-chip')));
     }
+    if (surface === 'User Settings') {
+      await act(() => userEvent.click(screen.getByRole('tab', { name: 'Session defaults' })));
+    }
     const input =
       surface === 'New Session'
         ? screen.getByRole('combobox', { name: '' })
-        : screen.getAllByRole('combobox').at(-1)!;
-    if (surface === 'Teammate / General') input.scrollIntoView({ block: 'center' });
+        : surface === 'User Settings'
+          ? screen.getByRole('combobox', { name: 'MCP Servers' })
+          : screen.getAllByRole('combobox').at(-1)!;
+    if (surface !== 'New Session') input.scrollIntoView({ block: 'center' });
+    if (window.innerWidth < 768 && surface !== 'New Session') {
+      expect(input.closest('.ant-drawer-section')).not.toBeNull();
+    }
     await act(() => userEvent.click(input));
-    await vi.waitFor(() => expectAnchoredAndUnclipped(input));
-    // Backspace must remove the final disabled attachment, not skip over it.
+    await waitFor(() => expectAnchoredAndUnclipped(input));
+    const selectedDisabled = input
+      .closest('.ant-select')!
+      .querySelector('[title="Disabled · Paused integration (http)"]');
+    expect(selectedDisabled).not.toBeNull();
+    expect(selectedDisabled).toHaveTextContent('Disabled ·');
+    const statusText = selectedDisabled!.querySelector('.ant-select-selection-item-content')!;
+    const statusRange = document.createRange();
+    statusRange.setStart(statusText.firstChild!, 0);
+    statusRange.setEnd(statusText.firstChild!, 'Disabled'.length);
+    // Status must remain visible before the label's native ellipsis.
+    expect(statusRange.getBoundingClientRect().right).toBeLessThanOrEqual(
+      statusText.getBoundingClientRect().right
+    );
+
+    await act(() => userEvent.type(input, 'Paused'));
+    // Native option accessible names include the status, not just color/title.
+    expect(
+      screen.getByRole('option', { name: 'Disabled · Paused integration (http)' })
+    ).toBeInTheDocument();
+    await act(() => userEvent.clear(input));
+    // Select guards against one held Backspace erasing search AND tags (250ms).
+    await act(() => new Promise((resolve) => setTimeout(resolve, 300)));
     await act(() => userEvent.keyboard('{Backspace}'));
-    expect(screen.queryByText('Disabled (http)')).not.toBeInTheDocument();
+    expect(screen.queryByText('Disabled · Paused integration (http)')).not.toBeInTheDocument();
     expect(input).toHaveFocus();
-    // On short viewports a tall list may shift across the field. Dismiss it
-    // before using the chip's mouse affordance; Escape must retain focus.
-    await act(() => userEvent.keyboard('{Escape}'));
-    expect(input).toHaveFocus();
+    await waitFor(() => expectAnchoredAndUnclipped(input));
     const trigger = input.closest('.ant-select')!;
     const unavailable = Array.from(trigger.querySelectorAll('.ant-select-selection-item')).find(
       (tag) => tag.textContent?.includes('Unavailable')
@@ -158,7 +260,36 @@ it.each(['New Session', 'Teammate / General'] as const)(
     );
     expect(trigger.textContent).not.toContain('Unavailable');
     expect(input).toHaveFocus();
+    await waitFor(() => expectAnchoredAndUnclipped(input));
+    // Search and keyboard-select a new attachment; removed disabled/unavailable
+    // entries are not offered anew. Escape retains the native input focus.
+    await act(() => userEvent.type(input, 'Extra 9'));
+    await act(() => userEvent.keyboard('{ArrowDown}{Enter}'));
+    expect(trigger.textContent).toContain('Extra 9');
+    expect(trigger.textContent).not.toContain('Paused integration');
+    await act(() => userEvent.keyboard('{Escape}'));
+    expect(input).toHaveFocus();
     await act(() => userEvent.keyboard('{ArrowDown}'));
+    await waitFor(() => expectAnchoredAndUnclipped(input));
+    // Exercise real wheel scrolling, not only search/virtual-list geometry.
+    const dropdown = document.querySelector(
+      '.ant-select-dropdown:not(.ant-select-dropdown-hidden)'
+    )!;
+    await act(() => userEvent.wheel(dropdown, { delta: { y: 1000 } }));
+    const lastOption = Array.from(dropdown.querySelectorAll('.ant-select-item-option')).find(
+      (option) => option.textContent?.includes('Extra 9')
+    )!;
+    await waitFor(() => {
+      const rect = lastOption.getBoundingClientRect();
+      expect(
+        lastOption.contains(
+          document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2)
+        )
+      ).toBe(true);
+    });
+    await act(() => userEvent.click(lastOption));
+    expect(trigger.textContent).not.toContain('Extra 9');
+    expect(input).toHaveFocus();
 
     // New Session's picker is portaled into a popover, so its originating
     // chip's modal scroll owners must also move while the dropdown is open.
@@ -179,16 +310,18 @@ it.each(['New Session', 'Teammate / General'] as const)(
       const before = parent.scrollTop;
       await act(async () => {
         parent.scrollTop = before > 24 ? before - 24 : before + 24;
+        // Wait for the actual browser scroll event, not the synchronous assignment.
+        await new Promise(requestAnimationFrame);
       });
       if (parent.scrollTop === before) continue;
       scrolled = true;
-      await vi.waitFor(() => expectAnchoredAndUnclipped(input));
+      await waitFor(() => expectAnchoredAndUnclipped(input));
     }
     if (window.innerHeight < 600) expect(scrolled).toBe(true);
     await act(() => userEvent.keyboard('{Escape}'));
     expect(input).toHaveFocus();
     await act(() => userEvent.keyboard('{ArrowDown}'));
-    await vi.waitFor(() => expectAnchoredAndUnclipped(input));
+    await waitFor(() => expectAnchoredAndUnclipped(input));
     expect(document.documentElement.scrollWidth).toBeLessThanOrEqual(window.innerWidth + 1);
   }
 );
@@ -204,6 +337,6 @@ it('Teammate / General respects read-only capability state', async () => {
   expect(
     input.closest('.ant-select')?.querySelector('.ant-select-selection-item-remove')
   ).toBeNull();
-  expect(screen.getByText('Disabled (http)')).toBeInTheDocument();
+  expect(screen.getByText('Disabled · Paused integration (http)')).toBeInTheDocument();
   expect(screen.getByText(/Unavailable MCP server/)).toBeInTheDocument();
 });

--- a/apps/agor-ui/src/components/MCPServerSelect/MCPServerSelect.browser.test.tsx
+++ b/apps/agor-ui/src/components/MCPServerSelect/MCPServerSelect.browser.test.tsx
@@ -1,0 +1,209 @@
+import type { Branch, MCPServer, Repo } from '@agor-live/client';
+import { act, cleanup, render, screen } from '@testing-library/react';
+import { App, ConfigProvider, Modal, theme } from 'antd';
+import { useState } from 'react';
+import { afterEach, expect, it, vi } from 'vitest';
+import { userEvent } from 'vitest/browser';
+import { agorStore } from '../../store/agorStore';
+import { GeneralTab } from '../BranchModal/tabs/GeneralTab';
+import type { GeneralFormState } from '../BranchModal/useBranchModalForm';
+import { NewSessionModal } from '../NewSessionModal/NewSessionModal';
+
+const enabledId = '01900000-0000-7000-8000-000000000001';
+const disabledId = '01900000-0000-7000-8000-000000000002';
+const unavailableId = '01900000-0000-7000-8000-000000000003';
+const servers = [
+  { mcp_server_id: enabledId, name: 'Enabled', enabled: true, transport: 'http' },
+  { mcp_server_id: disabledId, name: 'Disabled', enabled: false, transport: 'http' },
+  ...Array.from({ length: 10 }, (_, index) => ({
+    mcp_server_id: `extra-${index}`,
+    name: `Extra ${index}`,
+    enabled: true,
+    transport: 'http',
+  })),
+] as MCPServer[];
+const branch: Branch = {
+  branch_id: '01900000-0000-7000-8000-000000000004' as Branch['branch_id'],
+  repo_id: '01900000-0000-7000-8000-000000000005' as Branch['repo_id'],
+  created_by: '01900000-0000-7000-8000-000000000006' as Branch['created_by'],
+  branch_unique_id: 1,
+  name: 'Picker validation' as Branch['name'],
+  ref: 'main',
+  path: '/fictional/teammate',
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+  last_used: '2026-01-01T00:00:00.000Z',
+  new_branch: false,
+  archived: false,
+  needs_attention: false,
+  mcp_server_ids: [enabledId, unavailableId, disabledId],
+  custom_context: { teammate: { kind: 'teammate' } },
+};
+
+afterEach(() => {
+  cleanup();
+  agorStore.setState({ mcpServerById: new Map() });
+});
+
+function GeneralSurface({ canEdit = true }: { canEdit?: boolean }) {
+  const [state, setState] = useState<GeneralFormState>({
+    boardId: undefined,
+    issueUrl: '',
+    prUrl: '',
+    notes: '',
+    mcpServerIds: branch.mcp_server_ids ?? [],
+  });
+  return (
+    <Modal
+      open
+      title="Teammate / General"
+      footer={null}
+      styles={{ body: { maxHeight: '80vh', overflowY: 'auto' } }}
+    >
+      <GeneralTab
+        branch={branch}
+        repo={{ name: 'Fixture' } as Repo}
+        sessions={[]}
+        mcpServers={servers}
+        canEdit={canEdit}
+        state={state}
+        setField={(key, value) => setState((prev) => ({ ...prev, [key]: value }))}
+      />
+    </Modal>
+  );
+}
+
+function expectAnchoredAndUnclipped(input: HTMLElement) {
+  const trigger = input.closest('.ant-select')!;
+  const popup = document.querySelector('.ant-select-dropdown:not(.ant-select-dropdown-hidden)')!;
+  expect(popup).not.toBeNull();
+  expect(
+    (
+      trigger.closest('.ant-popover, .ant-modal-container, .ant-drawer-content') ??
+      trigger.parentElement
+    )?.contains(popup)
+  ).toBe(true);
+  const box = popup.getBoundingClientRect();
+  const anchor = trigger.getBoundingClientRect();
+  if (Math.max(anchor.top, window.innerHeight - anchor.bottom) >= box.height + 4) {
+    expect(
+      Math.min(Math.abs(box.top - anchor.bottom), Math.abs(box.bottom - anchor.top))
+    ).toBeLessThan(12);
+  }
+  expect(box.left).toBeGreaterThanOrEqual(-1);
+  expect(box.right).toBeLessThanOrEqual(window.innerWidth + 1);
+  expect(box.top).toBeGreaterThanOrEqual(0);
+  expect(box.bottom).toBeLessThanOrEqual(window.innerHeight + 1);
+  // Geometry alone misses clipping by an independently scrolling ancestor.
+  for (const y of [box.top + 8, box.bottom - 8]) {
+    expect(
+      popup.contains(document.elementFromPoint(box.left + box.width / 2, y)),
+      JSON.stringify({
+        box: box.toJSON(),
+        hit: document.elementFromPoint(box.left + box.width / 2, y)?.outerHTML.slice(0, 200),
+      })
+    ).toBe(true);
+  }
+}
+
+it.each(['New Session', 'Teammate / General'] as const)(
+  '%s keeps removal, focus, and popup anchoring through scrolling',
+  async (surface) => {
+    agorStore.setState({
+      mcpServerById: new Map(servers.map((server) => [server.mcp_server_id, server])),
+    });
+    render(
+      <ConfigProvider theme={{ algorithm: theme.darkAlgorithm, token: { motion: false } }}>
+        <App>
+          {surface === 'New Session' ? (
+            <NewSessionModal
+              open
+              branchId={branch.branch_id}
+              branch={branch}
+              availableAgents={[]}
+              client={null}
+              onClose={vi.fn()}
+              onCreate={vi.fn(async () => null)}
+            />
+          ) : (
+            <GeneralSurface />
+          )}
+        </App>
+      </ConfigProvider>
+    );
+    if (surface === 'New Session') {
+      await act(() => userEvent.click(screen.getByTestId('mcp-chip')));
+    }
+    const input =
+      surface === 'New Session'
+        ? screen.getByRole('combobox', { name: '' })
+        : screen.getAllByRole('combobox').at(-1)!;
+    if (surface === 'Teammate / General') input.scrollIntoView({ block: 'center' });
+    await act(() => userEvent.click(input));
+    await vi.waitFor(() => expectAnchoredAndUnclipped(input));
+    // Backspace must remove the final disabled attachment, not skip over it.
+    await act(() => userEvent.keyboard('{Backspace}'));
+    expect(screen.queryByText('Disabled (http)')).not.toBeInTheDocument();
+    expect(input).toHaveFocus();
+    // On short viewports a tall list may shift across the field. Dismiss it
+    // before using the chip's mouse affordance; Escape must retain focus.
+    await act(() => userEvent.keyboard('{Escape}'));
+    expect(input).toHaveFocus();
+    const trigger = input.closest('.ant-select')!;
+    const unavailable = Array.from(trigger.querySelectorAll('.ant-select-selection-item')).find(
+      (tag) => tag.textContent?.includes('Unavailable')
+    )!;
+    await act(() =>
+      userEvent.click(unavailable.querySelector('.ant-select-selection-item-remove')!)
+    );
+    expect(trigger.textContent).not.toContain('Unavailable');
+    expect(input).toHaveFocus();
+    await act(() => userEvent.keyboard('{ArrowDown}'));
+
+    // New Session's picker is portaled into a popover, so its originating
+    // chip's modal scroll owners must also move while the dropdown is open.
+    const origins = [input];
+    if (surface === 'New Session') origins.push(screen.getByTestId('mcp-chip'));
+    const scrollOwners = new Set<HTMLElement>();
+    for (const origin of origins) {
+      for (let parent = origin.parentElement; parent; parent = parent.parentElement) {
+        if (
+          /(auto|scroll)/.test(getComputedStyle(parent).overflowY) &&
+          parent.scrollHeight > parent.clientHeight
+        )
+          scrollOwners.add(parent);
+      }
+    }
+    let scrolled = false;
+    for (const parent of scrollOwners) {
+      const before = parent.scrollTop;
+      await act(async () => {
+        parent.scrollTop = before > 24 ? before - 24 : before + 24;
+      });
+      if (parent.scrollTop === before) continue;
+      scrolled = true;
+      await vi.waitFor(() => expectAnchoredAndUnclipped(input));
+    }
+    if (window.innerHeight < 600) expect(scrolled).toBe(true);
+    await act(() => userEvent.keyboard('{Escape}'));
+    expect(input).toHaveFocus();
+    await act(() => userEvent.keyboard('{ArrowDown}'));
+    await vi.waitFor(() => expectAnchoredAndUnclipped(input));
+    expect(document.documentElement.scrollWidth).toBeLessThanOrEqual(window.innerWidth + 1);
+  }
+);
+
+it('Teammate / General respects read-only capability state', async () => {
+  render(
+    <App>
+      <GeneralSurface canEdit={false} />
+    </App>
+  );
+  const input = screen.getAllByRole('combobox').at(-1)!;
+  expect(input).toBeDisabled();
+  expect(
+    input.closest('.ant-select')?.querySelector('.ant-select-selection-item-remove')
+  ).toBeNull();
+  expect(screen.getByText('Disabled (http)')).toBeInTheDocument();
+  expect(screen.getByText(/Unavailable MCP server/)).toBeInTheDocument();
+});

--- a/apps/agor-ui/src/components/MCPServerSelect/MCPServerSelect.component.test.tsx
+++ b/apps/agor-ui/src/components/MCPServerSelect/MCPServerSelect.component.test.tsx
@@ -12,7 +12,7 @@ const disabledId = '01900000-0000-7000-8000-000000000002';
 const unavailableId = '01900000-0000-7000-8000-000000000003';
 const servers = [
   { mcp_server_id: enabledId, name: 'Enabled', transport: 'http', enabled: true },
-  { mcp_server_id: disabledId, name: 'Disabled', transport: 'http', enabled: false },
+  { mcp_server_id: disabledId, name: 'Paused integration', transport: 'http', enabled: false },
 ] as MCPServer[];
 
 function Picker(props: Partial<MCPServerSelectProps>) {
@@ -35,7 +35,7 @@ describe('MCPServerSelect native attachment controls', () => {
     const onChange = vi.fn();
     render(<Picker onChange={onChange} />);
     fireEvent.mouseDown(screen.getByRole('combobox'));
-    expect(screen.queryByText('Disabled (http)')).not.toBeInTheDocument();
+    expect(screen.queryByText('Disabled · Paused integration (http)')).not.toBeInTheDocument();
     fireEvent.click(screen.getByText('Enabled (http)'));
     expect(onChange).toHaveBeenLastCalledWith([enabledId]);
   });
@@ -52,7 +52,7 @@ describe('MCPServerSelect native attachment controls', () => {
       expect(onChange).toHaveBeenLastCalledWith([]);
       fireEvent.mouseDown(screen.getByRole('combobox'));
       expect(screen.getByText('Enabled (http)')).toBeInTheDocument();
-      expect(screen.queryByText('Disabled (http)')).not.toBeInTheDocument();
+      expect(screen.queryByText('Disabled · Paused integration (http)')).not.toBeInTheDocument();
       expect(screen.queryByText(/Unavailable MCP server/)).not.toBeInTheDocument();
     }
   );
@@ -108,14 +108,36 @@ describe('MCPServerSelect native attachment controls', () => {
     render(<Picker mcpServers={[]} value={[unavailableId]} />);
     expect(screen.getByText(/Unavailable MCP server/)).toBeInTheDocument();
     expect(screen.queryByText('Enabled (http)')).not.toBeInTheDocument();
-    expect(screen.queryByText('Disabled (http)')).not.toBeInTheDocument();
+    expect(screen.queryByText('Disabled · Paused integration (http)')).not.toBeInTheDocument();
   });
 
-  it('anchors to the field parent by default and preserves explicit popup ownership', () => {
+  it.each(['onOpenChange', 'onDropdownVisibleChange'] as const)(
+    'preserves the caller’s %s callback',
+    (callback) => {
+      const onOpen = vi.fn();
+      render(<Picker {...{ [callback]: onOpen }} />);
+      fireEvent.mouseDown(screen.getByRole('combobox'));
+      expect(onOpen).toHaveBeenCalledWith(true);
+    }
+  );
+
+  it('uses a viewport host by default and preserves explicit popup overrides', () => {
     const { container, unmount } = render(<Picker open />);
-    expect(container.querySelector('.ant-select-dropdown')).not.toBeNull();
-    unmount();
-    render(<Picker open getPopupContainer={() => document.body} />);
+    expect(container.querySelector('.ant-select-dropdown')).toBeNull();
     expect(document.body.querySelector(':scope > .ant-select-dropdown')).not.toBeNull();
+    unmount();
+    render(
+      <Picker
+        open
+        getPopupContainer={() => container}
+        placement="topRight"
+        popupAlign={{ offset: [0, 10] }}
+        listHeight={80}
+      />
+    );
+    expect(container.querySelector('.ant-select-dropdown')).not.toBeNull();
+    expect(container.querySelector<HTMLElement>('.ant-select-dropdown')?.style.position).not.toBe(
+      'fixed'
+    );
   });
 });

--- a/apps/agor-ui/src/components/MCPServerSelect/MCPServerSelect.component.test.tsx
+++ b/apps/agor-ui/src/components/MCPServerSelect/MCPServerSelect.component.test.tsx
@@ -1,0 +1,121 @@
+import type { MCPServer } from '@agor-live/client';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { Form } from 'antd';
+import { useState } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MCPServerSelect, type MCPServerSelectProps } from './MCPServerSelect';
+
+afterEach(cleanup);
+
+const enabledId = '01900000-0000-7000-8000-000000000001';
+const disabledId = '01900000-0000-7000-8000-000000000002';
+const unavailableId = '01900000-0000-7000-8000-000000000003';
+const servers = [
+  { mcp_server_id: enabledId, name: 'Enabled', transport: 'http', enabled: true },
+  { mcp_server_id: disabledId, name: 'Disabled', transport: 'http', enabled: false },
+] as MCPServer[];
+
+function Picker(props: Partial<MCPServerSelectProps>) {
+  const [value, setValue] = useState(props.value ?? []);
+  return (
+    <MCPServerSelect
+      mcpServers={servers}
+      {...props}
+      value={value}
+      onChange={(ids) => {
+        setValue(ids);
+        props.onChange?.(ids);
+      }}
+    />
+  );
+}
+
+describe('MCPServerSelect native attachment controls', () => {
+  it('offers enabled servers for new attachment, never disabled servers', () => {
+    const onChange = vi.fn();
+    render(<Picker onChange={onChange} />);
+    fireEvent.mouseDown(screen.getByRole('combobox'));
+    expect(screen.queryByText('Disabled (http)')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText('Enabled (http)'));
+    expect(onChange).toHaveBeenLastCalledWith([enabledId]);
+  });
+
+  it.each([enabledId, disabledId, unavailableId])(
+    'removes %s by mouse and cannot reoffer disabled/missing servers',
+    (id) => {
+      const onChange = vi.fn();
+      const { container } = render(<Picker value={[id]} onChange={onChange} />);
+      const remove = container.querySelector('.ant-select-selection-item-remove');
+      expect(remove).not.toBeNull();
+      fireEvent.mouseDown(remove!);
+      fireEvent.click(remove!);
+      expect(onChange).toHaveBeenLastCalledWith([]);
+      fireEvent.mouseDown(screen.getByRole('combobox'));
+      expect(screen.getByText('Enabled (http)')).toBeInTheDocument();
+      expect(screen.queryByText('Disabled (http)')).not.toBeInTheDocument();
+      expect(screen.queryByText(/Unavailable MCP server/)).not.toBeInTheDocument();
+    }
+  );
+
+  it.each([enabledId, disabledId, unavailableId])('removes %s with Backspace', (id) => {
+    const onChange = vi.fn();
+    render(<Picker value={[id]} onChange={onChange} />);
+    const input = screen.getByRole('combobox');
+    fireEvent.focus(input);
+    fireEvent.keyDown(input, { key: 'Backspace', code: 'Backspace', keyCode: 8 });
+    expect(onChange).toHaveBeenLastCalledWith([]);
+  });
+
+  it.each(['field', 'form'] as const)(
+    'does not mutate a read-only %s, including disabled and unavailable selections',
+    (source) => {
+      const onChange = vi.fn();
+      const { container } = render(
+        <Form disabled={source === 'form'}>
+          <Picker
+            value={[enabledId, disabledId, unavailableId]}
+            disabled={source === 'field' ? true : undefined}
+            onChange={onChange}
+          />
+        </Form>
+      );
+      expect(screen.getByRole('combobox')).toBeDisabled();
+      expect(container.querySelector('.ant-select-selection-item-remove')).toBeNull();
+      expect(container.querySelector('.ant-select-clear')).toBeNull();
+      fireEvent.mouseDown(screen.getByRole('combobox'));
+      // A native disabled input cannot receive focus or real keyboard events.
+      screen.getByRole('combobox').focus();
+      expect(screen.getByRole('combobox')).not.toHaveFocus();
+      expect(onChange).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each([0, 1])('keeps synthetic overflow non-closable with maxTagCount=%s', (maxTagCount) => {
+    const { container } = render(
+      <Picker value={[disabledId, enabledId, unavailableId]} maxTagCount={maxTagCount} />
+    );
+    expect(container.querySelectorAll('.ant-select-selection-item-remove')).toHaveLength(
+      maxTagCount
+    );
+    const overflow = screen
+      .getByText(`+ ${3 - maxTagCount} ...`)
+      .closest('.ant-select-selection-item');
+    expect(overflow).not.toBeNull();
+    expect(overflow?.querySelector('.ant-select-selection-item-remove')).toBeNull();
+  });
+
+  it('uses only the unavailable placeholder for an ID absent from authorized hydration', () => {
+    render(<Picker mcpServers={[]} value={[unavailableId]} />);
+    expect(screen.getByText(/Unavailable MCP server/)).toBeInTheDocument();
+    expect(screen.queryByText('Enabled (http)')).not.toBeInTheDocument();
+    expect(screen.queryByText('Disabled (http)')).not.toBeInTheDocument();
+  });
+
+  it('anchors to the field parent by default and preserves explicit popup ownership', () => {
+    const { container, unmount } = render(<Picker open />);
+    expect(container.querySelector('.ant-select-dropdown')).not.toBeNull();
+    unmount();
+    render(<Picker open getPopupContainer={() => document.body} />);
+    expect(document.body.querySelector(':scope > .ant-select-dropdown')).not.toBeNull();
+  });
+});

--- a/apps/agor-ui/src/components/MCPServerSelect/MCPServerSelect.test.ts
+++ b/apps/agor-ui/src/components/MCPServerSelect/MCPServerSelect.test.ts
@@ -25,7 +25,7 @@ describe('buildMcpServerOptions', () => {
     const options = buildMcpServerOptions([disabled], [disabled.mcp_server_id]);
     expect(options).toEqual([
       expect.objectContaining({
-        label: expect.stringContaining('Friendly server'),
+        label: 'Disabled · Friendly server (http)',
         value: disabled.mcp_server_id,
         disabled: false,
       }),

--- a/apps/agor-ui/src/components/MCPServerSelect/MCPServerSelect.test.ts
+++ b/apps/agor-ui/src/components/MCPServerSelect/MCPServerSelect.test.ts
@@ -20,16 +20,17 @@ describe('buildMcpServerOptions', () => {
     expect(options[0]?.label).not.toContain('11111111-2222');
   });
 
-  it('keeps a selected disabled server labelled', () => {
+  it('keeps a selected disabled server labelled and removable, but never offers it anew', () => {
     const disabled = server({ enabled: false });
     const options = buildMcpServerOptions([disabled], [disabled.mcp_server_id]);
     expect(options).toEqual([
       expect.objectContaining({
         label: expect.stringContaining('Friendly server'),
         value: disabled.mcp_server_id,
-        disabled: true,
+        disabled: false,
       }),
     ]);
+    expect(buildMcpServerOptions([disabled], [])).toEqual([]);
   });
 
   // Connecting a marketplace entry writes the install before anybody signs in,

--- a/apps/agor-ui/src/components/MCPServerSelect/MCPServerSelect.tsx
+++ b/apps/agor-ui/src/components/MCPServerSelect/MCPServerSelect.tsx
@@ -52,7 +52,11 @@ export function buildMcpServerOptions(
       return {
         label: `${name} (${server.transport})${authSuffix}${needsAuthSuffix}`,
         value: server.mcp_server_id,
-        disabled: !server.enabled,
+        // Disabled servers reach here only while selected. Let AntD remove
+        // them (including with Backspace); after removal the filter above
+        // drops the option, so they cannot be newly attached. Using the native
+        // tags also preserves whole-field disabled and overflow behavior.
+        disabled: false,
       };
     });
 
@@ -114,6 +118,21 @@ export const MCPServerSelect: React.FC<MCPServerSelectProps> = ({
       value={value}
       onChange={onChange}
       options={options}
+      getPopupContainer={(trigger: HTMLElement) =>
+        // Stay with the owning overlay, but outside independently scrolling
+        // modal/drawer bodies so their overflow does not clip the options.
+        trigger.closest<HTMLElement>('.ant-popover, .ant-modal-container, .ant-drawer-content') ??
+        trigger.parentElement ??
+        document.body
+      }
+      // Select defaults to the scroll region and no horizontal adjustment for
+      // matching-width popups. Keep long lists inside the visible viewport;
+      // a zero gap also keeps shifted edges inside that boundary.
+      popupAlign={{
+        htmlRegion: 'visible',
+        offset: [0, 0],
+        overflow: { adjustX: true, adjustY: true, shiftX: true, shiftY: true },
+      }}
       {...selectProps}
     />
   );

--- a/apps/agor-ui/src/components/MCPServerSelect/MCPServerSelect.tsx
+++ b/apps/agor-ui/src/components/MCPServerSelect/MCPServerSelect.tsx
@@ -1,10 +1,14 @@
 import { type MCPServer, shortId } from '@agor-live/client';
 import { Select, type SelectProps } from 'antd';
+import type { RefSelectProps } from 'antd/es/select';
+import { type Ref, useImperativeHandle } from 'react';
 import { useAgorStore } from '../../store/agorStore';
 import { selectUserAuthenticatedMcpServerIds } from '../../store/selectors';
 import { mcpServerNeedsAuth } from '../../utils/mcpAuth';
+import { useMcpPopupLayout } from './useMcpPopupLayout';
 
 export interface MCPServerSelectProps extends Omit<SelectProps, 'options'> {
+  ref?: Ref<RefSelectProps>;
   mcpServers: MCPServer[];
   value?: string[];
   onChange?: (value: string[]) => void;
@@ -50,7 +54,8 @@ export function buildMcpServerOptions(
         ? NEEDS_AUTH_OPTION_SUFFIX
         : '';
       return {
-        label: `${name} (${server.transport})${authSuffix}${needsAuthSuffix}`,
+        // Put status first so native tag ellipsis cannot hide it on phones.
+        label: `${server.enabled ? '' : 'Disabled · '}${name} (${server.transport})${authSuffix}${needsAuthSuffix}`,
         value: server.mcp_server_id,
         // Disabled servers reach here only while selected. Let AntD remove
         // them (including with Backspace); after removal the filter above
@@ -93,6 +98,10 @@ export const MCPServerSelect: React.FC<MCPServerSelectProps> = ({
   onChange,
   placeholder = 'Select MCP servers...',
   filterByScope,
+  onOpenChange,
+  onDropdownVisibleChange,
+  ref: forwardedRef,
+  styles,
   ...selectProps
 }) => {
   // Read here rather than as a prop: every caller of this picker would
@@ -104,6 +113,21 @@ export const MCPServerSelect: React.FC<MCPServerSelectProps> = ({
   const filteredServers = filterByScope
     ? mcpServers.filter((server) => server.scope === filterByScope)
     : mcpServers;
+
+  const popup = useMcpPopupLayout(selectProps);
+  // Form.Item supplies a ref (React 19); preserve it without replacing the
+  // geometry ref that owns list sizing.
+  useImperativeHandle(forwardedRef, () => popup.ref.current!);
+
+  // Explicit popup owners/alignment keep AntD's positioning contract. The
+  // default viewport host instead uses measured fixed edges, avoiding rc-trigger
+  // scroll/flip races and ancestor clipping without shifting over the field.
+  const ownsPopup =
+    !selectProps.getPopupContainer &&
+    !selectProps.popupAlign &&
+    !selectProps.placement &&
+    !selectProps.builtinPlacements &&
+    selectProps.popupMatchSelectWidth === undefined;
 
   const options = buildMcpServerOptions(filteredServers, value, userAuthenticatedMcpServerIds);
 
@@ -118,22 +142,34 @@ export const MCPServerSelect: React.FC<MCPServerSelectProps> = ({
       value={value}
       onChange={onChange}
       options={options}
-      getPopupContainer={(trigger: HTMLElement) =>
-        // Stay with the owning overlay, but outside independently scrolling
-        // modal/drawer bodies so their overflow does not clip the options.
-        trigger.closest<HTMLElement>('.ant-popover, .ant-modal-container, .ant-drawer-content') ??
-        trigger.parentElement ??
-        document.body
-      }
-      // Select defaults to the scroll region and no horizontal adjustment for
-      // matching-width popups. Keep long lists inside the visible viewport;
-      // a zero gap also keeps shifted edges inside that boundary.
+      ref={popup.ref}
+      // A deliberate viewport host, not a guessed AntD overlay ancestor. Drawer
+      // bodies AND Modal containers can clip; AntD owns the overlay z-index.
+      getPopupContainer={(trigger) => trigger.ownerDocument.body}
+      placement={popup.placement}
+      listHeight={popup.listHeight}
       popupAlign={{
         htmlRegion: 'visible',
         offset: [0, 0],
-        overflow: { adjustX: true, adjustY: true, shiftX: true, shiftY: true },
+        // Size to one side of the field instead of shifting a tall list over
+        // its tags. Horizontal shifting is still needed near viewport edges.
+        overflow: { adjustX: true, adjustY: false, shiftX: true, shiftY: false },
       }}
       {...selectProps}
+      styles={(info) => {
+        const overrides = typeof styles === 'function' ? styles(info) : styles;
+        return {
+          ...overrides,
+          popup: {
+            ...overrides?.popup,
+            root: { ...(ownsPopup ? popup.style : undefined), ...overrides?.popup?.root },
+          },
+        };
+      }}
+      onOpenChange={(open) => {
+        popup.setOpen(open);
+        (onOpenChange ?? onDropdownVisibleChange)?.(open);
+      }}
     />
   );
 };

--- a/apps/agor-ui/src/components/MCPServerSelect/useMcpPopupLayout.ts
+++ b/apps/agor-ui/src/components/MCPServerSelect/useMcpPopupLayout.ts
@@ -1,0 +1,78 @@
+import type { SelectProps } from 'antd';
+import type { RefSelectProps } from 'antd/es/select';
+import { type CSSProperties, useLayoutEffect, useRef, useState } from 'react';
+
+/** Keep the native, scrollable option list beside (never over) the attachment field. */
+export function useMcpPopupLayout(
+  props: Pick<SelectProps, 'open' | 'defaultOpen' | 'placement' | 'listHeight'>
+) {
+  const ref = useRef<RefSelectProps>(null);
+  const [open, setOpen] = useState(props.defaultOpen ?? false);
+  const [layout, setLayout] = useState<{
+    placement: SelectProps['placement'];
+    listHeight: number;
+    style: CSSProperties;
+  }>({
+    placement: 'bottomLeft',
+    listHeight: 256,
+    style: {},
+  });
+
+  useLayoutEffect(() => {
+    const field = ref.current?.nativeElement;
+    if (!(props.open ?? open) || !field) return;
+    const win = field.ownerDocument.defaultView!;
+    const update = () => {
+      const box = ref.current?.nativeElement?.getBoundingClientRect();
+      if (!box) return;
+      const viewport = win.visualViewport;
+      const top = viewport?.offsetTop ?? 0;
+      const bottom = top + (viewport?.height ?? win.innerHeight);
+      // Reserve viewport breathing room and Select's popup padding. The list
+      // itself scrolls when there isn't room for its normal 256px height.
+      const above = Math.max(0, box.top - top - 16);
+      const below = Math.max(0, bottom - box.bottom - 16);
+      const placement = props.placement ?? (below >= above ? 'bottomLeft' : 'topLeft');
+      const space = placement.startsWith('top') ? above : below;
+      const listHeight = Math.max(1, Math.floor(Math.min(props.listHeight ?? 256, space)));
+      const width = Math.min(box.width, viewport?.width ?? win.innerWidth);
+      const left = Math.max(
+        viewport?.offsetLeft ?? 0,
+        Math.min(
+          box.left,
+          (viewport?.offsetLeft ?? 0) + (viewport?.width ?? win.innerWidth) - width
+        )
+      );
+      const style: CSSProperties = {
+        position: 'fixed',
+        left,
+        width,
+        right: 'auto',
+        top: placement.startsWith('top') ? 'auto' : box.bottom,
+        bottom: placement.startsWith('top') ? win.innerHeight - box.top : 'auto',
+      };
+      setLayout((prev) =>
+        prev.placement === placement &&
+        prev.listHeight === listHeight &&
+        prev.style.left === style.left &&
+        prev.style.width === width &&
+        prev.style.top === style.top &&
+        prev.style.bottom === style.bottom
+          ? prev
+          : { placement, listHeight, style }
+      );
+    };
+    // A body portal cannot follow a moving popover by DOM ancestry. Measure
+    // while open, including transforms, nested scrolling, tag reflow and the
+    // visual viewport (soft keyboard). Only changed geometry causes a render.
+    let frame = 0;
+    const follow = () => {
+      update();
+      frame = win.requestAnimationFrame(follow);
+    };
+    follow();
+    return () => win.cancelAnimationFrame(frame);
+  }, [open, props.open, props.placement, props.listHeight]);
+
+  return { ref, setOpen, ...layout };
+}


### PR DESCRIPTION
## Problem

Closes #1911.

Selected disabled MCP servers lose AntD's individual chip remove control, forcing users to clear all attachments. Picker dropdowns can also detach, clip, or cover the input/remove controls while scrolling modal, drawer, and nested popover surfaces.

**Existing partial fix:** #2548 (`ed5b075a`) already made unavailable/stale-ID chips removable by keeping their selected-only placeholder options enabled. This PR preserves that behavior and completes the **disabled-chip + popup** work; it does not claim the unavailable-chip fix as new.

## Design

- Keep selected disabled servers enabled as native AntD options so mouse removal and Backspace work. They disappear from the available options when detached and cannot be newly attached. Prefix labels with `Disabled ·` so status stays visible under narrow-screen ellipsis and is included in accessible option names.
- Preserve native tags rather than adding a custom tag renderer: whole-field/Form disabled state, synthetic overflow chips, focus, search, and keyboard behavior remain native.
- Use an explicit viewport/body popup host, with measured fixed edges and a list height bounded to available space above or below the field. Follow geometry only while open, including nested scrolling, moving popovers, tag reflow, and the visual viewport. Keep the list scrollable and beside—not over—the attachment controls.
- Preserve explicit popup owner/alignment/style overrides, Form refs, and open-change callbacks.
- Cover New Session, Teammate / General, and User Settings. Scope is limited to the shared picker, its layout hook, and regression tests (5 files).

## Validation and review

Completed before publication; no broad matrix rerun for this PR:

- **84 related tests passed:** 22 picker tests plus 62 related consumer tests.
- **16 browser tests passed** across 320×568, 768×900, 1000×900, and 844×390.
- Typecheck/lint and live validation passed.
- Two review passes completed. The initial review identified drawer popup obstruction and disabled-status presentation issues; the follow-up commit resolved both. Final delta review: **SHIP**, no new actionable findings.
- Coverage includes mouse/Backspace removal, no reattachment of disabled/unavailable entries, field/Form read-only behavior, overflow tags, authorized-hydration placeholders, accessible status, focus/search/keyboard interaction, popup hit-testing, clipping, and scrolling.

### Tenant/privacy assessment

MCP server identity and attachment selections are tenant-owned data already supplied through authorized hydration. This UI-only change does not alter API calls, persistence, credentials, authorization, or tenant boundaries. Missing/unauthorized hydrated entries retain only the existing unavailable placeholder; regression coverage guards against exposing a server label and preserves read-only capability behavior. Fixtures are synthetic. Outgoing paths and both commit patches were checked: no private data, session/transcript exports, credentials, or local environment artifacts are included.

## Publication boundary

- Exact reviewed HEAD: `b6e2e334ec9c43b36671c005ee78e091a285b3b2`.
- Ancestry: `0fb3643582504f3bc38f0c7f57f1c98a29b319cb` → `eb589398e223cb7f6d65b0d39464d60a53e4778a` → HEAD.
- At publication preflight, `main` was `4e0d0a02ee908351aa6e54a612358034e53e1eda`: three commits ahead of the common ancestor; this branch has exactly two outgoing commits. Non-mutating merge preview was conflict-free. The reviewed HEAD was preserved without rebasing or merging main.
- Clean worktree and outgoing whitespace check verified. Only this feature ref was pushed normally; no force push, tags, main, or unrelated refs.
