### PR TITLE
APM-driven performance improvements

### DIFF
--- a/apps/agor-daemon/src/services/tenant-agentic-tools.deployment-boundary.test.ts
+++ b/apps/agor-daemon/src/services/tenant-agentic-tools.deployment-boundary.test.ts
@@ -1,4 +1,5 @@
 import { TenantAgenticToolSettingsRepository, type TenantScopeAwareDatabase } from '@agor/core/db';
+import { TENANT_AGENTIC_TOOL_NAMES } from '@agor/core/types';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { TenantAgenticToolSettingsService } from './tenant-agentic-tools.js';
 
@@ -53,5 +54,39 @@ describe('tenant agentic tool deployment boundary', () => {
       connection: { ANTHROPIC_AUTH_TOKEN: { configured: true } },
     });
     expect(JSON.stringify(settings)).not.toContain(syntheticSecret);
+  });
+  it('uses one batch, retaining tool order, defaults, deployment policy and secret redaction', async () => {
+    const find = vi.spyOn(TenantAgenticToolSettingsRepository.prototype, 'find');
+    const all = vi
+      .spyOn(TenantAgenticToolSettingsRepository.prototype, 'findAll')
+      .mockResolvedValue(
+        new Map(
+          TENANT_AGENTIC_TOOL_NAMES.map((tool) => [
+            tool,
+            tool === 'codex'
+              ? { revision: 3, connection: { OPENAI_API_KEY: 'synthetic-secret' } }
+              : {},
+          ])
+        )
+      );
+    const service = new TenantAgenticToolSettingsService(
+      {} as TenantScopeAwareDatabase,
+      (tool) => tool !== 'codex'
+    );
+    const settings = await service.find();
+    expect(settings.map((setting) => setting.tool)).toEqual([...TENANT_AGENTIC_TOOL_NAMES]);
+    expect(settings.find((setting) => setting.tool === 'codex')).toMatchObject({
+      revision: 3,
+      enabled: false,
+      deployment_available: false,
+      connection: { OPENAI_API_KEY: { configured: true } },
+    });
+    expect(settings.find((setting) => setting.tool === 'claude-code')).toMatchObject({
+      revision: 0,
+      enabled: true,
+    });
+    expect(JSON.stringify(settings)).not.toContain('synthetic-secret');
+    expect(all).toHaveBeenCalledTimes(1);
+    expect(find).not.toHaveBeenCalled();
   });
 });

--- a/apps/agor-daemon/src/services/tenant-agentic-tools.ts
+++ b/apps/agor-daemon/src/services/tenant-agentic-tools.ts
@@ -7,6 +7,7 @@ import { AgenticToolPresetRepository, TenantAgenticToolSettingsRepository } from
 import { BadRequest } from '@agor/core/feathers';
 import type {
   Params,
+  StoredTenantAgenticToolSettings,
   TenantAgenticToolName,
   TenantAgenticToolSettings,
   TenantAgenticToolSettingsPatch,
@@ -40,8 +41,10 @@ export class TenantAgenticToolSettingsService {
     this.presets = new AgenticToolPresetRepository(db);
   }
 
-  private async publicSettings(tool: TenantAgenticToolName): Promise<TenantAgenticToolSettings> {
-    const stored = await this.repository.find(tool);
+  private publicSettings(
+    tool: TenantAgenticToolName,
+    stored: StoredTenantAgenticToolSettings
+  ): TenantAgenticToolSettings {
     const deploymentEnabled = this.deploymentAvailable(tool);
     const connection: TenantAgenticToolSettings['connection'] = {};
     if (isProviderConnectionTool(tool)) {
@@ -61,11 +64,13 @@ export class TenantAgenticToolSettingsService {
   }
 
   async find(_params?: Params): Promise<TenantAgenticToolSettings[]> {
-    return Promise.all(TENANT_AGENTIC_TOOL_NAMES.map((tool) => this.publicSettings(tool)));
+    const stored = await this.repository.findAll();
+    return TENANT_AGENTIC_TOOL_NAMES.map((tool) => this.publicSettings(tool, stored.get(tool)!));
   }
 
   async get(id: string, _params?: Params): Promise<TenantAgenticToolSettings> {
-    return this.publicSettings(parseTool(id));
+    const tool = parseTool(id);
+    return this.publicSettings(tool, await this.repository.find(tool));
   }
 
   async patch(
@@ -119,7 +124,7 @@ export class TenantAgenticToolSettingsService {
       }
       throw error;
     }
-    return this.publicSettings(tool);
+    return this.publicSettings(tool, await this.repository.find(tool));
   }
 }
 

--- a/apps/agor-daemon/src/services/users.credentials.test.ts
+++ b/apps/agor-daemon/src/services/users.credentials.test.ts
@@ -1,0 +1,63 @@
+import { UsersRepository } from '@agor/core/db';
+import type { UserID } from '@agor/core/types';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { dbTest } from '../../../../packages/core/src/db/test-helpers';
+import { UsersService } from './users';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe('UsersService credential reader delegation', () => {
+  dbTest(
+    'preserves values, user/tool isolation, and missing/corrupt result contracts',
+    async ({ db }) => {
+      vi.stubEnv('AGOR_MASTER_SECRET', 'synthetic-delegation-key');
+      const repository = new UsersRepository(db);
+      const service = new UsersService(db);
+      const own = await repository.create({ email: 'own@example.invalid' });
+      const other = await repository.create({ email: 'other@example.invalid' });
+      await repository.setToolConfigField(own.user_id, 'codex', 'OPENAI_API_KEY', 'synthetic-key');
+      await repository.setToolConfigField(
+        own.user_id,
+        'codex',
+        'OPENAI_BASE_URL',
+        'https://example.invalid'
+      );
+      const field = vi.spyOn(UsersRepository.prototype, 'getToolConfigField');
+      const bag = vi.spyOn(UsersRepository.prototype, 'getToolConfig');
+      expect(await service.getToolConfigField(own.user_id, 'codex', 'OPENAI_API_KEY')).toBe(
+        'synthetic-key'
+      );
+      expect(field).toHaveBeenCalledWith(own.user_id, 'codex', 'OPENAI_API_KEY');
+      expect(await service.getToolConfig(own.user_id, 'codex')).toEqual({
+        OPENAI_API_KEY: 'synthetic-key',
+        OPENAI_BASE_URL: 'https://example.invalid',
+      });
+      expect(bag).toHaveBeenCalledWith(own.user_id, 'codex');
+      expect(
+        await service.getToolConfigField(other.user_id, 'codex', 'OPENAI_API_KEY')
+      ).toBeUndefined();
+      expect(await service.getToolConfig(other.user_id, 'codex')).toBeNull();
+      expect(await service.getToolConfig(own.user_id, 'claude-code')).toBeNull();
+      vi.stubEnv('AGOR_MASTER_SECRET', 'wrong-key');
+      const logs = vi.spyOn(console, 'error').mockImplementation(() => {});
+      expect(
+        await service.getToolConfigField(own.user_id, 'codex', 'OPENAI_API_KEY')
+      ).toBeUndefined();
+      expect(await service.getToolConfig(own.user_id, 'codex')).toBeNull();
+      expect(logs).toHaveBeenCalledTimes(3);
+    }
+  );
+
+  it('does not turn storage errors into missing credentials', async () => {
+    const error = new Error('synthetic storage failure');
+    vi.spyOn(UsersRepository.prototype, 'getToolConfigField').mockRejectedValue(error);
+    vi.spyOn(UsersRepository.prototype, 'getToolConfig').mockRejectedValue(error);
+    const service = new UsersService({} as ConstructorParameters<typeof UsersService>[0]);
+    const user = '00000000-0000-7000-8000-000000000001' as UserID;
+    await expect(service.getToolConfigField(user, 'codex', 'OPENAI_API_KEY')).rejects.toBe(error);
+    await expect(service.getToolConfig(user, 'codex')).rejects.toBe(error);
+  });
+});

--- a/apps/agor-daemon/src/services/users.ts
+++ b/apps/agor-daemon/src/services/users.ts
@@ -36,7 +36,6 @@ import {
   branches,
   compare,
   decryptApiKey,
-  decryptApiKeyAsync,
   deleteFrom,
   encryptApiKey,
   eq,
@@ -57,6 +56,7 @@ import {
   type TenantScopeAwareDatabase,
   type TenantScopedDatabase,
   UserPrimaryTeammateRepository,
+  UsersRepository,
   update,
   users,
 } from '@agor/core/db';
@@ -1621,19 +1621,11 @@ export class UsersService {
     tool: T,
     field: keyof AgenticToolsConfig[T] & string
   ): Promise<string | undefined> {
-    const row = await select(this.db).from(users).where(eq(users.user_id, userId)).one();
-    if (!row) return undefined;
-
-    const data = row.data as { agentic_tools?: StoredAgenticTools };
-    const encrypted = data.agentic_tools?.[tool]?.[field];
-    if (!encrypted) return undefined;
-
-    try {
-      return await decryptApiKeyAsync(encrypted);
-    } catch (err) {
-      console.error(`Failed to decrypt agentic_tools.${tool}.${field} for user ${userId}:`, err);
-      return undefined;
-    }
+    // Preserve the service's undefined contract; storage and corruption handling
+    // belong to the repository shared with other credential consumers.
+    return (
+      (await new UsersRepository(this.db).getToolConfigField(userId, tool, field)) ?? undefined
+    );
   }
 
   /**
@@ -1645,24 +1637,7 @@ export class UsersService {
     userId: UserID,
     tool: T
   ): Promise<AgenticToolsConfig[T] | null> {
-    const row = await select(this.db).from(users).where(eq(users.user_id, userId)).one();
-    if (!row) return null;
-
-    const data = row.data as { agentic_tools?: StoredAgenticTools };
-    const fields = data.agentic_tools?.[tool];
-    if (!fields || Object.keys(fields).length === 0) return null;
-
-    const out: Record<string, string> = {};
-    for (const [field, encrypted] of Object.entries(fields)) {
-      if (!encrypted) continue;
-      try {
-        out[field] = await decryptApiKeyAsync(encrypted);
-      } catch (err) {
-        console.error(`Failed to decrypt agentic_tools.${tool}.${field} for user ${userId}:`, err);
-      }
-    }
-
-    return Object.keys(out).length > 0 ? (out as AgenticToolsConfig[T]) : null;
+    return new UsersRepository(this.db).getToolConfig(userId, tool);
   }
 
   /**

--- a/apps/agor-daemon/src/services/users.ts
+++ b/apps/agor-daemon/src/services/users.ts
@@ -36,6 +36,7 @@ import {
   branches,
   compare,
   decryptApiKey,
+  decryptApiKeyAsync,
   deleteFrom,
   encryptApiKey,
   eq,
@@ -1628,7 +1629,7 @@ export class UsersService {
     if (!encrypted) return undefined;
 
     try {
-      return decryptApiKey(encrypted);
+      return await decryptApiKeyAsync(encrypted);
     } catch (err) {
       console.error(`Failed to decrypt agentic_tools.${tool}.${field} for user ${userId}:`, err);
       return undefined;
@@ -1655,7 +1656,7 @@ export class UsersService {
     for (const [field, encrypted] of Object.entries(fields)) {
       if (!encrypted) continue;
       try {
-        out[field] = decryptApiKey(encrypted);
+        out[field] = await decryptApiKeyAsync(encrypted);
       } catch (err) {
         console.error(`Failed to decrypt agentic_tools.${tool}.${field} for user ${userId}:`, err);
       }

--- a/packages/core/src/config/env-resolver.test.ts
+++ b/packages/core/src/config/env-resolver.test.ts
@@ -12,8 +12,9 @@
 import type { BranchID, Session, SessionID, UserID, UUID } from '@agor/core/types';
 import { SessionStatus } from '@agor/core/types';
 import { eq } from 'drizzle-orm';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { select, update } from '../db/database-wrapper';
+import * as encryption from '../db/encryption';
 import { encryptApiKey } from '../db/encryption';
 import { BranchRepository } from '../db/repositories/branches';
 import { RepoRepository } from '../db/repositories/repos';
@@ -106,6 +107,8 @@ async function createSessionForUser(db: any, userId: UserID): Promise<SessionID>
   const session = await sessionRepo.create(data);
   return session.session_id as SessionID;
 }
+
+afterEach(() => vi.restoreAllMocks());
 
 describe('resolveUserEnvironment — scope filtering (v0.5)', () => {
   dbTest('global-scope vars are always included', async ({ db }) => {
@@ -220,6 +223,37 @@ describe('resolveUserEnvironment — scope filtering (v0.5)', () => {
     }
   );
 });
+
+dbTest(
+  'environment hydration opens only selected fields serially and retains corruption logging',
+  async ({ db }) => {
+    const userId = await createUserWithEnv(db, {
+      FIRST: encEntry('first', 'global'),
+      SECOND: encEntry('second', 'global'),
+      UNSELECTED: { value_encrypted: 'unreadable', scope: 'session' },
+      BAD: { value_encrypted: 'unreadable', scope: 'global' },
+    });
+    const native = encryption.decryptApiKeyAsync;
+    let active = 0;
+    let peak = 0;
+    const open = vi.spyOn(encryption, 'decryptApiKeyAsync').mockImplementation(async (...args) => {
+      peak = Math.max(peak, ++active);
+      try {
+        return await native(...args);
+      } finally {
+        active--;
+      }
+    });
+    const logs = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const env = await resolveUserEnvironment(userId, db);
+    expect(env).toMatchObject({ FIRST: 'first', SECOND: 'second' });
+    expect(env).not.toHaveProperty('BAD');
+    expect(env).not.toHaveProperty('UNSELECTED');
+    expect(open).toHaveBeenCalledTimes(3);
+    expect(peak).toBe(1);
+    expect(logs).toHaveBeenCalledTimes(1);
+  }
+);
 
 describe('buildAllowlistedEnv — daemon credential capabilities', () => {
   it('forwards only explicit runtime metadata, never ambient account context', () => {

--- a/packages/core/src/config/env-resolver.ts
+++ b/packages/core/src/config/env-resolver.ts
@@ -1,7 +1,7 @@
 import { eq } from 'drizzle-orm';
 import type { Database } from '../db/client';
 import { select } from '../db/database-wrapper';
-import { decryptApiKey } from '../db/encryption';
+import { decryptApiKeyAsync } from '../db/encryption';
 import { SessionEnvSelectionRepository } from '../db/repositories/session-env-selections';
 import { users } from '../db/schema';
 import type {
@@ -197,7 +197,7 @@ export async function resolveUserEnvironment(
         }
 
         try {
-          const decryptedValue = decryptApiKey(entry.value_encrypted);
+          const decryptedValue = await decryptApiKeyAsync(entry.value_encrypted);
           if (decryptedValue && decryptedValue.trim() !== '') {
             env[key] = decryptedValue;
           }
@@ -215,7 +215,7 @@ export async function resolveUserEnvironment(
           for (const [key, encryptedValue] of Object.entries(toolFields)) {
             if (!encryptedValue) continue;
             try {
-              const decryptedValue = decryptApiKey(encryptedValue);
+              const decryptedValue = await decryptApiKeyAsync(encryptedValue);
               if (decryptedValue && decryptedValue.trim() !== '') {
                 env[key] = decryptedValue;
               }

--- a/packages/core/src/config/key-resolver.test.ts
+++ b/packages/core/src/config/key-resolver.test.ts
@@ -10,8 +10,10 @@
 
 import type { UserID } from '@agor/core/types';
 import { eq } from 'drizzle-orm';
-import { beforeAll, describe, expect } from 'vitest';
+import { afterEach, beforeAll, describe, expect, vi } from 'vitest';
+import * as wrapper from '../db/database-wrapper';
 import { select, update } from '../db/database-wrapper';
+import * as encryption from '../db/encryption';
 import { encryptApiKey } from '../db/encryption';
 import { TenantAgenticToolSettingsRepository } from '../db/repositories/tenant-agentic-tools';
 import { UsersRepository } from '../db/repositories/users';
@@ -52,6 +54,8 @@ async function createUserWithToolCreds(
     .run();
   return user.user_id;
 }
+
+afterEach(() => vi.restoreAllMocks());
 
 describe('resolveApiKey — per-tool credential scoping', () => {
   dbTest('tool-scoped lookup ignores other tools buckets', async ({ db }) => {
@@ -197,6 +201,139 @@ describe('resolveApiKey — per-tool credential scoping', () => {
       });
       expect(result.connection).toEqual({ CLAUDE_CODE_OAUTH_TOKEN: 'subscription-token' });
       expect(result.apiKey).toBe('subscription-token');
+    }
+  );
+  dbTest(
+    'reads tenant settings once and opens selected user fields serially with no cross-user cache',
+    async ({ db }) => {
+      const userId = await createUserWithToolCreds(db, {
+        'claude-code': {
+          ANTHROPIC_API_KEY: encryptApiKey('user-key'),
+          ANTHROPIC_BASE_URL: encryptApiKey(' https://example.invalid '),
+        },
+      });
+      const other = await createUserWithToolCreds(db, {
+        'claude-code': { ANTHROPIC_API_KEY: encryptApiKey('other-key') },
+      });
+      const settings = new TenantAgenticToolSettingsRepository(db);
+      await settings.patch('claude-code', {
+        resolution_policy: 'user_required',
+        connection: { ANTHROPIC_API_KEY: 'tenant-key' },
+      });
+      const find = vi.spyOn(TenantAgenticToolSettingsRepository.prototype, 'find');
+      const selectSpy = vi.spyOn(wrapper, 'select');
+      let active = 0;
+      let peak = 0;
+      const native = encryption.decryptApiKeyAsync;
+      const open = vi
+        .spyOn(encryption, 'decryptApiKeyAsync')
+        .mockImplementation(async (...args) => {
+          peak = Math.max(peak, ++active);
+          try {
+            return await native(...args);
+          } finally {
+            active--;
+          }
+        });
+      const result = await resolveApiKey('ANTHROPIC_API_KEY', { userId, db, tool: 'claude-code' });
+      expect(result.apiKey).toBe('user-key');
+      expect(result.connection).toMatchObject({ ANTHROPIC_BASE_URL: 'https://example.invalid' });
+      expect(find).toHaveBeenCalledTimes(1);
+      expect(selectSpy).toHaveBeenCalledTimes(2); // tenant settings + user, formerly three
+      expect(open).toHaveBeenCalledTimes(3); // one tenant document + two user fields
+      expect(peak).toBe(1);
+      expect(
+        (await resolveApiKey('ANTHROPIC_API_KEY', { userId: other, db, tool: 'claude-code' }))
+          .apiKey
+      ).toBe('other-key');
+      await new UsersRepository(db).deleteToolConfigField(
+        userId,
+        'claude-code',
+        'ANTHROPIC_API_KEY'
+      );
+      expect(
+        (await resolveApiKey('ANTHROPIC_API_KEY', { userId, db, tool: 'claude-code' })).apiKey
+      ).toBeUndefined();
+      await settings.patch('claude-code', {
+        resolution_policy: 'tenant_required',
+        connection: { ANTHROPIC_API_KEY: 'rotated-tenant-key' },
+      });
+      expect(
+        (await resolveApiKey('ANTHROPIC_API_KEY', { userId, db, tool: 'claude-code' })).apiKey
+      ).toBe('rotated-tenant-key');
+    }
+  );
+  dbTest(
+    'async decryption failure rejects the entire user connection without falling back',
+    async ({ db }) => {
+      const userId = await createUserWithToolCreds(db, {
+        codex: {
+          OPENAI_API_KEY: encryptApiKey('valid-first-field'),
+          OPENAI_BASE_URL: 'corrupt-envelope',
+        },
+      });
+      await new TenantAgenticToolSettingsRepository(db).patch('codex', {
+        connection: { OPENAI_API_KEY: 'tenant-fallback' },
+      });
+      expect(await resolveApiKey('OPENAI_API_KEY', { userId, db, tool: 'codex' })).toMatchObject({
+        apiKey: undefined,
+        connection: {},
+        source: 'user',
+        decryptionFailed: true,
+      });
+    }
+  );
+
+  dbTest.skipIf(process.env.AGOR_BENCH_PROVIDER_READ !== '1')(
+    'benchmarks stored user provider resolution without network probes',
+    async ({ db }) => {
+      const userId = await createUserWithToolCreds(db, {
+        'claude-code': {
+          ANTHROPIC_API_KEY: encryptApiKey('user-key'),
+          ANTHROPIC_AUTH_TOKEN: encryptApiKey('user-token'),
+          ANTHROPIC_BASE_URL: encryptApiKey('https://example.invalid'),
+        },
+      });
+      const native = encryption.decryptApiKeyAsync;
+      const samples: Record<string, { elapsedMs: number; maxTickGapMs: number }[]> = {
+        sync: [],
+        async: [],
+      };
+      for (let round = 0; round < 4; round++) {
+        for (const mode of round % 2 ? ['async', 'sync'] : ['sync', 'async']) {
+          const spy = vi
+            .spyOn(encryption, 'decryptApiKeyAsync')
+            .mockImplementation(
+              mode === 'sync' ? async (...args) => encryption.decryptApiKey(...args) : native
+            );
+          let last = performance.now();
+          let maxTickGapMs = 0;
+          const tick = () => {
+            const now = performance.now();
+            maxTickGapMs = Math.max(maxTickGapMs, now - last);
+            last = now;
+          };
+          const timer = setInterval(tick, 5);
+          try {
+            const start = performance.now();
+            const result = await resolveApiKey('ANTHROPIC_API_KEY', {
+              userId,
+              db,
+              tool: 'claude-code',
+            });
+            const elapsedMs = performance.now() - start;
+            tick();
+            expect(result.apiKey).toBe('user-key');
+            if (round) samples[mode].push({ elapsedMs, maxTickGapMs });
+          } finally {
+            clearInterval(timer);
+            spy.mockRestore();
+          }
+        }
+      }
+      process.stdout.write(
+        `Provider resolution, real SQLite + 3 user fields (1 warmup, 3 samples): ${JSON.stringify(samples)}\n`
+      );
     }
   );
 });

--- a/packages/core/src/config/tenant-agentic-tool-resolver.ts
+++ b/packages/core/src/config/tenant-agentic-tool-resolver.ts
@@ -1,7 +1,7 @@
 import { eq } from 'drizzle-orm';
 import type { Database } from '../db/client';
 import { select } from '../db/database-wrapper';
-import { decryptApiKey } from '../db/encryption';
+import { decryptApiKeyAsync } from '../db/encryption';
 import { TenantAgenticToolSettingsRepository } from '../db/repositories/tenant-agentic-tools';
 import { users } from '../db/schema';
 import type {
@@ -138,7 +138,7 @@ async function resolveUserConnection(
       }
       const encrypted = stored[field];
       if (!encrypted) continue;
-      const value = decryptApiKey(encrypted).trim();
+      const value = (await decryptApiKeyAsync(encrypted)).trim();
       if (value) connection[field] = value;
     }
   } catch {
@@ -158,14 +158,15 @@ export async function resolveProviderConnection(
   }
 
   const repository = context.db ? new TenantAgenticToolSettingsRepository(context.db) : null;
-  const policy = repository
-    ? await repository.resolutionPolicy(canonical)
-    : DEFAULT_PROVIDER_RESOLUTION_POLICY;
+  // Resolve policy and its credential from one request-local snapshot, not two
+  // reads/decryptions of the same settings document separated by user hydration.
+  const settings = repository ? await repository.find(canonical) : null;
+  const policy = settings?.resolution_policy ?? DEFAULT_PROVIDER_RESOLUTION_POLICY;
   const user =
     context.userId && context.db
       ? await resolveUserConnection(canonical, context.userId, context.db)
       : null;
-  const tenantConnection = repository ? await repository.connection(canonical) : null;
+  const tenantConnection = settings?.connection ?? null;
   const userCandidate = user
     ? {
         source: 'user' as const,

--- a/packages/core/src/db/encryption.async.test.ts
+++ b/packages/core/src/db/encryption.async.test.ts
@@ -1,0 +1,18 @@
+import { scrypt, scryptSync } from 'node:crypto';
+import { expect, it, vi } from 'vitest';
+import { decryptApiKeyAsync, encryptApiKey } from './encryption';
+
+vi.mock('node:crypto', async (importOriginal) => {
+  const crypto = await importOriginal<typeof import('node:crypto')>();
+  return { ...crypto, scrypt: vi.fn(crypto.scrypt), scryptSync: vi.fn(crypto.scryptSync) };
+});
+
+it('dispatches the legacy envelope KDF to native async scrypt', async () => {
+  const envelope = encryptApiKey('synthetic', 'synthetic-master');
+  vi.mocked(scrypt).mockClear();
+  vi.mocked(scryptSync).mockClear();
+  const opening = decryptApiKeyAsync(envelope, 'synthetic-master');
+  expect(scrypt).toHaveBeenCalledTimes(1);
+  expect(scryptSync).not.toHaveBeenCalled();
+  await expect(opening).resolves.toBe('synthetic');
+});

--- a/packages/core/src/db/encryption.test.ts
+++ b/packages/core/src/db/encryption.test.ts
@@ -1,10 +1,13 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { decryptApiKey, encryptApiKey, isEncrypted } from './encryption';
+import { decryptApiKey, decryptApiKeyAsync, encryptApiKey, isEncrypted } from './encryption';
 
 const KEY_A = 'encryption-test-master-key-a';
 const KEY_B = 'encryption-test-master-key-b';
 
-describe('legacy deployment-secret envelope', () => {
+describe.each([
+  ['sync', async (value: string, key?: string) => decryptApiKey(value, key)],
+  ['async', decryptApiKeyAsync],
+] as const)('legacy deployment-secret envelope (%s)', (_mode, decrypt) => {
   const originalMasterSecret = process.env.AGOR_MASTER_SECRET;
 
   afterEach(() => {
@@ -12,7 +15,7 @@ describe('legacy deployment-secret envelope', () => {
     else process.env.AGOR_MASTER_SECRET = originalMasterSecret;
   });
 
-  it('round-trips without embedding plaintext and randomizes each envelope', () => {
+  it('round-trips without embedding plaintext and randomizes each envelope', async () => {
     const value = 'audit-canary-value';
     const first = encryptApiKey(value, KEY_A);
     const second = encryptApiKey(value, KEY_A);
@@ -21,36 +24,36 @@ describe('legacy deployment-secret envelope', () => {
     expect(second).not.toContain(value);
     expect(first).not.toBe(second);
     expect(isEncrypted(first)).toBe(true);
-    expect(decryptApiKey(first, KEY_A)).toBe(value);
-    expect(decryptApiKey(second, KEY_A)).toBe(value);
+    await expect(decrypt(first, KEY_A)).resolves.toBe(value);
+    await expect(decrypt(second, KEY_A)).resolves.toBe(value);
   });
 
-  it('round-trips an empty plaintext for credential classes that permit one', () => {
+  it('round-trips an empty plaintext for credential classes that permit one', async () => {
     const envelope = encryptApiKey('', KEY_A);
 
     expect(isEncrypted(envelope)).toBe(true);
-    expect(decryptApiKey(envelope, KEY_A)).toBe('');
+    await expect(decrypt(envelope, KEY_A)).resolves.toBe('');
   });
 
-  it('fails closed when the deployment master secret is unavailable', () => {
+  it('fails closed when the deployment master secret is unavailable', async () => {
     delete process.env.AGOR_MASTER_SECRET;
 
     expect(() => encryptApiKey('canary')).toThrow('Secret encryption requires AGOR_MASTER_SECRET');
-    expect(() => decryptApiKey('not-an-envelope')).toThrow(
+    await expect(decrypt('not-an-envelope')).rejects.toThrow(
       'Secret decryption requires AGOR_MASTER_SECRET'
     );
   });
 
-  it('rejects an explicitly empty deployment secret', () => {
+  it('rejects an explicitly empty deployment secret', async () => {
     expect(() => encryptApiKey('canary', '')).toThrow(
       'Secret encryption requires AGOR_MASTER_SECRET'
     );
-    expect(() => decryptApiKey(encryptApiKey('canary', KEY_A), '')).toThrow(
+    await expect(decrypt(encryptApiKey('canary', KEY_A), '')).rejects.toThrow(
       'Secret decryption requires AGOR_MASTER_SECRET'
     );
   });
 
-  it('normalizes wrong-key, tamper, and malformed-envelope failures', () => {
+  it('normalizes wrong-key, tamper, and malformed-envelope failures', async () => {
     const envelope = encryptApiKey('canary', KEY_A);
     const [salt, iv, tag, ciphertext] = envelope.split(':');
     const malformed = [
@@ -62,14 +65,14 @@ describe('legacy deployment-secret envelope', () => {
       `${salt}:${iv}:${tag}:${ciphertext}:extra`,
     ];
 
-    expect(() => decryptApiKey(envelope, KEY_B)).toThrow('Secret decryption failed');
+    await expect(decrypt(envelope, KEY_B)).rejects.toThrow('Secret decryption failed');
     for (const candidate of malformed) {
-      expect(() => decryptApiKey(candidate, KEY_A)).toThrow('Secret decryption failed');
+      await expect(decrypt(candidate, KEY_A)).rejects.toThrow('Secret decryption failed');
       expect(isEncrypted(candidate)).toBe(false);
     }
 
     const last = ciphertext.at(-1) === '0' ? '1' : '0';
     const tampered = `${salt}:${iv}:${tag}:${ciphertext.slice(0, -1)}${last}`;
-    expect(() => decryptApiKey(tampered, KEY_A)).toThrow('Secret decryption failed');
+    await expect(decrypt(tampered, KEY_A)).rejects.toThrow('Secret decryption failed');
   });
 });

--- a/packages/core/src/db/encryption.ts
+++ b/packages/core/src/db/encryption.ts
@@ -1,4 +1,4 @@
-import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from 'node:crypto';
+import { createCipheriv, createDecipheriv, randomBytes, scrypt, scryptSync } from 'node:crypto';
 
 const ALGORITHM = 'aes-256-gcm';
 const KEY_LENGTH = 32;
@@ -71,31 +71,59 @@ export function decryptApiKey(ciphertext: string, secret?: string): string {
   if (!masterSecret) throw new Error('Secret decryption requires AGOR_MASTER_SECRET');
 
   try {
-    const parts = ciphertext.split(':');
-    if (parts.length !== 4) throw new Error('invalid envelope');
-    const [saltHex, ivHex, authTagHex, encryptedHex] = parts;
-    if (
-      !isHexOfBytes(saltHex, SALT_LENGTH) ||
-      !isHexOfBytes(ivHex, IV_LENGTH) ||
-      !isHexOfBytes(authTagHex, 16) ||
-      !isEvenHex(encryptedHex)
-    ) {
-      throw new Error('invalid envelope');
-    }
-
-    const salt = Buffer.from(saltHex, 'hex');
-    const iv = Buffer.from(ivHex, 'hex');
-    const authTag = Buffer.from(authTagHex, 'hex');
-    const encrypted = Buffer.from(encryptedHex, 'hex');
-    const decipher = createDecipheriv(ALGORITHM, deriveKey(masterSecret, salt), iv);
-    decipher.setAuthTag(authTag);
-    return Buffer.concat([decipher.update(encrypted), decipher.final()]).toString('utf8');
+    const envelope = parseEnvelope(ciphertext);
+    return decryptEnvelope(envelope, deriveKey(masterSecret, envelope.salt));
   } catch {
     // Do not expose parser-vs-authentication distinctions (or OpenSSL details)
     // through API errors and logs. Operators only need to know that this field
     // cannot be opened with the active deployment key.
     throw new Error('Secret decryption failed');
   }
+}
+
+/** Same envelope and failure contract, with the expensive KDF on Node's worker pool. */
+export async function decryptApiKeyAsync(ciphertext: string, secret?: string): Promise<string> {
+  const masterSecret = secret ?? getMasterSecret('decryption');
+  if (!masterSecret) throw new Error('Secret decryption requires AGOR_MASTER_SECRET');
+
+  try {
+    const envelope = parseEnvelope(ciphertext);
+    const key = await new Promise<Buffer>((resolve, reject) => {
+      scrypt(masterSecret, envelope.salt, KEY_LENGTH, (error, derivedKey) => {
+        if (error) reject(error);
+        else resolve(derivedKey);
+      });
+    });
+    return decryptEnvelope(envelope, key);
+  } catch {
+    throw new Error('Secret decryption failed');
+  }
+}
+
+function parseEnvelope(ciphertext: string) {
+  const parts = ciphertext.split(':');
+  if (parts.length !== 4) throw new Error('invalid envelope');
+  const [saltHex, ivHex, authTagHex, encryptedHex] = parts;
+  if (
+    !isHexOfBytes(saltHex, SALT_LENGTH) ||
+    !isHexOfBytes(ivHex, IV_LENGTH) ||
+    !isHexOfBytes(authTagHex, 16) ||
+    !isEvenHex(encryptedHex)
+  ) {
+    throw new Error('invalid envelope');
+  }
+  return {
+    salt: Buffer.from(saltHex, 'hex'),
+    iv: Buffer.from(ivHex, 'hex'),
+    authTag: Buffer.from(authTagHex, 'hex'),
+    encrypted: Buffer.from(encryptedHex, 'hex'),
+  };
+}
+
+function decryptEnvelope(envelope: ReturnType<typeof parseEnvelope>, key: Buffer): string {
+  const decipher = createDecipheriv(ALGORITHM, key, envelope.iv);
+  decipher.setAuthTag(envelope.authTag);
+  return Buffer.concat([decipher.update(envelope.encrypted), decipher.final()]).toString('utf8');
 }
 
 function isEvenHex(value: string): boolean {

--- a/packages/core/src/db/oauth-secret-envelope.async.test.ts
+++ b/packages/core/src/db/oauth-secret-envelope.async.test.ts
@@ -1,0 +1,18 @@
+import { scrypt, scryptSync } from 'node:crypto';
+import { expect, it, vi } from 'vitest';
+import { openBoundSecretAsync, sealBoundSecret } from './oauth-secret-envelope';
+
+vi.mock('node:crypto', async (importOriginal) => {
+  const crypto = await importOriginal<typeof import('node:crypto')>();
+  return { ...crypto, scrypt: vi.fn(crypto.scrypt), scryptSync: vi.fn(crypto.scryptSync) };
+});
+
+it('uses callback-based scrypt rather than disguising synchronous KDF work in a promise', async () => {
+  const envelope = sealBoundSecret('synthetic', 'synthetic-master', 'access-token', 'binding');
+  vi.mocked(scrypt).mockClear();
+  vi.mocked(scryptSync).mockClear();
+  const opening = openBoundSecretAsync(envelope, 'synthetic-master', 'access-token', 'binding');
+  expect(scrypt).toHaveBeenCalledTimes(1);
+  expect(scryptSync).not.toHaveBeenCalled();
+  await expect(opening).resolves.toBe('synthetic');
+});

--- a/packages/core/src/db/oauth-secret-envelope.test.ts
+++ b/packages/core/src/db/oauth-secret-envelope.test.ts
@@ -1,10 +1,18 @@
 import { describe, expect, it } from 'vitest';
-import { isBoundSecretEnvelope, openBoundSecret, sealBoundSecret } from './oauth-secret-envelope';
+import {
+  isBoundSecretEnvelope,
+  openBoundSecret,
+  openBoundSecretAsync,
+  sealBoundSecret,
+} from './oauth-secret-envelope';
 
-describe('bound secret envelope', () => {
+describe.each([
+  ['sync', openBoundSecret],
+  ['async', openBoundSecretAsync],
+] as const)('bound secret envelope (%s)', (_name, open) => {
   const master = 'test-master-secret-with-enough-entropy';
 
-  it('round-trips with explicit OAuth format and no plaintext', () => {
+  it('round-trips with explicit OAuth format and no plaintext', async () => {
     const envelope = sealBoundSecret(
       'PKCE-DO-NOT-PERSIST-RAW',
       master,
@@ -14,35 +22,38 @@ describe('bound secret envelope', () => {
     expect(isBoundSecretEnvelope(envelope)).toBe(true);
     expect(envelope).toMatch(/^agor-mcp-oauth:v1:pending-exchange:/);
     expect(envelope).not.toContain('PKCE-DO-NOT-PERSIST-RAW');
-    expect(
-      openBoundSecret(envelope, master, 'pending-exchange', 'tenant\0user\0server\0attempt')
-    ).toBe('PKCE-DO-NOT-PERSIST-RAW');
+    expect(await open(envelope, master, 'pending-exchange', 'tenant\0user\0server\0attempt')).toBe(
+      'PKCE-DO-NOT-PERSIST-RAW'
+    );
   });
 
   it.each([
     ['wrong purpose', 'refresh-token', 'tenant\0user\0server\0attempt', master],
     ['wrong binding', 'pending-exchange', 'tenant\0other\0server\0attempt', master],
     ['wrong master secret', 'pending-exchange', 'tenant\0user\0server\0attempt', 'other'],
-  ] as const)('rejects %s through AEAD domain separation', (_label, purpose, binding, key) => {
-    const envelope = sealBoundSecret(
-      'secret',
-      master,
-      'pending-exchange',
-      'tenant\0user\0server\0attempt'
-    );
-    expect(() => openBoundSecret(envelope, key, purpose, binding)).toThrow();
-  });
+  ] as const)(
+    'rejects %s through AEAD domain separation',
+    async (_label, purpose, binding, key) => {
+      const envelope = sealBoundSecret(
+        'secret',
+        master,
+        'pending-exchange',
+        'tenant\0user\0server\0attempt'
+      );
+      await expect(async () => open(envelope, key, purpose, binding)).rejects.toThrow();
+    }
+  );
 
-  it('rejects legacy/plaintext and malformed envelopes without fallback', () => {
-    expect(() => openBoundSecret('raw-secret', master, 'access-token', 'binding')).toThrow(
+  it('rejects legacy/plaintext and malformed envelopes without fallback', async () => {
+    await expect(async () => open('raw-secret', master, 'access-token', 'binding')).rejects.toThrow(
       'Unsupported bound secret envelope'
     );
-    expect(() =>
-      openBoundSecret('agor-mcp-oauth:v2:access-token:a:b:c:d', master, 'access-token', 'binding')
-    ).toThrow('Unsupported bound secret envelope');
+    await expect(async () =>
+      open('agor-mcp-oauth:v2:access-token:a:b:c:d', master, 'access-token', 'binding')
+    ).rejects.toThrow('Unsupported bound secret envelope');
   });
 
-  it('keeps Claude attempt ciphertext outside the MCP exchange purpose domain', () => {
+  it('keeps Claude attempt ciphertext outside the MCP exchange purpose domain', async () => {
     const binding = 'tenant\0user\0attempt\x01';
     const envelope = sealBoundSecret(
       '{"codeVerifier":"verifier"}',
@@ -52,11 +63,9 @@ describe('bound secret envelope', () => {
     );
 
     expect(envelope).toMatch(/^agor-mcp-oauth:v1:claude-signin-attempt:/);
-    expect(() => openBoundSecret(envelope, master, 'pending-exchange', binding)).toThrow(
+    await expect(async () => open(envelope, master, 'pending-exchange', binding)).rejects.toThrow(
       'Unsupported bound secret envelope'
     );
-    expect(openBoundSecret(envelope, master, 'claude-signin-attempt', binding)).toContain(
-      'verifier'
-    );
+    expect(await open(envelope, master, 'claude-signin-attempt', binding)).toContain('verifier');
   });
 });

--- a/packages/core/src/db/oauth-secret-envelope.ts
+++ b/packages/core/src/db/oauth-secret-envelope.ts
@@ -1,4 +1,4 @@
-import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from 'node:crypto';
+import { createCipheriv, createDecipheriv, randomBytes, scrypt, scryptSync } from 'node:crypto';
 
 const PREFIX = 'agor-mcp-oauth';
 const FORMAT_VERSION = 'v1';
@@ -66,6 +66,33 @@ export function openBoundSecret(
   purpose: BoundSecretPurpose,
   binding: string
 ): string {
+  const parsed = parseEnvelope(envelope, masterSecret, purpose);
+  return decryptEnvelope(parsed, deriveKey(masterSecret, parsed.salt), purpose, binding);
+}
+
+/**
+ * Same envelope and AAD checks as the synchronous opener, without running the
+ * expensive KDF on the event loop. Callers processing inventories must await
+ * each field/row rather than enqueue the entire inventory on the worker pool.
+ * No keys or plaintext are cached across calls.
+ */
+export async function openBoundSecretAsync(
+  envelope: string,
+  masterSecret: string,
+  purpose: BoundSecretPurpose,
+  binding: string
+): Promise<string> {
+  const parsed = parseEnvelope(envelope, masterSecret, purpose);
+  const key = await new Promise<Buffer>((resolve, reject) => {
+    scrypt(masterSecret, parsed.salt, KEY_LENGTH, (error, derivedKey) => {
+      if (error) reject(error);
+      else resolve(derivedKey);
+    });
+  });
+  return decryptEnvelope(parsed, key, purpose, binding);
+}
+
+function parseEnvelope(envelope: string, masterSecret: string, purpose: BoundSecretPurpose) {
   if (!masterSecret) throw new Error('Bound secret opening requires AGOR_MASTER_SECRET');
   const [prefix, version, storedPurpose, salt, iv, tag, encrypted, ...extra] = envelope.split(':');
   if (
@@ -80,17 +107,24 @@ export function openBoundSecret(
   ) {
     throw new Error('Unsupported bound secret envelope');
   }
-  const decipher = createDecipheriv(
-    ALGORITHM,
-    deriveKey(masterSecret, Buffer.from(salt, 'base64url')),
-    Buffer.from(iv, 'base64url')
-  );
+  return {
+    salt: Buffer.from(salt, 'base64url'),
+    iv: Buffer.from(iv, 'base64url'),
+    tag: Buffer.from(tag, 'base64url'),
+    encrypted: Buffer.from(encrypted, 'base64url'),
+  };
+}
+
+function decryptEnvelope(
+  parsed: ReturnType<typeof parseEnvelope>,
+  key: Buffer,
+  purpose: BoundSecretPurpose,
+  binding: string
+): string {
+  const decipher = createDecipheriv(ALGORITHM, key, parsed.iv);
   decipher.setAAD(aad(purpose, binding));
-  decipher.setAuthTag(Buffer.from(tag, 'base64url'));
-  return Buffer.concat([
-    decipher.update(Buffer.from(encrypted, 'base64url')),
-    decipher.final(),
-  ]).toString('utf8');
+  decipher.setAuthTag(parsed.tag);
+  return Buffer.concat([decipher.update(parsed.encrypted), decipher.final()]).toString('utf8');
 }
 
 export function isBoundSecretEnvelope(value: string): boolean {

--- a/packages/core/src/db/repositories/app-variables.ts
+++ b/packages/core/src/db/repositories/app-variables.ts
@@ -1,9 +1,9 @@
 import type { UserID } from '@agor/core/types';
-import { and, eq, sql } from 'drizzle-orm';
+import { and, eq, inArray, sql } from 'drizzle-orm';
 import { generateId } from '../../lib/ids';
 import type { Database } from '../client';
 import { deleteFrom, insert, select, update } from '../database-wrapper';
-import { decryptApiKey, encryptApiKey } from '../encryption';
+import { decryptApiKeyAsync, encryptApiKey } from '../encryption';
 import { type AppVariableInsert, type AppVariableRow, appVariables } from '../schema';
 import { currentTenantInsert, RepositoryError } from './base';
 
@@ -60,14 +60,38 @@ export class AppVariableRepository {
 
   async getPlain(namespace: string, key: string): Promise<string | null> {
     const variable = await this.find(namespace, key);
+    return this.plainValue(variable);
+  }
+
+  /** A caller-bounded key set, read under the same ambient tenant scope as find(). */
+  async getPlainMany(
+    namespace: string,
+    keys: readonly string[]
+  ): Promise<Map<string, string | null>> {
+    if (keys.length === 0) return new Map();
+    const rows = await select(this.db)
+      .from(appVariables)
+      .where(and(eq(appVariables.namespace, namespace), inArray(appVariables.key, [...keys])))
+      .all();
+    const variables = new Map<string, AppVariable>(
+      rows.map((row: AppVariableRow) => [row.key, this.rowToVariable(row)])
+    );
+    const values = new Map<string, string | null>();
+    // Preserve caller order and bound native KDF concurrency independently of inventory size.
+    for (const key of new Set(keys))
+      values.set(key, await this.plainValue(variables.get(key) ?? null));
+    return values;
+  }
+
+  private async plainValue(variable: AppVariable | null): Promise<string | null> {
     if (!variable) return null;
     if (!variable.is_encrypted) return variable.value_text ?? null;
     if (!variable.value_encrypted) return null;
     try {
-      return decryptApiKey(variable.value_encrypted);
+      return await decryptApiKeyAsync(variable.value_encrypted);
     } catch (error) {
       throw new RepositoryError(
-        `Failed to decrypt app variable ${namespace}.${key}: ${
+        `Failed to decrypt app variable ${variable.namespace}.${variable.key}: ${
           error instanceof Error ? error.message : String(error)
         }`,
         error

--- a/packages/core/src/db/repositories/credential-inventory.reads.postgres.test.ts
+++ b/packages/core/src/db/repositories/credential-inventory.reads.postgres.test.ts
@@ -1,0 +1,118 @@
+import { sql } from 'drizzle-orm';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { generateId } from '../../lib/ids';
+import type { GatewayChannel, UserID } from '../../types';
+import { createDatabase, type Database } from '../client';
+import { select } from '../database-wrapper';
+import { initializeDatabase } from '../migrate';
+import { runWithTenantDatabaseScope } from '../tenant-scope';
+import { AppVariableRepository } from './app-variables';
+import { BranchRepository } from './branches';
+import { GatewayChannelRepository } from './gateway-channels';
+import { RepoRepository } from './repos';
+import { TenantAgenticToolSettingsRepository } from './tenant-agentic-tools';
+import { UsersRepository } from './users';
+
+const url = process.env.AGOR_TEST_POSTGRES_URL;
+
+describe.skipIf(!url || process.env.AGOR_DB_DIALECT !== 'postgresql')(
+  'credential inventories preserve PostgreSQL tenant isolation across async decryption',
+  () => {
+    let db: Database;
+    const tenants = [`inventory-a-${generateId()}`, `inventory-b-${generateId()}`];
+    const owners = new Map<string, { user: UserID; channel: GatewayChannel }>();
+
+    beforeAll(async () => {
+      vi.stubEnv('AGOR_MASTER_SECRET', 'synthetic-inventory-master');
+      db = createDatabase({ dialect: 'postgresql', url: url! });
+      await initializeDatabase(db);
+      const role = await select(db, { safe: sql<boolean>`NOT rolsuper AND NOT rolbypassrls` })
+        .from(sql`pg_roles`)
+        .where(sql`rolname = current_user`)
+        .one();
+      expect(role?.safe).toBe(true);
+      for (const [index, tenant] of tenants.entries()) {
+        await runWithTenantDatabaseScope(db, tenant, async (scoped) => {
+          const user = await new UsersRepository(scoped).create({
+            email: `${tenant}@example.invalid`,
+            name: 'Synthetic inventory test',
+          });
+          const repo = await new RepoRepository(scoped).create({
+            repo_id: generateId(),
+            slug: `inventory-${tenant}`,
+            name: 'Synthetic',
+            repo_type: 'remote',
+            remote_url: 'https://example.invalid/repo.git',
+            local_path: `/tmp/${generateId()}`,
+            default_branch: 'main',
+          });
+          const branch = await new BranchRepository(scoped).create({
+            branch_id: generateId(),
+            repo_id: repo.repo_id,
+            name: 'main',
+            ref: 'main',
+            branch_unique_id: 8123456 + index,
+            path: `/tmp/${generateId()}`,
+            created_by: user.user_id,
+          });
+          const channel = await new GatewayChannelRepository(scoped).create({
+            name: 'Synthetic',
+            channel_type: 'slack',
+            created_by: user.user_id,
+            agor_user_id: user.user_id,
+            target_branch_id: branch.branch_id,
+            channel_key: generateId(),
+            enabled: true,
+            config: { bot_token: `bot-${tenant}`, app_token: `app-${tenant}` },
+          });
+          owners.set(tenant, { user: user.user_id, channel });
+          await new TenantAgenticToolSettingsRepository(scoped).patch('codex', {
+            connection: { OPENAI_API_KEY: `key-${tenant}` },
+          });
+        });
+      }
+    }, 60000);
+
+    afterAll(async () => {
+      vi.unstubAllEnvs();
+      if (db) await (db as Database & { $client: { end(): Promise<void> } }).$client.end();
+    });
+
+    it('returns only the concurrent caller tenant, including same-key settings and user-filtered gateway reads', async () => {
+      await Promise.all(
+        tenants.map((tenant) =>
+          runWithTenantDatabaseScope(db, tenant, async (scoped) => {
+            const own = owners.get(tenant)!;
+            const foreign = owners.get(tenants.find((value) => value !== tenant)!)!;
+            const channels = new GatewayChannelRepository(scoped);
+            const settings = new TenantAgenticToolSettingsRepository(scoped);
+            const [inventory, tools] = await Promise.all([channels.findAll(), settings.findAll()]);
+            expect(inventory).toHaveLength(1);
+            expect(inventory[0]).toMatchObject({
+              id: own.channel.id,
+              config: { bot_token: `bot-${tenant}`, app_token: `app-${tenant}` },
+            });
+            expect(Object.getOwnPropertyDescriptor(inventory[0], 'tenant_id')).toMatchObject({
+              value: tenant,
+              enumerable: false,
+            });
+            expect(tools.get('codex')?.connection?.OPENAI_API_KEY).toBe(`key-${tenant}`);
+            expect((await channels.findByUser(own.user)).map((channel) => channel.id)).toEqual([
+              own.channel.id,
+            ]);
+            await expect(channels.findByUser(foreign.user)).resolves.toEqual([]);
+            await expect(channels.findById(foreign.channel.id)).resolves.toBeNull();
+            await expect(channels.findByKey(foreign.channel.channel_key)).resolves.toBeNull();
+            // No status/plaintext cache may outlive credential deletion or rotation.
+            await new AppVariableRepository(scoped).delete('agentic_tools', 'codex');
+            expect((await settings.findAll()).get('codex')).toEqual({});
+            await channels.update(own.channel.id, { config: { bot_token: 'rotated' } });
+            expect((await channels.findAll())[0].config.bot_token).toBe('rotated');
+            await channels.delete(own.channel.id);
+            await expect(channels.findAll()).resolves.toEqual([]);
+          })
+        )
+      );
+    });
+  }
+);

--- a/packages/core/src/db/repositories/credential-inventory.reads.postgres.test.ts
+++ b/packages/core/src/db/repositories/credential-inventory.reads.postgres.test.ts
@@ -1,5 +1,6 @@
 import { sql } from 'drizzle-orm';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { resolveProviderConnection } from '../../config/tenant-agentic-tool-resolver';
 import { generateId } from '../../lib/ids';
 import type { GatewayChannel, UserID } from '../../types';
 import { createDatabase, type Database } from '../client';
@@ -66,6 +67,12 @@ describe.skipIf(!url || process.env.AGOR_DB_DIALECT !== 'postgresql')(
             config: { bot_token: `bot-${tenant}`, app_token: `app-${tenant}` },
           });
           owners.set(tenant, { user: user.user_id, channel });
+          await new UsersRepository(scoped).setToolConfigField(
+            user.user_id,
+            'codex',
+            'OPENAI_API_KEY',
+            `user-key-${tenant}`
+          );
           await new TenantAgenticToolSettingsRepository(scoped).patch('codex', {
             connection: { OPENAI_API_KEY: `key-${tenant}` },
           });
@@ -97,6 +104,16 @@ describe.skipIf(!url || process.env.AGOR_DB_DIALECT !== 'postgresql')(
               enumerable: false,
             });
             expect(tools.get('codex')?.connection?.OPENAI_API_KEY).toBe(`key-${tenant}`);
+            expect(
+              await resolveProviderConnection('codex', { userId: own.user, db: scoped })
+            ).toMatchObject({
+              source: 'user',
+              connection: { OPENAI_API_KEY: `user-key-${tenant}` },
+            });
+            // A foreign user ID cannot select their credential; normal tenant fallback remains local.
+            expect(
+              await resolveProviderConnection('codex', { userId: foreign.user, db: scoped })
+            ).toMatchObject({ source: 'tenant', connection: { OPENAI_API_KEY: `key-${tenant}` } });
             expect((await channels.findByUser(own.user)).map((channel) => channel.id)).toEqual([
               own.channel.id,
             ]);

--- a/packages/core/src/db/repositories/credential-inventory.reads.postgres.test.ts
+++ b/packages/core/src/db/repositories/credential-inventory.reads.postgres.test.ts
@@ -1,5 +1,6 @@
 import { sql } from 'drizzle-orm';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { resolveUserEnvironment } from '../../config/env-resolver';
 import { resolveProviderConnection } from '../../config/tenant-agentic-tool-resolver';
 import { generateId } from '../../lib/ids';
 import type { GatewayChannel, UserID } from '../../types';
@@ -110,6 +111,23 @@ describe.skipIf(!url || process.env.AGOR_DB_DIALECT !== 'postgresql')(
               source: 'user',
               connection: { OPENAI_API_KEY: `user-key-${tenant}` },
             });
+            const users = new UsersRepository(scoped);
+            expect(await users.getToolConfigField(own.user, 'codex', 'OPENAI_API_KEY')).toBe(
+              `user-key-${tenant}`
+            );
+            expect(await users.getToolConfig(own.user, 'codex')).toMatchObject({
+              OPENAI_API_KEY: `user-key-${tenant}`,
+            });
+            await expect(users.getToolConfig(foreign.user, 'codex')).resolves.toBeNull();
+            await expect(
+              users.getToolConfigField(foreign.user, 'codex', 'OPENAI_API_KEY')
+            ).resolves.toBeNull();
+            expect(await resolveUserEnvironment(own.user, scoped, { tool: 'codex' })).toMatchObject(
+              { OPENAI_API_KEY: `user-key-${tenant}` }
+            );
+            expect(
+              await resolveUserEnvironment(foreign.user, scoped, { tool: 'codex' })
+            ).not.toHaveProperty('OPENAI_API_KEY');
             // A foreign user ID cannot select their credential; normal tenant fallback remains local.
             expect(
               await resolveProviderConnection('codex', { userId: foreign.user, db: scoped })

--- a/packages/core/src/db/repositories/gateway-channels.reads.test.ts
+++ b/packages/core/src/db/repositories/gateway-channels.reads.test.ts
@@ -1,0 +1,169 @@
+import { setImmediate as nextTurn } from 'node:timers/promises';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Database } from '../client';
+import * as encryption from '../encryption';
+import { GatewayChannelRepository } from './gateway-channels';
+
+const query = vi.hoisted(() => ({ rows: [] as Record<string, unknown>[], selects: 0 }));
+vi.mock('../database-wrapper', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../database-wrapper')>();
+  return {
+    ...original,
+    select: () => {
+      query.selects++;
+      const result = { all: async () => query.rows, one: async () => query.rows[0] };
+      return { from: () => ({ ...result, where: () => result }) };
+    },
+  };
+});
+
+function row(id = 'synthetic-channel') {
+  return {
+    id,
+    tenant_id: 'tenant-a',
+    name: id,
+    channel_type: 'slack',
+    enabled: true,
+    config: {
+      bot_token: encryption.encryptApiKey('bot'),
+      app_token: encryption.encryptApiKey('app'),
+      label: 'public',
+    },
+    agentic_config: {
+      envVars: [{ key: 'API_KEY', value: encryption.encryptApiKey('env'), isSecret: true }],
+    },
+    created_at: new Date('2026-01-01'),
+    updated_at: new Date('2026-01-01'),
+  };
+}
+
+beforeEach(() => {
+  vi.stubEnv('AGOR_MASTER_SECRET', 'synthetic-gateway-master');
+  query.rows = [];
+  query.selects = 0;
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe('gateway credential hydration', () => {
+  it('opens rows and fields serially, preserves order and hidden tenant, and does not cache', async () => {
+    query.rows = [row('second'), row('first')];
+    let active = 0;
+    let peak = 0;
+    const native = encryption.decryptApiKeyAsync;
+    const open = vi.spyOn(encryption, 'decryptApiKeyAsync').mockImplementation(async (...args) => {
+      peak = Math.max(peak, ++active);
+      await nextTurn();
+      try {
+        return await native(...args);
+      } finally {
+        active--;
+      }
+    });
+    const repo = new GatewayChannelRepository({} as Database);
+    const channels = await repo.findAll();
+    expect(channels.map((channel) => channel.id)).toEqual(['second', 'first']);
+    expect(channels[0]).toMatchObject({
+      config: { bot_token: 'bot', app_token: 'app', label: 'public' },
+      agentic_config: { envVars: [{ value: 'env', isSecret: true }] },
+    });
+    expect(Object.getOwnPropertyDescriptor(channels[0], 'tenant_id')).toMatchObject({
+      value: 'tenant-a',
+      enumerable: false,
+    });
+    expect(peak).toBe(1);
+    expect(open).toHaveBeenCalledTimes(6);
+    expect(query.selects).toBe(1);
+    query.rows = [];
+    await expect(repo.findAll()).resolves.toEqual([]);
+    expect(query.selects).toBe(2);
+  });
+
+  it.each(['array', 'legacy'])(
+    'preserves fail-closed omissions for corrupt credentials and %s env vars',
+    async (shape) => {
+      const fixture = row();
+      query.rows = [
+        {
+          ...fixture,
+          config: { ...fixture.config, bot_token: 'corrupt' },
+          agentic_config: {
+            envVars:
+              shape === 'array'
+                ? [
+                    { key: 'GOOD', value: encryption.encryptApiKey('good') },
+                    { key: 'BAD', value: 'corrupt' },
+                    { key: 'EMPTY', value: '' },
+                  ]
+                : {
+                    GOOD: encryption.encryptApiKey('good'),
+                    BAD: 'corrupt',
+                    EMPTY: '',
+                    OTHER: null,
+                  },
+          },
+        },
+      ];
+      const logs = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const [channel] = await new GatewayChannelRepository({} as Database).findAll();
+      expect(channel.config).toEqual({ app_token: 'app', label: 'public' });
+      expect(channel.agentic_config?.envVars).toEqual(
+        shape === 'array'
+          ? [
+              { key: 'GOOD', value: 'good' },
+              { key: 'EMPTY', value: '' },
+            ]
+          : { GOOD: 'good', EMPTY: '', OTHER: null }
+      );
+      expect(logs).toHaveBeenCalledTimes(2);
+      expect(JSON.stringify(logs.mock.calls)).not.toContain('corrupt:');
+    }
+  );
+
+  it.skipIf(process.env.AGOR_BENCH_GATEWAY_READ !== '1')(
+    'benchmarks six channels with three credentials each',
+    async () => {
+      query.rows = Array.from({ length: 6 }, (_, i) => row(String(i)));
+      const native = encryption.decryptApiKeyAsync;
+      const repo = new GatewayChannelRepository({} as Database);
+      const samples: Record<string, { elapsedMs: number; maxTickGapMs: number }[]> = {
+        sync: [],
+        async: [],
+      };
+      for (let round = 0; round < 4; round++) {
+        for (const mode of round % 2 ? ['async', 'sync'] : ['sync', 'async']) {
+          const spy = vi
+            .spyOn(encryption, 'decryptApiKeyAsync')
+            .mockImplementation(
+              mode === 'sync' ? async (...args) => encryption.decryptApiKey(...args) : native
+            );
+          let last = performance.now();
+          let maxTickGapMs = 0;
+          const tick = () => {
+            const now = performance.now();
+            maxTickGapMs = Math.max(maxTickGapMs, now - last);
+            last = now;
+          };
+          const timer = setInterval(tick, 5);
+          try {
+            const start = performance.now();
+            expect(await repo.findAll()).toHaveLength(6);
+            const elapsedMs = performance.now() - start;
+            await nextTurn();
+            tick();
+            if (round) samples[mode].push({ elapsedMs, maxTickGapMs });
+          } finally {
+            clearInterval(timer);
+            spy.mockRestore();
+          }
+        }
+      }
+      process.stdout.write(
+        `Gateway hydration benchmark (1 warmup, 3 samples): ${JSON.stringify(samples)}\n`
+      );
+    },
+    30000
+  );
+});

--- a/packages/core/src/db/repositories/gateway-channels.ts
+++ b/packages/core/src/db/repositories/gateway-channels.ts
@@ -38,7 +38,7 @@ import {
   select,
   update,
 } from '../database-wrapper';
-import { decryptApiKey, encryptApiKey } from '../encryption';
+import { decryptApiKeyAsync, encryptApiKey } from '../encryption';
 import { type GatewayChannelInsert, type GatewayChannelRow, gatewayChannels } from '../schema';
 import {
   AmbiguousIdError,
@@ -183,12 +183,12 @@ function encryptConfig(config: Record<string, unknown>): Record<string, unknown>
 /**
  * Decrypt sensitive fields within a config object
  */
-function decryptConfig(config: Record<string, unknown>): Record<string, unknown> {
+async function decryptConfig(config: Record<string, unknown>): Promise<Record<string, unknown>> {
   const decrypted = { ...config };
   for (const field of GATEWAY_SENSITIVE_CONFIG_FIELDS) {
     if (typeof decrypted[field] === 'string' && decrypted[field]) {
       try {
-        decrypted[field] = decryptApiKey(decrypted[field] as string);
+        decrypted[field] = await decryptApiKeyAsync(decrypted[field] as string);
       } catch (error) {
         console.error(
           `[gateway-channels] Failed to decrypt ${field}:`,
@@ -233,39 +233,42 @@ function encryptAgenticConfig(
   return encrypted;
 }
 
-function decryptAgenticConfig(
+async function decryptAgenticConfig(
   agenticConfig: Record<string, unknown> | null
-): Record<string, unknown> | null {
+): Promise<Record<string, unknown> | null> {
   if (!agenticConfig) return null;
 
   const decrypted = { ...agenticConfig };
   const rawEnvVars = decrypted.envVars;
 
   if (Array.isArray(rawEnvVars)) {
-    decrypted.envVars = (rawEnvVars as GatewayEnvVar[]).flatMap((envVar) => {
+    const envVars: GatewayEnvVar[] = [];
+    for (const envVar of rawEnvVars as GatewayEnvVar[]) {
       try {
-        return [
-          {
-            ...envVar,
-            value: envVar.value ? decryptApiKey(envVar.value) : envVar.value,
-          },
-        ];
+        envVars.push({
+          ...envVar,
+          value: envVar.value ? await decryptApiKeyAsync(envVar.value) : envVar.value,
+        });
       } catch {
-        return [];
+        // Preserve the existing fail-closed omission of unreadable variables.
       }
-    });
+    }
+    decrypted.envVars = envVars;
   } else if (rawEnvVars && typeof rawEnvVars === 'object') {
     // Legacy shape support: Record<string, string>
-    decrypted.envVars = Object.fromEntries(
-      Object.entries(rawEnvVars as Record<string, unknown>).flatMap(([key, value]) => {
-        if (typeof value !== 'string' || !value) return [[key, value]];
-        try {
-          return [[key, decryptApiKey(value)]];
-        } catch {
-          return [];
-        }
-      })
-    );
+    const entries: [string, unknown][] = [];
+    for (const [key, value] of Object.entries(rawEnvVars)) {
+      if (typeof value !== 'string' || !value) {
+        entries.push([key, value]);
+        continue;
+      }
+      try {
+        entries.push([key, await decryptApiKeyAsync(value)]);
+      } catch {
+        // Preserve the existing fail-closed omission of unreadable variables.
+      }
+    }
+    decrypted.envVars = Object.fromEntries(entries);
   }
 
   return decrypted;
@@ -526,7 +529,7 @@ export class GatewayChannelRepository
         .all();
 
       for (const row of rows as GatewayChannelRow[]) {
-        candidates.push(this.rowToChannel(row));
+        candidates.push(await this.rowToChannel(row));
         if (candidates.length === limit) break;
       }
 
@@ -541,9 +544,9 @@ export class GatewayChannelRepository
   /**
    * Convert database row to GatewayChannel type
    */
-  private rowToChannel(row: GatewayChannelRow): GatewayChannel {
+  private async rowToChannel(row: GatewayChannelRow): Promise<GatewayChannel> {
     const config = row.config as Record<string, unknown>;
-    const agenticConfig = decryptAgenticConfig(
+    const agenticConfig = await decryptAgenticConfig(
       (row.agentic_config as Record<string, unknown> | null) ?? null
     );
 
@@ -558,7 +561,7 @@ export class GatewayChannelRepository
         provider_installation_id: row.provider_installation_id ?? null,
         provider_config_generation: row.provider_config_generation ?? 1,
         channel_key: row.channel_key,
-        config: decryptConfig(config),
+        config: await decryptConfig(config),
         agentic_config: agenticConfig
           ? ({
               ...(agenticConfig as unknown as PersistedGatewayAgenticConfig),
@@ -576,6 +579,13 @@ export class GatewayChannelRepository
       },
       row
     );
+  }
+
+  private async rowsToChannels(rows: GatewayChannelRow[]): Promise<GatewayChannel[]> {
+    // One KDF at a time per inventory, not a worker-pool stampede proportional to its size.
+    const channels: GatewayChannel[] = [];
+    for (const row of rows) channels.push(await this.rowToChannel(row));
+    return channels;
   }
 
   /**
@@ -780,7 +790,7 @@ export class GatewayChannelRepository
         throw new RepositoryError('Failed to retrieve created gateway channel');
       }
 
-      return this.rowToChannel(row);
+      return await this.rowToChannel(row);
     } catch (error) {
       if (this.isDiscordInstallationConflict(error)) {
         throw this.duplicateDiscordInstallationError();
@@ -804,7 +814,7 @@ export class GatewayChannelRepository
         .where(eq(gatewayChannels.id, fullId))
         .one();
 
-      return row ? this.rowToChannel(row) : null;
+      return row ? await this.rowToChannel(row) : null;
     } catch (error) {
       if (error instanceof EntityNotFoundError) return null;
       if (error instanceof AmbiguousIdError) throw error;
@@ -821,7 +831,7 @@ export class GatewayChannelRepository
   async findAll(): Promise<GatewayChannel[]> {
     try {
       const rows = await select(this.db).from(gatewayChannels).all();
-      return rows.map((row: GatewayChannelRow) => this.rowToChannel(row));
+      return await this.rowsToChannels(rows);
     } catch (error) {
       throw new RepositoryError(
         `Failed to find all gateway channels: ${error instanceof Error ? error.message : String(error)}`,
@@ -888,7 +898,7 @@ export class GatewayChannelRepository
         throw new RepositoryError('Failed to retrieve updated gateway channel');
       }
 
-      return this.rowToChannel(updated);
+      return await this.rowToChannel(updated);
     } catch (error) {
       if (error instanceof EntityNotFoundError) throw error;
       if (this.isDiscordInstallationConflict(error)) {
@@ -937,7 +947,7 @@ export class GatewayChannelRepository
           .one();
         if (!currentRow) throw new EntityNotFoundError('GatewayChannel', id);
 
-        const current = this.rowToChannel(currentRow);
+        const current = await this.rowToChannel(currentRow);
         if (
           expectedProviderConfigGeneration !== undefined &&
           current.provider_config_generation !== expectedProviderConfigGeneration
@@ -1102,7 +1112,7 @@ export class GatewayChannelRepository
         .where(eq(gatewayChannels.channel_key, channelKey))
         .one();
 
-      return row ? this.rowToChannel(row) : null;
+      return row ? await this.rowToChannel(row) : null;
     } catch (error) {
       throw new RepositoryError(
         `Failed to find gateway channel by key: ${error instanceof Error ? error.message : String(error)}`,
@@ -1121,7 +1131,7 @@ export class GatewayChannelRepository
         .where(eq(gatewayChannels.agor_user_id, userId))
         .all();
 
-      return rows.map((row: GatewayChannelRow) => this.rowToChannel(row));
+      return await this.rowsToChannels(rows);
     } catch (error) {
       throw new RepositoryError(
         `Failed to find gateway channels by user: ${error instanceof Error ? error.message : String(error)}`,

--- a/packages/core/src/db/repositories/tenant-agentic-tools.test.ts
+++ b/packages/core/src/db/repositories/tenant-agentic-tools.test.ts
@@ -1,10 +1,16 @@
-import { beforeAll, describe, expect } from 'vitest';
+import { afterEach, beforeAll, describe, expect, vi } from 'vitest';
+import { TENANT_AGENTIC_TOOL_NAMES } from '../../types';
+import * as wrapper from '../database-wrapper';
+import * as encryption from '../encryption';
 import { dbTest } from '../test-helpers';
+import { AppVariableRepository } from './app-variables';
 import { TenantAgenticToolSettingsRepository } from './tenant-agentic-tools';
 
 beforeAll(() => {
   process.env.AGOR_MASTER_SECRET ||= 'tenant-agentic-tools-test-secret';
 });
+
+afterEach(() => vi.restoreAllMocks());
 
 describe('TenantAgenticToolSettingsRepository', () => {
   dbTest('infers enabled=true without materializing a row', async ({ db }) => {
@@ -91,4 +97,117 @@ describe('TenantAgenticToolSettingsRepository', () => {
     expect(Object.keys(first.connection ?? {})).toEqual(['ANTHROPIC_AUTH_TOKEN']);
     expect(Object.keys(second.connection ?? {})).toEqual(['ANTHROPIC_AUTH_TOKEN']);
   });
+  dbTest(
+    'batches exactly the supported tools in one select, preserving defaults and fresh values',
+    async ({ db }) => {
+      const repository = new TenantAgenticToolSettingsRepository(db);
+      const variables = new AppVariableRepository(db);
+      await repository.patch('codex', {
+        enabled: false,
+        connection: { OPENAI_API_KEY: 'synthetic' },
+      });
+      // Unknown keys and other namespaces must not be opened or parsed.
+      await variables.set({ namespace: 'agentic_tools', key: 'unknown', value: 'invalid-json' });
+      await variables.set({ namespace: 'other', key: 'codex', value: 'invalid-json' });
+      const expected = await Promise.all(
+        TENANT_AGENTIC_TOOL_NAMES.map(async (tool) => [tool, await repository.find(tool)] as const)
+      );
+      const select = vi.spyOn(wrapper, 'select');
+      expect(await repository.findAll()).toEqual(new Map(expected));
+      expect(select).toHaveBeenCalledTimes(1);
+      await variables.delete('agentic_tools', 'codex');
+      expect((await repository.findAll()).get('codex')).toEqual({});
+      await repository.patch('codex', { connection: { OPENAI_API_KEY: 'rotated' } });
+      expect((await repository.findAll()).get('codex')?.connection?.OPENAI_API_KEY).toBe('rotated');
+    }
+  );
+
+  dbTest('batch reads retain validation and wrapped decryption errors', async ({ db }) => {
+    const repository = new TenantAgenticToolSettingsRepository(db);
+    const variables = new AppVariableRepository(db);
+    await variables.set({ namespace: 'agentic_tools', key: 'codex', value: '{"enabled":"no"}' });
+    await expect(repository.findAll()).rejects.toThrow('Invalid enabled value');
+    await variables.setEncrypted('agentic_tools', 'codex', '{}');
+    vi.stubEnv('AGOR_MASTER_SECRET', 'wrong-master');
+    try {
+      await expect(repository.findAll()).rejects.toThrow(
+        'Failed to decrypt app variable agentic_tools.codex: Secret decryption failed'
+      );
+      await expect(repository.find('codex')).rejects.toThrow(
+        'Failed to decrypt app variable agentic_tools.codex: Secret decryption failed'
+      );
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  dbTest(
+    'batch plaintext decoding is serial and preserves missing, empty and null values',
+    async ({ db }) => {
+      const variables = new AppVariableRepository(db);
+      await variables.setEncrypted('batch-test', 'first', 'one');
+      await variables.setEncrypted('batch-test', 'second', 'two');
+      await variables.setEncrypted('batch-test', 'empty', '');
+      await variables.setEncrypted('batch-test', 'null', null);
+      let active = 0;
+      let peak = 0;
+      const native = encryption.decryptApiKeyAsync;
+      const open = vi
+        .spyOn(encryption, 'decryptApiKeyAsync')
+        .mockImplementation(async (...args) => {
+          peak = Math.max(peak, ++active);
+          try {
+            return await native(...args);
+          } finally {
+            active--;
+          }
+        });
+      const select = vi.spyOn(wrapper, 'select');
+      expect(await variables.getPlainMany('batch-test', [])).toEqual(new Map());
+      expect(select).not.toHaveBeenCalled();
+      expect(
+        await variables.getPlainMany('batch-test', [
+          'second',
+          'missing',
+          'first',
+          'empty',
+          'null',
+          'second',
+        ])
+      ).toEqual(
+        new Map([
+          ['second', 'two'],
+          ['missing', null],
+          ['first', 'one'],
+          ['empty', ''],
+          ['null', null],
+        ])
+      );
+      expect(select).toHaveBeenCalledTimes(1);
+      expect(open).toHaveBeenCalledTimes(3);
+      expect(peak).toBe(1);
+    }
+  );
+
+  dbTest.skipIf(process.env.AGOR_BENCH_SETTINGS_READ !== '1')(
+    'benchmarks default settings inventory query overhead',
+    async ({ db }) => {
+      const repository = new TenantAgenticToolSettingsRepository(db);
+      const samples: Record<string, number[]> = { individual: [], batch: [] };
+      for (let round = 0; round < 101; round++) {
+        for (const mode of round % 2 ? ['batch', 'individual'] : ['individual', 'batch']) {
+          const start = performance.now();
+          if (mode === 'individual')
+            await Promise.all(TENANT_AGENTIC_TOOL_NAMES.map((tool) => repository.find(tool)));
+          else await repository.findAll();
+          if (round) samples[mode].push(performance.now() - start);
+        }
+      }
+      const median = (values: number[]) =>
+        values.sort((a, b) => a - b)[Math.floor(values.length / 2)];
+      process.stdout.write(
+        `Settings inventory SQLite (1 warmup, 100 alternating samples): ${JSON.stringify({ individualMedianMs: median(samples.individual), batchMedianMs: median(samples.batch), individualSelects: TENANT_AGENTIC_TOOL_NAMES.length, batchSelects: 1 })}\n`
+      );
+    }
+  );
 });

--- a/packages/core/src/db/repositories/tenant-agentic-tools.ts
+++ b/packages/core/src/db/repositories/tenant-agentic-tools.ts
@@ -13,6 +13,7 @@ import {
   DEFAULT_PROVIDER_RESOLUTION_POLICY,
   isProviderConnectionTool,
   PROVIDER_RESOLUTION_POLICIES,
+  TENANT_AGENTIC_TOOL_NAMES,
   TENANT_PROVIDER_CONNECTION_FIELDS,
 } from '../../types';
 import type { Database } from '../client';
@@ -109,6 +110,19 @@ export class TenantAgenticToolSettingsRepository {
   async find(tool: TenantAgenticToolName): Promise<StoredTenantAgenticToolSettings> {
     const plaintext = await this.variables.getPlain(TENANT_AGENTIC_TOOLS_NAMESPACE, tool);
     return plaintext ? parseSettings(tool, plaintext) : {};
+  }
+
+  async findAll(): Promise<Map<TenantAgenticToolName, StoredTenantAgenticToolSettings>> {
+    const values = await this.variables.getPlainMany(
+      TENANT_AGENTIC_TOOLS_NAMESPACE,
+      TENANT_AGENTIC_TOOL_NAMES
+    );
+    return new Map(
+      TENANT_AGENTIC_TOOL_NAMES.map((tool) => {
+        const plaintext = values.get(tool);
+        return [tool, plaintext ? parseSettings(tool, plaintext) : {}];
+      })
+    );
   }
 
   async isEnabled(tool: TenantAgenticToolName): Promise<boolean> {

--- a/packages/core/src/db/repositories/user-mcp-oauth-tokens.reads.postgres.test.ts
+++ b/packages/core/src/db/repositories/user-mcp-oauth-tokens.reads.postgres.test.ts
@@ -47,7 +47,7 @@ describe.skipIf(!url || process.env.AGOR_DB_DIALECT !== 'postgresql')(
           for (const subject of [user, null]) {
             const seal = (
               value: string,
-              purpose: 'access-token' | 'refresh-token',
+              purpose: 'access-token' | 'refresh-token' | 'client-id' | 'client-secret',
               field: string
             ) =>
               sealBoundSecret(
@@ -63,6 +63,8 @@ describe.skipIf(!url || process.env.AGOR_DB_DIALECT !== 'postgresql')(
                 mcp_server_id: server.mcp_server_id,
                 oauth_access_token: seal('synthetic-access', 'access-token', 'access'),
                 oauth_refresh_token: seal('synthetic-refresh', 'refresh-token', 'refresh'),
+                oauth_client_id: seal('synthetic-client', 'client-id', 'client-id'),
+                oauth_client_secret: seal('synthetic-secret', 'client-secret', 'client-secret'),
                 grant_generation: 1,
                 created_at: new Date(),
               })
@@ -106,10 +108,35 @@ describe.skipIf(!url || process.env.AGOR_DB_DIALECT !== 'postgresql')(
             await expect(repo.listForUser(foreign.user)).resolves.toEqual([]);
             await expect(repo.getToken(foreign.user, foreign.server)).resolves.toBeNull();
             await expect(repo.getToken(null, foreign.server)).resolves.toBeNull();
+            const authority = await repo.listAuthorityForUserAndSharedByServerIds(own.user, [
+              own.server,
+              foreign.server,
+            ]);
+            expect(authority).toHaveLength(2);
+            expect(
+              authority.every(
+                (record) =>
+                  record.mcp_server_id === own.server &&
+                  record.oauth_client_secret === 'synthetic-secret'
+              )
+            ).toBe(true);
+            expect(await repo.getCatalogGrantAuthority(own.user, own.server)).toMatchObject({
+              oauth_client_id: 'synthetic-client',
+              oauth_client_secret: 'synthetic-secret',
+            });
+            await expect(
+              repo.getCatalogGrantAuthority(foreign.user, foreign.server)
+            ).resolves.toBeNull();
             // A valid same-tenant row belonging to a different user is not returned.
             const other = await ensureTestUser(scoped, generateId() as UserID);
             await expect(repo.listForUser(other)).resolves.toEqual([]);
             await expect(repo.getToken(other, own.server)).resolves.toBeNull();
+            const otherAuthority = await repo.listAuthorityForUserAndSharedByServerIds(other, [
+              own.server,
+            ]);
+            expect(otherAuthority).toHaveLength(1);
+            expect(otherAuthority[0].user_id).toBeNull();
+            await expect(repo.getCatalogGrantAuthority(other, own.server)).resolves.toBeNull();
             const rows = await select(scoped)
               .from(userMcpOauthTokens)
               .where(eq(userMcpOauthTokens.mcp_server_id, foreign.server))

--- a/packages/core/src/db/repositories/user-mcp-oauth-tokens.reads.postgres.test.ts
+++ b/packages/core/src/db/repositories/user-mcp-oauth-tokens.reads.postgres.test.ts
@@ -1,0 +1,123 @@
+import { eq, sql } from 'drizzle-orm';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { generateId } from '../../lib/ids';
+import type { MCPServerID, UserID } from '../../types';
+import { createDatabase, type Database } from '../client';
+import { insert, select } from '../database-wrapper';
+import { initializeDatabase } from '../migrate';
+import { sealBoundSecret } from '../oauth-secret-envelope';
+import { userMcpOauthTokens } from '../schema';
+import { runWithTenantDatabaseScope } from '../tenant-scope';
+import { ensureTestUser } from '../test-helpers';
+import { MCPServerRepository } from './mcp-servers';
+import { UserMCPOAuthTokenRepository } from './user-mcp-oauth-tokens';
+
+const url = process.env.AGOR_TEST_POSTGRES_URL;
+
+describe.skipIf(!url || process.env.AGOR_DB_DIALECT !== 'postgresql')(
+  'asynchronous grant reads preserve PostgreSQL RLS and subject isolation',
+  () => {
+    let db: Database;
+    const master = 'synthetic-grant-read-test-master';
+    const tenantA = `grant-a-${generateId()}`;
+    const tenantB = `grant-b-${generateId()}`;
+    const owners = new Map<string, { user: UserID; server: MCPServerID }>();
+
+    beforeAll(async () => {
+      db = createDatabase({ dialect: 'postgresql', url: url! });
+      await initializeDatabase(db);
+      const role = await select(db, { safe: sql<boolean>`NOT rolsuper AND NOT rolbypassrls` })
+        .from(sql`pg_roles`)
+        .where(sql`rolname = current_user`)
+        .one();
+      expect(role?.safe).toBe(true);
+      for (const tenant of [tenantA, tenantB]) {
+        await runWithTenantDatabaseScope(db, tenant, async (scoped) => {
+          const user = await ensureTestUser(scoped, generateId() as UserID);
+          const server = await new MCPServerRepository(scoped).create({
+            name: 'synthetic',
+            transport: 'http',
+            url: 'https://example.test/mcp',
+            scope: 'global',
+            enabled: true,
+            source: 'user',
+            owner_user_id: user,
+          });
+          owners.set(tenant, { user, server: server.mcp_server_id });
+          for (const subject of [user, null]) {
+            const seal = (
+              value: string,
+              purpose: 'access-token' | 'refresh-token',
+              field: string
+            ) =>
+              sealBoundSecret(
+                value,
+                master,
+                purpose,
+                [tenant, subject ?? '<shared>', server.mcp_server_id, '1', field].join('\0')
+              );
+            await insert(scoped, userMcpOauthTokens)
+              .values({
+                tenant_id: tenant,
+                user_id: subject,
+                mcp_server_id: server.mcp_server_id,
+                oauth_access_token: seal('synthetic-access', 'access-token', 'access'),
+                oauth_refresh_token: seal('synthetic-refresh', 'refresh-token', 'refresh'),
+                grant_generation: 1,
+                created_at: new Date(),
+              })
+              .run();
+          }
+        });
+      }
+    }, 60000);
+
+    afterAll(async () => {
+      if (db) await (db as Database & { $client: { end(): Promise<void> } }).$client.end();
+    });
+
+    it('retains each concurrent tenant context across KDF awaits and rejects foreign IDs', async () => {
+      await Promise.all(
+        [tenantA, tenantB].map(async (tenant) => {
+          await runWithTenantDatabaseScope(db, tenant, async (scoped) => {
+            const own = owners.get(tenant)!;
+            const foreign = owners.get(tenant === tenantA ? tenantB : tenantA)!;
+            const repo = new UserMCPOAuthTokenRepository(scoped, master);
+            const [personal, shared] = await Promise.all([
+              repo.listForUser(own.user),
+              repo.listShared(),
+            ]);
+            expect(personal).toMatchObject([
+              {
+                user_id: own.user,
+                mcp_server_id: own.server,
+                oauth_access_token: 'synthetic-access',
+              },
+            ]);
+            expect(shared).toMatchObject([
+              {
+                user_id: null,
+                mcp_server_id: own.server,
+                oauth_refresh_token: 'synthetic-refresh',
+              },
+            ]);
+            expect(personal).toHaveLength(1);
+            expect(shared).toHaveLength(1);
+            await expect(repo.listForUser(foreign.user)).resolves.toEqual([]);
+            await expect(repo.getToken(foreign.user, foreign.server)).resolves.toBeNull();
+            await expect(repo.getToken(null, foreign.server)).resolves.toBeNull();
+            // A valid same-tenant row belonging to a different user is not returned.
+            const other = await ensureTestUser(scoped, generateId() as UserID);
+            await expect(repo.listForUser(other)).resolves.toEqual([]);
+            await expect(repo.getToken(other, own.server)).resolves.toBeNull();
+            const rows = await select(scoped)
+              .from(userMcpOauthTokens)
+              .where(eq(userMcpOauthTokens.mcp_server_id, foreign.server))
+              .all();
+            expect(rows).toEqual([]);
+          });
+        })
+      );
+    });
+  }
+);

--- a/packages/core/src/db/repositories/user-mcp-oauth-tokens.reads.test.ts
+++ b/packages/core/src/db/repositories/user-mcp-oauth-tokens.reads.test.ts
@@ -1,0 +1,55 @@
+import { expect } from 'vitest';
+import { generateId } from '../../lib/ids';
+import type { UserID } from '../../types';
+import { dbTest, ensureTestUser } from '../test-helpers';
+import { MCPServerRepository } from './mcp-servers';
+import { UserMCPOAuthTokenRepository } from './user-mcp-oauth-tokens';
+
+dbTest(
+  'SQLite full grant reads preserve plaintext, nullable fields and subject isolation',
+  async ({ db }) => {
+    const owner = await ensureTestUser(db, generateId() as UserID);
+    const other = await ensureTestUser(db, generateId() as UserID);
+    const server = await new MCPServerRepository(db).create({
+      name: 'synthetic',
+      transport: 'http',
+      url: 'https://example.test/mcp',
+      scope: 'global',
+      enabled: true,
+      source: 'user',
+      owner_user_id: owner,
+    });
+    const repo = new UserMCPOAuthTokenRepository(db);
+    await repo.saveToken(owner, server.mcp_server_id, {
+      accessToken: 'personal',
+      refreshToken: 'refresh',
+      clientId: 'client',
+      clientSecret: 'secret',
+      expiresAt: new Date('2030-01-01T00:00:00Z'),
+    });
+    await repo.saveToken(null, server.mcp_server_id, { accessToken: 'shared', expiresAt: null });
+    const [personal, shared] = await Promise.all([repo.listForUser(owner), repo.listShared()]);
+    expect(personal).toHaveLength(1);
+    expect(personal[0]).toMatchObject({
+      user_id: owner,
+      oauth_access_token: 'personal',
+      oauth_refresh_token: 'refresh',
+      oauth_client_id: 'client',
+      oauth_client_secret: 'secret',
+    });
+    expect(personal[0].oauth_token_expires_at?.toISOString()).toBe('2030-01-01T00:00:00.000Z');
+    expect(shared).toHaveLength(1);
+    expect(shared[0]).toMatchObject({
+      user_id: null,
+      oauth_access_token: 'shared',
+      oauth_refresh_token: undefined,
+      oauth_token_expires_at: undefined,
+    });
+    await expect(repo.getToken(owner, server.mcp_server_id)).resolves.toEqual(personal[0]);
+    await expect(repo.listForUser(other)).resolves.toEqual([]);
+    await expect(repo.getToken(other, server.mcp_server_id)).resolves.toBeNull();
+    await repo.deleteToken(owner, server.mcp_server_id);
+    await expect(repo.listForUser(owner)).resolves.toEqual([]);
+    await expect(repo.getToken(null, server.mcp_server_id)).resolves.toEqual(shared[0]);
+  }
+);

--- a/packages/core/src/db/repositories/user-mcp-oauth-tokens.reads.test.ts
+++ b/packages/core/src/db/repositories/user-mcp-oauth-tokens.reads.test.ts
@@ -48,8 +48,24 @@ dbTest(
     await expect(repo.getToken(owner, server.mcp_server_id)).resolves.toEqual(personal[0]);
     await expect(repo.listForUser(other)).resolves.toEqual([]);
     await expect(repo.getToken(other, server.mcp_server_id)).resolves.toBeNull();
+    await expect(repo.getCatalogGrantAuthority(owner, server.mcp_server_id)).resolves.toMatchObject(
+      { oauth_client_id: 'client', oauth_client_secret: 'secret' }
+    );
+    const authority = await repo.listAuthorityForUserAndSharedByServerIds(owner, [
+      server.mcp_server_id,
+    ]);
+    expect(authority).toHaveLength(2);
+    expect(authority.find((record) => record.user_id === owner)).toMatchObject({
+      oauth_client_id: 'client',
+      oauth_client_secret: 'secret',
+    });
+    expect(authority.find((record) => record.user_id === null)?.oauth_client_id).toBeUndefined();
+    expect(
+      await repo.listAuthorityForUserAndSharedByServerIds(other, [server.mcp_server_id])
+    ).toHaveLength(1);
     await repo.deleteToken(owner, server.mcp_server_id);
     await expect(repo.listForUser(owner)).resolves.toEqual([]);
+    await expect(repo.getCatalogGrantAuthority(owner, server.mcp_server_id)).resolves.toBeNull();
     await expect(repo.getToken(null, server.mcp_server_id)).resolves.toEqual(shared[0]);
   }
 );

--- a/packages/core/src/db/repositories/user-mcp-oauth-tokens.status.test.ts
+++ b/packages/core/src/db/repositories/user-mcp-oauth-tokens.status.test.ts
@@ -181,11 +181,13 @@ describe('OAuth status grant read integrity and cost', () => {
 
     expect(syncOpen).not.toHaveBeenCalled();
     query.projections = [];
+    open.mockClear();
     const authority = await repo.getCatalogGrantAuthority(userId, serverId);
     expect(query.projections).toHaveLength(1);
     expect(query.projections[0]).not.toHaveProperty('oauth_access_token');
     expect(query.projections[0]).not.toHaveProperty('oauth_refresh_token');
-    expect(syncOpen.mock.calls.map((call) => call[2])).toEqual(['client-id', 'client-secret']);
+    expect(open.mock.calls.map((call) => call[2])).toEqual(['client-id', 'client-secret']);
+    expect(syncOpen).not.toHaveBeenCalled();
     expect(authority).toMatchObject({
       oauth_access_token: '<present>',
       oauth_client_id: 'client',
@@ -257,5 +259,53 @@ describe('OAuth status grant read integrity and cost', () => {
     await expect(repo.getCatalogGrantAuthority(userId, serverId)).rejects.toThrow(
       'Failed to read OAuth grant authority'
     );
+  });
+  it('authority inventories open client fields serially and never hydrate access/refresh tokens', async () => {
+    query.rows = [grant(), grant(null)];
+    const native = envelope.openBoundSecretAsync;
+    let active = 0;
+    let peak = 0;
+    const open = vi.spyOn(envelope, 'openBoundSecretAsync').mockImplementation(async (...args) => {
+      peak = Math.max(peak, ++active);
+      try {
+        return await native(...args);
+      } finally {
+        active--;
+      }
+    });
+    const repo = new UserMCPOAuthTokenRepository({} as Database, master);
+    const records = await repo.listAuthorityForUserAndSharedByServerIds(userId, [serverId]);
+    expect(records.map((record) => record.user_id)).toEqual([userId, null]);
+    expect(records.every((record) => record.oauth_client_secret === 'secret')).toBe(true);
+    expect(open.mock.calls.map((call) => call[2])).toEqual([
+      'client-id',
+      'client-secret',
+      'client-id',
+      'client-secret',
+    ]);
+    expect(peak).toBe(1);
+    expect(query.projections).toHaveLength(1);
+    expect(query.projections[0]).not.toHaveProperty('oauth_access_token');
+    expect(query.projections[0]).not.toHaveProperty('oauth_refresh_token');
+  });
+
+  it.each([
+    'oauth_client_id',
+    'oauth_client_secret',
+    'grant_generation',
+    'user_id',
+    'mcp_server_id',
+  ])('authority reads retain asynchronous corruption/binding failure for %s', async (field) => {
+    const repo = new UserMCPOAuthTokenRepository({} as Database, master);
+    query.rows = [{ ...grant(), [field]: field === 'grant_generation' ? 2 : 'foreign-or-corrupt' }];
+    await expect(repo.listAuthorityForUserAndSharedByServerIds(userId, [serverId])).rejects.toThrow(
+      'Failed to list OAuth grants for authority projection'
+    );
+    // Point reads bind to the requested subject/server, not caller-supplied row IDs.
+    if (field !== 'user_id' && field !== 'mcp_server_id') {
+      await expect(repo.getCatalogGrantAuthority(userId, serverId)).rejects.toThrow(
+        'Failed to read OAuth grant authority'
+      );
+    }
   });
 });

--- a/packages/core/src/db/repositories/user-mcp-oauth-tokens.status.test.ts
+++ b/packages/core/src/db/repositories/user-mcp-oauth-tokens.status.test.ts
@@ -1,4 +1,6 @@
 /** Characterize the envelope-integrity boundary before optimizing status reads. */
+
+import { setImmediate as nextTurn } from 'node:timers/promises';
 import type { MCPServerID, UserID } from '@agor/core/types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Database } from '../client';
@@ -75,9 +77,96 @@ beforeEach(() => {
 });
 
 describe('OAuth status grant read integrity and cost', () => {
+  it('awaits fields and rows serially, preserves order, and never caches a read', async () => {
+    query.rows = [grant(), { ...grant(), created_at: new Date('2026-02-01T00:00:00Z') }];
+    let active = 0;
+    let peak = 0;
+    const open = vi.spyOn(envelope, 'openBoundSecretAsync').mockImplementation(async (...args) => {
+      peak = Math.max(peak, ++active);
+      await nextTurn();
+      try {
+        return envelope.openBoundSecret(...args);
+      } finally {
+        active--;
+      }
+    });
+    const repo = new UserMCPOAuthTokenRepository({} as Database, master);
+    const tokens = await repo.listForUser(userId);
+    expect(peak).toBe(1);
+    expect(open).toHaveBeenCalledTimes(8);
+    expect(query.projections).toEqual([undefined]);
+    expect(tokens.map((token) => token.created_at.toISOString())).toEqual([
+      '2026-01-01T00:00:00.000Z',
+      '2026-02-01T00:00:00.000Z',
+    ]);
+    query.rows = [];
+    await expect(repo.listForUser(userId)).resolves.toEqual([]);
+    expect(query.projections).toEqual([undefined, undefined]);
+  });
+
+  it.each(['user_id', 'mcp_server_id', 'grant_generation'])(
+    'rejects a grant transplanted to a different %s and wraps async errors on point reads',
+    async (field) => {
+      query.rows = [{ ...grant(), [field]: field === 'grant_generation' ? 2 : 'other' }];
+      const repo = new UserMCPOAuthTokenRepository({} as Database, master);
+      await expect(repo.getToken(userId, serverId)).rejects.toThrow('Failed to get OAuth token');
+      await expect(repo.listForUser(userId)).rejects.toThrow(
+        'Failed to list OAuth tokens for user'
+      );
+    }
+  );
+
+  it.skipIf(process.env.AGOR_BENCH_OAUTH_READ !== '1')(
+    'benchmarks grant hydration and unrelated event-loop progress (synthetic, no DB timing)',
+    async () => {
+      query.rows = Array.from({ length: 6 }, () => grant());
+      const repo = new UserMCPOAuthTokenRepository({} as Database, master);
+      const nativeOpen = envelope.openBoundSecretAsync;
+      const samples: Record<string, Array<{ elapsedMs: number; maxTickGapMs: number }>> = {
+        sync: [],
+        async: [],
+      };
+      for (let round = 0; round < 4; round++) {
+        for (const mode of round % 2 ? ['async', 'sync'] : ['sync', 'async']) {
+          const spy = vi
+            .spyOn(envelope, 'openBoundSecretAsync')
+            .mockImplementation(
+              mode === 'sync' ? async (...args) => envelope.openBoundSecret(...args) : nativeOpen
+            );
+          let last = performance.now();
+          let maxTickGapMs = 0;
+          const tick = () => {
+            const now = performance.now();
+            maxTickGapMs = Math.max(maxTickGapMs, now - last);
+            last = now;
+          };
+          const timer = setInterval(tick, 5);
+          const start = performance.now();
+          try {
+            const tokens = await repo.listForUser(userId);
+            const elapsedMs = performance.now() - start;
+            await nextTurn();
+            tick();
+            expect(tokens).toHaveLength(6);
+            expect(tokens.every((token) => token.oauth_refresh_token === 'refresh')).toBe(true);
+            if (round) samples[mode].push({ elapsedMs, maxTickGapMs });
+          } finally {
+            clearInterval(timer);
+            spy.mockRestore();
+          }
+        }
+      }
+      process.stdout.write(
+        `OAuth read benchmark: 6 grants x 4 envelopes, 1 warmup, 3 samples\n${JSON.stringify(samples)}\n`
+      );
+    },
+    30000
+  );
+
   it('opens four envelopes on a full read versus two on catalog authority', async () => {
     query.rows = [grant()];
-    const open = vi.spyOn(envelope, 'openBoundSecret');
+    const open = vi.spyOn(envelope, 'openBoundSecretAsync');
+    const syncOpen = vi.spyOn(envelope, 'openBoundSecret');
     const repo = new UserMCPOAuthTokenRepository({} as Database, master);
     await expect(repo.listForUser(userId)).resolves.toMatchObject([
       { oauth_access_token: 'access', oauth_refresh_token: 'refresh' },
@@ -90,13 +179,13 @@ describe('OAuth status grant read integrity and cost', () => {
       'client-secret',
     ]);
 
-    open.mockClear();
+    expect(syncOpen).not.toHaveBeenCalled();
     query.projections = [];
     const authority = await repo.getCatalogGrantAuthority(userId, serverId);
     expect(query.projections).toHaveLength(1);
     expect(query.projections[0]).not.toHaveProperty('oauth_access_token');
     expect(query.projections[0]).not.toHaveProperty('oauth_refresh_token');
-    expect(open.mock.calls.map((call) => call[2])).toEqual(['client-id', 'client-secret']);
+    expect(syncOpen.mock.calls.map((call) => call[2])).toEqual(['client-id', 'client-secret']);
     expect(authority).toMatchObject({
       oauth_access_token: '<present>',
       oauth_client_id: 'client',

--- a/packages/core/src/db/repositories/user-mcp-oauth-tokens.ts
+++ b/packages/core/src/db/repositories/user-mcp-oauth-tokens.ts
@@ -22,7 +22,7 @@ import {
   select,
   update,
 } from '../database-wrapper';
-import { openBoundSecret, sealBoundSecret } from '../oauth-secret-envelope';
+import { openBoundSecret, openBoundSecretAsync, sealBoundSecret } from '../oauth-secret-envelope';
 import {
   type UserMCPOAuthTokenInsert,
   type UserMCPOAuthTokenRow,
@@ -188,10 +188,10 @@ function grantSecretBinding(
   return [tenantId, userId ?? '<shared>', serverId, String(generation), field].join('\0');
 }
 
-function rowToToken(
+async function rowToToken(
   row: UserMCPOAuthTokenRow,
   options: { postgres: boolean; tenantId?: string; masterSecret?: string }
-): UserMCPOAuthToken {
+): Promise<UserMCPOAuthToken> {
   const raw = row as UserMCPOAuthTokenRow & Record<string, unknown>;
   const userId = (row.user_id as UserID | null) ?? null;
   const serverId = row.mcp_server_id as MCPServerID;
@@ -206,7 +206,7 @@ function rowToToken(
     if (!options.tenantId || !options.masterSecret) {
       throw new RepositoryError('PostgreSQL MCP OAuth token decryption is not configured');
     }
-    return openBoundSecret(
+    return openBoundSecretAsync(
       String(value),
       options.masterSecret,
       purpose,
@@ -216,13 +216,13 @@ function rowToToken(
   return {
     user_id: userId,
     mcp_server_id: serverId,
-    oauth_access_token: open(row.oauth_access_token, 'access-token', 'access')!,
+    oauth_access_token: (await open(row.oauth_access_token, 'access-token', 'access'))!,
     oauth_token_expires_at: row.oauth_token_expires_at
       ? new Date(row.oauth_token_expires_at)
       : undefined,
-    oauth_refresh_token: open(row.oauth_refresh_token, 'refresh-token', 'refresh'),
-    oauth_client_id: open(row.oauth_client_id, 'client-id', 'client-id'),
-    oauth_client_secret: open(row.oauth_client_secret, 'client-secret', 'client-secret'),
+    oauth_refresh_token: await open(row.oauth_refresh_token, 'refresh-token', 'refresh'),
+    oauth_client_id: await open(row.oauth_client_id, 'client-id', 'client-id'),
+    oauth_client_secret: await open(row.oauth_client_secret, 'client-secret', 'client-secret'),
     grant_generation: generation,
     grant_binding_version:
       raw.grant_binding_version == null ? undefined : Number(raw.grant_binding_version),
@@ -284,12 +284,21 @@ export class UserMCPOAuthTokenRepository {
     return tenantId;
   }
 
-  private mapRow(row: UserMCPOAuthTokenRow): UserMCPOAuthToken {
+  private mapRow(row: UserMCPOAuthTokenRow): Promise<UserMCPOAuthToken> {
     return rowToToken(row, {
       postgres: this.postgres,
       tenantId: this.tenantId(),
       masterSecret: this.masterSecret,
     });
+  }
+
+  private async mapRows(rows: UserMCPOAuthTokenRow[]): Promise<UserMCPOAuthToken[]> {
+    // One KDF at a time per read, regardless of inventory size. Preserve row
+    // order and validate all envelopes (even expired/ambiguous grants) before
+    // returning anything. Promise.all here would flood the shared worker pool.
+    const tokens: UserMCPOAuthToken[] = [];
+    for (const row of rows) tokens.push(await this.mapRow(row));
+    return tokens;
   }
 
   private mapAuthorityRow(row: MCPOAuthGrantAuthorityRow): MCPOAuthGrantAuthorityRecord {
@@ -346,7 +355,7 @@ export class UserMCPOAuthTokenRepository {
         .where(matchKey(userId, serverId))
         .one();
 
-      return row ? this.mapRow(row) : null;
+      return row ? await this.mapRow(row) : null;
     } catch (error) {
       throw new RepositoryError(
         `Failed to get OAuth token: ${error instanceof Error ? error.message : String(error)}`,
@@ -822,7 +831,7 @@ export class UserMCPOAuthTokenRepository {
       );
       const row = rowsOf(claimed)[0];
       if (!row) return { outcome: 'observed', token: await this.getToken(userId, serverId) };
-      const token = this.mapRow(row as unknown as UserMCPOAuthTokenRow);
+      const token = await this.mapRow(row as unknown as UserMCPOAuthTokenRow);
       return {
         outcome: 'claimed',
         token,
@@ -1015,7 +1024,7 @@ export class UserMCPOAuthTokenRepository {
         .where(eq(userMcpOauthTokens.user_id, userId))
         .all();
 
-      return rows.map((row: UserMCPOAuthTokenRow) => this.mapRow(row));
+      return await this.mapRows(rows);
     } catch (error) {
       throw new RepositoryError(
         `Failed to list OAuth tokens for user: ${error instanceof Error ? error.message : String(error)}`,
@@ -1088,7 +1097,7 @@ export class UserMCPOAuthTokenRepository {
         .where(isNull(userMcpOauthTokens.user_id))
         .all();
 
-      return rows.map((row: UserMCPOAuthTokenRow) => this.mapRow(row));
+      return await this.mapRows(rows);
     } catch (error) {
       throw new RepositoryError(
         `Failed to list shared OAuth tokens: ${error instanceof Error ? error.message : String(error)}`,

--- a/packages/core/src/db/repositories/user-mcp-oauth-tokens.ts
+++ b/packages/core/src/db/repositories/user-mcp-oauth-tokens.ts
@@ -22,7 +22,7 @@ import {
   select,
   update,
 } from '../database-wrapper';
-import { openBoundSecret, openBoundSecretAsync, sealBoundSecret } from '../oauth-secret-envelope';
+import { openBoundSecretAsync, sealBoundSecret } from '../oauth-secret-envelope';
 import {
   type UserMCPOAuthTokenInsert,
   type UserMCPOAuthTokenRow,
@@ -301,22 +301,24 @@ export class UserMCPOAuthTokenRepository {
     return tokens;
   }
 
-  private mapAuthorityRow(row: MCPOAuthGrantAuthorityRow): MCPOAuthGrantAuthorityRecord {
+  private async mapAuthorityRow(
+    row: MCPOAuthGrantAuthorityRow
+  ): Promise<MCPOAuthGrantAuthorityRecord> {
     const userId = (row.user_id as UserID | null) ?? null;
     const serverId = row.mcp_server_id as MCPServerID;
     const generation = Number(row.grant_generation ?? 0);
     const tenantId = this.tenantId();
-    const openClientMaterial = (
+    const openClientMaterial = async (
       value: unknown,
       purpose: 'client-id' | 'client-secret',
       field: string
-    ): string | undefined => {
+    ): Promise<string | undefined> => {
       if (value == null || value === '') return undefined;
       if (!this.postgres) return String(value);
       if (!tenantId || !this.masterSecret) {
         throw new RepositoryError('PostgreSQL MCP OAuth token decryption is not configured');
       }
-      return openBoundSecret(
+      return openBoundSecretAsync(
         String(value),
         this.masterSecret,
         purpose,
@@ -326,8 +328,8 @@ export class UserMCPOAuthTokenRepository {
     return {
       user_id: userId,
       mcp_server_id: serverId,
-      oauth_client_id: openClientMaterial(row.oauth_client_id, 'client-id', 'client-id'),
-      oauth_client_secret: openClientMaterial(
+      oauth_client_id: await openClientMaterial(row.oauth_client_id, 'client-id', 'client-id'),
+      oauth_client_secret: await openClientMaterial(
         row.oauth_client_secret,
         'client-secret',
         'client-secret'
@@ -441,18 +443,18 @@ export class UserMCPOAuthTokenRepository {
         .one()) as Record<string, unknown> | undefined;
       if (!row) return null;
       const generation = Number(row.grant_generation ?? 0);
-      const openClient = (
+      const openClient = async (
         value: unknown,
         purpose: 'client-id' | 'client-secret',
         field: string
-      ): string | undefined => {
+      ): Promise<string | undefined> => {
         if (value == null || value === '') return undefined;
         if (!this.postgres) return String(value);
         const tenantId = this.tenantId();
         if (!tenantId || !this.masterSecret) {
           throw new RepositoryError('PostgreSQL MCP OAuth client decryption is not configured');
         }
-        return openBoundSecret(
+        return openBoundSecretAsync(
           String(value),
           this.masterSecret,
           purpose,
@@ -469,8 +471,12 @@ export class UserMCPOAuthTokenRepository {
         oauth_token_expires_at: row.oauth_token_expires_at
           ? new Date(row.oauth_token_expires_at as Date | string | number)
           : undefined,
-        oauth_client_id: openClient(row.oauth_client_id, 'client-id', 'client-id'),
-        oauth_client_secret: openClient(row.oauth_client_secret, 'client-secret', 'client-secret'),
+        oauth_client_id: await openClient(row.oauth_client_id, 'client-id', 'client-id'),
+        oauth_client_secret: await openClient(
+          row.oauth_client_secret,
+          'client-secret',
+          'client-secret'
+        ),
         grant_generation: generation,
         grant_binding_version:
           row.grant_binding_version == null ? undefined : Number(row.grant_binding_version),
@@ -1080,7 +1086,9 @@ export class UserMCPOAuthTokenRepository {
             .all())
         );
       }
-      return rows.map((row) => this.mapAuthorityRow(row));
+      const records: MCPOAuthGrantAuthorityRecord[] = [];
+      for (const row of rows) records.push(await this.mapAuthorityRow(row));
+      return records;
     } catch (error) {
       throw new RepositoryError(
         `Failed to list OAuth grants for authority projection: ${error instanceof Error ? error.message : String(error)}`,

--- a/packages/core/src/db/repositories/users.test.ts
+++ b/packages/core/src/db/repositories/users.test.ts
@@ -14,8 +14,9 @@
 import type { UserID } from '@agor/core/types';
 import bcrypt from 'bcryptjs';
 import { eq } from 'drizzle-orm';
-import { beforeAll, describe, expect, vi } from 'vitest';
+import { afterEach, beforeAll, describe, expect, vi } from 'vitest';
 import { select, update } from '../database-wrapper';
+import * as encryption from '../encryption';
 import { users } from '../schema';
 import { dbTest } from '../test-helpers';
 import { UsersRepository } from './users';
@@ -46,6 +47,8 @@ function deferred(): { promise: Promise<void>; resolve: () => void } {
   });
   return { promise, resolve };
 }
+
+afterEach(() => vi.restoreAllMocks());
 
 describe('UsersRepository password boundary', () => {
   dbTest('rejects plaintext and pre-hashed credential smuggling', async ({ db }) => {
@@ -421,3 +424,38 @@ describe('UsersRepository.update — credential blob preservation', () => {
     });
   });
 });
+
+dbTest(
+  'async credential reads omit corrupt fields and retain per-user isolation',
+  async ({ db }) => {
+    const repo = new UsersRepository(db);
+    const own = await makeUser(repo);
+    const other = await makeUser(repo);
+    await repo.setToolConfigField(own, 'codex', 'OPENAI_API_KEY', 'own-key');
+    await repo.setToolConfigField(own, 'codex', 'OPENAI_BASE_URL', 'https://example.invalid');
+    await repo.setToolConfigField(other, 'codex', 'OPENAI_API_KEY', 'other-key');
+    const native = encryption.decryptApiKeyAsync;
+    let active = 0;
+    let peak = 0;
+    const open = vi.spyOn(encryption, 'decryptApiKeyAsync').mockImplementation(async (...args) => {
+      peak = Math.max(peak, ++active);
+      try {
+        return await native(...args);
+      } finally {
+        active--;
+      }
+    });
+    expect(await repo.getToolConfig(own, 'codex')).toMatchObject({
+      OPENAI_API_KEY: 'own-key',
+      OPENAI_BASE_URL: 'https://example.invalid',
+    });
+    expect(open).toHaveBeenCalledTimes(2);
+    expect(peak).toBe(1);
+    expect(await repo.getToolConfigField(other, 'codex', 'OPENAI_API_KEY')).toBe('other-key');
+    open.mockRejectedValue(new Error('Secret decryption failed'));
+    const logs = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(repo.getToolConfigField(own, 'codex', 'OPENAI_API_KEY')).resolves.toBeNull();
+    await expect(repo.getToolConfig(own, 'codex')).resolves.toBeNull();
+    expect(logs).toHaveBeenCalledTimes(3);
+  }
+);

--- a/packages/core/src/db/repositories/users.ts
+++ b/packages/core/src/db/repositories/users.ts
@@ -23,7 +23,7 @@ import { generateId, shortId } from '../../lib/ids';
 import { isValidExecutionHomeKey } from '../../types/user';
 import type { Database } from '../client';
 import { deleteFrom, insert, lockRowForUpdate, select, update } from '../database-wrapper';
-import { decryptApiKey, encryptApiKey } from '../encryption';
+import { decryptApiKeyAsync, encryptApiKey } from '../encryption';
 import { type UserInsert as SchemaUserInsert, type UserRow, users } from '../schema';
 import { isExecutionHomeKeyAvailable } from '../user-execution-home';
 import {
@@ -620,7 +620,7 @@ export class UsersRepository
     for (const [field, encrypted] of Object.entries(fields)) {
       if (!encrypted) continue;
       try {
-        out[field] = decryptApiKey(encrypted);
+        out[field] = await decryptApiKeyAsync(encrypted);
       } catch (error) {
         console.error(
           `[users] Failed to decrypt ${tool}.${field} for user ${shortId(userId)}: ${
@@ -652,7 +652,7 @@ export class UsersRepository
     if (!encrypted) return null;
 
     try {
-      return decryptApiKey(encrypted);
+      return await decryptApiKeyAsync(encrypted);
     } catch (error) {
       console.error(
         `[users] Failed to decrypt ${tool}.${field} for user ${shortId(userId)}: ${


### PR DESCRIPTION
## Summary

Six evidence-led, limited-complexity improvements in one PR:

1. **MCP OAuth grant hydration:** move expensive scrypt derivation off the event loop, retaining all envelope authentication and the existing full-read contract.
2. **Gateway credential hydration:** apply the same approach to the existing legacy envelope interface. Gateway config and both array/legacy env-var formats retain their existing corruption omissions and logging. List, point, discovery, and locked-update mappers await hydration and preserve existing error wrappers.
3. **Tenant agentic-tool settings inventory:** replace six independent settings SELECTs with one namespace + supported-key-set SELECT. Reuse existing settings parsing and public redaction; preserve defaults, tool order, deployment policy, revisions, and current credentials. Shared app-variable plaintext reads use async legacy decryption rather than introducing a second decoding contract.
4. **Provider resolution used by `check-auth.create` and execution:** async opening of selected user credential fields, plus one tenant settings read/decryption for both policy and connection (formerly two). Candidate precedence, whole-connection failure, native-auth routing and provider verification are unchanged. This is a request-local policy/credential snapshot, not a cross-request cache; it also avoids combining two settings revisions within one resolution.
5. **Environment assembly and explicit user credential readers:** use the async legacy opener in `resolveUserEnvironment` and the repository/service `getToolConfig` / `getToolConfigField` methods. Keep sequential field processing, scope/tool selection, precedence, logged corrupt-field omission, and existing null/undefined contracts. This extends the measured legacy-KDF mechanism; no additional endpoint latency reduction is asserted.
6. **MCP OAuth authority/client projections:** switch the remaining `UserMCPOAuthTokenRepository` authority reads to the async bound-envelope opener. Catalog point reads and batched personal/shared authority reads retain their existing projections, client binding authentication, SQLite plaintext/null compatibility, and wrapped errors. Batch fields/rows are sequential; access/refresh columns remain excluded from authority projections.

Both envelope interfaces share parsing/AES-GCM validation between sync and async entry points; wire formats and scrypt parameters are unchanged. Only the expensive native KDF moves to Node's existing worker pool—not a subprocess. Fields and rows are awaited serially, with at most one outstanding KDF per inventory. Existing OAuth status runs two grant lists; no extra DB queries/connections are introduced.

**No cached keys, plaintext, grants, or credential status; no projection shortcut, polling change, migration, observability suppression, merge or deployment.**

## Evidence and provenance

Read-only Datadog investigation on **2026-09-09**, primary cohort **03:15–04:15 UTC**, with bounded lower-volume inventory trace selection extended to **02:15–04:15 UTC**, `service:agor-daemon env:sandbox`, inspected spans on `host:agor-2`. The supplied screenshot has no visible environment/time filters and is only an investigation lead (upload could not be materialized).

- Fresh main/implementation base: `46de44ff7e9c72792bfd72b60242dd52f70d6611`. Reviewed #2581, #2687–#2689, #2565/#2647, #2707 and subsequent #2566; do not duplicate the existing board batching/projection or weaken OAuth authority.
- Read-only `/health` at approximately **04:35 UTC** reports **0.26.3**, build **`393dc666c`** (the #2707 merge), built **2026-09-08 23:08:21 UTC**. Main additionally includes #2566, merged 00:35 UTC. Build time and merge time are **not rollout time**.
- Runtime uptime resets/mixed values occur roughly **23:10–23:45 UTC**, then progress steadily through the current cohort. Datadog change stories returned none; requested trace/version/git attributes were absent; a bounded literal-SHA log search found none. **Exact rollout timestamp and historical per-replica SHA cannot be verified. No version-matched pre/post deployment improvement is claimed.**
- Stable pre-restart contextual hour **Sep 8 22:00–23:00 UTC**: 783 OAuth-status hits from APM metrics, daemon mean CPU 38.846%, maximum reported loop delay 5.939 s. Current hour: 662 OAuth-status hits, mean daemon CPU 29.264%, maximum reported loop delay 3.819 s. Different traffic/cardinality and unverified old SHA mean this is context, not a causal before/after comparison. Do not average bucket percentiles into a whole-window p95.

Current retained-span endpoint inventory ranked OAuth status first by cumulative duration: 17 retained spans / 37.2 s, retained p50 ~2.38 s and p95 ~3.28 s. These are **diversity-retained samples, not traffic throughput or unbiased traffic percentiles**. APM hit metrics above are distinct from retained counts.

Representative complete traces (no payloads/credentials copied):

| Trace | Observation |
|---|---|
| [OAuth, 04:12:06](https://app.datadoghq.com/apm/trace/6aa0dc9600000000394c78892e3c0f71) | 2,102 ms service; overlapping grant-list spans 836 / 2,063 ms; only two subsequent server lookup spans (~6 ms each). Not a demonstrated large server-read N+1. |
| [OAuth control, 04:11:30](https://app.datadoghq.com/apm/trace/6aa0dc72000000001d5edbd8968ee99b) | 237 ms service; grant-list spans 2.4 / 218 ms. Different request shapes/cardinality remain unknown. |
| [Generic MCP list, 04:10:34](https://app.datadoghq.com/apm/trace/6aa0dc3a0000000055a3b7550739a27f) | 4,445 ms service; bounded page SELECT 3,544 ms, count 276 ms, no provider request in this trace. |
| [Gateway list, 03:12:43](https://app.datadoghq.com/apm/trace/6aa0ceab0000000023a81bc3217ea8e2) | 2,940 ms service; one gateway SELECT 18.8 ms and a large post-read gap. Source synchronously decrypts every channel's credentials/env vars. Local replay reproduces the blocking mechanism; this is not proof that all 2.9 s is attributable to crypto. |
| [Tool settings, 03:43:32](https://app.datadoghq.com/apm/trace/6aa0d5e400000000475c29aca6328515) | 134.2 ms service; six app-variable namespace/key SELECTs (2.3–119.5 ms, overlapping), no provider calls. Direct match to six `publicSettings` reads. The new test proves six SELECTs become one without changing settings. |
| [Session get, 04:08:52](https://app.datadoghq.com/apm/trace/6aa0dbd40000000075b4bb740d911421) | 642.7 ms service; one tenant-context `set_config` span 595.8 ms, other SELECTs individually ~1.7–7.2 ms. Deferred auth/query rewrites: this sample's tail is not predominantly redundant application work. |

Additional bounded `check-auth.create` traces, same service/environment/host, **02:15–04:15 UTC**:
- [02:24:25, 8,026.6 ms](https://app.datadoghq.com/apm/trace/6aa0c35900000000057c50355973bfd8): app-variable SELECT span 3,388.7 ms; Claude command span 5,021.6 ms extends past the service span. These are not additive/exclusive CPU measurements.
- [02:23:44, 5,469.7 ms](https://app.datadoghq.com/apm/trace/6aa0c33000000000376243fee388dafa): app-variable SELECT span 2,783.8 ms; Claude command span 2,379.3 ms. Both show three app-variable reads, consistent with enablement plus duplicate policy/connection reads in source. Resolver now needs one settings read plus one user read, not two settings plus user; the separate enablement check remains.
- `check-auth` calls `resolveApiKey` → `resolveProviderConnection`, which directly decrypts the user's stored fields. It does **not** use `UsersRepository.getToolConfig`; those repository helpers remain deferred. Earlier async app-variable work already covers encrypted tenant settings in this path. Provider/CLI waits remain, so this PR does **not** claim to eliminate these multi-second tails or optimize ordinary JWT verification.

For **04:10–04:13 UTC**, minute maxima of runtime event-loop delay are **3.819 / 1.249 / 1.225 s**, versus GC pause maxima **101 / 37 / 36 ms**; RSS averages **1.43–1.48 GB**. This supports investigating non-GC blocking, not attributing all stalls to this function. The Drizzle shim measures client-observed elapsed time: event-loop blocking can delay another query's promise completion. Overlapping/nested span durations are not additive CPU or exclusive SQL execution. Full-trace timestamps are second-rounded, so exact exclusive-time reconstruction is limited.

Source confirms full PG grants synchronously open up to four independently salted envelopes. A direct pre-change local probe of 24 real synthetic envelopes took **865 ms** and delayed a ready timer **865 ms**. Combined with current loop-stall evidence, this is sufficient to remove this reproducible blocking mechanism—not to assert it explains every live tail. Profiling tools were not exposed. Discovered `agor.database.pool.*` metrics belonged to a different `agor-cloud` service; target-host queries returned no data, so pool exhaustion is unproven. An existing disk-usage alert is a possible environmental confounder, not grounds for code or production changes.

## Controlled local measurement

Node 22.22.2, real encryption, six synthetic grants × four envelopes, one warmup and three alternating-order samples. No production database/provider activity. The synchronous-opener control exercises the same repository read/mapping fixture using the former blocking KDF; SQL is mocked, so no DB timing or live grant cardinality is implied.

| Metric (median of samples) | Synchronous opener | Asynchronous opener |
|---|---:|---:|
| Read wall time | 903.35 ms | 851.68 ms |
| Largest unrelated 5 ms timer gap | 903.41 ms | 5.78 ms |

Timer responsiveness is the primary result; small wall-time differences are not a guaranteed throughput/CPU saving. Both modes decrypt every field. No timing assertions in CI.

```sh
AGOR_BENCH_OAUTH_READ=1 pnpm --filter @agor/core exec vitest run src/db/repositories/user-mcp-oauth-tokens.status.test.ts
```

Additional local measurements on the same Node version:

| Fixture / median | Before/control | After |
|---|---:|---:|
| Gateway hydration: 6 channels × 3 envelopes, wall time | 614.56 ms | 625.27 ms |
| Gateway hydration: largest unrelated timer gap | 614.62 ms | 5.79 ms |
| Empty/default settings inventory: real SQLite, 100 alternating samples after warmup | 1.042 ms / 6 SELECTs | 0.214 ms / 1 SELECT |

Gateway uses the real mapper and crypto with selected synthetic rows, one warmup + three alternating samples. The synchronous opener control executes the prior blocking KDF through the current mapper; this is not a production cardinality assertion. **Gateway wall time increased slightly**; the win is event-loop responsiveness. Settings measurement isolates inventory SQL overhead on an unconfigured local DB, not a prediction of remote PG or encrypted-settings latency. The removed five round trips are verified deterministically. No production load generation.

```sh
AGOR_BENCH_GATEWAY_READ=1 AGOR_BENCH_SETTINGS_READ=1 pnpm --filter @agor/core exec vitest run src/db/repositories/gateway-channels.reads.test.ts src/db/repositories/tenant-agentic-tools.test.ts
```

Provider resolver local replay: real disposable SQLite, three synthetic user credential fields, no stored tenant document or provider/network probe, one warmup and three alternating samples. Synchronous-opener control versus async, with the same optimized SQL shape:
- Median resolver wall time: **109.13 → 133.10 ms** (slower in this run).
- Median maximum unrelated timer gap: **109.15 → 5.53 ms**.
- This isolates responsiveness, not the removed settings read. Separate deterministic regression proves **3 → 2 SELECTs** per resolver with a user and **2 → 1 tenant-document decryptions**, while still opening every selected user field serially.

```sh
AGOR_BENCH_PROVIDER_READ=1 pnpm --filter @agor/core exec vitest run src/config/key-resolver.test.ts
```

## Safety / tests

- Deterministic regression: the async opener must invoke callback-based scrypt, never scryptSync disguised as a Promise; full reads use the async opener; two-row reads issue one SELECT and open eight fields with peak per-read concurrency one.
- Both openers pass the same round-trip, malformed-format, wrong-purpose/key and AAD isolation cases. Existing corrupt access/refresh envelopes still fail even for expired/ambiguous grants. Added subject/server/generation transplant and async point-read error-wrapper checks.
- OAuth/gateway SQL predicates and projections, order, status/expiry/binding rules and response fields are unchanged. Settings batch SQL is restricted to the same namespace and six supported keys; no unknown-key or foreign-namespace parsing. Rereads see deletion; no cross-request cache. SQLite plaintext/null/subject behavior is covered with a real disposable SQLite DB.
- Real disposable PostgreSQL tests verify a NOSUPERUSER/NOBYPASSRLS role, concurrent tenant contexts across KDF awaits, shared/per-user isolation and foreign-ID denial; existing refresh integration covers fencing/claims. No production data or configuration changed.
- Gateway tests verify serial field/row decoding, hidden tenant metadata, array/legacy env-var shapes, corrupt credential omission with unchanged logging, empty values, and fresh rereads. Settings tests verify exactly one SELECT, no query for an empty key set, serial decryptions, nullable/empty values, defaults, invalid settings rejection, wrapped wrong-key errors, deletion/rotation, and public redaction/deployment policy.
- Additional real PostgreSQL tests run same-key settings and gateway inventories in concurrent tenant scopes, reject foreign channel/user/key reads, and reread after rotation/deletion. Existing gateway HA tests retain claim fencing and ownership behavior.
- Provider regression covers fresh user isolation, credential deletion, tenant policy/key rotation, one settings read, serial decryption, and whole-user-connection rejection on corrupt fields without fallback. Existing native/source and required/preferred-policy cases pass. PostgreSQL inventory regression additionally resolves own/foreign-user IDs in concurrent tenant scopes, proving foreign credentials do not leak through normal local-tenant fallback.
- Full grant point reads/claim hydration and gateway authority-update hydration now yield while existing transaction ownership remains unchanged. KDF CPU cost remains; concurrency across requests is bounded by the configured native worker pool, **not a new global application admission limit**. Worker-pool contention and transaction residency under load remain follow-up risks. No unbounded per-inventory fan-out was added.

Validation:
- `pnpm install --frozen-lockfile` passed.
- Core focused final suite: **79 passed, 3 opt-in benchmarks skipped**, eleven files. Initial OAuth benchmark separately **11 passed**; gateway/settings benchmark run **12 passed** before adding an additional serial-settings regression.
- Provider follow-up: **25 core tests passed, 1 opt-in benchmark skipped** across three suites; benchmark separately **10 passed** before the additional corruption regression. Expanded PostgreSQL credential-inventory test rerun passed.
- Daemon: initial OAuth status resolver/registration **12 passed**, two files; additional gateway/settings/preset regressions **36 passed**, seven files; check-auth service/helpers/real-SQLite regressions **32 passed**, three files.
- Disposable PostgreSQL: **16 passed, zero skipped**, four suites in separate fresh containers (grant/RLS + OAuth refresh + credential inventory/RLS + gateway listener HA), cleaned up afterward. This is not the full PostgreSQL lane. The OAuth-only and gateway/settings commits passed all GitHub CI checks, including full PG; later commits must rerun CI.
- `pnpm check` **passed** on the final source/tests: typecheck, lint, short-ID, multitenancy, daemon filesystem and realtime boundary guards, and requested workspace builds. Existing Vite config/chunk-size warnings remain; no warnings were suppressed.
- Initial typechecks caught an incorrect test-only ID import, a batch Map type inference issue, and a test assertion accessing a provider-union field without narrowing; all fixed. Initial custom PG invocation mistakenly ran both migration suites in one DB and hit a migration race; corrected to separate containers and reran successfully. Initial pre-commit backup failed because the inherited `PWD` used a different mount-path spelling than the actual working directory; aligning this invocation’s `PWD` with `process.cwd()` fixed Git stash creation. Hooks remained enabled, Git hardening remained intact. No bypasses or weakened tests.

### Remaining synchronous-decryption audit (not an “all off-loop” claim)

The async interfaces move **scrypt**, not the small AES operation, to the shared native pool. Source audit still finds synchronous KDF reads in:
- Claude/Codex attempt authority, MCP pending-flow/client-registration authority, and Slack recovery-token opening. Their synchronous return contracts and surrounding claim/lifetime checks need a separately tested async migration, not a blind replacement.
- Self-user DTO projection of allowlisted non-secret base URLs (`extractAgenticToolsPublicValues` callback in `services/users.ts`). Ordinary user reads do not automatically open provider secrets, but this self-response path can still derive keys for public fields.
- Historical double-encrypted gateway env compatibility paths in registration and MCP egress.

AES-only MCP egress capability opening has no scrypt KDF; it is a different, bounded operation. Encryption/sealing writes also still derive keys synchronously. No claim is made that cryptography can no longer stall the event loop. No process-wide plaintext cache or application-level admission pool was introduced.

### List endpoint audit

- `sessions.find`: common board/branch/recency queries push access/filter/sort/limit/offset into SQL; non-supported operators/projections can fall back to in-memory processing. Relationship enrichment is one batch; last-message enrichment is already opt-in and batched. [03:25:05 trace](https://app.datadoghq.com/apm/trace/6aa0d190000000005b622e6e45a273c3) is 46.9 ms, relationship batch 6.1 ms. Its containing MCP trace includes sibling endpoints; those are not session-list N+1 work.
- A deliberately widened, read-only **00:00–05:00 UTC** search for session lists over one second found [04:40:34 trace](https://app.datadoghq.com/apm/trace/6aa0e342000000004f31e096651a6f27): **25.117 s**, visibility-filtered count **6.667 s**, following SQL **7.094 s** labeled “Non-parsable SQL query,” plus another **191 ms** unparsed SQL span. Same env/service/host/process as earlier samples, but no extra deployed-SHA assertion. The following SQL is consistent with the source page read; its plan is not proven from this label. Count/page/client waits, uninstrumented gaps, and shared runtime contention deserve investigation before optional enrichment. This is not evidence of per-row enrichment queries or SQL CPU usage.
- `mcp-servers.find`: already filtered SQL count + page, repository clamps the requested limit to `PAGINATION.MAX_LIMIT`. The 4.445 s example is dominated by a page-read span, not provider hydration. Do not force new API filters based only on that tail.
- `agentic-tool-settings.find`: fixed six-tool inventory, now one settings query. Pagination is not a useful optimization here.

Next list gate: reproduce the sessions visibility-filtered count/page plan in disposable PG with representative cardinalities and verify timing boundaries. Consider additional supported filter/projection pushdown only for observed fallback requests. Optional totals/enrichment should be a deliberate caller/API change after benefit is measured, not a workaround for slow access predicates. No list response shape, authorization, filter requirement, pagination order or default enrichment changed in this pass.

Additional validation: **52 core environment/users tests**, **49 daemon users security/git-env/find tests**, and the extended PostgreSQL credential-inventory isolation test passed. PG now explicitly exercises own/foreign user credential reads and environment assembly across concurrent tenant scopes. Final `pnpm check` rerun passed; prior receipts above are cumulative, not a claim of rerunning every suite at every commit.

### Session-plan reproduction and authority follow-up

Reused the existing `sessions.inventory.postgres.test.ts` from **#2689 / `7b301aa1`**, rather than introducing another inventory fixture. On disposable local PostgreSQL with RLS, **200 branches / 20,000 sessions**, the suite passed both correctness/isolation and query-plan tests. `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)` execution times in this run:

| Query | Execution time |
|---|---:|
| Existing test's historical session-correlated control | 9,529.961 ms |
| Current visibility-filtered count | 109.786 ms |
| Current page | 123.719 ms |
| Current exact-branch inventory | 0.785 ms |

The existing plan assertions bound policy loops by branch cardinality, not session cardinality. **This is validation of prior work, not a new speedup delivered by this PR.** It does not reproduce the live 6–7-second spans or prove their cause. Production cardinality, grant distribution, statistics, query mix, client/DB scheduling and pool residency remain unresolved. Keep the current access predicates and pagination semantics; next investigate matched query shape/cardinality and the unparsed SQL timing boundary before proposing optional totals/enrichment or another query rewrite.

Authority follow-up validation: **17 focused core tests passed, 1 benchmark skipped**, including serial client hydration and corrupt client-ID/client-secret, subject/server/generation binding checks; real SQLite authority reads and deletion pass. Extended real PostgreSQL grant test passes with encrypted client fields, concurrent tenants, personal/shared authority inventory, and foreign tenant/user denial. Final `pnpm check` passed. There are now no synchronous envelope-open calls in `UserMCPOAuthTokenRepository`; other remaining paths are listed in the audit above.

## Ranked deferred opportunities / follow-up

| Priority | Candidate / evidence | Benefit, effort/risk, validation gate |
|---|---|---|
| 1 | Remaining synchronous attempt/recovery authority, self-profile public-value and legacy compatibility decryptions; see audit above | Gateway/settings, provider resolution, environment assembly, explicit user readers and catalog authority are now included; the remaining synchronous paths are listed above. Further shared-loop benefit is plausible; medium effort/security risk. Obtain code profiles or bounded local+trace attribution before extending conversion. Do not skip envelope authentication. |
| 2 | Request-wide task transactions plus fresh inner write scopes; prior telemetry trace, not a current incident diagnosis | Potential large tail benefit; high lifecycle/RLS/commit-order risk. Reproduce actual hook stack with disposable PG/pool size 1 and distinguish lock waits from acquisition. |
| 3 | OAuth server/binding lookup dedup and poll amplification | Smaller/unknown benefit: inspected trace has only two server lookups. Low–medium effort, revocation/private-visibility risk. Measure current grant cardinality and poll overlap first. |
| 4 | Generic list fallbacks, serialization, repeated auth checks | Current session trace is dominated by context-setup wait. Latest retained boards.find and repos.find examples were 36/70 ms; prior #2707 already batches board reads. Medium effort/access/order risk, uncertain incremental benefit. Match cardinality and exclusive work before changing. |
| 5 | check-auth/provider probes, streaming and message/task writes | External/process waits and publisher admission are not automatically daemon waste. Higher semantic risk; normalize by active tasks/chunks and inspect provider/lock/fanout boundaries first. |

After an independently authorized rollout: record actual per-replica SHA/start/end, allow warmup, then compare same host/service/env, endpoint/method/transport and request-size/cardinality mix. Measure event-loop delay/utilization, process CPU/RSS/GC, worker-pool contention, DB connection residency, traffic rates and endpoint tails. Preserve tracing depth and avoid mixing `POST /mcp`, `mcp.request`, facade/target `mcp.tool` and nested Feathers time as independent cost. Verify credential corruption, revocation and refresh outcomes remain unchanged. **This PR is not deployed.**

### AI review follow-up

Initial independent Codex review (`gpt-6-astra`, medium) found no substantive merge blockers at `c7abfc56`, with one nonblocking duplication finding. Addressed in `1fe95b28`: daemon user credential readers now delegate to `UsersRepository`, preserving service `undefined` versus repository `null`, scoped database ownership, and field-level corruption omission. Provider resolution retains its intentionally separate whole-connection rejection. Logging now uses the repository's canonical handling.

Added real-SQLite service regression coverage for delegation, user/tool isolation, missing values and corruption, plus database-error propagation coverage. All 51 focused daemon tests passed; `pnpm check` passed; commit hooks passed. Follow-up review of this change is pending in the same reviewer session. No deployment or production mutation.
