### PR TITLE
fix(ui): size teammate session trees to available panel height

### DIFF
--- a/apps/agor-docs/content/guide/sessions.mdx
+++ b/apps/agor-docs/content/guide/sessions.mdx
@@ -93,7 +93,9 @@ The tree is rendered on the branch card on the board, and in full detail in the 
 ### Large session lists
 
 Branch cards and the branch teammate panel keep manual and gateway genealogy
-trees in a virtual, scrollable viewport (up to 400 pixels high). On board cards,
+trees in a virtual, scrollable viewport. Board cards keep a 400-pixel maximum;
+the teammate panel sizes trees to its available height and resizes with its
+container. Expanded manual and gateway trees share the remaining space. On board cards,
 two-finger scrolling over a session tree pans the canvas, and pinching zooms it;
 drag the tree's scrollbar to reach older sessions. In the branch teammate panel,
 scroll inside the tree normally. Collapsing a parent still hides its descendants.

--- a/apps/agor-docs/content/guide/sessions.mdx
+++ b/apps/agor-docs/content/guide/sessions.mdx
@@ -95,7 +95,8 @@ The tree is rendered on the branch card on the board, and in full detail in the 
 Branch cards and the branch teammate panel keep manual and gateway genealogy
 trees in a virtual, scrollable viewport. Board cards keep a 400-pixel maximum;
 the teammate panel sizes trees to its available height and resizes with its
-container. Expanded manual and gateway trees share the remaining space. On board cards,
+container. Expanded manual and gateway trees share the remaining space; short
+trees release unused space to overflowing siblings. On board cards,
 two-finger scrolling over a session tree pans the canvas, and pinching zooms it;
 drag the tree's scrollbar to reach older sessions. In the branch teammate panel,
 scroll inside the tree normally. Collapsing a parent still hides its descendants.

--- a/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.height.browser.test.tsx
+++ b/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.height.browser.test.tsx
@@ -1,0 +1,222 @@
+import type { Board, Branch, Repo, Session } from '@agor-live/client';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { App } from 'antd';
+import { beforeEach, expect, it, vi } from 'vitest';
+import '../../index.css';
+import { EMPTY_MAPS } from '../../store/agorMaps';
+import { agorStore } from '../../store/agorStore';
+import { BoardTeammatePanel } from './BoardTeammatePanel';
+
+const branch = {
+  branch_id: 'teammate-1',
+  repo_id: 'repo-1',
+  name: 'Teammate',
+  filesystem_status: 'ready',
+} as Branch;
+
+beforeEach(() => {
+  localStorage.clear();
+  agorStore.setState({ ...EMPTY_MAPS });
+});
+
+function makeSessions(count = 1001, gateway = false): Session[] {
+  const sessions = Array.from(
+    { length: count },
+    (_, index): Session => ({
+      session_id: `session-${index}` as Session['session_id'],
+      branch_id: branch.branch_id,
+      title: `Conversation ${index}`,
+      agentic_tool: 'codex',
+      status: 'idle',
+      archived: false,
+      created_by: 'user-1',
+      unix_username: null,
+      sdk_home_scope: 'branch',
+      url: null,
+      contextFiles: [],
+      tasks: [],
+      scheduled_from_branch: false,
+      ready_for_prompt: true,
+      created_at: '2026-09-01T00:00:00.000Z',
+      last_updated: new Date(Date.UTC(2026, 8, 1) - index * 1000).toISOString(),
+      genealogy: {
+        children: [],
+        ...(index > 0 ? { parent_session_id: 'session-0' as Session['session_id'] } : {}),
+      },
+      ...(gateway && index === 0
+        ? {
+            custom_context: {
+              gateway_source: {
+                channel_id: 'channel-1',
+                channel_type: 'slack',
+                channel_name: 'Team',
+                thread_id: 'thread-1',
+              },
+            },
+          }
+        : {}),
+    })
+  );
+  return sessions;
+}
+
+function mount(sessions: Session[], panelBranch = branch) {
+  agorStore.setState({ sessionsByBranch: new Map([[branch.branch_id, sessions]]) });
+  const onSessionClick = vi.fn();
+  const { container } = render(
+    <App>
+      <div data-testid="panel-container" style={{ height: 1100, width: 300 }}>
+        <BoardTeammatePanel
+          board={{ board_id: 'board-1' } as Board}
+          primaryTeammateBranch={panelBranch}
+          primaryTeammateRepo={{ repo_id: branch.repo_id, slug: 'test/repo' } as Repo}
+          primaryTeammateInaccessible={false}
+          onSessionClick={onSessionClick}
+          client={null}
+        />
+      </div>
+    </App>
+  );
+  return { container, onSessionClick };
+}
+
+it.each([false, true])(
+  'fills and resizes the teammate container while virtualizing (gateway: %s)',
+  async (gateway) => {
+    const { container, onSessionClick } = mount(makeSessions(1001, gateway));
+    const host = screen.getByTestId('panel-container');
+    const scroller = () => container.querySelector<HTMLElement>('.ant-tree-list-holder')!;
+    const expectFillsPanel = async () => {
+      await waitFor(() => {
+        const bottom = scroller().getBoundingClientRect().bottom;
+        const gap = host.getBoundingClientRect().bottom - bottom;
+        expect(gap).toBeGreaterThanOrEqual(0);
+        expect(gap).toBeLessThan(40);
+        expect(
+          screen.getAllByRole('button', { name: /^Open session Conversation/ }).length
+        ).toBeLessThan(80);
+      });
+    };
+    await expectFillsPanel();
+    expect(scroller().clientHeight).toBeGreaterThan(600);
+    await act(async () => {
+      host.style.height = '500px';
+    });
+    await expectFillsPanel();
+    expect(scroller().clientHeight).toBeLessThan(400);
+    await act(async () => {
+      host.style.height = '950px';
+    });
+    await expectFillsPanel();
+    const section = screen.getByText(gateway ? 'Gateway Sessions' : 'Sessions', {
+      selector: 'strong',
+    });
+    fireEvent.click(section);
+    await waitFor(() => expect(screen.queryByRole('tree')).toBeNull());
+    fireEvent.click(section);
+    await expectFillsPanel();
+    fireEvent.click(screen.getByRole('tab', { name: /Comments/ }));
+    await act(async () => {
+      host.style.height = '1000px';
+    });
+    fireEvent.click(screen.getByRole('tab', { name: 'Teammate' }));
+    await expectFillsPanel();
+    for (let attempt = 0; attempt < 10; attempt++) {
+      await act(async () => {
+        scroller().scrollTop = scroller().scrollHeight;
+        fireEvent.scroll(scroller());
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      });
+    }
+    fireEvent.click(screen.getByRole('button', { name: 'Open session Conversation 1000' }));
+    expect(onSessionClick).toHaveBeenCalledWith('session-1000');
+  }
+);
+
+it('shares remaining space between trees and keeps scheduled runs and search reachable', async () => {
+  const manual = makeSessions(301);
+  const gateway = makeSessions(301, true).map((session, index) => ({
+    ...session,
+    session_id: `gateway-${index}` as Session['session_id'],
+    genealogy: {
+      children: [],
+      ...(index > 0 ? { parent_session_id: 'gateway-0' as Session['session_id'] } : {}),
+    },
+  }));
+  const scheduled = makeSessions(21).map((session, index) => ({
+    ...session,
+    session_id: `scheduled-${index}` as Session['session_id'],
+    scheduled_from_branch: true,
+    scheduled_run_at: 1000 - index,
+    genealogy: { children: [] },
+  }));
+  const { container } = mount([...manual, ...gateway, ...scheduled]);
+  const scrollers = () => [...container.querySelectorAll<HTMLElement>('.ant-tree-list-holder')];
+  await waitFor(() => {
+    expect(scrollers()).toHaveLength(2);
+    expect(scrollers()[0].clientHeight).toBeGreaterThan(80);
+    expect(scrollers()[1].clientHeight).toBeGreaterThan(80);
+  });
+  fireEvent.click(screen.getByRole('button', { name: /Scheduled Runs/ }));
+  await waitFor(() => expect(scrollers()[0].clientHeight).toBeGreaterThan(300));
+  const sharedHeight = scrollers()[1].clientHeight;
+  fireEvent.click(screen.getByText('Sessions', { selector: 'strong' }));
+  await waitFor(() => {
+    expect(scrollers()).toHaveLength(1);
+    expect(scrollers()[0].clientHeight).toBeGreaterThan(sharedHeight + 200);
+  });
+  fireEvent.click(screen.getByRole('button', { name: /Scheduled Runs/ }));
+  fireEvent.click(screen.getByTitle('Next Page'));
+  expect(screen.getByTitle('Previous Page')).not.toBeNull();
+  fireEvent.change(screen.getByPlaceholderText('Search sessions...'), {
+    target: { value: 'Conversation' },
+  });
+  await waitFor(() =>
+    expect(screen.getAllByRole('button', { name: /^Open session Conversation/ })).toHaveLength(20)
+  );
+  fireEvent.change(screen.getByPlaceholderText('Search sessions...'), { target: { value: '' } });
+  await waitFor(() => expect(scrollers()).toHaveLength(1));
+  expect(screen.getAllByRole('button', { name: /^Open session Conversation/ }).length).toBeLessThan(
+    80
+  );
+});
+
+it('keeps short and empty trees natural', async () => {
+  const { container } = mount(makeSessions(2));
+  expect(screen.getAllByRole('button', { name: /^Open session Conversation/ })).toHaveLength(2);
+  expect(container.querySelector<HTMLElement>('.ant-tree-list-holder')!.clientHeight).toBeLessThan(
+    200
+  );
+  await act(async () => {
+    agorStore.setState({ sessionsByBranch: new Map() });
+  });
+  expect(screen.queryByRole('tree')).toBeNull();
+});
+
+it('keeps the tree reachable below a long description in a short container', async () => {
+  const { container } = mount(makeSessions(), {
+    ...branch,
+    notes: Array.from({ length: 12 }, (_, index) => `Paragraph ${index}: teammate context.`).join(
+      '\n\n'
+    ),
+  });
+  const host = screen.getByTestId('panel-container');
+  await act(async () => {
+    host.style.height = '450px';
+  });
+  const tree = container.querySelector<HTMLElement>('.ant-tree-list-holder')!;
+  await waitFor(() => {
+    expect(tree.clientHeight).toBeGreaterThan(50);
+    expect(tree.clientHeight).toBeLessThan(200);
+  });
+  tree.scrollIntoView({ block: 'end' });
+  await waitFor(() => {
+    expect(tree.getBoundingClientRect().bottom).toBeLessThanOrEqual(
+      host.getBoundingClientRect().bottom
+    );
+    expect(tree.getBoundingClientRect().top).toBeGreaterThan(host.getBoundingClientRect().top);
+  });
+  expect(screen.getAllByRole('button', { name: /^Open session Conversation/ }).length).toBeLessThan(
+    40
+  );
+});

--- a/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.height.browser.test.tsx
+++ b/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.height.browser.test.tsx
@@ -1,5 +1,5 @@
 import type { Board, Branch, Repo, Session } from '@agor-live/client';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { App } from 'antd';
 import { beforeEach, expect, it, vi } from 'vitest';
 import '../../index.css';
@@ -58,6 +58,17 @@ function makeSessions(count = 1001, gateway = false): Session[] {
     })
   );
   return sessions;
+}
+
+function makeGatewaySessions(count: number): Session[] {
+  return makeSessions(count, true).map((session, index) => ({
+    ...session,
+    session_id: `gateway-${index}` as Session['session_id'],
+    genealogy: {
+      children: [],
+      ...(index > 0 ? { parent_session_id: 'gateway-0' as Session['session_id'] } : {}),
+    },
+  }));
 }
 
 function mount(sessions: Session[], panelBranch = branch) {
@@ -135,14 +146,7 @@ it.each([false, true])(
 
 it('shares remaining space between trees and keeps scheduled runs and search reachable', async () => {
   const manual = makeSessions(301);
-  const gateway = makeSessions(301, true).map((session, index) => ({
-    ...session,
-    session_id: `gateway-${index}` as Session['session_id'],
-    genealogy: {
-      children: [],
-      ...(index > 0 ? { parent_session_id: 'gateway-0' as Session['session_id'] } : {}),
-    },
-  }));
+  const gateway = makeGatewaySessions(301);
   const scheduled = makeSessions(21).map((session, index) => ({
     ...session,
     session_id: `scheduled-${index}` as Session['session_id'],
@@ -158,6 +162,17 @@ it('shares remaining space between trees and keeps scheduled runs and search rea
     expect(scrollers()[1].clientHeight).toBeGreaterThan(80);
   });
   fireEvent.click(screen.getByRole('button', { name: /Scheduled Runs/ }));
+  await waitFor(() => expect(scrollers()[0].clientHeight).toBeGreaterThan(300));
+  const beforeParentCollapseHeight = scrollers()[1].clientHeight;
+  const manualSection = scrollers()[0].closest('.ant-collapse') as HTMLElement;
+  fireEvent.click(within(manualSection).getByRole('button', { name: 'Collapse Conversation 0' }));
+  await waitFor(() => {
+    expect(scrollers()[1].clientHeight).toBeGreaterThan(beforeParentCollapseHeight + 150);
+    expect(
+      manualSection.getBoundingClientRect().bottom - scrollers()[0].getBoundingClientRect().bottom
+    ).toBeLessThan(20);
+  });
+  fireEvent.click(within(manualSection).getByRole('button', { name: 'Expand Conversation 0' }));
   await waitFor(() => expect(scrollers()[0].clientHeight).toBeGreaterThan(300));
   const sharedHeight = scrollers()[1].clientHeight;
   fireEvent.click(screen.getByText('Sessions', { selector: 'strong' }));
@@ -220,3 +235,61 @@ it('keeps the tree reachable below a long description in a short container', asy
     40
   );
 });
+
+it.each([
+  { manualCount: 1, gatewayCount: 301 },
+  { manualCount: 1, gatewayCount: 1 },
+  { manualCount: 2, gatewayCount: 301 },
+  { manualCount: 301, gatewayCount: 2 },
+  { manualCount: 2, gatewayCount: 2 },
+])(
+  'releases unused space with $manualCount manual and $gatewayCount gateway sessions',
+  async ({ manualCount, gatewayCount }) => {
+    const { container } = mount([
+      ...makeSessions(manualCount),
+      ...makeGatewaySessions(gatewayCount),
+    ]);
+    const scrollers = () => [...container.querySelectorAll<HTMLElement>('.ant-tree-list-holder')];
+    await waitFor(() => {
+      expect(scrollers()).toHaveLength(2);
+      for (const [index, count] of [manualCount, gatewayCount].entries()) {
+        const tree = scrollers()[index];
+        if (count <= 2) {
+          const section = tree.closest('.ant-collapse')!;
+          // Only the Collapse body padding may follow the rendered short tree.
+          expect(
+            section.getBoundingClientRect().bottom - tree.getBoundingClientRect().bottom
+          ).toBeLessThan(20);
+        } else {
+          expect(tree.clientHeight).toBeGreaterThan(500);
+        }
+      }
+    });
+    // Realtime growth must remove the short-tree cap; later shrink must restore it.
+    await act(async () => {
+      agorStore.setState({
+        sessionsByBranch: new Map([
+          [branch.branch_id, [...makeSessions(301), ...makeGatewaySessions(301)]],
+        ]),
+      });
+    });
+    await waitFor(() => {
+      for (const tree of scrollers()) expect(tree.clientHeight).toBeGreaterThan(300);
+    });
+    await act(async () => {
+      agorStore.setState({
+        sessionsByBranch: new Map([
+          [branch.branch_id, [...makeSessions(2), ...makeGatewaySessions(2)]],
+        ]),
+      });
+    });
+    await waitFor(() => {
+      for (const tree of scrollers()) {
+        expect(
+          tree.closest('.ant-collapse')!.getBoundingClientRect().bottom -
+            tree.getBoundingClientRect().bottom
+        ).toBeLessThan(20);
+      }
+    });
+  }
+);

--- a/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.height.browser.test.tsx
+++ b/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.height.browser.test.tsx
@@ -273,9 +273,14 @@ it.each([
         ]),
       });
     });
-    await waitFor(() => {
-      for (const tree of scrollers()) expect(tree.clientHeight).toBeGreaterThan(300);
-    });
+    // Real tree motion and ResizeObserver allocation can settle after the default
+    // timeout under CI load; keep the geometry assertion and allow bounded convergence.
+    await waitFor(
+      () => {
+        for (const tree of scrollers()) expect(tree.clientHeight).toBeGreaterThan(300);
+      },
+      { timeout: 5_000 }
+    );
     await act(async () => {
       agorStore.setState({
         sessionsByBranch: new Map([

--- a/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.tsx
+++ b/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.tsx
@@ -266,12 +266,21 @@ const BoardTeammatePanelComponent: React.FC<BoardTeammatePanelProps> = ({
       const isCreating = primaryTeammateBranch.filesystem_status === 'creating';
 
       return (
-        <div style={{ padding: 16 }}>
+        <div
+          style={{
+            padding: 16,
+            height: '100%',
+            boxSizing: 'border-box',
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
           <div
             style={{
               display: 'flex',
               flexDirection: 'column',
               gap: 10,
+              flexShrink: 0,
               paddingBottom: 12,
               marginBottom: 4,
               borderBottom: `1px solid ${token.colorBorderSecondary}`,
@@ -349,6 +358,7 @@ const BoardTeammatePanelComponent: React.FC<BoardTeammatePanelProps> = ({
               onSpawnSession={onSpawnSession}
               onOpenSessionSettings={onOpenSessionSettings}
               mode="panel"
+              fillAvailableHeight
               client={client}
             />
           ) : (
@@ -443,11 +453,7 @@ const BoardTeammatePanelComponent: React.FC<BoardTeammatePanelProps> = ({
           {
             key: 'teammate',
             label: 'Teammate',
-            children: (
-              <div style={{ height: 'calc(100vh - 112px)', overflow: 'auto' }}>
-                {teammateContent}
-              </div>
-            ),
+            children: <div style={{ height: '100%', overflow: 'auto' }}>{teammateContent}</div>,
           },
           {
             key: 'all-sessions',
@@ -529,6 +535,7 @@ const BoardTeammatePanelComponent: React.FC<BoardTeammatePanelProps> = ({
           },
         ]}
         style={{ height: '100%' }}
+        styles={{ body: { height: '100%' }, content: { height: '100%' } }}
         tabBarStyle={{ margin: 0, padding: '0 12px' }}
         tabBarExtraContent={{
           right: onCollapse ? (

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -29,7 +29,6 @@ import {
   Space,
   Spin,
   Tooltip,
-  Tree,
   Typography,
   theme,
 } from 'antd';
@@ -69,7 +68,7 @@ import {
   SessionSortButton,
 } from '../SessionSearchControls';
 import { ToolIcon } from '../ToolIcon';
-import { BRANCH_SESSION_VIEWPORT_HEIGHT } from './branchCardLayout';
+import { BranchSessionTree } from './BranchSessionTree';
 import {
   buildSessionTree,
   collectSessionSubtreeIds,
@@ -120,6 +119,8 @@ export interface BranchSessionSectionsProps {
   peekedSessionIds?: Set<string>;
   onTogglePeekSession?: (sessionId: string) => void;
   mode?: BranchSessionSectionsMode;
+  /** The caller supplies a bounded flex-column container (not an auto-sized card). */
+  fillAvailableHeight?: boolean;
   client: AgorClient | null;
 }
 
@@ -284,6 +285,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
   peekedSessionIds,
   onTogglePeekSession,
   mode = 'card',
+  fillAvailableHeight = false,
   client,
 }) => {
   const { token } = theme.useToken();
@@ -306,6 +308,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
   const [sort, setSort] = useLocalStorage<SessionSort>(SESSION_SORT_STORAGE_KEY, 'recent');
 
   const isPanel = mode === 'panel';
+  const fillPanel = isPanel && fillAvailableHeight;
   // Every collapsible node (sections + parent sessions in the tree) defaults
   // to expanded; only user-collapsed exceptions are kept. Board cards persist
   // them per branch in the shared collapsedBranchNodes store; the teammate
@@ -981,10 +984,9 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
     expandedKeys: React.Key[],
     expandableKeys: React.Key[]
   ) => (
-    <Tree
+    <BranchSessionTree
       className="agor-flat-tree nodrag nowheel"
-      height={BRANCH_SESSION_VIEWPORT_HEIGHT}
-      virtual
+      fillAvailableHeight={fillPanel}
       treeData={treeData}
       expandedKeys={expandedKeys}
       onExpand={(keys) => handleSessionTreeExpand(keys as React.Key[], expandableKeys)}
@@ -996,6 +998,21 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
       titleRender={renderSessionNode}
     />
   );
+
+  const panelFlexStyle: React.CSSProperties | undefined = fillPanel
+    ? { display: 'flex', flexDirection: 'column', flexGrow: 1, flexBasis: 0, minHeight: 0 }
+    : undefined;
+  const treeBodyStyles = {
+    header: { flexShrink: 0 },
+    body: {
+      ...panelFlexStyle,
+      background: 'transparent',
+      paddingInline: isPanel ? 0 : undefined,
+    },
+  };
+  // Leave a few rows reachable when headers/other sections exceed a short
+  // panel. The outer teammate viewport then scrolls instead of clipping them.
+  const expandedPanelStyle = fillPanel ? { ...panelFlexStyle, minHeight: 140 } : undefined;
 
   const sessionListContent = isManualSessionsOpen
     ? renderSessionTree(sessionTreeData, expandedManualKeys, manualExpandableKeys)
@@ -1122,7 +1139,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
 
   const sessionSearchBar =
     isPanel && activeSessions.length > 0 ? (
-      <div style={{ paddingBottom: 12, paddingTop: 4 }}>
+      <div style={{ paddingBottom: 12, paddingTop: 4, flexShrink: 0 }}>
         <SessionSearchToolbar
           value={searchQuery}
           onChange={setSearchQuery}
@@ -1248,6 +1265,9 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
         <>
           {manualSessions.length > 0 ? (
             <Collapse
+              className={
+                fillPanel && isManualSessionsOpen ? 'agor-panel-session-tree-section' : undefined
+              }
               activeKey={openSectionKeys}
               onChange={handleManualSessionsChange}
               items={[
@@ -1255,13 +1275,16 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
                   key: 'sessions',
                   label: sessionListHeader,
                   children: sessionListContent,
-                  styles: {
-                    body: { background: 'transparent', paddingInline: isPanel ? 0 : undefined },
-                  },
+                  style: panelFlexStyle,
+                  styles: treeBodyStyles,
                 },
               ]}
               ghost
-              style={{ marginTop: 8 }}
+              style={{
+                marginTop: 8,
+                flexShrink: 0,
+                ...(isManualSessionsOpen ? expandedPanelStyle : undefined),
+              }}
             />
           ) : onCreateSession ? (
             <div style={{ marginTop: 8 }}>{sessionListHeader}</div>
@@ -1282,12 +1305,15 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
                 },
               ]}
               ghost
-              style={{ marginTop: manualSessions.length > 0 ? 0 : 8 }}
+              style={{ marginTop: manualSessions.length > 0 ? 0 : 8, flexShrink: 0 }}
             />
           )}
 
           {gatewayRootSessions.length > 0 && (
             <Collapse
+              className={
+                fillPanel && isGatewaySessionsOpen ? 'agor-panel-session-tree-section' : undefined
+              }
               activeKey={openSectionKeys}
               onChange={handleGatewaySessionsChange}
               items={[
@@ -1295,14 +1321,15 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
                   key: 'gateway-sessions',
                   label: gatewaySessionsHeader,
                   children: gatewaySessionsContent,
-                  styles: {
-                    body: { background: 'transparent', paddingInline: isPanel ? 0 : undefined },
-                  },
+                  style: panelFlexStyle,
+                  styles: treeBodyStyles,
                 },
               ]}
               ghost
               style={{
                 marginTop: manualSessions.length > 0 || scheduledSessions.length > 0 ? 0 : 8,
+                flexShrink: 0,
+                ...(isGatewaySessionsOpen ? expandedPanelStyle : undefined),
               }}
             />
           )}

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionSections.tsx
@@ -33,7 +33,7 @@ import {
   theme,
 } from 'antd';
 import type React from 'react';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { useConnectionDisabled } from '../../contexts/ConnectionContext';
 import { useLocalStorage } from '../../hooks/useLocalStorage';
 import { useSessionActions } from '../../hooks/useSessionActions';
@@ -271,6 +271,19 @@ const SessionItemWithActions: React.FC<{
   );
 };
 
+/** Cap a section at its actual content plus measured chrome, freeing space for siblings. */
+function useTreeSectionHeight() {
+  const ref = useRef<HTMLDivElement>(null);
+  const [maxHeight, setMaxHeight] = useState<number>();
+  const onContentSizeChange = useCallback((contentHeight: number, viewportHeight: number) => {
+    const sectionHeight = ref.current?.clientHeight;
+    if (!sectionHeight) return;
+    // Header/padding remain owned by Collapse/theme; do not duplicate their sizes.
+    setMaxHeight(sectionHeight - viewportHeight + contentHeight);
+  }, []);
+  return { ref, maxHeight, onContentSizeChange };
+}
+
 export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
   branch,
   sessions,
@@ -309,6 +322,8 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
 
   const isPanel = mode === 'panel';
   const fillPanel = isPanel && fillAvailableHeight;
+  const manualTreeSection = useTreeSectionHeight();
+  const gatewayTreeSection = useTreeSectionHeight();
   // Every collapsible node (sections + parent sessions in the tree) defaults
   // to expanded; only user-collapsed exceptions are kept. Board cards persist
   // them per branch in the shared collapsedBranchNodes store; the teammate
@@ -982,11 +997,13 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
   const renderSessionTree = (
     treeData: SessionTreeNode[],
     expandedKeys: React.Key[],
-    expandableKeys: React.Key[]
+    expandableKeys: React.Key[],
+    onContentSizeChange: (contentHeight: number, viewportHeight: number) => void
   ) => (
     <BranchSessionTree
       className="agor-flat-tree nodrag nowheel"
       fillAvailableHeight={fillPanel}
+      onContentSizeChange={onContentSizeChange}
       treeData={treeData}
       expandedKeys={expandedKeys}
       onExpand={(keys) => handleSessionTreeExpand(keys as React.Key[], expandableKeys)}
@@ -1012,10 +1029,18 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
   };
   // Leave a few rows reachable when headers/other sections exceed a short
   // panel. The outer teammate viewport then scrolls instead of clipping them.
-  const expandedPanelStyle = fillPanel ? { ...panelFlexStyle, minHeight: 140 } : undefined;
+  const expandedPanelStyle = (maxHeight?: number): React.CSSProperties | undefined =>
+    fillPanel
+      ? { ...panelFlexStyle, minHeight: Math.min(140, maxHeight ?? 140), maxHeight }
+      : undefined;
 
   const sessionListContent = isManualSessionsOpen
-    ? renderSessionTree(sessionTreeData, expandedManualKeys, manualExpandableKeys)
+    ? renderSessionTree(
+        sessionTreeData,
+        expandedManualKeys,
+        manualExpandableKeys,
+        manualTreeSection.onContentSizeChange
+      )
     : null;
 
   const sessionListHeader = (
@@ -1134,7 +1159,12 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
   );
 
   const gatewaySessionsContent = isGatewaySessionsOpen
-    ? renderSessionTree(gatewaySessionTreeData, expandedGatewayKeys, gatewayExpandableKeys)
+    ? renderSessionTree(
+        gatewaySessionTreeData,
+        expandedGatewayKeys,
+        gatewayExpandableKeys,
+        gatewayTreeSection.onContentSizeChange
+      )
     : null;
 
   const sessionSearchBar =
@@ -1265,6 +1295,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
         <>
           {manualSessions.length > 0 ? (
             <Collapse
+              ref={manualTreeSection.ref}
               className={
                 fillPanel && isManualSessionsOpen ? 'agor-panel-session-tree-section' : undefined
               }
@@ -1283,7 +1314,9 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
               style={{
                 marginTop: 8,
                 flexShrink: 0,
-                ...(isManualSessionsOpen ? expandedPanelStyle : undefined),
+                ...(isManualSessionsOpen
+                  ? expandedPanelStyle(manualTreeSection.maxHeight)
+                  : undefined),
               }}
             />
           ) : onCreateSession ? (
@@ -1311,6 +1344,7 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
 
           {gatewayRootSessions.length > 0 && (
             <Collapse
+              ref={gatewayTreeSection.ref}
               className={
                 fillPanel && isGatewaySessionsOpen ? 'agor-panel-session-tree-section' : undefined
               }
@@ -1329,7 +1363,9 @@ export const BranchSessionSections: React.FC<BranchSessionSectionsProps> = ({
               style={{
                 marginTop: manualSessions.length > 0 || scheduledSessions.length > 0 ? 0 : 8,
                 flexShrink: 0,
-                ...(isGatewaySessionsOpen ? expandedPanelStyle : undefined),
+                ...(isGatewaySessionsOpen
+                  ? expandedPanelStyle(gatewayTreeSection.maxHeight)
+                  : undefined),
               }}
             />
           )}

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionTree.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionTree.tsx
@@ -1,0 +1,40 @@
+import { Tree, type TreeProps } from 'antd';
+import { useLayoutEffect, useRef, useState } from 'react';
+import { BRANCH_SESSION_VIEWPORT_HEIGHT } from './branchCardLayout';
+import type { SessionTreeNode } from './buildSessionTree';
+
+/** AntD needs a numeric height to virtualize; CSS alone only clips mounted rows. */
+export function BranchSessionTree({
+  fillAvailableHeight,
+  ...props
+}: TreeProps<SessionTreeNode> & { fillAvailableHeight: boolean }) {
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const [height, setHeight] = useState(BRANCH_SESSION_VIEWPORT_HEIGHT);
+
+  useLayoutEffect(() => {
+    const viewport = viewportRef.current;
+    if (!fillAvailableHeight || !viewport) return;
+    // Measure the flex slot, not the tree content, so changing the virtual
+    // window cannot grow its own container. Hidden tabs must not disable virtualization.
+    const measure = () => setHeight(Math.max(1, viewport.clientHeight));
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(viewport);
+    return () => observer.disconnect();
+  }, [fillAvailableHeight]);
+
+  const tree = (
+    <Tree
+      {...props}
+      height={fillAvailableHeight ? height : BRANCH_SESSION_VIEWPORT_HEIGHT}
+      virtual
+    />
+  );
+  return fillAvailableHeight ? (
+    <div ref={viewportRef} style={{ flex: 1, minHeight: 0, overflow: 'hidden' }}>
+      {tree}
+    </div>
+  ) : (
+    tree
+  );
+}

--- a/apps/agor-ui/src/components/BranchCard/BranchSessionTree.tsx
+++ b/apps/agor-ui/src/components/BranchCard/BranchSessionTree.tsx
@@ -6,8 +6,12 @@ import type { SessionTreeNode } from './buildSessionTree';
 /** AntD needs a numeric height to virtualize; CSS alone only clips mounted rows. */
 export function BranchSessionTree({
   fillAvailableHeight,
+  onContentSizeChange,
   ...props
-}: TreeProps<SessionTreeNode> & { fillAvailableHeight: boolean }) {
+}: Omit<TreeProps<SessionTreeNode>, 'height' | 'virtual'> & {
+  fillAvailableHeight: boolean;
+  onContentSizeChange?: (contentHeight: number, viewportHeight: number) => void;
+}) {
   const viewportRef = useRef<HTMLDivElement>(null);
   const [height, setHeight] = useState(BRANCH_SESSION_VIEWPORT_HEIGHT);
 
@@ -16,12 +20,27 @@ export function BranchSessionTree({
     if (!fillAvailableHeight || !viewport) return;
     // Measure the flex slot, not the tree content, so changing the virtual
     // window cannot grow its own container. Hidden tabs must not disable virtualization.
-    const measure = () => setHeight(Math.max(1, viewport.clientHeight));
+    // AntD exposes no total-height callback. Its scroll holder includes the
+    // virtual spacer, so scrollHeight measures the whole collection, not just
+    // mounted rows. Observe the spacer too: short lists can grow without
+    // changing their currently capped viewport.
+    const holder = viewport.querySelector<HTMLElement>('.ant-tree-list-holder');
+    const measure = () => {
+      const viewportHeight = viewport.clientHeight;
+      setHeight(Math.max(1, viewportHeight));
+      if (viewportHeight > 0 && holder) {
+        onContentSizeChange?.(holder.scrollHeight, viewportHeight);
+      }
+    };
     measure();
     const observer = new ResizeObserver(measure);
     observer.observe(viewport);
+    if (holder) {
+      observer.observe(holder);
+      if (holder.firstElementChild) observer.observe(holder.firstElementChild);
+    }
     return () => observer.disconnect();
-  }, [fillAvailableHeight]);
+  }, [fillAvailableHeight, onContentSizeChange]);
 
   const tree = (
     <Tree

--- a/apps/agor-ui/src/components/BranchCard/branchCardLayout.ts
+++ b/apps/agor-ui/src/components/BranchCard/branchCardLayout.ts
@@ -1,7 +1,7 @@
 import type { Session } from '@agor-live/client';
 import { isGatewaySession } from '@agor-live/client';
 
-// Keep mounted lists and the deferred card's fit-to-view footprint in sync.
+// Keep auto-sized card lists and the deferred card's fit-to-view footprint in sync.
 export const BRANCH_SESSION_VIEWPORT_HEIGHT = 400;
 
 const EMPTY_SESSIONS_SHELL_HEIGHT = 72;

--- a/apps/agor-ui/src/index.css
+++ b/apps/agor-ui/src/index.css
@@ -165,3 +165,13 @@
   border-radius: 0;
   padding: 0;
 }
+
+/* Collapse's motion wrapper has no semantic style prop. Carry the bounded
+   teammate flex slot through it; never affect auto-sized canvas cards or
+   override the hidden-panel display rule during collapse. */
+.agor-panel-session-tree-section > .ant-collapse-item > .ant-collapse-panel-active {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}


### PR DESCRIPTION
## Summary

Refs #2699 (Max). Current commit: `2e88170d30af0b66c12c5b33efd5a00e3faac005`. Restore container-sized teammate session trees without undoing #2687's rendering bounds.

- Size the teammate tab from its actual parent, not `100vh - 112px`, and carry the available flex height through its header and expanded sections.
- Measure each tree's independent flex slot with `ResizeObserver` and pass a positive numeric height to AntD. Manual/gateway trees share available space; short sections are capped at measured content plus header/padding so overflowing siblings reclaim unused space. Short panels with long descriptions or several sections retain outer scrolling and a small usable tree minimum.
- Keep auto-sized board cards/popovers and deferred-card estimates at 400px. Scheduled/search pagination remains 20 rows. Preserve genealogy, selection, collapse state and the #2692/#2693 wheel routing.
- Prefer AntD item/semantic styles; one narrowly scoped CSS rule handles the Collapse motion wrapper that has no semantic style prop. Disconnect observers on unmount. Update the existing sessions guide.

## Investigation and reproduction

Fetched live issue body, all comments (none), timeline, and #2687/#2692/#2693 bodies, comments, reviews and review comments. Also inspected open #1814: it targets the separate all-sessions list, not this teammate tree. Issue/PR searches found no existing #2699 fix. Rechecked before publication.

Fresh main: `bd2019357dc130b1aa98b7298f7158a84262d969` (unchanged on final fetch). Deepened the isolated depth-1 clone by 100 commits and inspected the introducing diff and subsequent path history:

- #2687 / `74e96187b663cd533a1925a46d3ba5db72047890` introduced `Tree.height=400` in the shared renderer.
- #2692 / `6cfcd66a5c1c366bb4872e12617839a58f4bad37` and #2693 / `b6ab9654d0d4fef49aee808cac0d28e477d870b5` changed wheel behavior, not sizing.
- The later #2678 change affected archive actions, not this layout.

**Red before any production edit:** mounted the actual `BoardTeammatePanel`, actual AntD tree and stylesheet with 1,001 sessions in a 1,100px container. All four Chromium profiles failed the remaining-space assertion: **426.15625px unused below the tree**, expected <40px. Precisely, AntD's height is a *maximum*, not a forced height for short collections; the reported cap affects overflowing trees.

**Root cause end-to-end:** the teammate and auto-sized canvas card shared a fixed numeric virtualization viewport. The teammate tab also relied on viewport-based height and ordinary document flow rather than a bounded, flexible height chain. Removing `height` would restore unbounded row mounting; increasing the constant would still ignore the container and break card footprint assumptions. The fix gives the bounded teammate caller an explicit opt-in, preserves its header space, measures the flex slot independently of tree content, and retains numeric virtualization through resize/hidden-tab transitions.

## Validation

All passed:

- `pnpm install --frozen-lockfile` — no lockfile changes.
- `pnpm --filter agor-ui test src/components/BranchCard src/components/BoardTeammatePanel src/components/SessionCanvas` — **167 tests / 30 files**.
- `pnpm --filter agor-ui test:browser src/components/BoardTeammatePanel/BoardTeammatePanel.height.browser.test.tsx src/components/BranchCard/BranchSessionSections.bounds.browser.test.tsx src/components/BranchCard/BranchCard.wheel.browser.test.tsx src/components/CardNode/CardNode.markdown.browser.test.tsx` — **104 cases**, Chromium desktop/phone/tablet/short-landscape.
- Final new panel suite rerun after typed-fixture cleanup: **20 passed / 4 profiles**. A cold Vite dependency-optimizer reload initially prevented test import; removed the unnecessary extra matcher runtime import and reran successfully.
- New panel suite covers container-only shrink/grow, manual/gateway descendant tails and click callbacks, collapse/reopen, hidden-tab resizing, mixed tree allocation, scheduled pagination, search/clear, short/empty lists and long-description overflow. Existing cases retain card virtualization/deferred bounds, wheel/pinch/drag contracts and Markdown scroll boundaries.
- `pnpm typecheck` — **21 successful workspace tasks** (the standard Turbo typecheck graph also runs dependency builds). Final `pnpm --filter agor-ui typecheck` passed.
- Strict test-file no-emit check: `pnpm exec tsc -p apps/agor-ui/node_modules/.tmp/issue2699-tsconfig.json --pretty false`. Temporary ignored config extends `../../tsconfig.app.json`, sets `include` to `../../src/components/BoardTeammatePanel/BoardTeammatePanel.height.browser.test.tsx`, clears `exclude`, and uses a separate `/tmp` build-info path. No type-safety overrides. The new fixture constructs canonical `Session` values.
- `pnpm lint` — Biome plus **330 frontend design-system fixture cases**; strict touched-file Biome; `pnpm exec prettier --check apps/agor-docs/content/guide/sessions.mdx`.
- `pnpm check:shortid`, `pnpm check:multitenancy-boundaries`, `pnpm check:daemon-filesystem-boundaries`, `pnpm check:realtime-boundaries`, `pnpm check:ci-test-coverage`; diff whitespace check.

### Managed environment browser verification

Started this isolated branch's configured SQLite environment through Agor MCP. Signed into its seeded development account and opened the full board UI at `http://10.33.92.175:10521/b/default/`. Used **browser-memory-only** fixtures on the authorized seed branch/board: 1,001 genealogy sessions, no service writes or agent execution. Screenshots inspected in tall/short layouts:

| Browser viewport | Measured tree | Mounted rows | Gap below tree |
| --- | ---: | ---: | ---: |
| 1440 × 1100 | 732px | 12 | ~28px |
| 1440 × 650 | 282px | 6 | ~28px |

No page errors. Environment remains available for review. Fixture sessions disappear on refresh; no production access or mutation was needed.

Normal pre-commit hooks passed (lint-staged/Biome), no bypass; working tree clean. Git commands use simple-git. Normalized the aliased workspace PWD while retaining inherited environment/security configuration for the hook run.

## Scope, security and limitations

Reviewed tenancy at shaping and again against the final diff. This is local presentation of already-authorized session props/store data; no query, hydration, ID resolution, credentials, authorization, tenant context, realtime transport, database schema, persistence or lifecycle boundary changes. SQLite/PostgreSQL and HA contracts are unchanged; adding cross-tenant plumbing/tests here would not exercise a changed boundary. No new backend, PostgreSQL/RLS or HA integration run was needed.

Chromium profiles are viewport sizes, not four operating systems. No Safari/Firefox or physical-trackpad run. Full UI hydration remains unchanged, and scheduled/search lists retain their existing independent bounds. Unit runs emit existing jsdom CSS/pseudo-element warnings. Boundary guard reports an existing improved raw-transaction baseline, then passes. No whole-repository test run or production load benchmark.

No merge, release, deployment, production mutation or issue closure.


## Requested full-check follow-up

Reran against committed/pushed `082706883444831fa7a088c2a1ae671b15edd8de`:

- `pnpm i` — passed, already up to date; no lockfile or source changes.
- **`pnpm check` — passed in full:** 21 successful typecheck/dependency tasks, repository lint and 330 frontend design-system fixtures, all four repository boundary guards, then 15 successful configured build tasks (excluding docs as defined by the command).
- `pnpm --filter agor-ui test src/components/BranchCard src/components/BoardTeammatePanel src/components/SessionCanvas` — **167 passed / 30 files**.
- The four focused browser suites listed above — **104 passed / 16 profile-file combinations**.
- Strict no-emit typecheck of the regression test with the temporary ignored config documented above — passed.
- Diff whitespace check and working-tree status — clean. No additional commit was necessary; the existing commit was created with normal hooks and remains pushed.
- Existing Markdown PR retained rather than opening a duplicate; worktree attachment reconfirmed through `agor_branches_update` MCP.

GitHub CI is also green for all executed checks, including browser layout, unit lanes, typecheck/build, docs and Redis HA isolation; the main-image promotion and optional all-packaged-integrations checks are intentionally skipped. No merge or deployment performed.


## Review follow-up — `df0cef51de3ffe817fc66ccd232801876f703d50`

Addressed both findings from the independent Codex review of `082706883444831fa7a088c2a1ae671b15edd8de`; no feedback intentionally skipped. Follow-up review confirmed both fixes; it identified the test-timing issue below.

- **P2 reproduced before editing production code:** asymmetric and both-short browser cases failed in all four Chromium profiles (**12 failures**). AntD kept short trees natural, but equal-flex enclosing sections still reserved empty space.
- Each section now caps itself at its measured full tree content plus its own header/padding; normal flex allocation releases excess space to an overflowing sibling. The minimum cannot override a genuinely shorter tree. Viewport measurement remains independent and numeric virtualization stays enabled. The tree adapter observes AntD's scroll holder and virtual spacer because AntD exposes no total-content-height callback; this dependency stays local to the adapter, without duplicating row/header/theme dimensions.
- **P3:** the adapter's public signature now omits `height` and `virtual`, making its ownership explicit.
- Regression cases cover manual/gateway counts **1/301, 1/1, 2/301, 301/2 and 2/2**, live growth to two long trees, shrink back to two short trees, and genealogy collapse/re-expansion releasing/restoring space. Existing resize, hidden-tab, tail access, pagination, card/popover bounds and wheel cases remain passing.

Validation on the follow-up code:

- `pnpm check` — **passed in full**: 21 typecheck/dependency tasks, repository lint and 330 design-system fixture cases, all four boundary guards, 15 configured build tasks.
- Focused unit command above — **167 passed / 30 files**.
- Four focused browser suites above — **124 passed / 16 profile-file combinations**. One intermediate run overlapped workspace builds and hit Vite module-import errors; the complete final run after builds settled passed without skips.
- Strict regression-file no-emit typecheck, strict touched-file Biome, docs Prettier and diff whitespace checks — passed.
- Normal commit hooks — passed; no bypass.
- Managed full-board UI verification with browser-memory-only **2 manual / 301 gateway** fixtures: at 1440×1100 the manual tree measured 119px and gateway 500px, with only 15px/~12px section trailing padding; at 1440×650 they measured 85px/87px. Long labels and the development onboarding banner consume real panel space. No page errors; tall screenshot inspected. No persisted session writes or production access.

The existing security/tenancy assessment and platform limitations remain applicable. New CI runs are triggered by this follow-up push; the green CI statement above describes the original commit.


## Review timing follow-up — `2e88170d30af0b66c12c5b33efd5a00e3faac005`

The second independent review confirmed the production fix and signature improvement, but correctly flagged a separate CI regression-test timing failure. I verified the [failed browser job](https://github.com/preset-io/agor/actions/runs/34259026883/job/102172022702): **7 failures / 264 cases**, all at the live-growth assertion (`283px > 300px`), not Vite imports. The reviewer independently observed the intermediate 283px settle to 364px under 4× Chromium CPU throttling.

This commit changes only that assertion's `waitFor` timeout to a bounded **5 seconds**, with a comment explaining real tree motion and ResizeObserver convergence. It retains the >300px assertion, real animation, and all growth/shrink coverage; no retries, skips, global timeout changes or production changes. No feedback intentionally skipped.

Validation rerun:

- **`pnpm --filter agor-ui test:browser` — entire browser lane passed: 264 tests / 52 profile-file combinations.**
- Focused unit command above — **167 tests / 30 files passed**.
- **`pnpm check` — passed in full**, including typechecks, lint, boundary guards and configured builds.
- Strict regression-test no-emit typecheck with the previously documented ignored config and touched-file Biome — passed.
- Diff whitespace check and normal commit hooks — passed; pushed, clean worktree.

The browser lane emitted AntD deprecation and CSSMotion act warnings; no test failures. No new managed full-shell run was needed for this test-only change. Platform limitations remain unchanged. Follow-up review passed as recorded below; new-head GitHub CI remains in progress, not claimed green.


## Final independent AI review — PASS

- **Reviewed commit:** `2e88170d30af0b66c12c5b33efd5a00e3faac005` (live PR head and clean local HEAD verified).
- **Reviewer:** Codex subsession running **gpt-6-astra**, model verified through Agor context; [same reviewer session](https://agor.sandbox.preset.zone/ui/s/01a08211678077b08526b009/) reused for both follow-ups, with automatic system callbacks.
- **Verdict:** no remaining substantive issues or blockers. All three findings resolved: short sections release space, the adapter owns height/virtual explicitly, and the live-growth test allows bounded animated convergence without weakening its assertion.
- Final independent rerun: **40 panel browser cases passed across four Chromium profiles**; diff whitespace passed. Reviewer inspected the full-browser/full-check evidence above and accepted the production modeling and boundaries.
- Applied `ai-reviewed-gpt-6-astra` to identify the actual reviewing model. This is AI-review evidence, not a human approval or a claim that CI has completed.
- At final verification, completed CI checks were passing and browser/other jobs were still running. No merge, deployment or issue closure.
