### PR TITLE
fix(codex): distinguish runtime notices from MCP failures

### DIFF
--- a/apps/agor-docs/content/guide/sessions.mdx
+++ b/apps/agor-docs/content/guide/sessions.mdx
@@ -261,6 +261,25 @@ shared branch-scoped session, the child is attributed to that collaborator, so a
 borrow the parent's secret. Execution-home sessions cannot be continued across users. Callbacks
 carry message content, not an environment grant.
 
+### Codex runtime notices and tool failures
+
+A **Codex runtime notice** is non-fatal at the time it is emitted, not proof that
+an MCP operation failed or succeeded. Codex uses the same item shape for several
+kinds of warnings, including configuration and deprecation notices, without
+preserving their classification. Agor keeps the notice visible but does not copy
+provider error text, which can contain sensitive data.
+
+A **failed MCP tool result** remains marked as an error even if Codex continues
+and completes the turn. Before retrying a write, check its resulting state: a
+transport error can occur after a change has committed. An empty tool catalog is
+not itself an error, and a failed turn is separate from an individual tool failure.
+
+Recurring notices and failed MCP calls include a diagnostic reference. Give that
+reference and the task to an authorized administrator. The reference correlates
+bounded, content-free executor operational logs; it does not grant access to logs
+or expose the provider payload. High-volume diagnostics are summarized after the
+per-run log limit, without hiding notices or tool failures in the conversation.
+
 ### Historical Claude CLI sessions
 
 Agor previously included an experimental `claude-code-cli` runtime. That integration has been

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.test.ts
@@ -1366,6 +1366,34 @@ describe('CodexPromptService - tool payload mapping', () => {
     });
   });
 
+  it('does not hide an explicit MCP error behind result content or a success status', () => {
+    const service = new CodexPromptService(
+      mockMessagesRepo,
+      mockSessionsRepo,
+      mockSessionMCPServerRepo,
+      mockBranchesRepo,
+      undefined,
+      'test-api-key',
+      mockDb
+    );
+    const toolUse = (service as any).itemToToolUse(
+      {
+        id: 'mcp-conflicting',
+        type: 'mcp_tool_call',
+        server: 'agor',
+        tool: 'write',
+        arguments: {},
+        status: 'completed',
+        result: { content: [{ type: 'text', text: 'partial result' }] },
+        error: { message: 'SENTINEL_PROVIDER_BODY' },
+      },
+      'completed'
+    );
+    expect(toolUse.status).toBe('failed');
+    expect(toolUse.output).toContain('check the resulting state before retrying');
+    expect(JSON.stringify(toolUse)).not.toContain('SENTINEL_PROVIDER_BODY');
+  });
+
   it('sanitizes MCP provider error messages on failure', () => {
     const service = new CodexPromptService(
       mockMessagesRepo,
@@ -1397,7 +1425,7 @@ describe('CodexPromptService - tool payload mapping', () => {
       name: 'agor.agor_execute_tool',
       input: {},
       output:
-        'The MCP operation failed. Retry, then ask an administrator to review the secure operational event if it continues.',
+        'The MCP tool call failed. A write may already have taken effect; check the resulting state before retrying. If it continues, ask an administrator to review the operational diagnostics.',
       status: 'failed',
     });
   });
@@ -1441,7 +1469,7 @@ describe('CodexPromptService - tool payload mapping', () => {
     );
 
     expect(JSON.stringify(toolUse)).not.toContain(sentinel);
-    expect(toolUse.output).toContain('The MCP operation failed');
+    expect(toolUse.output).toContain('The MCP tool call failed');
   });
 
   it('falls back to structured_content when MCP content blocks are empty', () => {
@@ -1978,6 +2006,119 @@ describe('CodexPromptService - event_msg terminal handling (issue #1749)', () =>
       totalTokens: 30_000,
       maxTokens: 272_000,
     });
+  });
+
+  it('persists a failed MCP result as is_error even when the Codex turn subsequently completes', async () => {
+    const { service } = await makeInitializedStreamingService(null);
+    const initialRuns = mockRunStreamedInputs.length;
+    const messagesRepo = {
+      findInitialUserMessagesByTaskId: vi.fn(async () => []),
+      getNextIndexBySessionId: vi.fn(async () => 0),
+    };
+    const messagesService = {
+      create: vi.fn(async (message: Partial<Message>) => message as Message),
+      patch: vi.fn(async (_id: string, message: Partial<Message>) => message as Message),
+    } satisfies MessagesService;
+    const tool = new CodexTool(
+      messagesRepo as unknown as MessagesRepository,
+      mockSessionsRepo,
+      mockSessionMCPServerRepo,
+      mockBranchesRepo,
+      undefined,
+      'test-api-key',
+      messagesService
+    );
+    (tool as unknown as { promptService: CodexPromptService }).promptService = service;
+    mockBranchesRepo.findById.mockResolvedValue({ branch_id: 'branch-1' });
+    // The CLI maps MCP isError:true to failed status while retaining result content.
+    mockStreamEvents = [
+      {
+        type: 'item.completed',
+        item: {
+          id: 'failed-call',
+          type: 'mcp_tool_call',
+          server: 'agor',
+          tool: 'agor_execute_tool',
+          arguments: {},
+          status: 'failed',
+          result: { content: [{ type: 'text', text: '{"code":"invalid_tool_arguments"}' }] },
+        },
+      },
+      {
+        type: 'item.completed',
+        item: { id: 'answer', type: 'agent_message', text: 'Please correct the input.' },
+      },
+      {
+        type: 'turn.completed',
+        usage: { input_tokens: 1, output_tokens: 1, cached_input_tokens: 0 },
+      },
+    ];
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      const result = await tool.executePromptWithStreaming(testSessionId, 'go');
+      expect(result.rawSdkResponse).toMatchObject({ type: 'turn.completed' });
+      const saved = messagesService.create.mock.calls.flatMap(([message]) => message.content ?? []);
+      expect(saved).toContainEqual(
+        expect.objectContaining({ type: 'tool_result', is_error: true })
+      );
+      expect(JSON.stringify(saved)).toContain('invalid_tool_arguments');
+      const reference = JSON.stringify(saved).match(/reference=([a-f0-9-]+:\d+)/)?.[1];
+      expect(reference).toBeDefined();
+      expect(JSON.stringify(warn.mock.calls)).toContain(`reference=${reference}`);
+      expect(JSON.stringify(warn.mock.calls)).toContain('failure_kind=failed_result');
+      expect(mockRunStreamedInputs).toHaveLength(initialRuns + 1);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('does not let a nonfatal notice mask a later failed turn', async () => {
+    const { service } = await makeInitializedStreamingService(null);
+    mockStreamEvents = [
+      { type: 'item.completed', item: { id: 'notice', type: 'error', message: 'SENTINEL_NOTICE' } },
+      { type: 'turn.failed', error: { message: 'SENTINEL_FAILURE' } },
+    ];
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    try {
+      await expect(drain(service)).rejects.toThrow('Codex failed the turn');
+      expect(JSON.stringify([...warn.mock.calls, ...error.mock.calls])).not.toContain('SENTINEL_');
+    } finally {
+      warn.mockRestore();
+      error.mockRestore();
+    }
+  });
+
+  it('surfaces opaque Codex notices without inventing an MCP failure or losing correlation', async () => {
+    const { service } = await makeInitializedStreamingService(null);
+    const initialRuns = mockRunStreamedInputs.length;
+    mockStreamEvents = [
+      {
+        type: 'item.completed',
+        item: { type: 'error', id: 'SENTINEL_ITEM_ID', message: 'SENTINEL_CONFIG_WARNING' },
+      },
+      { type: 'item.completed', item: { type: 'agent_message', id: 'answer', text: 'Done.' } },
+      {
+        type: 'turn.completed',
+        usage: { input_tokens: 1, output_tokens: 1, cached_input_tokens: 0 },
+      },
+    ];
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      const emitted = await drain(service);
+      const serialized = JSON.stringify(emitted);
+      expect(serialized).toContain('[Codex runtime notice]');
+      expect(serialized).not.toContain('MCP operation failed');
+      expect(serialized).not.toContain('SENTINEL_');
+      expect(serialized).toContain('Done.');
+      const reference = serialized.match(/reference=([a-f0-9-]+:\d+)/)?.[1];
+      expect(reference).toBeDefined();
+      expect(JSON.stringify(warn.mock.calls)).toContain(`reference=${reference}`);
+      expect(JSON.stringify(warn.mock.calls)).not.toContain('SENTINEL_');
+      expect(mockRunStreamedInputs).toHaveLength(initialRuns + 1);
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it.each([

--- a/packages/executor/src/sdk-handlers/codex/prompt-service.ts
+++ b/packages/executor/src/sdk-handlers/codex/prompt-service.ts
@@ -66,6 +66,11 @@ import { resolveContextUserId } from '../base/context-user.js';
 import type { TasksService } from '../base/index.js';
 import { forkCodexThreadViaAppServer } from './app-server-client.js';
 import { applyAgorCodexLaunchPolicy } from './launch-policy.js';
+import {
+  CODEX_MCP_UNKNOWN_FAILURE,
+  CodexRuntimeDiagnostics,
+  codexRuntimeNotice,
+} from './runtime-diagnostics.js';
 import { extractCodexContextSnapshotFromEvent, extractCodexTokenUsage } from './usage.js';
 
 type CodexSdkReasoningEffort = NonNullable<
@@ -201,6 +206,7 @@ function logCodexRuntimeFailure(
   event: 'stream_error_observed' | 'turn_completed_without_response' | 'turn_failed',
   error: unknown,
   sessionId: SessionID,
+  taskId?: TaskID,
   category?: 'configuration_required'
 ): void {
   const safe = sanitizeMCPExternalError(error, {
@@ -208,7 +214,7 @@ function logCodexRuntimeFailure(
     ...(category ? { category } : {}),
   });
   const code = safe.diagnostic.code;
-  const message = `[codex.runtime] event=${event} session_id=${sessionId} category=${safe.category} type=${safe.diagnostic.type}${code ? ` code=${code}` : ''}`;
+  const message = `[codex.runtime] event=${event} session_id=${sessionId}${taskId ? ` task_id=${taskId}` : ''} category=${safe.category} type=${safe.diagnostic.type}${code ? ` code=${code}` : ''}`;
   if (event === 'stream_error_observed') {
     console.warn(`${message} outcome=awaiting_terminal_event`);
   } else {
@@ -1001,12 +1007,16 @@ export class CodexPromptService {
         // This matches Claude's "start/end + payload" visibility model.
         let mcpOutput: string | Array<Record<string, unknown>> | undefined;
         if (status === 'completed') {
-          if (Array.isArray(item.result?.content) && item.result.content.length > 0) {
+          if (item.error) {
+            const safe = sanitizeMCPExternalError(item.error, { stage: 'runtime' });
+            mcpOutput =
+              safe.category === 'unknown'
+                ? CODEX_MCP_UNKNOWN_FAILURE
+                : `${safe.message} Before retrying a write, check whether it already took effect.`;
+          } else if (Array.isArray(item.result?.content) && item.result.content.length > 0) {
             mcpOutput = item.result.content as Array<Record<string, unknown>>;
           } else if (item.result?.structured_content !== undefined) {
             mcpOutput = JSON.stringify(item.result.structured_content, null, 2);
-          } else if (item.error) {
-            mcpOutput = sanitizeMCPExternalError(item.error, { stage: 'runtime' }).message;
           }
         }
         return {
@@ -1020,7 +1030,7 @@ export class CodexPromptService {
             output: mcpOutput,
           }),
           ...(status === 'completed' && {
-            status: item.status,
+            status: item.error ? 'failed' : item.status,
           }),
         };
       }
@@ -1366,6 +1376,7 @@ export class CodexPromptService {
       thread = this.getCodexClient().startThread(threadOptions);
     }
 
+    const diagnostics = new CodexRuntimeDiagnostics(sessionId, taskId);
     let receivedTerminalEvent = false;
     const clearFreshThreadResumeState = async () => {
       if (startedFreshThread) {
@@ -1514,7 +1525,8 @@ export class CodexPromptService {
               logCodexRuntimeFailure(
                 'turn_completed_without_response',
                 observedStreamError,
-                sessionId
+                sessionId,
+                taskId
               );
               throw new CodexLifecycleError('completed_without_response');
             }
@@ -1585,6 +1597,26 @@ export class CodexPromptService {
               // Emit tool_complete for tool items
               const toolUseComplete = this.itemToToolUse(event.item, 'completed');
               if (toolUseComplete) {
+                if (event.item.type === 'mcp_tool_call' && toolUseComplete.status === 'failed') {
+                  // The SDK retains failed result content (including MCP isError),
+                  // but call errors expose only opaque prose: transport vs JSON-RPC
+                  // cannot safely be inferred from that error field alone.
+                  const failureKind = event.item.error
+                    ? 'call_error'
+                    : event.item.result
+                      ? 'failed_result'
+                      : 'failed_item';
+                  const reference = diagnostics.record(
+                    'mcp_tool_failed',
+                    event.item.error,
+                    failureKind
+                  );
+                  const detail = `MCP call failed; check write outcomes before retrying (reference=${reference}).`;
+                  toolUseComplete.output = Array.isArray(toolUseComplete.output)
+                    ? [...toolUseComplete.output, { type: 'text', text: detail }]
+                    : `${toolUseComplete.output || '[failed]'} ${detail}`;
+                }
+
                 const isDuplicateTodoCompletion =
                   event.item.type === 'todo_list' &&
                   todoIdsEmittedViaUpdate.has(toolUseComplete.id);
@@ -1663,9 +1695,9 @@ export class CodexPromptService {
 
               // Surface non-fatal item-level errors as assistant text so users can see
               // what happened instead of dropping them silently.
-              if ('message' in event.item && event.item.type === 'error') {
-                const safe = sanitizeMCPExternalError(event.item, { stage: 'runtime' });
-                const errorContent = [{ type: 'text', text: `[Codex item error] ${safe.message}` }];
+              if (event.item.type === 'error') {
+                const reference = diagnostics.record('item_notice', event.item);
+                const errorContent = [{ type: 'text', text: codexRuntimeNotice(reference) }];
                 yield {
                   type: 'complete',
                   content: errorContent,
@@ -1683,7 +1715,8 @@ export class CodexPromptService {
               logCodexRuntimeFailure(
                 'turn_completed_without_response',
                 observedStreamError,
-                sessionId
+                sessionId,
+                taskId
               );
               throw new CodexLifecycleError('completed_without_response');
             }
@@ -1716,6 +1749,7 @@ export class CodexPromptService {
               'turn_failed',
               event.error,
               sessionId,
+              taskId,
               missingAuthentication ? 'configuration_required' : undefined
             );
             throw new CodexLifecycleError(
@@ -1731,7 +1765,7 @@ export class CodexPromptService {
             // not parse provider prose or terminate early: remember the error
             // and wait for the authoritative turn.completed / turn.failed / EOF.
             observedStreamError = event;
-            logCodexRuntimeFailure('stream_error_observed', event, sessionId);
+            logCodexRuntimeFailure('stream_error_observed', event, sessionId, taskId);
             break;
           }
 
@@ -1772,6 +1806,8 @@ export class CodexPromptService {
       throw new CodexLifecycleError(
         runtimePhase === 'starting' ? 'stream_start_failed' : 'stream_interrupted'
       );
+    } finally {
+      diagnostics.finish();
     }
   }
 

--- a/packages/executor/src/sdk-handlers/codex/runtime-diagnostics.test.ts
+++ b/packages/executor/src/sdk-handlers/codex/runtime-diagnostics.test.ts
@@ -1,0 +1,67 @@
+import type { SessionID, TaskID } from '@agor/core/types';
+import { describe, expect, it, vi } from 'vitest';
+import { CodexRuntimeDiagnostics } from './runtime-diagnostics.js';
+
+describe('Codex runtime diagnostics', () => {
+  it('projects only allowlisted metadata without invoking hostile fields', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const getter = vi.fn(() => {
+      throw new Error('SENTINEL');
+    });
+    const error = Object.defineProperties(
+      { code: 'ETIMEDOUT', status: 503 },
+      {
+        message: { get: getter },
+        cause: { get: getter },
+        stack: { get: getter },
+        id: { get: getter },
+        headers: { get: getter },
+      }
+    );
+    try {
+      const diagnostics = new CodexRuntimeDiagnostics('session-a' as SessionID, 'task-a' as TaskID);
+      const ref = diagnostics.record('mcp_tool_failed', error);
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining(`reference=${ref}`));
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('code=ETIMEDOUT status=503'));
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('task_id=task-a'));
+      expect(getter).not.toHaveBeenCalled();
+      expect(JSON.stringify(warn.mock.calls)).not.toContain('SENTINEL');
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('caps operational events but still assigns every notice a reference and summarizes omissions', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      const diagnostics = new CodexRuntimeDiagnostics('session-a' as SessionID);
+      const refs = Array.from({ length: 100 }, () => diagnostics.record('item_notice', {}));
+      expect(new Set(refs).size).toBe(100);
+      expect(warn).toHaveBeenCalledTimes(20);
+      diagnostics.finish();
+      expect(warn).toHaveBeenCalledTimes(21);
+      expect(warn).toHaveBeenLastCalledWith(expect.stringContaining('omitted=80'));
+      diagnostics.finish();
+      expect(warn).toHaveBeenCalledTimes(21);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('does not reuse references or invocation context across sessions/tenants', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      const a = new CodexRuntimeDiagnostics('session-a' as SessionID, 'task-a' as TaskID);
+      const b = new CodexRuntimeDiagnostics('session-b' as SessionID, 'task-b' as TaskID);
+      const refA = a.record('item_notice', {});
+      const refB = b.record('item_notice', {});
+      expect(refA).not.toBe(refB);
+      expect(warn.mock.calls[0][0]).toContain('session_id=session-a task_id=task-a');
+      expect(warn.mock.calls[1][0]).toContain('session_id=session-b task_id=task-b');
+      expect(warn.mock.calls[1][0]).not.toContain(refA);
+      expect(warn.mock.calls[1][0]).not.toContain('session-a');
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/packages/executor/src/sdk-handlers/codex/runtime-diagnostics.ts
+++ b/packages/executor/src/sdk-handlers/codex/runtime-diagnostics.ts
@@ -1,0 +1,70 @@
+import { randomUUID } from 'node:crypto';
+import { sanitizeMCPExternalError } from '@agor/core/mcp';
+import type { SessionID, TaskID } from '@agor/core/types';
+
+/**
+ * Executor operational channel only; never persist a provider object or copy it
+ * to analytics. Session/task IDs come from the authorized invocation, not the SDK.
+ * References are local random IDs, NOT provider item/call IDs or lookup authority.
+ * No shared state: concurrent tasks/tenants cannot inherit another run's context.
+ */
+export class CodexRuntimeDiagnostics {
+  private readonly runId = randomUUID();
+  private sequence = 0;
+  private omitted = 0;
+
+  constructor(
+    private readonly sessionId: SessionID,
+    private readonly taskId?: TaskID
+  ) {}
+
+  record(
+    event: 'item_notice' | 'mcp_tool_failed',
+    error: unknown,
+    failureKind?: 'call_error' | 'failed_result' | 'failed_item'
+  ): string {
+    const reference = `${this.runId}:${++this.sequence}`;
+    // Keep every outcome visible in the conversation, but cap operational volume.
+    if (this.sequence > 20) {
+      this.omitted++;
+      return reference;
+    }
+    const safe = sanitizeMCPExternalError(error, { stage: 'runtime' });
+    const { code, status, type } = safe.diagnostic;
+    console.warn(
+      `[codex.runtime] event=${event} reference=${reference} session_id=${this.sessionId}` +
+        `${this.taskId ? ` task_id=${this.taskId}` : ''}` +
+        ` category=${safe.category} type=${type}` +
+        `${failureKind ? ` failure_kind=${failureKind}` : ''}` +
+        `${code ? ` code=${code}` : ''}${status !== undefined ? ` status=${status}` : ''}` +
+        ` outcome=${event === 'item_notice' ? 'notice_origin_unknown' : 'tool_failed_write_outcome_unknown'}`
+    );
+    return reference;
+  }
+
+  finish(): void {
+    if (this.omitted === 0) return;
+    console.warn(
+      `[codex.runtime] event=diagnostics_limited run_id=${this.runId}` +
+        ` session_id=${this.sessionId}${this.taskId ? ` task_id=${this.taskId}` : ''}` +
+        ` omitted=${this.omitted}`
+    );
+    this.omitted = 0;
+  }
+}
+
+export function codexRuntimeNotice(reference: string): string {
+  // Codex 0.153 exec JSONL maps config warnings, deprecations, model rerouting,
+  // and general warnings to the same {type:'error', id, message} item. It does
+  // not retain their discriminators. Do not infer MCP, retryability, or success
+  // from that lossy shape, nor parse/echo provider-controlled prose.
+  return (
+    '[Codex runtime notice] Codex reported a non-fatal notice; the turn is still running. ' +
+    'This does not establish whether a tool succeeded or failed. If it recurs, ask an administrator ' +
+    `to review the operational diagnostics (reference=${reference}). Check write outcomes before retrying.`
+  );
+}
+
+export const CODEX_MCP_UNKNOWN_FAILURE =
+  'The MCP tool call failed. A write may already have taken effect; check the resulting state before retrying. ' +
+  'If it continues, ask an administrator to review the operational diagnostics.';


### PR DESCRIPTION
## Summary

- Stop labelling every Codex nonfatal `error` item as an MCP failure. Preserve a visible, provider-text-free **Codex runtime notice** instead.
- Add per-invocation, content-free diagnostic references for notices and failed MCP calls; include trusted task identity in existing stream/turn failure diagnostics.
- Never let an explicit MCP error be hidden by result content or a contradictory success status. Preserve failed result content and `is_error` through persistence even when the turn completes.
- Warn that writes can have committed before an error; **no automatic retries or conversation suppression**.

## Confirmed findings and evidence

### Origins and versions

The exact `[Codex item error]` prefix is Agor's `packages/executor/src/sdk-handlers/codex/prompt-service.ts`. The generic “The MCP operation failed…” sentence is Agor's `packages/core/src/tools/mcp/external-error.ts`, not provider-authored text. Applying that sanitizer to generic Codex items was introduced by [#2553](https://github.com/preset-io/agor/pull/2553) (`2b7ab42`). Its intentional secret protection is preserved here.

The inspected installed package and managed integration are **Agor 0.26.3**, with **Codex SDK 0.153.0 / CLI 0.153.0**. The installed executor contains the same offending mapping. The host source checkout was `f935ed5`; this investigation began at `bdc05c2` and fetched fresh main again at `3360957`. The installed npm package did not expose a gitHead, so the host checkout is **not** asserted to prove the installed artifact's exact source commit.

Pinned upstream source: [Codex 0.153 JSONL projection](https://github.com/openai/codex/blob/rust-v0.153.0/codex-rs/exec/src/event_processor_with_jsonl_output.rs#L402-L502). Config warnings, general warnings, deprecations, and model rerouting are all projected to the same `{type: 'error', id, message}` item. The public SDK does not retain the discriminator. A nonfatal item therefore cannot establish an MCP failure. The old code additionally told users to inspect an operational event **without emitting an item diagnostic at that site**.

### Bounded affected-session sample (September 8, 2026, UTC)

Authorized transcript, task, journal, and the exact parent SDK thread's rollout records were inspected without dumping prompts, arguments, provider bodies, or other users' transcripts. Private session and invocation identifiers are deliberately not copied into this public PR.

| Task window | Displayed item notices | Durable task outcome |
| --- | --- | --- |
| 17:40:13–17:49:07 | 17:40:36, 17:42:42 | stopped |
| 17:50:09–17:56:51 | 17:50:19, 17:52:20 | completed |

Within 17:40–17:57 the journal also contains **8 separate `stream_error_observed` events**, classified `unknown/UnknownError`. Those are not the four item messages. The rollout contains **7 MCP call-end results**, all `Ok`, without `isError:true`, a top-level error, or `success:false`. Calls include the empty server-list result (about **0.178s**), branch creation (about **10.723s**, returned a branch ID), and session creation (about **0.939s**). These recorded responses give no evidence that those operations caused the notices. This is a bounded sample, not a fleet-wide failure-rate estimate or proof that every possible write succeeded.

The original warning text/discriminator is not retained in the inspected rollout or item diagnostic logs. Its precise upstream cause remains **unestablished**. No blanket dedupe/suppression is justified. No overlap with the active OAuth-stack implementation was established; this PR does not modify OAuth.

### Boundary trace / treatment by class

| Input class | Trace / treatment |
| --- | --- |
| Generic Codex `error` item | Upstream warning → lossy exec JSONL item → SDK → Agor runtime notice → existing message persistence/realtime/UI. No MCP exception or JSON-RPC failure is established by this chain. Keep visible, record `item_notice` / `notice_origin_unknown`. |
| MCP call error | MCP/client/transport/protocol failure → SDK `mcp_tool_call.error` → sanitized failed tool result → `CodexTool` persists `is_error:true` → UI error status. Record `failure_kind=call_error`; opaque prose does **not** distinguish transport from JSON-RPC. |
| Failed MCP result / invalid input | Agor's tool validation/discovery dispatcher returns `isError:true`; CLI retains result content with failed status. Keep that actionable content and failed state, even if Codex later completes. Record `failed_result`; an absent result/error is `failed_item`. |
| MCP discovery/auth exception | Existing daemon/core sanitizer and protected operational logging remain unchanged. They are not automatically the source of a generic Codex notice. Empty discovery results alone are not failures. |
| Top-level Codex stream `error` | Keep existing [#2625](https://github.com/preset-io/agor/pull/2625) semantics: await authoritative completion/failure/EOF, not an immediate task failure. Add task correlation; do not parse retry prose or claim recovery merely because execution continues. |
| Failed turn / EOF | Remain terminal failures. A preceding nonfatal notice does not mask them. |

A synthetic conflicting MCP item (`error` plus result content and `status:completed`) was previously shown as successful and its error hidden. The defensive fix fails closed. This defect is reproduced, **not claimed to have occurred in the sampled live calls**.

### Separate terminal disconnect during this investigation

At **18:09:14.119** and **18:09:14.166**, two independent tasks recorded `socket has been disconnected` failures, 47ms apart. Bounded journal metadata shows a batch of server-initiated `io server disconnect` notifications around **18:09:11.813–18:09:12.001** across multiple executor PIDs. The literal error exists in Socket.IO client's `_clearAcks()`, which rejects outstanding acknowledgement callbacks on disconnect. This is a separate executor↔daemon transport boundary, not the Codex item-warning path. The initiating cause/restart is not proven by this evidence and is not changed here.

Later pulses were observed at **18:09:21.704** and **18:09:23.753**. `completed_at` is built before asynchronous failure-message/task persistence (`handlers/sdk/base-executor.ts`); heartbeat/pulse times are daemon observation times. Terminal task rows reject new telemetry in `TaskRepository.reportRuntimeTelemetry`. These timestamps therefore do not prove SDK progress after a committed terminal transition or prove process absence. Exactly when settlement committed would require additional correlated delivery/commit evidence.

## Safety and tenancy review

- No provider message/stack/cause/body, SDK item IDs, tool names/arguments, headers, credentials, prompts, or full stderr added to logs. Only fixed classes, existing allowlisted code/status/type, trusted session/task IDs, and locally generated references.
- References correlate the authorized conversation's output with the existing protected executor operational channel; they confer no lookup authority. No new log API, analytics stream, cross-tenant cache, or access policy change.
- Per-invocation state; regression coverage proves another session cannot inherit a prior run's context/reference. No tenant database boundary changes. Existing cross-tenant MCP tests remain green.
- New operational records capped at 20/run, with one omission summary. **All notices and failed tool outcomes remain visible**; this is log-volume limiting, not swallowing agent outcomes.
- No automatic retry of writes. Tool failure does not establish rollback. Verify resulting state first.

## Initial validation (before full-check authorization)

Two new regression tests were run against the original implementation and failed for the misleading notice and hidden contradictory MCP failure. They pass with the fix.

- Executor: **167 passed**, 11 files (Codex adapters/fixtures, base executor, heartbeat, Feathers client).
- Daemon: **30 passed**, 4 files (MCP search/validation, tenant scope, executor heartbeat).
- Core sanitizer: **29 passed**.
- Reactive client: **41 passed**.
- UI ToolBlock: **1 passed**.
- **268 tests total**, all passed; includes synthetic failed-result persistence, later failed-turn handling, no-retry assertions, hostile getter/secret sentinels, log bounds, and per-invocation isolation.
- Executor source-mode typecheck passed: `tsc --noEmit --customConditions source --rootDir ../..`.
- Standard package typecheck was initially blocked by absent workspace `dist` declarations in this fresh install; no builds were run. Source-mode resolves and checks the workspace sources instead.
- Biome CI and normal pre-commit hooks passed; multitenancy, realtime, and daemon-filesystem boundary checks passed.
- No managed environment, browser/provider reproduction, merge, deployment, or real-provider mutation performed. UI coverage is automated, not a live browser reproduction.

## Remaining gaps / next diagnostic step

We fix the proven classification, visibility, and correlation defects, **not an unproven provider/auth failure**. Exact historical notice origin and the shared disconnect initiator remain unknown. To classify future opaque notices more precisely without logging sensitive prose, the upstream exec/SDK boundary needs a reviewed closed notice-kind/reason discriminator (or an adapter with access to that structured notification). Do not restore raw SDK logging, parse arbitrary provider prose as control flow, or suppress unknown notices to make them disappear.


## Follow-up full validation (September 8, 2026)

At the user's request, ran the full local validation workflow on `0399c4569662dbbd475660ade14bf4c501b3c0a1`:

- `pnpm i`: passed; dependencies already current.
- `pnpm check`: **passed**, including standard workspace typechecks, lint, short-ID/tenancy/filesystem/realtime boundary checks, and the configured builds. This supersedes the initial missing-dist typecheck limitation above; builds are now explicitly authorized and were run.
- Relevant executor, daemon MCP/heartbeat, core sanitizer, client, and UI tests: **268 passed** again.
- Investigated the original CI daemon failure: `sessions.branch-archive.test.ts` exceeded its 10-second test timeout. That unchanged test passed locally without changing its timeout (about 6.54 seconds test execution), for **269 passing local tests total**. This does not establish that the full CI suite is green.
- Started one rerun of the failed jobs in [CI run 34263846447](https://github.com/preset-io/agor/actions/runs/34263846447); results pending at this update. No timeout increases, test skips, or suppression added.
- Worktree remains clean and synchronized with the pushed commit. No additional code changes or empty commit were necessary. Existing Markdown PR retained; no duplicate PR.
