### PR TITLE
docs(sandbox): clarify Docker bind source visibility (#2703)

### DIFF
--- a/apps/agor-daemon/src/utils/sandbox-wrap.test.ts
+++ b/apps/agor-daemon/src/utils/sandbox-wrap.test.ts
@@ -100,6 +100,53 @@ describe.runIf(bwrapRuntimeAvailable)('Claude credential sandbox containment', (
 
   afterEach(async () => rm(root, { recursive: true, force: true }));
 
+  it('preserves host identity for branch writes but not projected home paths', async () => {
+    const siblingBranch = join(root, 'data', 'worktrees', 'repo', 'sibling');
+    await mkdir(siblingBranch);
+    await writeFile(join(siblingBranch, 'private.txt'), 'sibling-private');
+
+    const wrapped = buildSandboxWrap({
+      sandbox: {
+        enabled: true,
+        home_mode: 'per_user',
+        preserve_canonical_home_alias: true,
+        fail_if_unavailable: true,
+        include: { tmp: false },
+      },
+      branchPath: branch,
+      branchAccess: 'write',
+      cmd: '/bin/sh',
+      args: [
+        '-c',
+        `set -eu
+printf branch-write > "$1/branch-canary"
+printf home-write > "$2/home-canary"
+test "$(cat "$3/home-canary")" = home-write
+if cat "$4/private.txt" 2>/dev/null; then exit 70; fi`,
+        'sh',
+        branch,
+        home,
+        canonicalHome,
+        siblingBranch,
+      ],
+      ownerHomeStore: ownerStore,
+      runtimePaths,
+    });
+    expect(wrapped).not.toBeNull();
+    const result = spawnSync(wrapped!.cmd, wrapped!.args, { encoding: 'utf8' });
+    expect(result.status, result.stderr).toBe(0);
+
+    // A consumer outside this mount namespace (e.g. dockerd) sees branch
+    // writes at the same path. Home writes reach the owner store instead:
+    // resolving a home alias outside the sandbox does not reach that inode.
+    expect(await readFile(join(branch, 'branch-canary'), 'utf8')).toBe('branch-write');
+    expect(await readFile(join(ownerStore, 'home-canary'), 'utf8')).toBe('home-write');
+    for (const alias of [home, canonicalHome]) {
+      await expect(readFile(join(alias, 'home-canary'))).rejects.toMatchObject({ code: 'ENOENT' });
+    }
+    expect(await readFile(join(siblingBranch, 'private.txt'), 'utf8')).toBe('sibling-private');
+  });
+
   it('blocks parent/sidecar attacks through every live alias while ordinary Claude state stays writable', async () => {
     const authorityPaths = AUTHORITY_FILENAMES.map((filename) =>
       join(ownerStore, '.claude', filename)

--- a/apps/agor-docs/content/guide/multiplayer-unix-isolation.mdx
+++ b/apps/agor-docs/content/guide/multiplayer-unix-isolation.mdx
@@ -45,6 +45,80 @@ required for the next heartbeat decision.
 
 `users.filesystem_home` can point at a migrated home. Otherwise Agor uses its canonical tenant-scoped home store. Never derive this path from untrusted request data.
 
+### Docker bind mounts from a sandbox
+
+Docker resolves bind-mount source paths in the **Docker daemon's filesystem**, not
+in the calling session. A sandbox path is not necessarily a host path:
+
+- The private home store is mounted onto the session's home aliases. A file
+  written under `$HOME` persists in that user's store, not at the same home path
+  seen by a host Docker daemon.
+- With the default per-user temporary storage, `/tmp` is backed by the user's
+  private `tmp` directory; `/var/tmp` is a private tmpfs.
+- The authorized Agor branch is re-exposed from its host directory. Newly written
+  files beneath that mount can be bind-mounted when Docker sees the same directory
+  at the same path. Creating a directory elsewhere with an Agor-like worktree name
+  does **not** register a branch or grant it a host-identity mount.
+
+Mount propagation controls mount/unmount events, not ordinary writes to an
+existing filesystem. `private` or `slave` propagation alone does not make files
+invisible. Do not change propagation to `rshared`, join the host mount namespace,
+or disable sandboxing to repair a path mismatch: those changes do not preserve
+Agor's isolation contract. `realpath` resolves symlinks inside the session; it
+cannot translate a private home overlay into a Docker-host path.
+
+#### Verify the exact source before provisioning
+
+Only use a Docker endpoint that the operator has authorized for this workload.
+Run this Bash probe **from the intended source directory**, using an already
+available, approved image with `cat`. It writes only a disposable canary, mounts
+it read-only, and removes it on exit:
+
+```bash
+set -euo pipefail
+image=alpine:3.19 # Replace with your approved local image.
+probe=$(mktemp -d "$(pwd -P)/.docker-source-check-XXXXXX")
+cleanup() { unlink "$probe/canary"; rmdir "$probe"; }
+trap cleanup EXIT
+printf '%s\n' "${probe##*/}" > "$probe/canary"
+actual=$(docker run --rm --pull=never --network=none --read-only \
+  --mount "type=bind,src=$probe,dst=/probe,readonly" "$image" cat /probe/canary)
+test "$actual" = "${probe##*/}"
+```
+
+Prefer `--mount` without `bind-create-src` for diagnostics: it rejects a missing
+host source, whereas `-v` can create an empty host directory and hide the mismatch.
+Repeat the canary for each source root, not just the driver checkout. See
+[Docker's bind-mount constraints](https://docs.docker.com/engine/storage/bind-mounts/#considerations-and-constraints).
+
+#### Choose the workflow boundary
+
+- **Same-host source:** keep temporary source checkouts beneath an authorized
+  branch mount that passes the probe. Account for generated files, cleanup, and
+  concurrent runs; do not place them in sibling branches or guess another user's
+  physical home path.
+- **Session-private or remote source:** transfer only the required source bytes
+  using a client-side build context or a tar stream into a fresh per-run Docker
+  volume. Remove all original source bind mounts from the consuming configuration;
+  copying bytes alone does not change Compose mounts. Track the volume/container
+  IDs and clean up only that run's resources on every exit path.
+- **Isolated container workloads:** use an operator-reviewed delegated substrate
+  with explicit tenant/user storage and Docker access policy when host Docker
+  access is not appropriate.
+
+Docker volumes and containers do not inherit Agor's tenant/branch RBAC. A unique
+resource name prevents accidental collisions, not unauthorized access. Access to
+an unrestricted host Docker daemon is a separate privileged capability; the
+filesystem sandbox does not constrain what that daemon can mount. Do not expose
+it to untrusted tenants as a workaround. See
+[Docker daemon security](https://docs.docker.com/engine/security/#docker-daemon-attack-surface).
+
+In HA or remote-Docker deployments, a local canary is insufficient: it must pass
+against the endpoint that will provision the workload. Local volumes belong to
+that Docker host; cleanup and retries must target the same host, or the workflow
+must explicitly restage its source. No database setting makes these files or
+volumes portable between hosts.
+
 ### Per-branch SDK homes
 
 Agent SDK state can be relocated from the session owner's home into a directory


### PR DESCRIPTION
## Summary

Refs #2703. **This does not close the issue or restore the private QAgor pipeline.** It documents the actual Docker source-path contract and adds live sandbox coverage instead of weakening isolation based on an incorrect blanket diagnosis.

- Explain why session-private HOME/tmp paths are not Docker-host paths, while an authorized branch mount can retain host identity.
- Add a disposable, read-only Docker source canary and bounded remediation options: verified branch-local sources, client-side source transfer, or an explicitly isolated delegated substrate.
- Add a real bubblewrap test proving branch write-through, private-home alias separation, and sibling-branch masking.

## Investigation / root cause

Read the full live issue (no comments/timeline references at initial fetch), its linked Knowledge write-up, and failing session `01a07cee-62d4-77ae-94af-fddcb2fb8c08`. The latter reports 14 provisioning aborts since August 17 and 15 pending PRs; those pipeline runs were not independently repeated.

Deepened the shallow clone by 300 commits. #2362 introduced the home/tmp projection at `915c8b1cdb05ffcb80e4efae72cb2c28707d5072`, merged **2026-08-17T04:18:51Z**, matching the reported onset. The same commit already re-exposed the authorized branch at its host path. #2653 (`3f73029dc1239a4c9a866ae4dc4169a5b1d0bff9`) subsequently fixed artifact actor-home propagation and pinned tmp; it does not translate Docker paths. Searches of related open/merged PRs found no duplicate fix. No actual overlap with the parallel APM or OAuth work required coordination.

Docker resolves bind sources in its own filesystem namespace. A home alias can resolve to the caller's private store inside a session and somewhere else outside. Mount propagation concerns mount events, **not ordinary writes**. Changing to `rshared`, entering the host mount namespace, or exposing physical homes is not a justified isolation-preserving fix.

## Revisions and before/after evidence

- Base exercised: `bdc05c24d8a543429c664f6fea0aaf0b3ff39158`.
- PR commit: `b7571b12d3e7945d78acf91bd3cc449c1b7d9651`.
- Fresh main checked after task resume: `ae3a4d6ca21533edd3938851842e0fb5216584a7`; intervening #2702 changes only UI, not sandbox implementation or these files.

Live canaries on this isolated branch used existing `alpine:3.19`, `--pull=never --network=none --read-only`, and read-only `--mount` binds:

| Source / operation | Result |
| --- | --- |
| Newly written authorized branch file, logical home alias | Exit 0; exact canary bytes |
| Same branch file, canonical `/var/lib/agor/...` alias | Exit 0; exact canary bytes |
| Newly written `$HOME` directory | Exit 125: bind source path does not exist |
| Newly written `/tmp` directory | Exit 125: bind source path does not exist |
| Tar-stream the same HOME canary into a new named volume, read from another container | Exact bytes round-trip |

All disposable canaries/containers and the single generated volume were removed. No pre-existing resource was mutated. Using `--mount` rather than `-v` avoided creating misleading empty host directories. The verbatim documentation probe also passed from the branch directory.

The new bubblewrap test passes against **unchanged main runtime code**. This is contract coverage, not a claimed red-to-green product-code fix. Live observations of the existing deployment are separate from this source-level test; its deployed binary revision was not established.

## Remaining QAgor decision

Recommend first testing temporary source roots **beneath the authorized branch mount**, with the canary against every actual provisioning source. Alternatively stream required source bytes into fresh per-run storage and replace all original Compose source bind mounts, with owned cleanup. This PR does not edit private pipeline scripts, its schedule, production configuration, or host mounts, and does not claim a successful Superset provisioning run.

## Security / tenancy / HA

No runtime, authorization, schema, query, or configuration change. Tenant-owned homes and derived branch files keep the existing trusted actor/RBAC mount policy; sibling masking remains covered. SQLite/Postgres behavior is unchanged. Docker resources do not inherit Agor RBAC: documentation explicitly warns that unique names are not access control and unrestricted Docker is a separate privileged boundary. Remote/HA source checks and cleanup must target the actual Docker endpoint; local volumes are not portable merely because Agor has shared database state.

## Validation

Re-run after resuming the task, all passed:

- `pnpm --filter @agor/daemon exec vitest run src/utils/sandbox-wrap.test.ts` — **10 passed**, real bubblewrap tests executed.
- `pnpm --filter @agor/core exec vitest run src/config/sandbox-policy.test.ts` — **44 passed**.
- Targeted `tsc --noEmit` configuration extending daemon tsconfig, explicitly including `sandbox-wrap.test.ts` and `customConditions: ["source"]` — passed (the normal daemon tsconfig excludes tests).
- `pnpm --filter @agor/docs typecheck`.
- Biome on the changed test; Prettier check on the MDX guide.
- Multitenancy, daemon-filesystem, realtime boundary checks; diff whitespace check.
- Verbatim guide shell probe syntax/execution and live Docker matrix above.
- Commit hooks passed; no hook bypass. Initial lint-staged stash failure was resolved by matching inherited `PWD` to the actual command cwd across mount aliases, retaining Git hardening.

Gaps: no full monorepo typecheck/build, browser-rendered docs verification, database integration suite, cross-host Docker/HA run, or production QAgor run. These are not represented as passing.

## Interrupted-task recovery

The prior task records generic `operation has timed out` at `18:10:50.624Z`; metadata names no failing operation. The last visible command had successfully committed. Resume verified a clean worktree, no remote branch/PR, and no lingering relevant process visible in the new session namespace before push. A shared infrastructure incident is possible but unproven. Full durable evidence is also attached to this Agor branch's notes.
