### PR TITLE
perf: APM-informed board read improvements and MCP attribution

### DIFF
--- a/apps/agor-daemon/src/hooks/board-artifact-visibility.test.ts
+++ b/apps/agor-daemon/src/hooks/board-artifact-visibility.test.ts
@@ -1,0 +1,128 @@
+import { type ArtifactRepository, attachHiddenTenant, getHiddenTenantId } from '@agor/core/db';
+import type { ArtifactID, Board, BoardObject, HookContext } from '@agor/core/types';
+import { describe, expect, it, vi } from 'vitest';
+import { filterBoardArtifactObjects } from './board-artifact-visibility.js';
+
+const artifact = (id: string): BoardObject => ({
+  type: 'artifact',
+  artifact_id: id as ArtifactID,
+  x: 11,
+  y: 22,
+  width: 600,
+  height: 400,
+});
+const note: BoardObject = { type: 'text', content: 'keep', x: 0, y: 0 };
+const board = (objects: Board['objects']) => ({ objects, name: 'unchanged' }) as Board;
+const context = (method: 'get' | 'find', result: unknown) =>
+  ({
+    method,
+    result,
+    params: { user: { user_id: 'viewer' } },
+  }) as HookContext<Board>;
+
+describe('board artifact visibility after hooks', () => {
+  it.each(['get', 'find'] as const)(
+    'preserves %s no-op identity and hidden tenant metadata',
+    async (method) => {
+      const findVisibleReferenceIds = vi
+        .fn<ArtifactRepository['findVisibleReferenceIds']>()
+        .mockResolvedValue(new Set(['visible']));
+      const hook = filterBoardArtifactObjects({ findVisibleReferenceIds });
+      const variants: Board['objects'][] = [undefined, {}, { note }, { ref: artifact('visible') }];
+      for (const objects of variants) {
+        const original = attachHiddenTenant(board(objects), { tenant_id: 'tenant-a' });
+        const ctx = context(method, method === 'get' ? original : [original]);
+        await hook(ctx);
+        if (method === 'get') expect(ctx.result).toBe(original);
+        expect(original.objects).toBe(objects);
+        expect(getHiddenTenantId(original)).toBe('tenant-a');
+        expect(Object.keys(original)).not.toContain('tenant_id');
+      }
+    }
+  );
+
+  it('retains hidden tenant metadata when get replaces a filtered board', async () => {
+    const findVisibleReferenceIds = vi
+      .fn<ArtifactRepository['findVisibleReferenceIds']>()
+      .mockResolvedValue(new Set());
+    const original = attachHiddenTenant(board({ hidden: artifact('private'), note }), {
+      tenant_id: 'tenant-a',
+    });
+    const ctx = context('get', original);
+    await filterBoardArtifactObjects({ findVisibleReferenceIds })(ctx);
+    expect(ctx.result).not.toBe(original);
+    expect(ctx.result!.objects).toEqual({ note });
+    expect(original.objects!.hidden).toBeDefined();
+    expect(getHiddenTenantId(ctx.result)).toBe('tenant-a');
+    expect(Object.keys(ctx.result!)).not.toContain('tenant_id');
+  });
+
+  it.each(['array', 'paginated', 'get'] as const)(
+    'batches %s results without changing keys, order or pagination',
+    async (shape) => {
+      const findVisibleReferenceIds = vi
+        .fn<ArtifactRepository['findVisibleReferenceIds']>()
+        .mockResolvedValue(new Set(['public', 'own-short']));
+      const objects = {
+        first: artifact('public'),
+        hidden: artifact('private'),
+        duplicate: artifact('public'),
+        own: artifact('own-short'),
+        missing: artifact('missing'),
+        note,
+        placeholder: artifact(''),
+      };
+      const boards = [board(objects), board({ repeated: artifact('public') })];
+      const result =
+        shape === 'get'
+          ? boards[0]
+          : shape === 'array'
+            ? boards
+            : { data: boards, total: 42, limit: 2, skip: 4 };
+      const ctx = context(shape === 'get' ? 'get' : 'find', result);
+      await filterBoardArtifactObjects({ findVisibleReferenceIds })(ctx);
+      expect(findVisibleReferenceIds).toHaveBeenCalledExactlyOnceWith(
+        ['public', 'private', 'own-short', 'missing'],
+        'viewer'
+      );
+      const filtered = shape === 'get' ? ctx.result : boards[0];
+      expect(Object.keys(filtered!.objects!)).toEqual([
+        'first',
+        'duplicate',
+        'own',
+        'note',
+        'placeholder',
+      ]);
+      expect(filtered!.objects!.first).toBe(objects.first);
+      expect(filtered!.name).toBe('unchanged');
+      if (shape === 'paginated')
+        expect(result).toMatchObject({ total: 42, limit: 2, skip: 4, data: boards });
+      if (shape !== 'get') expect(ctx.result).toBe(result);
+    }
+  );
+
+  it('fails closed on a read error without removing other object types', async () => {
+    const findVisibleReferenceIds = vi
+      .fn<ArtifactRepository['findVisibleReferenceIds']>()
+      .mockRejectedValue(new Error('database unavailable'));
+    const ctx = context('get', board({ hidden: artifact('private'), note }));
+    await filterBoardArtifactObjects({ findVisibleReferenceIds })(ctx);
+    expect(Object.keys(ctx.result!.objects!)).toEqual(['note']);
+  });
+
+  it('does no lookup for an empty page or non-artifact objects and never caches across requests', async () => {
+    const findVisibleReferenceIds = vi
+      .fn<ArtifactRepository['findVisibleReferenceIds']>()
+      .mockResolvedValueOnce(new Set(['id']))
+      .mockResolvedValueOnce(new Set());
+    const hook = filterBoardArtifactObjects({ findVisibleReferenceIds });
+    await hook(context('find', { data: [], total: 0 }));
+    await hook(context('get', board({ note })));
+    expect(findVisibleReferenceIds).not.toHaveBeenCalled();
+    await hook(context('get', board({ ref: artifact('id') })));
+    const second = context('get', board({ ref: artifact('id') }));
+    await hook(second);
+    expect(second.result!.objects).toEqual({});
+    expect(findVisibleReferenceIds).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/agor-daemon/src/hooks/board-artifact-visibility.test.ts
+++ b/apps/agor-daemon/src/hooks/board-artifact-visibility.test.ts
@@ -24,10 +24,10 @@ describe('board artifact visibility after hooks', () => {
   it.each(['get', 'find'] as const)(
     'preserves %s no-op identity and hidden tenant metadata',
     async (method) => {
-      const findVisibleReferenceIds = vi
-        .fn<ArtifactRepository['findVisibleReferenceIds']>()
+      const findBoardReferenceVisibleIds = vi
+        .fn<ArtifactRepository['findBoardReferenceVisibleIds']>()
         .mockResolvedValue(new Set(['visible']));
-      const hook = filterBoardArtifactObjects({ findVisibleReferenceIds });
+      const hook = filterBoardArtifactObjects({ findBoardReferenceVisibleIds });
       const variants: Board['objects'][] = [undefined, {}, { note }, { ref: artifact('visible') }];
       for (const objects of variants) {
         const original = attachHiddenTenant(board(objects), { tenant_id: 'tenant-a' });
@@ -42,14 +42,14 @@ describe('board artifact visibility after hooks', () => {
   );
 
   it('retains hidden tenant metadata when get replaces a filtered board', async () => {
-    const findVisibleReferenceIds = vi
-      .fn<ArtifactRepository['findVisibleReferenceIds']>()
+    const findBoardReferenceVisibleIds = vi
+      .fn<ArtifactRepository['findBoardReferenceVisibleIds']>()
       .mockResolvedValue(new Set());
     const original = attachHiddenTenant(board({ hidden: artifact('private'), note }), {
       tenant_id: 'tenant-a',
     });
     const ctx = context('get', original);
-    await filterBoardArtifactObjects({ findVisibleReferenceIds })(ctx);
+    await filterBoardArtifactObjects({ findBoardReferenceVisibleIds })(ctx);
     expect(ctx.result).not.toBe(original);
     expect(ctx.result!.objects).toEqual({ note });
     expect(original.objects!.hidden).toBeDefined();
@@ -60,8 +60,8 @@ describe('board artifact visibility after hooks', () => {
   it.each(['array', 'paginated', 'get'] as const)(
     'batches %s results without changing keys, order or pagination',
     async (shape) => {
-      const findVisibleReferenceIds = vi
-        .fn<ArtifactRepository['findVisibleReferenceIds']>()
+      const findBoardReferenceVisibleIds = vi
+        .fn<ArtifactRepository['findBoardReferenceVisibleIds']>()
         .mockResolvedValue(new Set(['public', 'own-short']));
       const objects = {
         first: artifact('public'),
@@ -80,8 +80,8 @@ describe('board artifact visibility after hooks', () => {
             ? boards
             : { data: boards, total: 42, limit: 2, skip: 4 };
       const ctx = context(shape === 'get' ? 'get' : 'find', result);
-      await filterBoardArtifactObjects({ findVisibleReferenceIds })(ctx);
-      expect(findVisibleReferenceIds).toHaveBeenCalledExactlyOnceWith(
+      await filterBoardArtifactObjects({ findBoardReferenceVisibleIds })(ctx);
+      expect(findBoardReferenceVisibleIds).toHaveBeenCalledExactlyOnceWith(
         ['public', 'private', 'own-short', 'missing'],
         'viewer'
       );
@@ -102,27 +102,27 @@ describe('board artifact visibility after hooks', () => {
   );
 
   it('fails closed on a read error without removing other object types', async () => {
-    const findVisibleReferenceIds = vi
-      .fn<ArtifactRepository['findVisibleReferenceIds']>()
+    const findBoardReferenceVisibleIds = vi
+      .fn<ArtifactRepository['findBoardReferenceVisibleIds']>()
       .mockRejectedValue(new Error('database unavailable'));
     const ctx = context('get', board({ hidden: artifact('private'), note }));
-    await filterBoardArtifactObjects({ findVisibleReferenceIds })(ctx);
+    await filterBoardArtifactObjects({ findBoardReferenceVisibleIds })(ctx);
     expect(Object.keys(ctx.result!.objects!)).toEqual(['note']);
   });
 
   it('does no lookup for an empty page or non-artifact objects and never caches across requests', async () => {
-    const findVisibleReferenceIds = vi
-      .fn<ArtifactRepository['findVisibleReferenceIds']>()
+    const findBoardReferenceVisibleIds = vi
+      .fn<ArtifactRepository['findBoardReferenceVisibleIds']>()
       .mockResolvedValueOnce(new Set(['id']))
       .mockResolvedValueOnce(new Set());
-    const hook = filterBoardArtifactObjects({ findVisibleReferenceIds });
+    const hook = filterBoardArtifactObjects({ findBoardReferenceVisibleIds });
     await hook(context('find', { data: [], total: 0 }));
     await hook(context('get', board({ note })));
-    expect(findVisibleReferenceIds).not.toHaveBeenCalled();
+    expect(findBoardReferenceVisibleIds).not.toHaveBeenCalled();
     await hook(context('get', board({ ref: artifact('id') })));
     const second = context('get', board({ ref: artifact('id') }));
     await hook(second);
     expect(second.result!.objects).toEqual({});
-    expect(findVisibleReferenceIds).toHaveBeenCalledTimes(2);
+    expect(findBoardReferenceVisibleIds).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/agor-daemon/src/hooks/board-artifact-visibility.ts
+++ b/apps/agor-daemon/src/hooks/board-artifact-visibility.ts
@@ -1,0 +1,62 @@
+import { type ArtifactRepository, attachHiddenTenant } from '@agor/core/db';
+import type { Board, HookContext } from '@agor/core/types';
+
+/** Filter only artifact references; board authorization and tenant scope are upstream. */
+export function filterBoardArtifactObjects(
+  artifacts: Pick<ArtifactRepository, 'findVisibleReferenceIds'>
+) {
+  return async (context: HookContext<Board>) => {
+    const result = context.result;
+    if (!result) return context;
+    const boards: Board[] =
+      context.method === 'get'
+        ? [result]
+        : Array.isArray(result)
+          ? result
+          : (result as unknown as { data: Board[] }).data;
+    if (!boards?.length) return context;
+
+    const references = new Set<string>();
+    for (const board of boards) {
+      for (const object of Object.values(board.objects ?? {})) {
+        if (
+          object?.type === 'artifact' &&
+          typeof object.artifact_id === 'string' &&
+          object.artifact_id
+        ) {
+          references.add(object.artifact_id);
+        }
+      }
+    }
+    const userId = (context.params as { user?: { user_id: string } }).user?.user_id;
+    let visible = new Set<string>();
+    if (references.size) {
+      try {
+        visible = await artifacts.findVisibleReferenceIds([...references], userId);
+      } catch {
+        // Ordinary query failures are denied per bounded repository chunk,
+        // retaining other verified successes. A boundary/unexpected failure
+        // here denies all references; it must never expose private/stale data.
+      }
+    }
+    for (const board of boards) {
+      if (!board.objects) continue;
+      let filtered: Board['objects'];
+      for (const [key, object] of Object.entries(board.objects)) {
+        // Preserve legacy placeholders with no artifact_id, and all non-artifact
+        // objects. Do not rewrite keys, positions, or other board metadata.
+        if (object?.type === 'artifact' && object.artifact_id && !visible.has(object.artifact_id)) {
+          filtered ??= { ...board.objects };
+          delete filtered[key];
+        }
+      }
+      // No-op reads preserve identity and nonenumerable metadata. Changed get
+      // responses retain the trusted tenant marker for downstream assertions.
+      if (!filtered) continue;
+      if (context.method === 'get') {
+        context.result = attachHiddenTenant({ ...board, objects: filtered }, board);
+      } else board.objects = filtered;
+    }
+    return context;
+  };
+}

--- a/apps/agor-daemon/src/hooks/board-artifact-visibility.ts
+++ b/apps/agor-daemon/src/hooks/board-artifact-visibility.ts
@@ -3,7 +3,7 @@ import type { Board, HookContext } from '@agor/core/types';
 
 /** Filter only artifact references; board authorization and tenant scope are upstream. */
 export function filterBoardArtifactObjects(
-  artifacts: Pick<ArtifactRepository, 'findVisibleReferenceIds'>
+  artifacts: Pick<ArtifactRepository, 'findBoardReferenceVisibleIds'>
 ) {
   return async (context: HookContext<Board>) => {
     const result = context.result;
@@ -32,7 +32,7 @@ export function filterBoardArtifactObjects(
     let visible = new Set<string>();
     if (references.size) {
       try {
-        visible = await artifacts.findVisibleReferenceIds([...references], userId);
+        visible = await artifacts.findBoardReferenceVisibleIds([...references], userId);
       } catch {
         // Ordinary query failures are denied per bounded repository chunk,
         // retaining other verified successes. A boundary/unexpected failure

--- a/apps/agor-daemon/src/mcp/server.test.ts
+++ b/apps/agor-daemon/src/mcp/server.test.ts
@@ -136,7 +136,7 @@ describe('MCP tool registry', () => {
  */
 function captureMcpHandler(
   config: Parameters<typeof setupMCPRoutes>[3] = { multi_tenancy: undefined }
-) {
+): (req: Request, res: Response) => Promise<unknown> | unknown {
   let handler: ((req: Request, res: Response) => Promise<unknown> | unknown) | null = null;
   const register = (_path: string, fn: typeof handler) => {
     handler = fn;
@@ -186,6 +186,34 @@ describe('POST /mcp token source', () => {
     // Restore any spies installed per-test (e.g. console.warn) so later
     // suites start from a clean slate.
     vi.restoreAllMocks();
+  });
+
+  it('attributes admission failures without recording the credential or arbitrary method', async () => {
+    const { resolveTracerModule } = await import('../tracing/feathers.js');
+    const tracingModule = await import('../tracing/feathers.js');
+    const calls: unknown[] = [];
+    vi.spyOn(tracingModule, 'resolveTracerModule').mockReturnValue({
+      trace(name, options, work) {
+        calls.push({ name, options });
+        return work();
+      },
+    } satisfies NonNullable<ReturnType<typeof resolveTracerModule>>);
+    const handler = captureMcpHandler({ metrics: { apm: { trace_services: 'full' } } });
+    const res = buildRes();
+    await handler(
+      {
+        method: 'POST',
+        query: {},
+        headers: {},
+        body: { method: 'secret-method', params: { token: 'secret-token' } },
+      } as unknown as Request,
+      res as unknown as Response
+    );
+    expect(res.statusCode).toBe(401);
+    expect(calls).toEqual([
+      { name: 'mcp.request', options: { resource: 'other', tags: { 'mcp.method': 'other' } } },
+    ]);
+    expect(JSON.stringify(calls)).not.toContain('secret');
   });
 
   it('rejects requests with ?sessionToken= query param (400)', async () => {
@@ -424,6 +452,68 @@ describe('POST /mcp with personal API keys', () => {
       error?: { message: string };
     };
   }
+
+  it.each([
+    { search: false, facade: false },
+    { search: true, facade: false },
+    { search: true, facade: true },
+  ])(
+    'traces the registered tool with search=$search facade=$facade',
+    async ({ search, facade }) => {
+      await mockPersonalApiKeyUser();
+      const tracingModule = await import('../tracing/feathers.js');
+      const calls: { name: string; resource?: string }[] = [];
+      vi.spyOn(tracingModule, 'resolveTracerModule').mockReturnValue({
+        trace(name, options, work) {
+          calls.push({ name, resource: options.resource });
+          return work();
+        },
+      });
+      await withMcpServer(
+        {
+          users: {
+            get: vi.fn(async () => ({
+              user_id: 'user-1',
+              email: 'alice@example.com',
+              role: 'member',
+            })),
+          },
+        },
+        async (baseUrl) => {
+          const resp = await fetch(`${baseUrl}/mcp`, {
+            method: 'POST',
+            headers: {
+              Accept: 'application/json, text/event-stream',
+              'Content-Type': 'application/json',
+              'X-API-Key': 'agor_sk_valid',
+            },
+            body: JSON.stringify({
+              jsonrpc: '2.0',
+              id: 1,
+              method: 'tools/call',
+              params: facade
+                ? {
+                    name: 'agor_execute_tool',
+                    arguments: { tool_name: 'agor_users_get_current', arguments: {} },
+                  }
+                : { name: 'agor_users_get_current', arguments: {} },
+            }),
+          });
+          expect(resp.status).toBe(200);
+          const parsed = parseMcpResponse(await resp.text());
+          expect(parsed.error).toBeUndefined();
+          expect(JSON.parse(parsed.result!.content![0].text)).toMatchObject({ user_id: 'user-1' });
+        },
+        { metrics: { apm: { trace_services: 'entrypoint' } } },
+        search
+      );
+      expect(calls).toEqual([
+        { name: 'mcp.request', resource: 'tools/call' },
+        ...(facade ? [{ name: 'mcp.tool', resource: 'agor_execute_tool' }] : []),
+        { name: 'mcp.tool', resource: 'agor_users_get_current' },
+      ]);
+    }
+  );
 
   it('can call a non-session-scoped tool without X-Agor-Session-Id / ?sessionId', async () => {
     const { UserApiKeysRepository } = await import('@agor/core/db');

--- a/apps/agor-daemon/src/mcp/server.ts
+++ b/apps/agor-daemon/src/mcp/server.ts
@@ -59,6 +59,7 @@ import { registerSessionTools } from './tools/sessions.js';
 import { registerTaskTools } from './tools/tasks.js';
 import { registerUserTools } from './tools/users.js';
 import { registerWidgetTools } from './tools/widgets.js';
+import { createMcpTracing } from './tracing.js';
 
 const DEBUG_MCP_REQUESTS =
   process.env.AGOR_DEBUG_MCP_REQUESTS === '1' || process.env.DEBUG?.includes('mcp-requests');
@@ -336,7 +337,8 @@ function getRegistry(): {
 function createMcpServer(
   ctx: McpContext,
   toolSearchEnabled: boolean,
-  serverVersion: string
+  serverVersion: string,
+  tracing: ReturnType<typeof createMcpTracing>
 ): McpServer {
   const server = new McpServer(
     {
@@ -368,10 +370,13 @@ function createMcpServer(
     // though progressive discovery intentionally omits it from tools/list.
     // Both paths retain the same authenticated tenant wrapper and SDK input /
     // output validation.
-    registerDomainTools(tenantScopedToolProxy(toolDispatcherProxy(server, dispatcher), ctx), ctx);
+    registerDomainTools(
+      tenantScopedToolProxy(tracing.toolProxy(toolDispatcherProxy(server, dispatcher)), ctx),
+      ctx
+    );
 
     // Register search/detail/execute as the complete visible MCP catalog.
-    registerSearchTools(server, registry, dispatcher);
+    registerSearchTools(tracing.toolProxy(server), registry, dispatcher);
 
     // Keep the advertised catalog to the three progressive-discovery facade
     // tools without removing direct tools/call compatibility. This uses the
@@ -385,7 +390,7 @@ function createMcpServer(
       throw new Error(`Expected 3 progressive-discovery MCP tools, got ${toolsList.tools.length}`);
     }
   } else {
-    registerDomainTools(tenantScopedToolProxy(server, ctx), ctx);
+    registerDomainTools(tenantScopedToolProxy(tracing.toolProxy(server), ctx), ctx);
   }
 
   // McpServer.registerTool() conservatively advertises listChanged=true.
@@ -409,10 +414,11 @@ export function setupMCPRoutes(
   app: Application,
   db: TenantScopeAwareDatabase,
   toolSearchEnabled = true,
-  config: Pick<AgorConfig, 'multi_tenancy'> = { multi_tenancy: undefined },
+  config: Pick<AgorConfig, 'multi_tenancy' | 'metrics'> = { multi_tenancy: undefined },
   options: { serverVersion?: string } = {}
 ): void {
   const serverVersion = options.serverVersion ?? '0.0.0';
+  const tracing = createMcpTracing(config.metrics?.apm?.trace_services ?? 'off');
   // Eagerly build the registry at startup so first request isn't slower
   if (toolSearchEnabled) {
     getRegistry();
@@ -430,7 +436,7 @@ export function setupMCPRoutes(
         throw new Error('Authenticated MCP request context is unavailable');
       }
       mcpRequestDebug(`🔌 Serving MCP ${era} protocol request`);
-      return createMcpServer(ctx, toolSearchEnabled, serverVersion);
+      return createMcpServer(ctx, toolSearchEnabled, serverVersion, tracing);
     },
     {
       // One endpoint serves the 2026-07-28 per-request protocol and every
@@ -539,7 +545,7 @@ export function setupMCPRoutes(
     return fromHeader ?? fromQuery;
   };
 
-  const handler = async (req: Request, res: Response) => {
+  const handleRequest = async (req: Request, res: Response) => {
     try {
       mcpRequestDebug(`🔌 Incoming MCP request: ${req.method} /mcp`);
 
@@ -794,6 +800,9 @@ export function setupMCPRoutes(
       }
     }
   };
+
+  const handler = (req: Request, res: Response) =>
+    tracing.request(req.body, () => handleRequest(req, res));
 
   // GET and DELETE remain registered only to return an explicit, authenticated
   // 405 response to Streamable HTTP clients that optimistically probe them.

--- a/apps/agor-daemon/src/mcp/tracing.test.ts
+++ b/apps/agor-daemon/src/mcp/tracing.test.ts
@@ -1,0 +1,126 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import type { DatadogTracer } from '@agor/core/tracing/datadog';
+import type { McpServer } from '@modelcontextprotocol/server';
+import { describe, expect, it, vi } from 'vitest';
+import { ToolDispatcher, type ToolHandler, toolDispatcherProxy } from './register-tool-proxy.js';
+import { createMcpTracing } from './tracing.js';
+
+function recordingTracer() {
+  const calls: { name: string; options: Parameters<DatadogTracer['trace']>[1] }[] = [];
+  const tracer: DatadogTracer = {
+    trace(name, options, work) {
+      calls.push({ name, options });
+      return work();
+    },
+  };
+  return { tracer, calls };
+}
+
+describe('MCP tracing', () => {
+  it('does not resolve a tracer when tracing is off', () => {
+    const resolveTracer = vi.fn();
+    const tracing = createMcpTracing('off', { resolveTracer });
+    const result = {};
+    expect(tracing.request({ method: 'tools/call' }, () => result)).toBe(result);
+    const server = {} as McpServer;
+    expect(tracing.toolProxy(server)).toBe(server);
+    expect(resolveTracer).not.toHaveBeenCalled();
+  });
+
+  it('preserves passthrough behavior without an optional tracer', () => {
+    const tracing = createMcpTracing('full', { tracer: null });
+    const promise = Promise.resolve({ isError: true });
+    expect(tracing.request(undefined, () => promise)).toBe(promise);
+    const server = {} as McpServer;
+    expect(tracing.toolProxy(server)).toBe(server);
+  });
+
+  it.each(['entrypoint', 'full'] as const)('bounds request tags at %s depth', (depth) => {
+    const { tracer, calls } = recordingTracer();
+    const tracing = createMcpTracing(depth, { tracer });
+    for (const method of [
+      'tools/call',
+      'tools/list',
+      'initialize',
+      'server/discover',
+      'private-data',
+    ]) {
+      tracing.request(
+        { method, id: 'sensitive-id', params: { arguments: 'private-data' } },
+        () => 1
+      );
+    }
+    tracing.request([{ method: 'private-data' }], () => 1);
+    tracing.request(null, () => 1);
+    expect(calls.map((call) => call.options.resource)).toEqual([
+      'tools/call',
+      'tools/list',
+      'initialize',
+      'server/discover',
+      'other',
+      'batch',
+      'other',
+    ]);
+    expect(JSON.stringify(calls)).not.toContain('private-data');
+    expect(JSON.stringify(calls)).not.toContain('sensitive-id');
+  });
+
+  it('traces the same registered handler through direct and facade dispatch without reading args', async () => {
+    const { tracer, calls } = recordingTracer();
+    const tracing = createMcpTracing('entrypoint', { tracer });
+    const direct = new Map<string, ToolHandler>();
+    const server = {
+      registerTool: (name: string, _config: unknown, handler: ToolHandler) =>
+        direct.set(name, handler),
+    } as unknown as McpServer;
+    const dispatcher = new ToolDispatcher();
+    const proxy = tracing.toolProxy(toolDispatcherProxy(server, dispatcher));
+    const args = { private: 'secret' };
+    const extra = {};
+    const result = {
+      isError: true,
+      content: [{ type: 'text' as const, text: 'sensitive output' }],
+    };
+    const handler = vi.fn(async (received: unknown, receivedExtra?: unknown) => {
+      expect(received).toBe(args);
+      expect(receivedExtra).toBe(extra);
+      return result;
+    });
+    proxy.registerTool('agor_boards_get', {}, handler);
+    expect(await direct.get('agor_boards_get')!(args, extra)).toBe(result);
+    expect(await dispatcher.get('agor_boards_get')!.handler(args, extra)).toBe(result);
+    expect(handler).toHaveBeenCalledTimes(2);
+    expect(calls).toEqual(
+      Array.from({ length: 2 }, () => ({
+        name: 'mcp.tool',
+        options: { resource: 'agor_boards_get', tags: { 'mcp.tool': 'agor_boards_get' } },
+      }))
+    );
+    expect(JSON.stringify(calls)).not.toMatch(/secret|sensitive/);
+  });
+
+  it('preserves rejection identity and concurrent caller context', async () => {
+    const { tracer } = recordingTracer();
+    const tracing = createMcpTracing('full', { tracer });
+    const identity = new AsyncLocalStorage<string>();
+    const work = (tenant: string) =>
+      identity.run(tenant, () =>
+        tracing.request({ method: 'tools/call' }, async () => {
+          await Promise.resolve();
+          return identity.getStore();
+        })
+      );
+    expect(await Promise.all([work('tenant-a'), work('tenant-b')])).toEqual([
+      'tenant-a',
+      'tenant-b',
+    ]);
+    expect(identity.getStore()).toBeUndefined();
+    const error = new Error('expected');
+    await expect(tracing.request({}, () => Promise.reject(error))).rejects.toBe(error);
+    expect(() =>
+      tracing.request({}, () => {
+        throw error;
+      })
+    ).toThrow(error);
+  });
+});

--- a/apps/agor-daemon/src/mcp/tracing.ts
+++ b/apps/agor-daemon/src/mcp/tracing.ts
@@ -1,0 +1,63 @@
+import type { ApmTraceServiceDepth } from '@agor/core/config';
+import type { DatadogTracer } from '@agor/core/tracing/datadog';
+import type { McpServer } from '@modelcontextprotocol/server';
+import { resolveTracerModule } from '../tracing/feathers.js';
+import { wrapRegisterTool } from './register-tool-proxy.js';
+
+/** Bounded protocol labels, not client-provided method strings or request IDs. */
+const REQUEST_METHODS = new Set([
+  'initialize',
+  'ping',
+  'server/discover',
+  'tools/list',
+  'tools/call',
+  'notifications/initialized',
+  'notifications/cancelled',
+]);
+
+function requestMethod(body: unknown): string {
+  if (Array.isArray(body)) return 'batch';
+  const method = body && typeof body === 'object' ? (body as { method?: unknown }).method : null;
+  return typeof method === 'string' && REQUEST_METHODS.has(method) ? method : 'other';
+}
+
+/**
+ * One request span includes admission; tool spans cover only registered handlers.
+ * Both direct tools/call and the execute facade must register through toolProxy
+ * BEFORE the dispatcher captures the handler. The facade and target are nested
+ * spans, not independent requests. No args, results, tenant/user IDs or secrets
+ * enter tags. Registration names are server-authored and bounded by the catalog.
+ */
+export function createMcpTracing(
+  depth: ApmTraceServiceDepth,
+  options: { tracer?: DatadogTracer | null; resolveTracer?: () => DatadogTracer | null } = {}
+) {
+  const tracer =
+    depth === 'off'
+      ? null
+      : options.tracer !== undefined
+        ? options.tracer
+        : (options.resolveTracer ?? resolveTracerModule)();
+
+  return {
+    request<T>(body: unknown, work: () => T): T {
+      if (!tracer) return work();
+      const method = requestMethod(body);
+      return tracer.trace(
+        'mcp.request',
+        { resource: method, tags: { 'mcp.method': method } },
+        work
+      );
+    },
+    toolProxy(server: McpServer): McpServer {
+      if (!tracer) return server;
+      return wrapRegisterTool(server, (register, name, config, handler) =>
+        register(name, config, (args, extra) =>
+          tracer.trace('mcp.tool', { resource: name, tags: { 'mcp.tool': name } }, () =>
+            handler(args, extra)
+          )
+        )
+      );
+    },
+  };
+}

--- a/apps/agor-daemon/src/register-hooks.ts
+++ b/apps/agor-daemon/src/register-hooks.ts
@@ -111,6 +111,7 @@ import type {
   TasksServiceImpl,
 } from './declarations.js';
 import { rejectInConstrainedHa } from './ha-support.js';
+import { filterBoardArtifactObjects } from './hooks/board-artifact-visibility.js';
 import {
   classifyMissingCredentialFailure,
   protectExternalProviderFailureMetadata,
@@ -3544,74 +3545,9 @@ export function registerHooks(ctx: RegisterHooksContext): void {
       ],
     },
     after: {
-      // Strip private artifact objects from board.objects for non-owners
-      get: [
-        async (context: HookContext<Board>) => {
-          const board = context.result;
-          if (!board?.objects) return context;
-          const userId = (context.params as { user?: { user_id: string } }).user?.user_id;
-          const artifactObjectIds = Object.entries(board.objects)
-            .filter(([, obj]) => obj && (obj as { type?: string }).type === 'artifact')
-            .map(([id, obj]) => ({
-              id,
-              artifactId: (obj as { artifact_id?: string }).artifact_id,
-            }));
-          if (artifactObjectIds.length === 0) return context;
-
-          const artifactRepo = new ArtifactRepository(db);
-          const filtered = { ...board.objects };
-          for (const { id, artifactId } of artifactObjectIds) {
-            if (!artifactId) continue;
-            try {
-              const artifact = await artifactRepo.findById(artifactId);
-              if (!artifact) {
-                delete filtered[id]; // orphaned reference
-              } else if (!artifact.public && artifact.created_by !== userId) {
-                delete filtered[id]; // private, not owned
-              }
-            } catch {
-              // artifact not found, remove stale reference
-              delete filtered[id];
-            }
-          }
-          context.result = { ...board, objects: filtered };
-          return context;
-        },
-      ],
-      find: [
-        async (context: HookContext<Board>) => {
-          const result = context.result;
-          if (!result) return context;
-          const boards = Array.isArray(result) ? result : (result as { data: Board[] }).data;
-          if (!boards?.length) return context;
-          const userId = (context.params as { user?: { user_id: string } }).user?.user_id;
-          const artifactRepo = new ArtifactRepository(db);
-
-          for (const board of boards) {
-            if (!board.objects) continue;
-            const artifactEntries = Object.entries(board.objects).filter(
-              ([, obj]) => obj && (obj as { type?: string }).type === 'artifact'
-            );
-            if (artifactEntries.length === 0) continue;
-
-            const filtered = { ...board.objects };
-            for (const [id, obj] of artifactEntries) {
-              const artifactId = (obj as { artifact_id?: string }).artifact_id;
-              if (!artifactId) continue;
-              try {
-                const artifact = await artifactRepo.findById(artifactId);
-                if (!artifact || (!artifact.public && artifact.created_by !== userId)) {
-                  delete filtered[id];
-                }
-              } catch {
-                delete filtered[id];
-              }
-            }
-            board.objects = filtered;
-          }
-          return context;
-        },
-      ],
+      // Batch minimal visibility reads across the complete returned board page.
+      get: [filterBoardArtifactObjects(new ArtifactRepository(db))],
+      find: [filterBoardArtifactObjects(new ArtifactRepository(db))],
       update: [clearRealtimeBranchVisibility, publishMarketplaceInvalidation],
       patch: [clearRealtimeBranchVisibility, publishMarketplaceInvalidation],
       remove: [clearRealtimeBranchVisibility, publishMarketplaceInvalidation],

--- a/apps/agor-daemon/src/services/mcp-oauth-status.test.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-status.test.ts
@@ -30,6 +30,27 @@ function buildDeps(overrides: Partial<OAuthStatusDeps> = {}): OAuthStatusDeps {
 }
 
 describe('resolveAuthenticatedServerIds', () => {
+  it.each(['listForUser', 'listShared'] as const)(
+    'propagates %s envelope failures without returning partial status',
+    async (failedList) => {
+      const error = new Error('Unsupported bound secret envelope');
+      const findServer = vi.fn(async () => serverOwnedBy('server-valid'));
+      const deps = buildDeps({
+        listForUser: async () => [grantFor('server-valid')],
+        listShared: async () => [grantFor('server-valid')],
+        findServer,
+        [failedList]: async () => {
+          throw error;
+        },
+      });
+
+      // The endpoint catches this and returns an empty authenticated set. A
+      // projection must not silently turn a failed list into partial success.
+      await expect(resolveAuthenticatedServerIds(deps)).rejects.toBe(error);
+      expect(findServer).not.toHaveBeenCalled();
+    }
+  );
+
   it("does not name another user's private server through its shared grant", async () => {
     // A shared grant belongs to the server, so it is returned to everybody who
     // asks. The server behind it may still be private, and a private server is

--- a/apps/agor-docs/content/guide/config-yaml.mdx
+++ b/apps/agor-docs/content/guide/config-yaml.mdx
@@ -356,7 +356,7 @@ by [single-step instrumentation](https://docs.datadoghq.com/tracing/trace_collec
 via `NODE_OPTIONS` — HTTP, Express, Postgres, and Redis are auto-instrumented.
 FeathersJS and postgres.js are not: dd-trace ships no native plugins for
 Feathers service methods or the postgres.js driver used by Drizzle. This setting
-controls both custom layers. It adds an app-level hook that wraps each service
+controls the custom Feathers, PostgreSQL and MCP layers. It adds an app-level hook that wraps each service
 method in a `feathers.request` span whose **resource** name is
 `<service>.<method>` (for example `sessions.find`), and enables the Drizzle
 `postgres.query` shim. Service spans nest under the active HTTP span, with
@@ -365,18 +365,30 @@ their child Postgres queries beneath the method that issued them:
 ```yaml
 metrics:
   apm:
-    trace_services: off # off | entrypoint | full; controls Feathers + PostgreSQL tracing
+    trace_services: off # off | entrypoint | full; controls Feathers + PostgreSQL + MCP tracing
 ```
 
-- **`off`** (default) — neither custom tracing layer is registered; zero custom
+- **`off`** (default) — all custom tracing layers are disabled; zero custom
   tracing overhead, including no PostgreSQL shim patch or tracer resolution.
-- **`entrypoint`** — one span per top-level request; nested service-to-service
+- **`entrypoint`** — one Feathers span per top-level service request; nested service-to-service
   fan-out is suppressed. PostgreSQL query spans are also enabled. Cheap and
   bounded — safe to leave on in production.
 - **`full`** — a span per service-method invocation including nested calls, so
   the full fan-out and its child queries are visible. Highest span volume (and
   ingestion cost); PostgreSQL query spans are also enabled. Intended for active
   investigation, not steady state.
+
+Both enabled depths also add an `mcp.request` span covering MCP admission and
+protocol handling, plus `mcp.tool` spans for registered tool handlers. Filter by
+`mcp.method` to separate protocol methods and by `mcp.tool` to identify the actual
+Agor tool. Calls through `agor_execute_tool` have nested facade and target-tool
+spans; do not sum those durations as independent requests. Method labels are
+bounded (`other` for unknown/malformed methods, `batch` for arrays), and tool
+names come from server registration, never arbitrary request arguments.
+Arguments, results, credentials and user/session/tenant IDs are not added to
+these tags. Tool spans measure handler execution, not pre-handler SDK validation;
+an MCP result containing `isError: true` remains a returned result rather than
+an exception. Use the protocol response to assess application success.
 
 `AGOR_APM_TRACE_SERVICES` (`off`, `entrypoint`, or `full`) overrides the YAML
 value so depth can be changed without editing config. Like all metrics

--- a/packages/core/src/db/repositories/artifacts.ts
+++ b/packages/core/src/db/repositories/artifacts.ts
@@ -20,14 +20,16 @@ import type {
   SessionID,
   UUID,
 } from '@agor/core/types';
-import { and, eq, inArray, like, or } from 'drizzle-orm';
+import { and, eq, inArray, like, or, sql } from 'drizzle-orm';
 import { getBaseUrl } from '../../config/config-manager';
-import { generateId } from '../../lib/ids';
+import { generateId, isValidUUID } from '../../lib/ids';
 import { canonicalizeAgorGrants } from '../../types/artifact-grants';
+import { prefixToLikePattern } from '../../types/id';
 import { getArtifactFullscreenUrl, getArtifactUrl } from '../../utils/url';
 import type { Database } from '../client';
-import { deleteFrom, insert, select, update } from '../database-wrapper';
+import { deleteFrom, insert, isSQLiteDatabase, rawRows, select, update } from '../database-wrapper';
 import { type ArtifactInsert, type ArtifactRow, artifacts } from '../schema';
+import { MissingTenantDatabaseScopeError } from '../tenant-scope';
 import {
   AmbiguousIdError,
   type BaseRepository,
@@ -91,6 +93,111 @@ const artifactWithoutFilesColumns = {
 
 export class ArtifactRepository implements BaseRepository<Artifact, Partial<Artifact>> {
   constructor(private db: Database) {}
+
+  /**
+   * Board-reference visibility only, inside the caller's trusted tenant scope.
+   * Never load source/runtime JSON or resolve share URLs. Resolve ambiguity
+   * BEFORE visibility: a hidden second match must not authorize a prefix.
+   * Exact IDs use bounded IN queries; prefixes use bounded UNION ALL probes,
+   * each returning at most two candidates. No request-independent cache.
+   * Read failures deny the failed chunk, not previously verified references.
+   * This changes failure availability from one reference to at most 200 exact
+   * IDs or 100 prefix probes, never authorization. No retry/per-ID fallback.
+   * An unusable transaction/connection can make subsequent chunks fail too;
+   * this read path does not recover or replace the caller's transaction.
+   */
+  async findVisibleReferenceIds(ids: readonly string[], userId?: string): Promise<Set<string>> {
+    const references = [...new Set(ids)];
+    const exact = references.filter(isValidUUID);
+    const prefixes = new Map<string, string[]>();
+    for (const id of references) {
+      if (isValidUUID(id)) continue;
+      // Board JSON is not an ID validation boundary. Never interpret SQL LIKE
+      // wildcards (or an empty prefix) from a malformed stored reference.
+      const clean = id.replace(/-/g, '');
+      if (!/^[a-f0-9]{1,32}$/i.test(clean)) continue;
+      const pattern = prefixToLikePattern(id);
+      const aliases = prefixes.get(pattern);
+      if (aliases) aliases.push(id);
+      else prefixes.set(pattern, [id]);
+    }
+    const visible = new Set<string>();
+    const columns = {
+      artifact_id: artifacts.artifact_id,
+      public: artifacts.public,
+      created_by: artifacts.created_by,
+    };
+    type VisibilityRow = Pick<ArtifactRow, 'artifact_id' | 'public' | 'created_by'>;
+    // Match rowToArtifact's null-to-undefined creator projection, including
+    // legacy internal calls without a user. This is not a new auth boundary.
+    const canSee = (row: VisibilityRow) =>
+      Boolean(row.public) || (row.created_by ?? undefined) === userId;
+    const readChunk = async <T>(work: () => Promise<T>): Promise<T | undefined> => {
+      try {
+        return await work();
+      } catch (error) {
+        // Missing trusted scope is a boundary failure, not partial availability.
+        if (error instanceof MissingTenantDatabaseScopeError) throw error;
+        return undefined;
+      }
+    };
+
+    const exactBatchSize = 200;
+    for (let offset = 0; offset < exact.length; offset += exactBatchSize) {
+      const rows = await readChunk<VisibilityRow[]>(() =>
+        select(this.db, columns)
+          .from(artifacts)
+          .where(inArray(artifacts.artifact_id, exact.slice(offset, offset + exactBatchSize)))
+          .all()
+      );
+      if (!rows) continue;
+      for (const row of rows) if (canSee(row)) visible.add(row.artifact_id);
+    }
+
+    const probes = [...prefixes];
+    const prefixBatchSize = 100; // <=200 returned rows and <=200 bind parameters
+    for (let offset = 0; offset < probes.length; offset += prefixBatchSize) {
+      const batch = probes.slice(offset, offset + prefixBatchSize);
+      const query = sql.join(
+        batch.map(
+          ([pattern], index) => sql`
+        SELECT ${index} AS reference_index, artifact_id, public, created_by
+        FROM (
+          SELECT ${artifacts.artifact_id}, ${artifacts.public}, ${artifacts.created_by}
+          FROM ${artifacts} WHERE ${artifacts.artifact_id} LIKE ${pattern} LIMIT 2
+        ) AS candidates`
+        ),
+        sql` UNION ALL `
+      );
+      // SQLite run() discards SELECT rows. As with other raw read projections,
+      // use all() there and execute() on PostgreSQL, retaining the scoped handle.
+      const rows = await readChunk(async () => {
+        const result = isSQLiteDatabase(this.db)
+          ? await (this.db as unknown as { all(query: unknown): Promise<unknown> }).all(query)
+          : await (this.db as unknown as { execute(query: unknown): Promise<unknown> }).execute(
+              query
+            );
+        return rawRows<VisibilityRow & { reference_index: number }>(result);
+      });
+      if (!rows) continue;
+      for (const [index, [, aliases]] of batch.entries()) {
+        const matches = rows.filter((row) => Number(row.reference_index) === index);
+        try {
+          // Keep the canonical resolver's zero/one/many contract. Its callback
+          // consumes already-batched candidates instead of issuing another SQL.
+          await resolveByShortIdPrefix(aliases[0], 'Artifact', async () =>
+            matches.map((row) => row.artifact_id)
+          );
+          if (canSee(matches[0])) for (const alias of aliases) visible.add(alias);
+        } catch (error) {
+          if (!(error instanceof EntityNotFoundError || error instanceof AmbiguousIdError)) {
+            throw error;
+          }
+        }
+      }
+    }
+    return visible;
+  }
 
   /**
    * Convert database row to Artifact type.

--- a/packages/core/src/db/repositories/artifacts.ts
+++ b/packages/core/src/db/repositories/artifacts.ts
@@ -95,7 +95,10 @@ export class ArtifactRepository implements BaseRepository<Artifact, Partial<Arti
   constructor(private db: Database) {}
 
   /**
-   * Board-reference visibility only, inside the caller's trusted tenant scope.
+   * Board-reference visibility only, after board authorization and inside the
+   * caller's trusted tenant scope. Not a general artifact authorization API:
+   * preserves the board hook's legacy comparison for userless internal calls.
+   * External board calls must pass their authenticated user ID.
    * Never load source/runtime JSON or resolve share URLs. Resolve ambiguity
    * BEFORE visibility: a hidden second match must not authorize a prefix.
    * Exact IDs use bounded IN queries; prefixes use bounded UNION ALL probes,
@@ -106,7 +109,10 @@ export class ArtifactRepository implements BaseRepository<Artifact, Partial<Arti
    * An unusable transaction/connection can make subsequent chunks fail too;
    * this read path does not recover or replace the caller's transaction.
    */
-  async findVisibleReferenceIds(ids: readonly string[], userId?: string): Promise<Set<string>> {
+  async findBoardReferenceVisibleIds(
+    ids: readonly string[],
+    userId?: string
+  ): Promise<Set<string>> {
     const references = [...new Set(ids)];
     const exact = references.filter(isValidUUID);
     const prefixes = new Map<string, string[]>();

--- a/packages/core/src/db/repositories/artifacts.visibility.postgres.test.ts
+++ b/packages/core/src/db/repositories/artifacts.visibility.postgres.test.ts
@@ -75,7 +75,7 @@ describe.skipIf(!url || process.env.AGOR_DB_DIALECT !== 'postgresql')(
       });
       const guarded = createTenantScopedDatabaseProxy(db);
       const repo = new ArtifactRepository(guarded);
-      await expect(repo.findVisibleReferenceIds([foreignId])).rejects.toThrow();
+      await expect(repo.findBoardReferenceVisibleIds([foreignId])).rejects.toThrow();
       await runWithTenantDatabaseScope(guarded, tenantA, async (scoped) => {
         const owner = await new UsersRepository(scoped).create({
           user_id: ownerAId,
@@ -111,7 +111,7 @@ describe.skipIf(!url || process.env.AGOR_DB_DIALECT !== 'postgresql')(
         ];
         capture = true;
         try {
-          expect(await repo.findVisibleReferenceIds(refs, owner.user_id)).toEqual(
+          expect(await repo.findBoardReferenceVisibleIds(refs, owner.user_id)).toEqual(
             new Set([uniqueId, uniquePrefix, publicId, privateId])
           );
         } finally {
@@ -121,7 +121,7 @@ describe.skipIf(!url || process.env.AGOR_DB_DIALECT !== 'postgresql')(
         expect(queries.join('\n')).not.toMatch(
           /\b(files|agor_runtime|sandpack_config|dependencies|required_env_vars|agor_grants)\b/
         );
-        expect(await repo.findVisibleReferenceIds(refs, generateId())).toEqual(
+        expect(await repo.findBoardReferenceVisibleIds(refs, generateId())).toEqual(
           new Set([uniqueId, uniquePrefix, publicId])
         );
       });
@@ -147,7 +147,7 @@ describe.skipIf(!url || process.env.AGOR_DB_DIALECT !== 'postgresql')(
         failQueryNumber = 2;
         capture = true;
         try {
-          expect(await repo.findVisibleReferenceIds(ids, owner.user_id)).toEqual(
+          expect(await repo.findBoardReferenceVisibleIds(ids, owner.user_id)).toEqual(
             new Set([ids[0], ids[400]])
           );
           expect(queries).toHaveLength(3);

--- a/packages/core/src/db/repositories/artifacts.visibility.postgres.test.ts
+++ b/packages/core/src/db/repositories/artifacts.visibility.postgres.test.ts
@@ -1,0 +1,161 @@
+import { drizzle } from 'drizzle-orm/postgres-js';
+import type postgres from 'postgres';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { generateId, shortId } from '../../lib/ids';
+import type { UUID } from '../../types';
+import { createDatabase, type Database } from '../client';
+import { initializeDatabase } from '../migrate';
+import * as schema from '../schema.postgres';
+import { createTenantScopedDatabaseProxy, runWithTenantDatabaseScope } from '../tenant-scope';
+import { ArtifactRepository } from './artifacts';
+import { BoardRepository } from './boards';
+import { UsersRepository } from './users';
+
+const url = process.env.AGOR_TEST_POSTGRES_URL;
+describe.skipIf(!url || process.env.AGOR_DB_DIALECT !== 'postgresql')(
+  'board artifact visibility projection (PostgreSQL RLS)',
+  () => {
+    let db: Database;
+    let client: ReturnType<typeof postgres>;
+    let capture = false;
+    let failQueryNumber: number | undefined;
+    const queries: string[] = [];
+    beforeAll(async () => {
+      const raw = createDatabase({ dialect: 'postgresql', url: url! });
+      client = (raw as unknown as { $client: ReturnType<typeof postgres> }).$client;
+      db = drizzle(client, {
+        schema,
+        logger: {
+          logQuery(query) {
+            if (capture) {
+              queries.push(query);
+              // A client-side failure before dispatch leaves the PostgreSQL
+              // transaction usable. Server transaction aborts are not recovery
+              // promises of this projection; later chunks then fail closed too.
+              if (queries.length === failQueryNumber) throw new Error('middle chunk unavailable');
+            }
+          },
+        },
+      });
+      await initializeDatabase(db);
+    });
+    afterAll(async () => {
+      await client?.end();
+    });
+
+    it('keeps full/prefix/public/creator reads tenant-bound and resolves ambiguity before visibility', async () => {
+      const tenantA = `artifact-a-${generateId()}`;
+      const tenantB = `artifact-b-${generateId()}`;
+      const ownerAId = generateId();
+      const ownerBId = generateId();
+      const uniqueId = generateId();
+      // A foreign same-prefix row must not make A's unique prefix ambiguous.
+
+      const foreignCollision = uniqueId.replace(/.$/, uniqueId.endsWith('0') ? '1' : '0') as UUID;
+      const foreignId = generateId();
+      await runWithTenantDatabaseScope(db, tenantB, async (scoped) => {
+        const owner = await new UsersRepository(scoped).create({
+          user_id: ownerBId,
+          email: `${generateId()}@example.invalid`,
+          role: 'member',
+        });
+        const board = await new BoardRepository(scoped).create({
+          name: 'foreign',
+          created_by: owner.user_id,
+        });
+        const repo = new ArtifactRepository(scoped);
+        for (const artifact_id of [foreignId, foreignCollision]) {
+          await repo.create({
+            artifact_id,
+            board_id: board.board_id,
+            public: true,
+            created_by: owner.user_id,
+          });
+        }
+      });
+      const guarded = createTenantScopedDatabaseProxy(db);
+      const repo = new ArtifactRepository(guarded);
+      await expect(repo.findVisibleReferenceIds([foreignId])).rejects.toThrow();
+      await runWithTenantDatabaseScope(guarded, tenantA, async (scoped) => {
+        const owner = await new UsersRepository(scoped).create({
+          user_id: ownerAId,
+          email: `${generateId()}@example.invalid`,
+          role: 'member',
+        });
+        const board = await new BoardRepository(scoped).create({
+          name: 'local',
+          created_by: owner.user_id,
+        });
+        const publicId = generateId();
+
+        const privateId = publicId.replace(/.$/, publicId.endsWith('0') ? '1' : '0') as UUID;
+        await repo.create({ artifact_id: uniqueId, board_id: board.board_id, public: true });
+        await repo.create({ artifact_id: publicId, board_id: board.board_id, public: true });
+        await repo.create({
+          artifact_id: privateId,
+          board_id: board.board_id,
+          public: false,
+          created_by: owner.user_id,
+        });
+        const uniquePrefix = shortId(uniqueId);
+        const ambiguous = shortId(publicId);
+        const refs = [
+          uniqueId,
+          uniquePrefix,
+          publicId,
+          privateId,
+          ambiguous,
+          foreignId,
+          shortId(foreignId),
+          foreignCollision,
+        ];
+        capture = true;
+        try {
+          expect(await repo.findVisibleReferenceIds(refs, owner.user_id)).toEqual(
+            new Set([uniqueId, uniquePrefix, publicId, privateId])
+          );
+        } finally {
+          capture = false;
+        }
+        expect(queries).toHaveLength(2);
+        expect(queries.join('\n')).not.toMatch(
+          /\b(files|agor_runtime|sandpack_config|dependencies|required_env_vars|agor_grants)\b/
+        );
+        expect(await repo.findVisibleReferenceIds(refs, generateId())).toEqual(
+          new Set([uniqueId, uniquePrefix, publicId])
+        );
+      });
+    });
+
+    it('retains successful chunks around a recoverable client-side read failure', async () => {
+      await runWithTenantDatabaseScope(db, `artifact-chunks-${generateId()}`, async (scoped) => {
+        const owner = await new UsersRepository(scoped).create({
+          user_id: generateId(),
+          email: `${generateId()}@example.invalid`,
+          role: 'member',
+        });
+        const board = await new BoardRepository(scoped).create({
+          name: 'chunks',
+          created_by: owner.user_id,
+        });
+        const repo = new ArtifactRepository(scoped);
+        const ids = Array.from({ length: 401 }, () => generateId());
+        for (const artifact_id of [ids[0], ids[200], ids[400]]) {
+          await repo.create({ artifact_id, board_id: board.board_id, public: true });
+        }
+        queries.length = 0;
+        failQueryNumber = 2;
+        capture = true;
+        try {
+          expect(await repo.findVisibleReferenceIds(ids, owner.user_id)).toEqual(
+            new Set([ids[0], ids[400]])
+          );
+          expect(queries).toHaveLength(3);
+        } finally {
+          capture = false;
+          failQueryNumber = undefined;
+        }
+      });
+    });
+  }
+);

--- a/packages/core/src/db/repositories/artifacts.visibility.test.ts
+++ b/packages/core/src/db/repositories/artifacts.visibility.test.ts
@@ -1,0 +1,163 @@
+import type { Logger } from 'drizzle-orm/logger';
+import { describe, expect, vi } from 'vitest';
+import { generateId, shortId } from '../../lib/ids';
+import type { UUID } from '../../types';
+import { insert } from '../database-wrapper';
+import { artifacts } from '../schema';
+import { createTenantScopedDatabaseProxy } from '../tenant-scope';
+import { ownedDbTest as dbTest } from '../test-helpers';
+import { ArtifactRepository } from './artifacts';
+import { BoardRepository } from './boards';
+
+describe('ArtifactRepository board visibility projection', () => {
+  dbTest('replaces 84 artifact SELECTs with two bounded minimal queries', async ({ db }) => {
+    const board = await new BoardRepository(db).create({
+      name: 'visibility',
+      created_by: 'test-user',
+    });
+    const ids = Array.from({ length: 72 }, () => generateId());
+    await insert(db, artifacts)
+      .values(
+        ids.map((artifact_id) => ({
+          artifact_id,
+          board_id: board.board_id,
+          name: 'payload',
+          public: true,
+          files: { '/index.ts': 'source must not be selected' },
+          created_at: new Date(),
+          updated_at: new Date(),
+        }))
+      )
+      .run();
+    const refs = [...ids, ...ids.slice(0, 6).map(shortId)];
+    const logger = (db as unknown as { session: { logger: Logger } }).session.logger;
+    const queries = vi.spyOn(logger, 'logQuery');
+    const repo = new ArtifactRepository(db);
+
+    // Record the old caller path as an executable before/after comparison.
+    for (const ref of refs) await repo.findById(ref);
+    expect(queries).toHaveBeenCalledTimes(84); // 72 exact + 6 (resolve + full read)
+    queries.mockClear();
+    const visible = await repo.findVisibleReferenceIds([...refs, ...refs], 'test-user');
+    expect(visible).toEqual(new Set(refs));
+    expect(queries).toHaveBeenCalledTimes(2);
+    for (const [query] of queries.mock.calls) {
+      expect(query).not.toMatch(
+        /\b(files|agor_runtime|sandpack_config|dependencies|required_env_vars|agor_grants)\b/
+      );
+      expect(query).not.toMatch(/select\s+\*/i);
+      expect(query).not.toMatch(/\b(name|description|board_id|branch_id|created_at|updated_at)\b/);
+    }
+    queries.mockClear();
+    expect(await repo.findVisibleReferenceIds([], 'test-user')).toEqual(new Set());
+    expect(queries).not.toHaveBeenCalled();
+  });
+
+  dbTest(
+    'fails closed for missing/invalid/ambiguous references before applying visibility',
+    async ({ db }) => {
+      const board = await new BoardRepository(db).create({
+        name: 'visibility',
+        created_by: 'test-user',
+      });
+      const repo = new ArtifactRepository(db);
+      const publicId = generateId();
+      // Deliberately retain one shared prefix; neither visibility nor ownership
+      // may turn this two-row reference into an unambiguous result.
+
+      const privateId = publicId.replace(/.$/, publicId.endsWith('0') ? '1' : '0') as UUID;
+      await repo.create({ artifact_id: publicId, board_id: board.board_id, public: true });
+      await repo.create({
+        artifact_id: privateId,
+        board_id: board.board_id,
+        public: false,
+        created_by: 'test-user' as UUID,
+      });
+      const ownPrefix = privateId.replace(/-/g, '');
+      const ambiguous = shortId(publicId);
+      const refs = [publicId, privateId, ownPrefix, ambiguous, generateId(), 'missing', '%', '_'];
+      expect(await repo.findVisibleReferenceIds(refs, 'test-user')).toEqual(
+        new Set([publicId, privateId, ownPrefix])
+      );
+      expect(await repo.findVisibleReferenceIds(refs, 'another-user')).toEqual(new Set([publicId]));
+      expect(await repo.findVisibleReferenceIds(refs)).toEqual(new Set([publicId]));
+      expect(await repo.findVisibleReferenceIds([ownPrefix.toUpperCase()], 'test-user')).toEqual(
+        new Set([ownPrefix.toUpperCase()])
+      );
+      // Preserve the old DTO comparison for internal callers with no user;
+      // normal authenticated callers cannot see an ownerless private artifact.
+      const ownerless = await repo.create({ board_id: board.board_id, public: false });
+      expect(await repo.findVisibleReferenceIds([ownerless.artifact_id], 'test-user')).toEqual(
+        new Set()
+      );
+      expect(await repo.findVisibleReferenceIds([ownerless.artifact_id])).toEqual(
+        new Set([ownerless.artifact_id])
+      );
+    }
+  );
+
+  dbTest('chunks identifiers and denies failed chunks', async ({ db }) => {
+    const logger = (db as unknown as { session: { logger: Logger } }).session.logger;
+    const queries = vi.spyOn(logger, 'logQuery');
+    const repo = new ArtifactRepository(db);
+    expect(
+      await repo.findVisibleReferenceIds(Array.from({ length: 401 }, () => generateId()))
+    ).toEqual(new Set());
+    expect(queries).toHaveBeenCalledTimes(3);
+    queries.mockClear();
+    const prefixes = Array.from({ length: 101 }, () => shortId(generateId()));
+    expect(await repo.findVisibleReferenceIds([...prefixes, ...prefixes])).toEqual(new Set());
+    expect(queries).toHaveBeenCalledTimes(2);
+    expect(queries.mock.calls.every(([query]) => query.includes('LIMIT 2'))).toBe(true);
+    queries.mockImplementationOnce(() => {
+      throw new Error('read unavailable');
+    });
+    expect(await repo.findVisibleReferenceIds([generateId()])).toEqual(new Set());
+    const guarded = new ArtifactRepository(createTenantScopedDatabaseProxy(db));
+    for (const id of [generateId(), shortId(generateId())]) {
+      await expect(guarded.findVisibleReferenceIds([id])).rejects.toThrow(
+        'Missing tenant database scope'
+      );
+    }
+  });
+
+  for (const kind of ['exact', 'prefix'] as const) {
+    dbTest(
+      `retains successful ${kind} chunks before and after a failed chunk without retries`,
+      async ({ db }) => {
+        const board = await new BoardRepository(db).create({
+          name: 'chunk failure',
+          created_by: 'test-user',
+        });
+        const chunkSize = kind === 'exact' ? 200 : 100;
+        const ids = Array.from({ length: chunkSize * 2 + 1 }, () => generateId());
+        const presentIds = [ids[0], ids[chunkSize], ids[chunkSize * 2]];
+        await insert(db, artifacts)
+          .values(
+            presentIds.map((artifact_id) => ({
+              artifact_id,
+              board_id: board.board_id,
+              name: 'public',
+              public: true,
+              created_at: new Date(),
+              updated_at: new Date(),
+            }))
+          )
+          .run();
+        const refs = kind === 'exact' ? ids : ids.map(shortId);
+        const logger = (db as unknown as { session: { logger: Logger } }).session.logger;
+        const queries = vi
+          .spyOn(logger, 'logQuery')
+          .mockImplementationOnce(() => undefined)
+          .mockImplementationOnce(() => {
+            throw new Error('middle chunk unavailable');
+          })
+          .mockImplementationOnce(() => undefined);
+        expect(await new ArtifactRepository(db).findVisibleReferenceIds(refs, 'test-user')).toEqual(
+          new Set([refs[0], refs[chunkSize * 2]])
+        );
+        expect(queries).toHaveBeenCalledTimes(3);
+      }
+    );
+  }
+});

--- a/packages/core/src/db/repositories/artifacts.visibility.test.ts
+++ b/packages/core/src/db/repositories/artifacts.visibility.test.ts
@@ -38,7 +38,7 @@ describe('ArtifactRepository board visibility projection', () => {
     for (const ref of refs) await repo.findById(ref);
     expect(queries).toHaveBeenCalledTimes(84); // 72 exact + 6 (resolve + full read)
     queries.mockClear();
-    const visible = await repo.findVisibleReferenceIds([...refs, ...refs], 'test-user');
+    const visible = await repo.findBoardReferenceVisibleIds([...refs, ...refs], 'test-user');
     expect(visible).toEqual(new Set(refs));
     expect(queries).toHaveBeenCalledTimes(2);
     for (const [query] of queries.mock.calls) {
@@ -49,7 +49,7 @@ describe('ArtifactRepository board visibility projection', () => {
       expect(query).not.toMatch(/\b(name|description|board_id|branch_id|created_at|updated_at)\b/);
     }
     queries.mockClear();
-    expect(await repo.findVisibleReferenceIds([], 'test-user')).toEqual(new Set());
+    expect(await repo.findBoardReferenceVisibleIds([], 'test-user')).toEqual(new Set());
     expect(queries).not.toHaveBeenCalled();
   });
 
@@ -76,21 +76,23 @@ describe('ArtifactRepository board visibility projection', () => {
       const ownPrefix = privateId.replace(/-/g, '');
       const ambiguous = shortId(publicId);
       const refs = [publicId, privateId, ownPrefix, ambiguous, generateId(), 'missing', '%', '_'];
-      expect(await repo.findVisibleReferenceIds(refs, 'test-user')).toEqual(
+      expect(await repo.findBoardReferenceVisibleIds(refs, 'test-user')).toEqual(
         new Set([publicId, privateId, ownPrefix])
       );
-      expect(await repo.findVisibleReferenceIds(refs, 'another-user')).toEqual(new Set([publicId]));
-      expect(await repo.findVisibleReferenceIds(refs)).toEqual(new Set([publicId]));
-      expect(await repo.findVisibleReferenceIds([ownPrefix.toUpperCase()], 'test-user')).toEqual(
-        new Set([ownPrefix.toUpperCase()])
+      expect(await repo.findBoardReferenceVisibleIds(refs, 'another-user')).toEqual(
+        new Set([publicId])
       );
+      expect(await repo.findBoardReferenceVisibleIds(refs)).toEqual(new Set([publicId]));
+      expect(
+        await repo.findBoardReferenceVisibleIds([ownPrefix.toUpperCase()], 'test-user')
+      ).toEqual(new Set([ownPrefix.toUpperCase()]));
       // Preserve the old DTO comparison for internal callers with no user;
       // normal authenticated callers cannot see an ownerless private artifact.
       const ownerless = await repo.create({ board_id: board.board_id, public: false });
-      expect(await repo.findVisibleReferenceIds([ownerless.artifact_id], 'test-user')).toEqual(
+      expect(await repo.findBoardReferenceVisibleIds([ownerless.artifact_id], 'test-user')).toEqual(
         new Set()
       );
-      expect(await repo.findVisibleReferenceIds([ownerless.artifact_id])).toEqual(
+      expect(await repo.findBoardReferenceVisibleIds([ownerless.artifact_id])).toEqual(
         new Set([ownerless.artifact_id])
       );
     }
@@ -101,21 +103,21 @@ describe('ArtifactRepository board visibility projection', () => {
     const queries = vi.spyOn(logger, 'logQuery');
     const repo = new ArtifactRepository(db);
     expect(
-      await repo.findVisibleReferenceIds(Array.from({ length: 401 }, () => generateId()))
+      await repo.findBoardReferenceVisibleIds(Array.from({ length: 401 }, () => generateId()))
     ).toEqual(new Set());
     expect(queries).toHaveBeenCalledTimes(3);
     queries.mockClear();
     const prefixes = Array.from({ length: 101 }, () => shortId(generateId()));
-    expect(await repo.findVisibleReferenceIds([...prefixes, ...prefixes])).toEqual(new Set());
+    expect(await repo.findBoardReferenceVisibleIds([...prefixes, ...prefixes])).toEqual(new Set());
     expect(queries).toHaveBeenCalledTimes(2);
     expect(queries.mock.calls.every(([query]) => query.includes('LIMIT 2'))).toBe(true);
     queries.mockImplementationOnce(() => {
       throw new Error('read unavailable');
     });
-    expect(await repo.findVisibleReferenceIds([generateId()])).toEqual(new Set());
+    expect(await repo.findBoardReferenceVisibleIds([generateId()])).toEqual(new Set());
     const guarded = new ArtifactRepository(createTenantScopedDatabaseProxy(db));
     for (const id of [generateId(), shortId(generateId())]) {
-      await expect(guarded.findVisibleReferenceIds([id])).rejects.toThrow(
+      await expect(guarded.findBoardReferenceVisibleIds([id])).rejects.toThrow(
         'Missing tenant database scope'
       );
     }
@@ -153,9 +155,9 @@ describe('ArtifactRepository board visibility projection', () => {
             throw new Error('middle chunk unavailable');
           })
           .mockImplementationOnce(() => undefined);
-        expect(await new ArtifactRepository(db).findVisibleReferenceIds(refs, 'test-user')).toEqual(
-          new Set([refs[0], refs[chunkSize * 2]])
-        );
+        expect(
+          await new ArtifactRepository(db).findBoardReferenceVisibleIds(refs, 'test-user')
+        ).toEqual(new Set([refs[0], refs[chunkSize * 2]]));
         expect(queries).toHaveBeenCalledTimes(3);
       }
     );

--- a/packages/core/src/db/repositories/boards.lean.postgres.test.ts
+++ b/packages/core/src/db/repositories/boards.lean.postgres.test.ts
@@ -1,0 +1,129 @@
+import { eq, sql } from 'drizzle-orm';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { generateId } from '../../lib/ids';
+import type { BoardID, UserID } from '../../types/id';
+import { createDatabase, type Database } from '../client';
+import { select, update } from '../database-wrapper';
+import { initializeDatabase } from '../migrate';
+import { boards } from '../schema';
+import { runWithTenantDatabaseScope } from '../tenant-scope';
+import { ensureTestUser } from '../test-helpers';
+import { getHiddenTenantId } from './base';
+import { BoardRepository } from './boards';
+
+const url = process.env.AGOR_TEST_POSTGRES_URL;
+
+describe.skipIf(!url || process.env.AGOR_DB_DIALECT !== 'postgresql')(
+  'board lean PostgreSQL/RLS',
+  () => {
+    let db: Database;
+    const tenantA = `board-lean-a-${generateId()}`;
+    const tenantB = `board-lean-b-${generateId()}`;
+    let foreignId: BoardID;
+
+    beforeAll(async () => {
+      db = createDatabase({ dialect: 'postgresql', url: url! });
+      await initializeDatabase(db);
+      // A bypass role would make negative RLS coverage meaningless.
+      const role = await select(db, { safe: sql<boolean>`NOT rolsuper AND NOT rolbypassrls` })
+        .from(sql`pg_roles`)
+        .where(sql`rolname = current_user`)
+        .one();
+      expect(role?.safe).toBe(true);
+      for (const tenant of [tenantA, tenantB]) {
+        await runWithTenantDatabaseScope(db, tenant, async (scoped) => {
+          // User IDs are globally unique even though visibility is tenant-scoped.
+          const owner = await ensureTestUser(scoped, generateId() as UserID);
+          const board = await new BoardRepository(scoped).create({
+            name: 'Same name',
+            slug: 'same-slug',
+            created_by: owner,
+            custom_css: '/* large */'.repeat(10000),
+          });
+          if (tenant === tenantB) foreignId = board.board_id;
+          await update(scoped, boards)
+            .set({
+              data: {
+                objects: { note: { type: 'markdown', content: 'annotation'.repeat(10000) } },
+                custom_css: '/* large */'.repeat(10000),
+                description: null,
+                future_field: { objects: 'keep nested', custom_css: null },
+              },
+            })
+            .where(eq(boards.board_id, board.board_id))
+            .run();
+        });
+      }
+    }, 60000);
+
+    afterAll(async () => {
+      if (db) await (db as Database & { $client: { end(): Promise<void> } }).$client.end();
+    });
+
+    it('projects before decoding, retains hidden identity, and cannot read/count foreign boards', async () => {
+      await runWithTenantDatabaseScope(db, tenantA, async (scoped) => {
+        const repo = new BoardRepository(scoped);
+        const full = await repo.findAll();
+        expect(full).toHaveLength(1);
+        const { objects: _objects, custom_css: _css, ...expected } = full[0];
+        const decoder = vi.spyOn(boards.data, 'mapFromDriverValue');
+        try {
+          for (const read of [
+            () => repo.findAll({ lean: true }),
+            async () => (await repo.findPage({ lean: true, limit: 1, sort: { name: 1 } })).data,
+          ]) {
+            decoder.mockClear();
+            const rows = await read();
+            expect(rows).toEqual([expected]);
+            expect(getHiddenTenantId(rows[0])).toBe(tenantA);
+            expect(Object.keys(rows[0])).not.toContain('tenant_id');
+            expect(decoder.mock.calls).toHaveLength(1);
+            const value = decoder.mock.calls[0][0];
+            const data = typeof value === 'string' ? JSON.parse(value) : value;
+            expect(data).not.toHaveProperty('objects');
+            expect(data).not.toHaveProperty('custom_css');
+            expect(data).toMatchObject({
+              future_field: { objects: 'keep nested', custom_css: null },
+            });
+          }
+          expect(await repo.findAll({ lean: true, boardIds: [foreignId] })).toEqual([]);
+          expect(await repo.findPage({ lean: true, boardIds: [foreignId] })).toEqual({
+            data: [],
+            total: 0,
+          });
+          expect((await repo.findPage({ lean: true })).total).toBe(1);
+          expect(await repo.findById(foreignId)).toBeNull();
+          expect(await repo.findById(full[0].board_id)).toEqual(full[0]);
+        } finally {
+          decoder.mockRestore();
+        }
+      });
+    });
+    it('matches full conversion for missing/null fields and non-object legacy JSON', async () => {
+      await runWithTenantDatabaseScope(db, tenantB, async (scoped) => {
+        const repo = new BoardRepository(scoped);
+        for (const data of [
+          {},
+          { objects: null, custom_css: null, retained: null },
+          { objects: {}, custom_css: '', retained: false },
+          ['objects', 'custom_css'],
+          'legacy',
+        ]) {
+          await update(scoped, boards).set({ data }).where(eq(boards.board_id, foreignId)).run();
+          const full = (await repo.findAll())[0];
+          const { objects: _objects, custom_css: _css, ...expected } = full;
+          expect(await repo.findAll({ lean: true })).toEqual([expected]);
+          expect((await repo.findPage({ lean: true })).data).toEqual([expected]);
+        }
+        // JSON null was already rejected by rowToBoard; SQL must not turn it into {}.
+        await update(scoped, boards)
+          .set({ data: sql`'null'::jsonb` })
+          .where(eq(boards.board_id, foreignId))
+          .run();
+        await expect(repo.findAll()).rejects.toThrow('Failed to find all boards');
+        await expect(repo.findAll({ lean: true })).rejects.toThrow('Failed to find all boards');
+        await expect(repo.findPage({ lean: true })).rejects.toThrow();
+      });
+    });
+  }
+);

--- a/packages/core/src/db/repositories/boards.lean.test.ts
+++ b/packages/core/src/db/repositories/boards.lean.test.ts
@@ -1,0 +1,179 @@
+import { Buffer } from 'node:buffer';
+import { performance } from 'node:perf_hooks';
+import type { UserID } from '@agor/core/types';
+import { eq, sql } from 'drizzle-orm';
+import { expect, vi } from 'vitest';
+import { update } from '../database-wrapper';
+import { boards } from '../schema';
+import { ownedDbTest as dbTest } from '../test-helpers';
+import { BoardRepository } from './boards';
+
+function omitAnnotations<T extends object>(board: T) {
+  const {
+    objects: _objects,
+    custom_css: _css,
+    ...rest
+  } = board as T & {
+    objects?: unknown;
+    custom_css?: unknown;
+  };
+  return rest;
+}
+
+dbTest('lean lists remove only annotations before driver JSON decoding', async ({ db }) => {
+  const repo = new BoardRepository(db);
+  const board = await repo.create({ name: 'Projection', created_by: 'test-user' });
+  const data = {
+    description: 'retained',
+    icon: ':rocket:',
+    color: null,
+    custom_context: { objects: 'nested objects stay', custom_css: 'nested CSS stays' },
+    future_field: { nullable: null, list: [1, false, 'λ'] },
+    objects: { note: { type: 'markdown', content: 'large'.repeat(20000) } },
+    custom_css: 'css'.repeat(10000),
+  };
+  await update(db, boards).set({ data }).where(eq(boards.board_id, board.board_id)).run();
+  const full = await repo.findById(board.board_id);
+  const decoder = vi.spyOn(boards.data, 'mapFromDriverValue');
+  try {
+    for (const read of [
+      () => repo.findAll({ lean: true }),
+      async () => (await repo.findPage({ lean: true, limit: 1 })).data,
+    ]) {
+      decoder.mockClear();
+      const result = await read();
+      expect(result).toEqual([omitAnnotations(full!)]);
+      const decoded = decoder.mock.calls.map(([value]) =>
+        typeof value === 'string' ? JSON.parse(value) : value
+      );
+      expect(decoded).toEqual([omitAnnotations(data)]);
+    }
+    expect(await repo.findAll()).toEqual([full]);
+    expect((await repo.findPage({ lean: false })).data).toEqual([full]);
+  } finally {
+    decoder.mockRestore();
+  }
+});
+
+dbTest(
+  'lean preserves missing/null fields, SQL filters, paging, sorting and RBAC',
+  async ({ db }) => {
+    const repo = new BoardRepository(db);
+    const ids = [];
+    for (const [name, data] of [
+      ['A', {}],
+      ['B', { objects: null, custom_css: null, description: null }],
+      ['C', { objects: {}, custom_css: '', extra: false }],
+    ] as const) {
+      const board = await repo.create({ name, created_by: 'test-user', access_mode: 'private' });
+      await update(db, boards).set({ data }).where(eq(boards.board_id, board.board_id)).run();
+      ids.push(board.board_id);
+    }
+    await update(db, boards).set({ archived: true }).where(eq(boards.board_id, ids[2])).run();
+    const options = { archived: false, sort: { name: -1 as const }, offset: 1, limit: 1 };
+    const full = await repo.findPage(options);
+    expect(full.total).toBe(2);
+    expect(full.data.map((b) => b.name)).toEqual(['A']);
+    expect(await repo.findPage({ ...options, lean: true })).toEqual({
+      total: full.total,
+      data: full.data.map(omitAnnotations),
+    });
+    expect(await repo.findAll({ lean: true })).toEqual((await repo.findAll()).map(omitAnnotations));
+    expect(await repo.findAll({ lean: true, boardIds: [] })).toEqual([]);
+    expect(await repo.findPage({ lean: true, boardIds: [] })).toEqual({ data: [], total: 0 });
+    const stranger = 'unknown-user' as UserID;
+    expect(await repo.findAll({ lean: true, visibleToUserId: stranger })).toEqual([]);
+    expect(await repo.findPage({ lean: true, visibleToUserId: stranger })).toEqual({
+      data: [],
+      total: 0,
+    });
+  }
+);
+
+dbTest('lean retains legacy non-object conversion and JSON-null errors', async ({ db }) => {
+  const repo = new BoardRepository(db);
+  const board = await repo.create({ name: 'Legacy JSON', created_by: 'test-user' });
+  for (const data of [['objects', 'custom_css'], 'legacy', 42, true]) {
+    await update(db, boards).set({ data }).where(eq(boards.board_id, board.board_id)).run();
+    expect(await repo.findAll({ lean: true })).toEqual((await repo.findAll()).map(omitAnnotations));
+    expect((await repo.findPage({ lean: true })).data).toEqual(
+      (await repo.findAll()).map(omitAnnotations)
+    );
+  }
+  await update(db, boards)
+    .set({ data: sql`'null'` })
+    .where(eq(boards.board_id, board.board_id))
+    .run();
+  await expect(repo.findAll()).rejects.toThrow('Failed to find all boards');
+  await expect(repo.findAll({ lean: true })).rejects.toThrow('Failed to find all boards');
+  await expect(repo.findPage({ lean: true })).rejects.toThrow();
+});
+
+// Bounded synthetic benchmark, opt-in so CI never asserts noisy timing thresholds.
+dbTest.skipIf(process.env.AGOR_BENCH_BOARD_LEAN !== '1')(
+  'benchmark large annotations: previous full-fetch-and-strip versus SQL lean',
+  async ({ db }) => {
+    const repo = new BoardRepository(db);
+    for (let i = 0; i < 24; i++) {
+      await repo.create({
+        name: `Benchmark ${i}`,
+        created_by: 'test-user',
+        objects: {
+          note: {
+            type: 'markdown',
+            x: 0,
+            y: 0,
+            width: 300,
+            content: 'Synthetic annotation λ '.repeat(12000),
+          },
+        },
+        custom_css: '/* synthetic */'.repeat(4000),
+        description: 'small retained metadata',
+      });
+    }
+    const decoder = vi.spyOn(boards.data, 'mapFromDriverValue');
+    const measure = async (lean: boolean) => {
+      decoder.mockClear();
+      const start = performance.now();
+      const rows = await repo.findAll({ lean });
+      const result = lean ? rows : rows.map(omitAnnotations);
+      const ms = performance.now() - start;
+      const bytes = decoder.mock.calls.reduce(
+        (sum, [value]) =>
+          sum + Buffer.byteLength(typeof value === 'string' ? value : JSON.stringify(value)),
+        0
+      );
+      return { ms, bytes, result };
+    };
+    try {
+      await measure(false);
+      await measure(true);
+      const before = [],
+        after = [];
+      for (let i = 0; i < 9; i++) {
+        const a = await measure(i % 2 === 0);
+        const b = await measure(i % 2 !== 0);
+        expect(a.result).toEqual(b.result);
+        before.push(i % 2 === 0 ? b : a);
+        after.push(i % 2 === 0 ? a : b);
+      }
+      const median = (values: number[]) => values.sort((a, b) => a - b)[4];
+      process.stdout.write(
+        'BOARD_LEAN_BENCHMARK ' +
+          JSON.stringify({
+            boards: 24,
+            samples: 9,
+            beforeBytes: before[0].bytes,
+            afterBytes: after[0].bytes,
+            beforeMedianMs: median(before.map((v) => v.ms)),
+            afterMedianMs: median(after.map((v) => v.ms)),
+          }) +
+          '\n'
+      );
+      expect(after[0].bytes).toBeLessThan(before[0].bytes / 100);
+    } finally {
+      decoder.mockRestore();
+    }
+  },
+  30000
+);

--- a/packages/core/src/db/repositories/boards.ts
+++ b/packages/core/src/db/repositories/boards.ts
@@ -17,7 +17,19 @@ import type {
   UUID,
 } from '@agor/core/types';
 import { isTeammate } from '@agor/core/types';
-import { and, asc, desc, eq, inArray, isNull, like, ne, type SQL, sql } from 'drizzle-orm';
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  getTableColumns,
+  inArray,
+  isNull,
+  like,
+  ne,
+  type SQL,
+  sql,
+} from 'drizzle-orm';
 import * as yaml from 'js-yaml';
 import { getBaseUrl } from '../../config/config-manager';
 import { generateId } from '../../lib/ids';
@@ -25,7 +37,14 @@ import { generateSlug } from '../../lib/slugs';
 import { normalizeExactEmojiShortcode } from '../../utils/emoji-shortcodes';
 import { getBoardUrl } from '../../utils/url';
 import type { Database } from '../client';
-import { deleteFrom, insert, runDatabaseTransaction, select, update } from '../database-wrapper';
+import {
+  deleteFrom,
+  insert,
+  isPostgresDatabase,
+  runDatabaseTransaction,
+  select,
+  update,
+} from '../database-wrapper';
 import { type BoardInsert, type BoardRow, boards, users } from '../schema';
 import {
   AmbiguousIdError,
@@ -93,6 +112,19 @@ export function mapBoardExportBlobToCreateData(
  */
 export class BoardRepository implements BaseRepository<Board, Partial<Board>> {
   constructor(private db: Database) {}
+
+  /** Keep every column (including hidden tenant identity), projecting only lean annotations.
+   * Use the column decoder: SQLite returns JSON text; PostgreSQL returns JSONB.
+   * Non-object JSON is left alone to preserve legacy conversion/error behavior.
+   */
+  private listSelection(lean?: boolean) {
+    if (!lean) return getTableColumns(boards);
+    const data = isPostgresDatabase(this.db)
+      ? sql`CASE WHEN jsonb_typeof(${boards.data}) = 'object'
+          THEN ${boards.data} - 'objects' - 'custom_css' ELSE ${boards.data} END`
+      : sql`json_remove(${boards.data}, '$.objects', '$.custom_css')`;
+    return { ...getTableColumns(boards), data: data.mapWith(boards.data) };
+  }
 
   /**
    * Convert database row to Board type
@@ -431,7 +463,7 @@ export class BoardRepository implements BaseRepository<Board, Partial<Board>> {
       }
 
       const baseUrl = await getBaseUrl();
-      const query = select(this.db).from(boards);
+      const query = select(this.db, this.listSelection(filter?.lean)).from(boards);
       const rows =
         conditions.length > 0 ? await query.where(and(...conditions)).all() : await query.all();
       return rows.map((row: BoardRow) => this.rowToBoard(row, baseUrl, { lean: filter?.lean }));
@@ -498,7 +530,7 @@ export class BoardRepository implements BaseRepository<Board, Partial<Board>> {
     if (orderBy.length === 0) orderBy.push(asc(boards.created_at));
     if (!Object.hasOwn(opts.sort ?? {}, 'board_id')) orderBy.push(asc(boards.board_id));
 
-    let dataQuery = select(this.db).from(boards);
+    let dataQuery = select(this.db, this.listSelection(opts.lean)).from(boards);
     if (whereClause) dataQuery = dataQuery.where(whereClause);
     dataQuery = dataQuery.orderBy(...orderBy);
     if (opts.limit !== undefined) dataQuery = dataQuery.limit(opts.limit);

--- a/packages/core/src/db/repositories/user-mcp-oauth-tokens.status.test.ts
+++ b/packages/core/src/db/repositories/user-mcp-oauth-tokens.status.test.ts
@@ -1,0 +1,172 @@
+/** Characterize the envelope-integrity boundary before optimizing status reads. */
+import type { MCPServerID, UserID } from '@agor/core/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Database } from '../client';
+import * as envelope from '../oauth-secret-envelope';
+import { UserMCPOAuthTokenRepository } from './user-mcp-oauth-tokens';
+
+const query = vi.hoisted(() => ({
+  rows: [] as Record<string, unknown>[],
+  projections: [] as Array<Record<string, unknown> | undefined>,
+  tenantId: 'tenant-a',
+}));
+
+// Exercise the real repository mapping and authenticated encryption, without
+// a PG connection. This is not SQL/RLS coverage; the adapter supplies selected
+// rows just as the database wrapper does.
+vi.mock('../database-wrapper', () => ({
+  select: (_db: unknown, projection?: Record<string, unknown>) => {
+    query.projections.push(projection);
+    const selected = () =>
+      query.rows.map((row) =>
+        projection
+          ? Object.fromEntries(
+              Object.keys(projection).map((key) => [
+                key,
+                key === 'has_access_token' ? row.oauth_access_token != null : row[key],
+              ])
+            )
+          : row
+      );
+    return {
+      from: () => ({
+        where: () => ({
+          all: async () => selected(),
+          one: async () => selected()[0],
+        }),
+      }),
+    };
+  },
+}));
+vi.mock('../tenant-scope', () => ({ isPostgresDatabaseHandle: () => true }));
+vi.mock('../tenant-context', () => ({ getCurrentTenantId: () => query.tenantId }));
+
+const userId = '00000000-0000-7000-8000-00000000a11c' as UserID;
+const serverId = '00000000-0000-7000-8000-00000000b0b0' as MCPServerID;
+const master = 'status-characterization-test-master';
+
+function grant(subject: UserID | null = userId): Record<string, unknown> {
+  const seal = (value: string, purpose: envelope.BoundSecretPurpose, field: string) =>
+    envelope.sealBoundSecret(
+      value,
+      master,
+      purpose,
+      ['tenant-a', subject ?? '<shared>', serverId, '1', field].join('\0')
+    );
+  return {
+    user_id: subject,
+    mcp_server_id: serverId,
+    grant_generation: 1,
+    oauth_access_token: seal('access', 'access-token', 'access'),
+    oauth_refresh_token: seal('refresh', 'refresh-token', 'refresh'),
+    oauth_client_id: seal('client', 'client-id', 'client-id'),
+    oauth_client_secret: seal('secret', 'client-secret', 'client-secret'),
+    oauth_token_expires_at: new Date('2030-01-01T00:00:00Z'),
+    refresh_status: 'idle',
+    created_at: new Date('2026-01-01T00:00:00Z'),
+  };
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  query.rows = [];
+  query.projections = [];
+  query.tenantId = 'tenant-a';
+});
+
+describe('OAuth status grant read integrity and cost', () => {
+  it('opens four envelopes on a full read versus two on catalog authority', async () => {
+    query.rows = [grant()];
+    const open = vi.spyOn(envelope, 'openBoundSecret');
+    const repo = new UserMCPOAuthTokenRepository({} as Database, master);
+    await expect(repo.listForUser(userId)).resolves.toMatchObject([
+      { oauth_access_token: 'access', oauth_refresh_token: 'refresh' },
+    ]);
+    expect(query.projections).toEqual([undefined]);
+    expect(open.mock.calls.map((call) => call[2])).toEqual([
+      'access-token',
+      'refresh-token',
+      'client-id',
+      'client-secret',
+    ]);
+
+    open.mockClear();
+    query.projections = [];
+    const authority = await repo.getCatalogGrantAuthority(userId, serverId);
+    expect(query.projections).toHaveLength(1);
+    expect(query.projections[0]).not.toHaveProperty('oauth_access_token');
+    expect(query.projections[0]).not.toHaveProperty('oauth_refresh_token');
+    expect(open.mock.calls.map((call) => call[2])).toEqual(['client-id', 'client-secret']);
+    expect(authority).toMatchObject({
+      oauth_access_token: '<present>',
+      oauth_client_id: 'client',
+      oauth_client_secret: 'secret',
+    });
+    expect(authority).not.toHaveProperty('oauth_refresh_token');
+  });
+
+  it.each(['oauth_access_token', 'oauth_refresh_token'] as const)(
+    'full status lists reject corrupt %s even on expired/ambiguous grants',
+    async (field) => {
+      const repo = new UserMCPOAuthTokenRepository({} as Database, master);
+      for (const subject of [userId, null]) {
+        query.rows = [
+          {
+            ...grant(subject),
+            [field]: 'corrupt-envelope',
+            oauth_token_expires_at: new Date('2000-01-01T00:00:00Z'),
+            refresh_status: 'ambiguous',
+          },
+        ];
+        await expect(
+          subject === null ? repo.listShared() : repo.listForUser(subject)
+        ).rejects.toThrow('Unsupported bound secret envelope');
+      }
+      // The existing catalog projection deliberately has a different contract.
+      // Reusing that contract for status would remove its fail-closed behavior.
+      query.rows = [{ ...grant(), [field]: 'corrupt-envelope' }];
+      await expect(repo.getCatalogGrantAuthority(userId, serverId)).resolves.toMatchObject({
+        has_access_token: true,
+      });
+    }
+  );
+
+  it.each([
+    ['oauth_access_token', 'access-token', 'access'],
+    ['oauth_refresh_token', 'refresh-token', 'refresh'],
+  ] as const)(
+    'full lists detect a valid but foreign-tenant %s envelope',
+    async (column, purpose, field) => {
+      query.rows = [
+        {
+          ...grant(),
+          [column]: envelope.sealBoundSecret(
+            'foreign-token',
+            master,
+            purpose,
+            ['tenant-b', userId, serverId, '1', field].join('\0')
+          ),
+        },
+      ];
+      const repo = new UserMCPOAuthTokenRepository({} as Database, master);
+      await expect(repo.listForUser(userId)).rejects.toThrow(
+        'Failed to list OAuth tokens for user'
+      );
+      // Format/presence checks are insufficient: only opening the envelope
+      // authenticates the token's tenant/subject/server/generation binding.
+      await expect(repo.getCatalogGrantAuthority(userId, serverId)).resolves.toMatchObject({
+        has_access_token: true,
+      });
+    }
+  );
+
+  it('rejects same-purpose ciphertext transplanted from another tenant', async () => {
+    query.rows = [grant()];
+    query.tenantId = 'tenant-b';
+    const repo = new UserMCPOAuthTokenRepository({} as Database, master);
+    await expect(repo.listForUser(userId)).rejects.toThrow('Failed to list OAuth tokens for user');
+    await expect(repo.getCatalogGrantAuthority(userId, serverId)).rejects.toThrow(
+      'Failed to read OAuth grant authority'
+    );
+  });
+});


### PR DESCRIPTION
## Follow-up validation — September 8, 22:12 UTC

At the user's explicit request, **`pnpm i` and full `pnpm check` passed**, including workspace typechecks, lint/policy guards and builds. This supersedes the earlier local no-build limitation below. Focused tests reran: **268 daemon + 124 core passed** (one opt-in benchmark skipped). The worktree remains clean at `bf6fff10e7a516719091715454fc84223c2ea04b`; no empty follow-up commit was created. PR attached to the Agor worktree through MCP.

CI's daemon suite had one 10-second timeout in `sessions.branch-archive.test.ts` (1,001-session fixture). That test **passed locally** on rerun; failed CI jobs have been rerun, with their result pending. No timeout increase or unrelated source change was made.

---

Commit: `bf6fff10e7a516719091715454fc84223c2ea04b`.

## Summary

A directed **APM-informed performance improvements** PR, not a transaction or cache rewrite:

- Batch board artifact visibility reads, deduplicate references, and select only ID/public/creator. Bound exact-ID queries to 200 IDs and prefix probes to 100, with at most two candidates per prefix; resolve ambiguity before checking visibility.
- Push `lean:true` board annotation removal into SQLite/PostgreSQL SQL, before transfer/JSON decoding. Preserve full reads, unknown/nested JSON, hidden tenant identity, SQL filtering/paging/sorting and legacy JSON error behavior.
- Add bounded `mcp.request` / registered `mcp.tool` attribution, including direct calls and progressive-discovery facade targets. No argument/result/credential/identity tags; `off` remains passthrough.
- Add OAuth integrity characterization tests **without changing OAuth production code**. Trimming access/refresh envelopes would change fail-closed corruption behavior, so that candidate was rejected.

## Evidence and measured local results

Investigated sandbox `service:agor-daemon env:sandbox host:agor-2`, **2026-09-08 17:15–18:15 UTC**. This is a new explicit window, not the original screenshot window.

[Board trace](https://app.datadoghq.com/apm/trace/6aa04fa10000000056d9a432cb5a7ba0?spanID=8874175195964945673): 11,008 ms and **84 artifact SELECTs**, including prefix resolution. Artifact spans sum to 3,312 ms, but that is **not** a proven removable wall-clock delta. Source matched the serial full-row response enrichment.

| Controlled local workload | Before | After |
|---|---:|---:|
| Artifact lookup fixture: 72 exact references + 6 short aliases | 84 SELECTs | 2 SELECTs, also with duplicated references |
| Lean board fixture: 24 annotation-heavy boards, JSON bytes reaching decoder | 8,355,192 | 984 |
| Same SQLite fixture: nine alternating samples after warmup, median read/conversion | 43.91 ms | 7.08 ms |

The lean projection regression failed before the SQL change. Artifact tests compare the executable former lookup path with the new projection; missing-method regressions failed initially. MCP admission-attribution regression failed before wiring. These are **synthetic work reductions, not deployed latency improvements**.

## Safety and scope

- No cross-request cache, new index/migration, tenant/policy bypass, provider write, production configuration change, or lifecycle/stream batching.
- Both dialects retain existing ID primary keys and query predicates. PostgreSQL tests use isolated migrated databases and verified NOSUPERUSER/NOBYPASSRLS app role, including public foreign-tenant references and tenant-local prefix ambiguity.
- Hidden tenant metadata survives filtered board `get`; no-op reads retain object identity.
- Ordinary artifact query failures deny the **failed bounded chunk**, retain successfully checked chunks, and do not retry per ID. This intentionally changes availability granularity from one reference to a chunk; it does not broaden visibility. Missing trusted database scope still fails closed. An aborted PostgreSQL transaction may also prevent later chunks from succeeding.
- Tracing preserves returned MCP `isError` results, thrown/rejected errors, caller context and response streaming. Facade/target spans overlap and are not independent request totals.
- Fresh main base: `8958f2e53e6639ded71c7c07a2fb0f989312ff08`; includes merged **#2565 and #2647**. Their OAuth authority/encryption behavior is unchanged.

## Validation

- Focused daemon integration/unit suites: **268 passed** (8 files).
- Core board/artifact/OAuth suites: **124 passed**, 1 opt-in benchmark skipped (5 files); benchmark run separately: **4 passed**.
- Targeted isolated PostgreSQL lane: **4 passed, zero skipped**, 2 files (lean boards and artifact visibility), including RLS and recoverable client-side chunk-failure coverage. Used the repo Docker bootstrap/isolation/cleanup harness with a temporary test-file selection; this is not a claim that the full PostgreSQL lane ran. The standard `pnpm test:postgres:docker` includes these `*.postgres.test.ts` suites.
- Existing session-auth, message, adapter, heartbeat and callback contracts: **51 passed** (5 additional files).
- Both source-aware no-emit typechecks passed; focused new MCP/artifact test typechecks passed.
- Biome (15 changed TS files), Prettier docs, short-ID guard, tenant/realtime/filesystem boundaries and whitespace check passed. This worktree has no configured Git hooks path; checks were run explicitly, and no `--no-verify` was used.
- Independent read-only review approved MCP changes and re-reviewed both resolved board findings.

Reproduce the opt-in bounded benchmark:
```bash
AGOR_BENCH_BOARD_LEAN=1 pnpm --filter @agor/core exec vitest run src/db/repositories/boards.lean.test.ts
```

Source-aware no-build typechecks:
```bash
pnpm --filter @agor/core exec tsc --noEmit --incremental false --customConditions source --rootDir ../..
pnpm --filter @agor/daemon exec tsc --noEmit --incremental false --customConditions source --rootDir ../..
```

Ordinary typechecks without the source condition cannot resolve the unbuilt workspace exports; no build was run. Managed branch environment was not running, and its startup command requires a build, so no managed-dev smoke test was claimed. In-process MCP HTTP integration tests were used instead. Recording-tracer tests are not live Datadog span-parentage validation.

## Follow-ups, not included

1. **Telemetry transaction waits**: the 71.47-second `reportRuntimeTelemetry` error trace has 9.46-second `FOR UPDATE`, 8.69-second tenant `set_config`, and untraced gaps. Source can hold an outer request transaction while acquiring a fresh inner connection. Reproduce with disposable PG and small pools; distinguish acquisition+BEGIN, locks, event-loop/CPU, network and DB time before changing transaction ownership.
2. **OAuth query/crypto cost**: separate list-query elapsed time from synchronous envelope opening. Four envelope opens versus two in the existing catalog projection is not permission to remove integrity checks. Investigate polling/coalescing only with authority, HA and invalidation tests.
3. Reconnect Datadog for exact build/cohort follow-through and evaluate actual MCP tool costs using the new bounded tags after an independently authorized deployment.

The sampled spans were diversity-retained, not unbiased traffic percentiles; git/version attributes were absent. A contemporaneous sandbox health build `0fb364358` does not establish the historical traced revision or fleet version. Datadog reads worked earlier, but the connector later reported authentication required and tools disappeared. No CPU or production P95 savings are claimed.

Durable investigation, endpoint inventory, trace/query receipts and prioritized experiments: [Agor Knowledge article](https://agor.sandbox.preset.zone/ui/kb/agor-cloud-team/engineering/performance/apm-total-time-latency.md).

