### PR TITLE
feat(analytics): operator metadata and env-backed HTTP auth

### DIFF
--- a/apps/agor-daemon/src/utils/spawn-executor.configured.test.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.configured.test.ts
@@ -310,6 +310,8 @@ describe('configured executor spawning', () => {
       GOOGLE_APPLICATION_CREDENTIALS: '/synthetic/daemon/google-credentials.json',
       AWS_SECRET_ACCESS_KEY: 'synthetic-object-store-credential',
       SYNTHETIC_DAEMON_INTERNAL_SECRET: 'synthetic-unknown-future-daemon-secret',
+      AGOR_ANALYTICS_AUTHORIZATION: 'synthetic-analytics-credential',
+      CUSTOM_ANALYTICS_AUTH: 'synthetic-custom-analytics-credential',
     } as const;
     const ambient = { ...launcherCredentials, ...withheldDaemonEnvironment };
     const previous = Object.fromEntries(Object.keys(ambient).map((key) => [key, process.env[key]]));

--- a/apps/agor-daemon/src/utils/spawn-executor.resolved-config.test.ts
+++ b/apps/agor-daemon/src/utils/spawn-executor.resolved-config.test.ts
@@ -131,6 +131,13 @@ describe('buildResolvedConfigSlice', () => {
         '  base_url: https://example.com',
         'analytics:',
         '  enabled: true',
+        '  client: { app: agor-cloud-daemon }',
+        '  extras: { environment: cloud }',
+        '  plugins:',
+        '    - type: http_batch',
+        '      enabled: true',
+        '      options:',
+        '        headers_from_env: { Authorization: AGOR_ANALYTICS_AUTHORIZATION }',
         'security:',
         '  csp:',
         '    extras:',
@@ -148,6 +155,7 @@ describe('buildResolvedConfigSlice', () => {
     expect(slice.daemon?.host_ip_address).toBe('10.0.0.5');
     // Non-allowed top-level sections are absent — slice is a strict subset.
     expect(slice).not.toHaveProperty('analytics');
+    expect(JSON.stringify(slice)).not.toContain('AGOR_ANALYTICS_AUTHORIZATION');
     expect(slice).not.toHaveProperty('security');
     // Non-allowed fields within an allowed section are also absent.
     expect(slice.execution).not.toHaveProperty('unix_user_mode');

--- a/apps/agor-daemon/src/utils/trusted-launcher-environment.ts
+++ b/apps/agor-daemon/src/utils/trusted-launcher-environment.ts
@@ -1,13 +1,4 @@
-import { buildAllowlistedEnv } from '@agor/core/config';
-
-/**
- * Reserved ambient namespace for operator-configured Cloud launcher helpers.
- *
- * These values are intentionally available only to trusted external launcher
- * processes. They are not part of the user/session environment and must never
- * be copied into an executor payload.
- */
-const TRUSTED_LAUNCHER_ENV_PREFIX = 'AGOR_CLOUD_';
+import { buildAllowlistedEnv, TRUSTED_LAUNCHER_ENV_PREFIX } from '@agor/core/config';
 
 /**
  * Build the environment for a trusted operator-configured launcher/helper.

--- a/apps/agor-docs/content/guide/config-yaml.mdx
+++ b/apps/agor-docs/content/guide/config-yaml.mdx
@@ -285,6 +285,89 @@ stamps the stable operational defaults needed for a working deployment, but deli
 materialize every optional long-tail field. Leaving those absent preserves their documented
 default-following semantics across upgrades.
 
+## Operator-configured analytics
+
+Analytics is disabled by default. It sends curated analytics events to the configured
+`stdout` (JSON) and/or `http_batch` plugins. It does **not** tag all application logs,
+enable opt-in open-source telemetry, or configure DogStatsD/APM metrics.
+
+```yaml
+analytics:
+  enabled: true
+  client: { app: agor-cloud-daemon, version: '1.0', debug: false }
+  extras:
+    environment: cloud
+    deployment: agor-cloud-production-aws-us1a
+  filters:
+    exclude_events: ['private.*']
+  plugins:
+    - type: http_batch
+      enabled: true
+      options:
+        url: https://api.segment.io/v1/batch
+        headers_from_env: { Authorization: AGOR_ANALYTICS_AUTHORIZATION }
+        flush_interval_ms: 1000
+        max_batch_size: 50
+        timeout_ms: 3000
+```
+
+Both built-in transports emit `context.app.name` from `client.app`,
+`context.app.version` from `client.version` (finite numbers become strings), and
+`context.extras` from the configured extras, or `{}` when absent. Client defaults
+remain `app: agor-daemon`, `version: dev`, `debug: false`. App/version strings must
+be nonblank and at most 256 UTF-8 bytes. Metadata is snapshotted at initialization;
+restart the daemon to apply a change.
+
+App and extras are operator-owned deployment metadata, not tenant identity.
+Callers cannot override either reserved context field. `context.tenant_id` comes
+only from the trusted ambient runtime tenant scope; it is absent outside that
+scope, even if a caller supplies one. Other caller context, event properties,
+`userId`, and `anonymousId` are preserved. Exact-name and simple `*`-glob exclusions
+run before delivery. Prototype-poison context keys are discarded before passing
+options to the analytics client.
+
+`extras` is a flat mapping with at most **32 keys**. Keys match
+`[A-Za-z0-9_][A-Za-z0-9_.-]{0,63}` (1–64 ASCII characters); `__proto__`,
+`prototype`, and `constructor` are rejected. Values are strings of at most
+**1024 UTF-8 bytes**, finite numbers, or booleans—not null, arrays, or objects.
+Only use non-secret, non-PII deployment labels. Bounds are structural validation,
+not a PII detector; operators own field selection and destination access/retention.
+
+### HTTP authentication from daemon environment
+
+`options.headers_from_env` maps HTTP header names to **environment variable names**.
+Provision the complete header value (for example, the required authorization scheme
+and token) separately in the daemon's secret environment. Do not put credentials
+in YAML, `extras`, static `headers`, URLs, or event data. No generic interpolation
+or startup config rewrite occurs. Values resolve only inside the transport at
+analytics initialization; they never enter exported/resolved config or the analytics
+SDK's plugin configuration. Rotate a credential by replacing the daemon secret and
+restarting every replica. HTTP redirects are refused.
+
+Each of `headers` and `headers_from_env` permits at most 32 entries. Header names
+are HTTP token names, at most 128 ASCII characters, excluding prototype-poison
+names (case-insensitive). Duplicate names within or across the maps are rejected
+case-insensitively. Env names match `[A-Z_][A-Z0-9_]*`, at most 128 characters.
+Names inherited by child processes (the runtime env allowlist, `LC_*`, and the
+reserved launcher namespace `AGOR_CLOUD_*`) cannot be used for analytics secrets;
+use a dedicated name such as `AGOR_ANALYTICS_AUTHORIZATION`. The daemon's minimal
+child-env allowlist withholds these dedicated names from executors and tools, and
+the executor resolved-config projection excludes analytics entirely. Do not separately
+map daemon credentials into user/tool environments. `simple` execution remains
+trusted-local execution, not filesystem or host-account isolation.
+
+Header values allow only horizontal tab and printable ASCII, at most **8192
+characters/bytes**. Env-backed values must also be present and nonblank. Invalid,
+missing, empty, or conflicting auth fails closed: analytics initialization fails,
+the daemon logs a bounded warning without credential values and continues with
+analytics disabled. Delivery failures never log raw fetch exceptions. Config shape
+validation still applies to disabled plugins, but disabled analytics/plugins never
+read or require env values. Static non-secret headers remain supported.
+
+Older runtimes reject the new config keys. Roll out an Agor runtime containing this
+contract to every replica **before** enabling these fields in deployment config;
+do not assume an older published release supports them.
+
 ## DogStatsD daemon metrics
 
 Operational daemon metrics can be sent over UDP to a locally reachable

--- a/packages/core/src/analytics/delivery.test.ts
+++ b/packages/core/src/analytics/delivery.test.ts
@@ -1,0 +1,221 @@
+import * as yaml from 'js-yaml';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { assertValidRawConfig } from '../config/config-manager.js';
+import { buildAllowlistedEnv, createUserProcessEnvironment } from '../config/env-resolver.js';
+import type { AgorAnalyticsSettings } from '../config/types.js';
+import { runWithTenantContext } from '../db/tenant-context.js';
+import {
+  configureAnalyticsLogger,
+  createAnalyticsLogger,
+  resolveAnalyticsConfig,
+} from './logger.js';
+
+const SECRET = 'synthetic-test-only-authorization';
+const ENV_NAME = 'AGOR_ANALYTICS_AUTHORIZATION';
+
+function settings(environment = 'cloud'): AgorAnalyticsSettings {
+  return {
+    enabled: true,
+    client: { app: `agor-${environment}-daemon`, version: 1, debug: true },
+    extras: {
+      environment,
+      deployment: `${environment}-production-us1a`,
+      replicas: 2,
+      managed: true,
+    },
+    filters: { exclude_events: ['private.*'] },
+    plugins: [
+      {
+        type: 'http_batch',
+        enabled: true,
+        options: {
+          url: 'https://example.test/batch',
+          max_batch_size: 1,
+          headers: { 'x-source': 'agor' },
+          headers_from_env: { Authorization: ENV_NAME },
+        },
+      },
+      { type: 'stdout', enabled: true },
+    ],
+  };
+}
+
+describe('actual Analytics client delivery', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it('owns app/extras and tenant identity across environments while preserving caller data', async () => {
+    vi.stubEnv(ENV_NAME, SECRET);
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    for (const environment of ['cloud', 'sandbox']) {
+      const config = settings(environment);
+      const snapshot = JSON.stringify(config);
+      assertValidRawConfig({ analytics: config });
+      const logger = await createAnalyticsLogger(config);
+      expect(JSON.stringify(config)).toBe(snapshot);
+      const context = JSON.parse(
+        '{"source":"caller","app":{"name":"spoof"},"extras":{"environment":"spoof"},"tenant_id":"foreign-tenant","__proto__":{"polluted":true},"constructor":{"prototype":{"polluted":true}},"prototype":{"polluted":true}}'
+      );
+      runWithTenantContext(`tenant-${environment}`, () => {
+        logger.track(
+          'task.completed',
+          { duration_ms: 123 },
+          {
+            userId: 'user-1',
+            anonymousId: 'anon-1',
+            context,
+          }
+        );
+        logger.track('private.event');
+      });
+      logger.track('daemon.event', {}, { context });
+      // Mutating input after initialization must not rewrite the operator snapshot.
+      if (config.extras) config.extras.environment = 'mutated';
+      if (config.client) config.client.app = 'mutated';
+      await vi.waitFor(() =>
+        expect(fetchMock.mock.calls.length).toBe(environment === 'cloud' ? 2 : 4)
+      );
+      for (const [offset, tenant] of [
+        [0, `tenant-${environment}`],
+        [1, undefined],
+      ] as const) {
+        const index = (environment === 'cloud' ? 0 : 2) + offset;
+        const [url, init] = fetchMock.mock.calls[index];
+        expect(url).toBe('https://example.test/batch');
+        expect(init?.headers).toMatchObject({ Authorization: SECRET, 'x-source': 'agor' });
+        expect(init?.redirect).toBe('error');
+        const event = JSON.parse(init?.body as string).batch[0];
+        expect(event.context).toEqual({
+          source: 'caller',
+          app: { name: `agor-${environment}-daemon`, version: '1' },
+          extras: {
+            environment,
+            deployment: `${environment}-production-us1a`,
+            replicas: 2,
+            managed: true,
+          },
+          ...(tenant ? { tenant_id: tenant } : {}),
+        });
+        if (tenant)
+          expect(event).toMatchObject({
+            userId: 'user-1',
+            anonymousId: 'anon-1',
+            properties: { duration_ms: 123 },
+          });
+        const stdoutEvents = log.mock.calls
+          .flat()
+          .filter((value): value is string => typeof value === 'string' && value.startsWith('{'))
+          .map((value) => JSON.parse(value));
+        expect(stdoutEvents).toContainEqual(event);
+      }
+      expect(snapshot).not.toContain(SECRET);
+      expect(JSON.stringify(resolveAnalyticsConfig(config))).not.toContain(SECRET);
+      expect(yaml.dump(config)).not.toContain(SECRET);
+    }
+    expect({}).not.toHaveProperty('polluted');
+    expect(JSON.stringify(log.mock.calls)).not.toContain(SECRET);
+    expect(JSON.stringify(warn.mock.calls)).not.toContain(SECRET);
+    expect(buildAllowlistedEnv()).not.toHaveProperty(ENV_NAME);
+    expect(await createUserProcessEnvironment()).not.toHaveProperty(ENV_NAME);
+  });
+
+  it('ignores inherited caller context, uses defaults, and leaves tenant absent outside scope', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const logger = await createAnalyticsLogger({
+      enabled: true,
+      plugins: [
+        {
+          type: 'http_batch',
+          enabled: true,
+          options: { url: 'https://example.test', max_batch_size: 1 },
+        },
+      ],
+    });
+    logger.track(
+      'legacy.event',
+      {},
+      {
+        context: Object.create({
+          tenant_id: 'foreign',
+          source: 'inherited',
+          app: { name: 'spoof' },
+        }),
+      }
+    );
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+    expect(JSON.parse(fetchMock.mock.calls[0][1]?.body as string).batch[0].context).toEqual({
+      app: { name: 'agor-daemon', version: 'dev' },
+      extras: {},
+    });
+  });
+
+  it.each([undefined, '', '   ', 'secret\r\ninjected: true', 'é', 'x'.repeat(8193)])(
+    'fails closed with bounded safe errors for invalid env case %#',
+    async (value) => {
+      vi.stubEnv(ENV_NAME, value);
+      const fetchMock = vi.fn<typeof fetch>();
+      vi.stubGlobal('fetch', fetchMock);
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const logger = await configureAnalyticsLogger(settings());
+      expect(logger.isEnabled()).toBe(false);
+      logger.track('event');
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(warn).toHaveBeenCalledWith(
+        '[analytics] failed to configure analytics; continuing with analytics disabled:',
+        'Analytics http_batch header environment value is missing, empty, or invalid'
+      );
+    }
+  );
+
+  it('does not resolve missing credentials for disabled analytics or plugins', async () => {
+    vi.stubEnv(ENV_NAME, undefined);
+    expect((await createAnalyticsLogger({ ...settings(), enabled: false })).isEnabled()).toBe(
+      false
+    );
+    const config = settings();
+    for (const plugin of config.plugins ?? []) plugin.enabled = false;
+    expect((await createAnalyticsLogger(config)).isEnabled()).toBe(true);
+  });
+
+  it('fails closed on a static/env header collision without sending or logging either value', async () => {
+    vi.stubEnv(ENV_NAME, SECRET);
+    const fetchMock = vi.fn<typeof fetch>();
+    vi.stubGlobal('fetch', fetchMock);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const config = settings();
+    const plugin = config.plugins?.[0];
+    if (plugin?.type !== 'http_batch' || !plugin.options) throw new Error('missing test plugin');
+    plugin.options.headers = { authorization: 'synthetic-static-secret' };
+    const logger = await configureAnalyticsLogger(config);
+    expect(logger.isEnabled()).toBe(false);
+    logger.track('event');
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      '[analytics] failed to configure analytics; continuing with analytics disabled:',
+      'Config error: invalid analytics header names (invalid or case-insensitive conflict)'
+    );
+    expect(JSON.stringify(warn.mock.calls)).not.toContain(SECRET);
+    expect(JSON.stringify(warn.mock.calls)).not.toContain('synthetic-static-secret');
+  });
+
+  it('never logs credential-bearing fetch exceptions', async () => {
+    vi.stubEnv(ENV_NAME, SECRET);
+    vi.stubGlobal('fetch', vi.fn<typeof fetch>().mockRejectedValue(new Error(SECRET)));
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const logger = await createAnalyticsLogger(settings());
+    logger.track('event');
+    await vi.waitFor(() =>
+      expect(warn).toHaveBeenCalledWith('[analytics] http_batch delivery failed')
+    );
+    expect(JSON.stringify(warn.mock.calls)).not.toContain(SECRET);
+  });
+});

--- a/packages/core/src/analytics/logger.ts
+++ b/packages/core/src/analytics/logger.ts
@@ -1,6 +1,7 @@
 import type { AnalyticsInstance } from 'analytics';
 import { Analytics } from 'analytics';
 import { getDefaultAnalyticsConfig } from '../config/analytics-defaults.js';
+import { isSafeAnalyticsKey } from '../config/analytics-validation.js';
 import type { AgorAnalyticsSettings, AgorConfig } from '../config/types.js';
 import { getCurrentTenantId } from '../db/tenant-context.js';
 import { isAnalyticsEventExcluded } from './filters.js';
@@ -68,8 +69,12 @@ export class AnalyticsPackageLogger implements AnalyticsLogger {
     const trackOptions: Record<string, unknown> = {};
     const tenantId = getCurrentTenantId();
     if (options.context || tenantId) {
-      const callerContext = { ...options.context };
-      delete callerContext.tenant_id;
+      // Strip reserved and poison keys before the analytics package can merge options.
+      const callerContext = Object.fromEntries(
+        Object.entries(options.context ?? {}).filter(
+          ([key]) => isSafeAnalyticsKey(key) && !['tenant_id', 'app', 'extras'].includes(key)
+        )
+      );
       trackOptions.context = {
         ...callerContext,
         ...(tenantId ? { tenant_id: tenantId } : {}),

--- a/packages/core/src/analytics/logger.ts
+++ b/packages/core/src/analytics/logger.ts
@@ -6,7 +6,12 @@ import type { AgorAnalyticsSettings, AgorConfig } from '../config/types.js';
 import { getCurrentTenantId } from '../db/tenant-context.js';
 import { isAnalyticsEventExcluded } from './filters.js';
 import { resolveAnalyticsPlugins } from './plugins.js';
-import type { AnalyticsLogger, AnalyticsProperties, AnalyticsTrackOptions } from './types.js';
+import {
+  type AnalyticsLogger,
+  type AnalyticsProperties,
+  type AnalyticsTrackOptions,
+  OPERATOR_OWNED_ANALYTICS_CONTEXT_KEYS,
+} from './types.js';
 
 function mergeAnalyticsConfig(config?: AgorAnalyticsSettings): AgorAnalyticsSettings {
   const defaults = getDefaultAnalyticsConfig();
@@ -72,7 +77,10 @@ export class AnalyticsPackageLogger implements AnalyticsLogger {
       // Strip reserved and poison keys before the analytics package can merge options.
       const callerContext = Object.fromEntries(
         Object.entries(options.context ?? {}).filter(
-          ([key]) => isSafeAnalyticsKey(key) && !['tenant_id', 'app', 'extras'].includes(key)
+          ([key]) =>
+            isSafeAnalyticsKey(key) &&
+            key !== 'tenant_id' &&
+            !OPERATOR_OWNED_ANALYTICS_CONTEXT_KEYS.includes(key)
         )
       );
       trackOptions.context = {

--- a/packages/core/src/analytics/plugins.ts
+++ b/packages/core/src/analytics/plugins.ts
@@ -1,3 +1,9 @@
+import {
+  isSafeAnalyticsKey,
+  isValidAnalyticsHeaderValue,
+  validateAnalyticsHeaders,
+  validateAnalyticsMetadata,
+} from '../config/analytics-validation.js';
 import type {
   AgorAnalyticsHttpBatchPluginSettings,
   AgorAnalyticsSettings,
@@ -36,7 +42,10 @@ function toTrackPayload(input: unknown): AnalyticsTrackPayload {
   return payload as AnalyticsTrackPayload;
 }
 
-export function toSegmentLikeTrack(payloadInput: unknown): Record<string, unknown> {
+export function toSegmentLikeTrack(
+  payloadInput: unknown,
+  metadata?: Pick<AgorAnalyticsSettings, 'client' | 'extras'>
+): Record<string, unknown> {
   const payload = toTrackPayload(payloadInput);
   const timestamp = payload.meta?.ts
     ? new Date(payload.meta.ts).toISOString()
@@ -48,7 +57,24 @@ export function toSegmentLikeTrack(payloadInput: unknown): Record<string, unknow
     type: 'track',
     event: payload.event,
     properties: payload.properties ?? {},
-    context: payload.options?.context ?? {},
+    context: {
+      ...Object.fromEntries(
+        Object.entries(payload.options?.context ?? {}).filter(
+          ([key]) => isSafeAnalyticsKey(key) && (!metadata || !['app', 'extras'].includes(key))
+        )
+      ),
+      ...(metadata
+        ? {
+            app: {
+              name: metadata.client?.app,
+              ...(metadata.client?.version !== undefined
+                ? { version: String(metadata.client.version) }
+                : {}),
+            },
+            extras: { ...metadata.extras },
+          }
+        : {}),
+    },
     timestamp,
   };
 
@@ -58,7 +84,8 @@ export function toSegmentLikeTrack(payloadInput: unknown): Record<string, unknow
 }
 
 export function createStdoutAnalyticsPlugin(
-  settings: AgorAnalyticsStdoutPluginSettings
+  settings: AgorAnalyticsStdoutPluginSettings,
+  metadata?: Pick<AgorAnalyticsSettings, 'client' | 'extras'>
 ): ResolvedAnalyticsPlugin {
   const pretty = settings.options?.pretty === true;
   return {
@@ -66,7 +93,7 @@ export function createStdoutAnalyticsPlugin(
     loaded: () => true,
     track: (input: unknown) => {
       try {
-        const event = toSegmentLikeTrack(input);
+        const event = toSegmentLikeTrack(input, metadata);
         console.log(pretty ? JSON.stringify(event, null, 2) : JSON.stringify(event));
       } catch (error) {
         warnAnalytics('stdout plugin failed', error);
@@ -76,7 +103,8 @@ export function createStdoutAnalyticsPlugin(
 }
 
 export function createHttpBatchAnalyticsPlugin(
-  settings: AgorAnalyticsHttpBatchPluginSettings
+  settings: AgorAnalyticsHttpBatchPluginSettings,
+  metadata?: Pick<AgorAnalyticsSettings, 'client' | 'extras'>
 ): ResolvedAnalyticsPlugin | null {
   const options = settings.options ?? {};
   const url = options.url;
@@ -88,7 +116,18 @@ export function createHttpBatchAnalyticsPlugin(
   const flushIntervalMs = Math.max(1, options.flush_interval_ms ?? 1000);
   const maxBatchSize = Math.max(1, options.max_batch_size ?? 50);
   const timeoutMs = Math.max(1, options.timeout_ms ?? 3000);
-  const headers = options.headers ?? {};
+  validateAnalyticsHeaders(options);
+  // Credentials exist only in this transport closure, never plugin config / SDK state.
+  const headers: Record<string, string> = { ...options.headers };
+  for (const [name, envName] of Object.entries(options.headers_from_env ?? {})) {
+    const value = process.env[envName];
+    if (!isValidAnalyticsHeaderValue(value, true)) {
+      throw new Error(
+        'Analytics http_batch header environment value is missing, empty, or invalid'
+      );
+    }
+    headers[name] = value;
+  }
   let batch: Record<string, unknown>[] = [];
   let timer: NodeJS.Timeout | undefined;
   let flushing: Promise<void> | undefined;
@@ -123,12 +162,14 @@ export function createHttpBatchAnalyticsPlugin(
             batch: events,
           }),
           signal: controller.signal,
+          redirect: 'error',
         });
         if (!response.ok) {
           warnAnalytics(`http_batch delivery returned HTTP ${response.status}`);
         }
-      } catch (error) {
-        warnAnalytics('http_batch delivery failed', error);
+      } catch {
+        // Fetch errors can include request headers or URLs. Never log their details.
+        warnAnalytics('http_batch delivery failed');
       } finally {
         clearTimeout(timeout);
         flushing = undefined;
@@ -154,7 +195,7 @@ export function createHttpBatchAnalyticsPlugin(
     loaded: () => true,
     track: (input: unknown) => {
       try {
-        batch.push(toSegmentLikeTrack(input));
+        batch.push(toSegmentLikeTrack(input, metadata));
         if (batch.length >= maxBatchSize) {
           void flush();
         } else {
@@ -198,16 +239,19 @@ export function wrapAnalyticsPlugin(plugin: ResolvedAnalyticsPlugin): ResolvedAn
 export async function resolveAnalyticsPlugins(
   config: AgorAnalyticsSettings
 ): Promise<ResolvedAnalyticsPlugin[]> {
+  validateAnalyticsMetadata(config);
+  // Snapshot operator metadata so later caller mutation cannot change event identity.
+  const metadata = { client: { ...config.client }, extras: { ...config.extras } };
   const resolved: ResolvedAnalyticsPlugin[] = [];
   for (const pluginConfig of config.plugins ?? []) {
     if (pluginConfig.enabled !== true) continue;
 
     switch (pluginConfig.type) {
       case 'stdout':
-        resolved.push(createStdoutAnalyticsPlugin(pluginConfig));
+        resolved.push(createStdoutAnalyticsPlugin(pluginConfig, metadata));
         break;
       case 'http_batch': {
-        const plugin = createHttpBatchAnalyticsPlugin(pluginConfig);
+        const plugin = createHttpBatchAnalyticsPlugin(pluginConfig, metadata);
         if (plugin) resolved.push(plugin);
         break;
       }

--- a/packages/core/src/analytics/plugins.ts
+++ b/packages/core/src/analytics/plugins.ts
@@ -9,7 +9,7 @@ import type {
   AgorAnalyticsSettings,
   AgorAnalyticsStdoutPluginSettings,
 } from '../config/types.js';
-import type { ResolvedAnalyticsPlugin } from './types.js';
+import { OPERATOR_OWNED_ANALYTICS_CONTEXT_KEYS, type ResolvedAnalyticsPlugin } from './types.js';
 
 interface AnalyticsTrackPayload {
   type?: string;
@@ -60,7 +60,9 @@ export function toSegmentLikeTrack(
     context: {
       ...Object.fromEntries(
         Object.entries(payload.options?.context ?? {}).filter(
-          ([key]) => isSafeAnalyticsKey(key) && (!metadata || !['app', 'extras'].includes(key))
+          ([key]) =>
+            isSafeAnalyticsKey(key) &&
+            (!metadata || !OPERATOR_OWNED_ANALYTICS_CONTEXT_KEYS.includes(key))
         )
       ),
       ...(metadata

--- a/packages/core/src/analytics/types.ts
+++ b/packages/core/src/analytics/types.ts
@@ -3,6 +3,12 @@ import type { AnalyticsPlugin } from 'analytics';
 export type AnalyticsProperties = Record<string, unknown>;
 export type AnalyticsContext = Record<string, unknown>;
 
+/** Deployment-owned fields. Trusted tenant identity is handled separately by the logger. */
+export const OPERATOR_OWNED_ANALYTICS_CONTEXT_KEYS: readonly string[] = Object.freeze([
+  'app',
+  'extras',
+]);
+
 export interface AnalyticsTrackOptions {
   userId?: string | null;
   anonymousId?: string | null;

--- a/packages/core/src/config/analytics-validation.test.ts
+++ b/packages/core/src/config/analytics-validation.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { validateAnalyticsHeaders, validateAnalyticsMetadata } from './analytics-validation.js';
+import { assertValidRawConfig } from './config-manager.js';
+import type { AgorAnalyticsHttpBatchPluginSettings, AgorAnalyticsSettings } from './types.js';
+
+describe('analytics config bounds', () => {
+  it('accepts exact metadata bounds and flat scalar values', () => {
+    const extras = Object.fromEntries(
+      Array.from({ length: 32 }, (_, i) => [`key${i}`, 'é'.repeat(512)])
+    );
+    expect(() =>
+      assertValidRawConfig({ analytics: { extras, client: { app: 'a'.repeat(256), version: 0 } } })
+    ).not.toThrow();
+    expect(() =>
+      validateAnalyticsMetadata({ extras: { ['k'.repeat(64)]: true, number: 1.5 } })
+    ).not.toThrow();
+  });
+
+  it.each([
+    null,
+    [],
+    'bad',
+    { nested: {} },
+    { array: [] },
+    { empty: null },
+    { nonfinite: Infinity },
+    { nonfinite: NaN },
+    { ['k'.repeat(65)]: 'x' },
+    { 'bad key': true },
+    { large: 'é'.repeat(513) },
+    Object.fromEntries(Array.from({ length: 33 }, (_, i) => [`k${i}`, i])),
+    JSON.parse('{"__proto__":"bad"}'),
+    { constructor: 'bad' },
+    { prototype: true },
+    Object.create({ inherited: 'bad' }),
+  ])('rejects invalid extras case %#, even when disabled', (extras) => {
+    expect(() => assertValidRawConfig({ analytics: { enabled: false, extras } })).toThrow(
+      'invalid analytics extras'
+    );
+  });
+
+  it.each([
+    { app: '' },
+    { app: 'a'.repeat(257) },
+    { app: 1 },
+    { version: Infinity },
+    { version: '' },
+    { version: 'a'.repeat(257) },
+    { debug: 'yes' },
+  ])('rejects invalid client case %#', (client) => {
+    expect(() => validateAnalyticsMetadata({ client } as AgorAnalyticsSettings)).toThrow(
+      'invalid analytics client'
+    );
+  });
+
+  it('accepts bounded static headers and unresolved env names', () => {
+    expect(() =>
+      assertValidRawConfig({
+        analytics: {
+          plugins: [
+            {
+              type: 'http_batch',
+              enabled: false,
+              options: {
+                headers: { ['x'.repeat(128)]: 'x'.repeat(8192) },
+                headers_from_env: { Authorization: 'A'.repeat(128) },
+              },
+            },
+          ],
+        },
+      })
+    ).not.toThrow();
+  });
+
+  it.each([
+    {
+      headers: { Authorization: 'synthetic' },
+      headers_from_env: { authorization: 'AGOR_ANALYTICS_AUTHORIZATION' },
+    },
+    { headers_from_env: { Authorization: 'ONE', authorization: 'TWO' } },
+    { headers: { X: 'one', x: 'two' } },
+    { headers_from_env: { 'bad:name': 'VALID' } },
+    { headers_from_env: { Authorization: '' } },
+    { headers_from_env: { Authorization: 'NOT-A-NAME' } },
+    { headers_from_env: { Authorization: 'A'.repeat(129) } },
+    { headers_from_env: { Authorization: 'PATH' } },
+    { headers_from_env: { Authorization: 'LC_SECRET' } },
+    { headers_from_env: { Authorization: 'AGOR_CLOUD_SECRET' } },
+    { headers_from_env: JSON.parse('{"__proto__":"VALID"}') },
+    { headers: { prototype: 'value' } },
+    { headers: { X: 'secret\r\nx: yes' } },
+    { headers: { X: 'é' } },
+    { headers: { X: 'secret\0' } },
+    { headers: { X: 'x'.repeat(8193) } },
+    { headers: { ['x'.repeat(129)]: 'value' } },
+    { headers: Object.fromEntries(Array.from({ length: 33 }, (_, i) => [`x-${i}`, 'value'])) },
+  ])('rejects unsafe/conflicting header config case %# without echoing values', (options) => {
+    const typedOptions = options as AgorAnalyticsHttpBatchPluginSettings['options'];
+    expect(() => validateAnalyticsHeaders(typedOptions)).toThrow(
+      /^Config error: invalid analytics /
+    );
+    expect(() =>
+      assertValidRawConfig({
+        analytics: { plugins: [{ type: 'http_batch', enabled: false, options: typedOptions }] },
+      })
+    ).toThrow(/^Config error: invalid analytics /);
+  });
+});

--- a/packages/core/src/config/analytics-validation.ts
+++ b/packages/core/src/config/analytics-validation.ts
@@ -1,0 +1,106 @@
+import { ENV_VAR_NAME_PATTERN } from './env-blocklist.js';
+import { isAllowedEnvVar, TRUSTED_LAUNCHER_ENV_PREFIX } from './env-inheritance.js';
+import { isPlainConfigRecord } from './plain-record.js';
+import type { AgorAnalyticsHttpBatchPluginSettings, AgorAnalyticsSettings } from './types.js';
+
+const POISON_KEYS = new Set(['__proto__', 'prototype', 'constructor']);
+
+export function isSafeAnalyticsKey(key: string): boolean {
+  return !POISON_KEYS.has(key);
+}
+
+function invalid(field: string): never {
+  // Never interpolate keys or values: even malformed configuration can contain credentials.
+  throw new Error(`Config error: invalid analytics ${field}`);
+}
+
+function entries(value: unknown, field: string, limit: number): [string, unknown][] {
+  if (!isPlainConfigRecord(value)) invalid(field);
+  const result = Object.entries(value);
+  if (result.length > limit) invalid(field);
+  return result;
+}
+
+export function validateAnalyticsMetadata(config: AgorAnalyticsSettings): void {
+  if (config.extras !== undefined) {
+    for (const [key, value] of entries(config.extras, 'extras', 32)) {
+      if (
+        !isSafeAnalyticsKey(key) ||
+        !/^[A-Za-z0-9_][A-Za-z0-9_.-]{0,63}$/.test(key) ||
+        !(
+          (typeof value === 'string' && Buffer.byteLength(value, 'utf8') <= 1024) ||
+          (typeof value === 'number' && Number.isFinite(value)) ||
+          typeof value === 'boolean'
+        )
+      )
+        invalid('extras');
+    }
+  }
+  const client = config.client;
+  if (client === undefined) return;
+  if (!isPlainConfigRecord(client)) invalid('client');
+  if (
+    client.app !== undefined &&
+    (typeof client.app !== 'string' ||
+      !client.app.trim() ||
+      Buffer.byteLength(client.app, 'utf8') > 256)
+  )
+    invalid('client.app');
+  if (
+    client.version !== undefined &&
+    !(
+      (typeof client.version === 'string' &&
+        !!client.version.trim() &&
+        Buffer.byteLength(client.version, 'utf8') <= 256) ||
+      (typeof client.version === 'number' && Number.isFinite(client.version))
+    )
+  )
+    invalid('client.version');
+  if (client.debug !== undefined && typeof client.debug !== 'boolean') invalid('client.debug');
+}
+
+/** Validate config names without reading the environment or materializing any secret. */
+export function validateAnalyticsHeaders(
+  options: AgorAnalyticsHttpBatchPluginSettings['options']
+): void {
+  const seen = new Set<string>();
+  for (const [kind, map] of [
+    ['headers', options?.headers],
+    ['headers_from_env', options?.headers_from_env],
+  ] as const) {
+    if (map === undefined) continue;
+    for (const [name, value] of entries(map, kind, 32)) {
+      const lower = name.toLowerCase();
+      if (
+        !isSafeAnalyticsKey(lower) ||
+        name.length > 128 ||
+        !/^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/.test(name) ||
+        seen.has(lower)
+      )
+        invalid('header names (invalid or case-insensitive conflict)');
+      seen.add(lower);
+      if (kind === 'headers_from_env') {
+        if (
+          typeof value !== 'string' ||
+          value.length > 128 ||
+          !ENV_VAR_NAME_PATTERN.test(value) ||
+          isAllowedEnvVar(value) ||
+          value.startsWith(TRUSTED_LAUNCHER_ENV_PREFIX)
+        )
+          invalid('headers_from_env variable name (must not be inherited by child processes)');
+      } else if (!isValidAnalyticsHeaderValue(value, false)) invalid('headers value');
+    }
+  }
+}
+
+export function isValidAnalyticsHeaderValue(
+  value: unknown,
+  requireNonempty: boolean
+): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length <= 8192 &&
+    (!requireNonempty || value.trim().length > 0) &&
+    /^[\t\x20-\x7e]*$/.test(value)
+  );
+}

--- a/packages/core/src/config/config-manager.test.ts
+++ b/packages/core/src/config/config-manager.test.ts
@@ -1480,6 +1480,43 @@ describe('loadConfig cache', () => {
     }
   );
 
+  it('keeps analytics env references unresolved across load/export paths without rewriting YAML', async () => {
+    const body = `# Deployment-owned configuration\nanalytics:
+  enabled: true
+  client: { app: agor-cloud-daemon, version: "1.0", debug: false }
+  extras: { environment: cloud, deployment: agor-cloud-production-aws-us1a }
+  plugins:
+    - type: http_batch
+      enabled: true
+      options:
+        url: https://example.test/batch
+        headers_from_env: { Authorization: AGOR_ANALYTICS_TEST_EXPORT_AUTH }
+`;
+    const configPath = await writeConfigFile(body);
+    vi.stubEnv('AGOR_ANALYTICS_TEST_EXPORT_AUTH', 'synthetic-secret-not-for-config');
+    try {
+      for (const loaded of [await loadConfig(), loadConfigSync()]) {
+        const resolved = resolveEffectiveConfig(loaded);
+        expect(resolved.analytics?.extras).toEqual({
+          environment: 'cloud',
+          deployment: 'agor-cloud-production-aws-us1a',
+        });
+        expect(yaml.dump(resolved)).toContain('AGOR_ANALYTICS_TEST_EXPORT_AUTH');
+        expect(yaml.dump(resolved)).not.toContain('synthetic-secret-not-for-config');
+        expect(JSON.stringify(resolved)).not.toContain('synthetic-secret-not-for-config');
+      }
+      expect(await fs.readFile(configPath, 'utf-8')).toBe(body);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('rejects poisoned analytics extras on both YAML load paths', async () => {
+    await writeConfigFile('analytics:\n  extras:\n    __proto__: poisoned\n');
+    expect(() => loadConfigSync()).toThrow('invalid analytics extras');
+    await expect(loadConfig()).rejects.toThrow('invalid analytics extras');
+  });
+
   it('rejects removed analytics module plugins on every load path', async () => {
     await writeConfigFile(
       'analytics:\n  enabled: false\n  plugins:\n    - type: module\n      enabled: false\n      options:\n        module_path: /opt/agor/plugin.js\n'

--- a/packages/core/src/config/config-manager.ts
+++ b/packages/core/src/config/config-manager.ts
@@ -16,6 +16,7 @@ import type { AgenticToolName } from '../types';
 import { normalizeHttpBaseUrl } from '../utils/url';
 import { ensureAgorHome, ensureAgorHomeSync, getAgorHome, getConfigPath } from './agor-home';
 import { getDefaultAnalyticsConfig } from './analytics-defaults.js';
+import { validateAnalyticsHeaders, validateAnalyticsMetadata } from './analytics-validation.js';
 import { DAEMON, ENVIRONMENT, MCP_TOKEN } from './constants';
 import { validateRedisKeyPrefix, validateRedisUrl } from './deployment';
 import {
@@ -1007,9 +1008,10 @@ function validateConfig(config: AgorConfig): void {
   only(legacyConfig.branches, 'branches', RETIRED_CONFIG_KEYS.branches);
   only(config.teammates, 'teammates', ['framework_repo_url']);
   only(config.paths, 'paths', ['data_home']);
-  only(config.analytics, 'analytics', ['enabled', 'client', 'filters', 'plugins']);
+  only(config.analytics, 'analytics', ['enabled', 'client', 'extras', 'filters', 'plugins']);
   only(config.analytics?.client, 'analytics.client', ['app', 'version', 'debug']);
   only(config.analytics?.filters, 'analytics.filters', ['exclude_events']);
+  if (config.analytics) validateAnalyticsMetadata(config.analytics);
   for (const [index, plugin] of (config.analytics?.plugins ?? []).entries()) {
     only(plugin, `analytics.plugins[${index}]`, ['type', 'enabled', 'options']);
     switch (plugin.type) {
@@ -1023,7 +1025,9 @@ function validateConfig(config: AgorConfig): void {
           'max_batch_size',
           'timeout_ms',
           'headers',
+          'headers_from_env',
         ]);
+        validateAnalyticsHeaders(plugin.options);
         break;
       default: {
         const unsupported: never = plugin;

--- a/packages/core/src/config/env-inheritance.ts
+++ b/packages/core/src/config/env-inheritance.ts
@@ -1,0 +1,86 @@
+/** Reserved ambient credential namespace for trusted operator launcher helpers only. */
+export const TRUSTED_LAUNCHER_ENV_PREFIX = 'AGOR_CLOUD_';
+
+/**
+ * SECURITY: Allowlisted environment variable names that are safe to pass
+ * to user/agent processes. Any variable NOT in this list (or matching a
+ * prefix below) will be stripped.
+ *
+ * This is an allowlist (not a blocklist) so that new sensitive variables
+ * added to the daemon environment don't accidentally leak to sessions.
+ */
+export const ALLOWED_ENV_VARS = new Set([
+  // Shell essentials
+  'PATH',
+  'HOME',
+  'USER',
+  'LOGNAME',
+  'SHELL',
+
+  // Temp directories
+  'TMPDIR',
+  'TMP',
+  'TEMP',
+
+  // Locale
+  'LANG',
+  'LANGUAGE',
+
+  // Terminal
+  'TERM',
+  'COLORTERM',
+  'TERM_PROGRAM',
+  'TERM_PROGRAM_VERSION',
+
+  // Host SSH/GPG agent sockets are intentionally not forwarded. They are
+  // credential capabilities, not inert process metadata; projecting the
+  // daemon account's socket into a user, sandbox, or delegated executor would
+  // let that executor authenticate as the daemon. Users may still configure
+  // their own explicit env mapping where the execution substrate provides a
+  // user-scoped agent.
+
+  // Logging controls. Keep executor log filtering aligned with the daemon.
+  'LOG_LEVEL',
+
+  // Explicit operator-owned Git safety policy. This is resolved from
+  // security.git_config_parameters at daemon startup; it is not arbitrary
+  // shell context inherited from the account that launched the daemon.
+  'GIT_CONFIG_PARAMETERS',
+
+  // Agor session context (safe for executor/sessions)
+  'DAEMON_URL',
+
+  // Managed agentic tool runtime. These locate the version-aligned integration
+  // tree (~/.agor/agentic-tools/<version>/<tool>) that loadManagedAgenticToolSdk
+  // resolves against; they are host runtime metadata, identical for every
+  // tenant, and carry no credentials.
+  //
+  // They must be allowlisted, not merely forwarded: session executors are
+  // spawned with `preparedEnv` built by createUserProcessEnvironment(), which
+  // takes precedence over spawn-executor's own forwarding. Without them here
+  // the executor sees AGOR_MANAGED_AGENTIC_TOOLS unset, falls back to importing
+  // the vendor SDK by bare specifier, and every session fails with
+  // "Cannot find package '@openai/codex-sdk'".
+  'AGOR_VERSION',
+  'AGOR_AGENTIC_TOOLS_DIR',
+  'AGOR_MANAGED_AGENTIC_TOOLS',
+]);
+
+/**
+ * Environment variable prefixes that are safe to pass through.
+ * Any variable starting with one of these prefixes is allowed.
+ */
+export const ALLOWED_ENV_PREFIXES = [
+  'LC_', // Locale settings (LC_ALL, LC_CTYPE, etc.)
+];
+
+/**
+ * Check if an environment variable name is allowed to be passed to child processes.
+ */
+export function isAllowedEnvVar(key: string): boolean {
+  if (ALLOWED_ENV_VARS.has(key)) return true;
+  for (const prefix of ALLOWED_ENV_PREFIXES) {
+    if (key.startsWith(prefix)) return true;
+  }
+  return false;
+}

--- a/packages/core/src/config/env-resolver.ts
+++ b/packages/core/src/config/env-resolver.ts
@@ -12,80 +12,14 @@ import type {
   UserID,
 } from '../types';
 import { filterEnv } from './env-blocklist';
+import { isAllowedEnvVar } from './env-inheritance';
 import { normalizeStoredEnvMap, type StoredEnvVar } from './env-vars';
 
-/**
- * SECURITY: Allowlisted environment variable names that are safe to pass
- * to user/agent processes. Any variable NOT in this list (or matching a
- * prefix below) will be stripped.
- *
- * This is an allowlist (not a blocklist) so that new sensitive variables
- * added to the daemon environment don't accidentally leak to sessions.
- */
-export const ALLOWED_ENV_VARS = new Set([
-  // Shell essentials
-  'PATH',
-  'HOME',
-  'USER',
-  'LOGNAME',
-  'SHELL',
-
-  // Temp directories
-  'TMPDIR',
-  'TMP',
-  'TEMP',
-
-  // Locale
-  'LANG',
-  'LANGUAGE',
-
-  // Terminal
-  'TERM',
-  'COLORTERM',
-  'TERM_PROGRAM',
-  'TERM_PROGRAM_VERSION',
-
-  // Host SSH/GPG agent sockets are intentionally not forwarded. They are
-  // credential capabilities, not inert process metadata; projecting the
-  // daemon account's socket into a user, sandbox, or delegated executor would
-  // let that executor authenticate as the daemon. Users may still configure
-  // their own explicit env mapping where the execution substrate provides a
-  // user-scoped agent.
-
-  // Logging controls. Keep executor log filtering aligned with the daemon.
-  'LOG_LEVEL',
-
-  // Explicit operator-owned Git safety policy. This is resolved from
-  // security.git_config_parameters at daemon startup; it is not arbitrary
-  // shell context inherited from the account that launched the daemon.
-  'GIT_CONFIG_PARAMETERS',
-
-  // Agor session context (safe for executor/sessions)
-  'DAEMON_URL',
-
-  // Managed agentic tool runtime. These locate the version-aligned integration
-  // tree (~/.agor/agentic-tools/<version>/<tool>) that loadManagedAgenticToolSdk
-  // resolves against; they are host runtime metadata, identical for every
-  // tenant, and carry no credentials.
-  //
-  // They must be allowlisted, not merely forwarded: session executors are
-  // spawned with `preparedEnv` built by createUserProcessEnvironment(), which
-  // takes precedence over spawn-executor's own forwarding. Without them here
-  // the executor sees AGOR_MANAGED_AGENTIC_TOOLS unset, falls back to importing
-  // the vendor SDK by bare specifier, and every session fails with
-  // "Cannot find package '@openai/codex-sdk'".
-  'AGOR_VERSION',
-  'AGOR_AGENTIC_TOOLS_DIR',
-  'AGOR_MANAGED_AGENTIC_TOOLS',
-]);
-
-/**
- * Environment variable prefixes that are safe to pass through.
- * Any variable starting with one of these prefixes is allowed.
- */
-export const ALLOWED_ENV_PREFIXES = [
-  'LC_', // Locale settings (LC_ALL, LC_CTYPE, etc.)
-];
+export {
+  ALLOWED_ENV_PREFIXES,
+  ALLOWED_ENV_VARS,
+  TRUSTED_LAUNCHER_ENV_PREFIX,
+} from './env-inheritance';
 
 /**
  * @deprecated Use ALLOWED_ENV_VARS instead. Kept for backward compatibility
@@ -261,17 +195,6 @@ export function resolveSystemEnvironment(): Record<string, string> {
  * Used by MCP template resolver to restrict template context to user-scoped vars only.
  */
 export const AGOR_USER_ENV_KEYS_VAR = 'AGOR_USER_ENV_KEYS';
-
-/**
- * Check if an environment variable name is allowed to be passed to child processes.
- */
-function isAllowedEnvVar(key: string): boolean {
-  if (ALLOWED_ENV_VARS.has(key)) return true;
-  for (const prefix of ALLOWED_ENV_PREFIXES) {
-    if (key.startsWith(prefix)) return true;
-  }
-  return false;
-}
 
 /**
  * Build a minimal environment from process.env using the allowlist.

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -1290,6 +1290,9 @@ export interface AgorAnalyticsSettings {
     debug?: boolean;
   };
 
+  /** Operator-owned, flat non-secret deployment metadata. See the config guide for bounds. */
+  extras?: Record<string, string | number | boolean>;
+
   /** Simple event-name filters. */
   filters?: {
     /** Exact names or simple `*` globs to exclude before delivery. */
@@ -1322,8 +1325,10 @@ export interface AgorAnalyticsHttpBatchPluginSettings {
     flush_interval_ms?: number;
     max_batch_size?: number;
     timeout_ms?: number;
-    /** Static headers only. */
+    /** Static non-secret headers. Use headers_from_env for credentials. */
     headers?: Record<string, string>;
+    /** Header names mapped to daemon environment variable names, never resolved into config. */
+    headers_from_env?: Record<string, string>;
   };
 }
 


### PR DESCRIPTION
## Summary
Implements the agreed upstream runtime contract for companion agor-cloud branch `cloud-env-telemetry-tagging` ([Cloud draft PR #518](https://github.com/preset-io/agor-cloud/pull/518)). This changes operator-configured **analytics**, not application-wide logs, opt-in OSS telemetry, or metrics/APM. No agor-cloud files were changed and no live credentials/endpoints were used.

## Config and payload contract
```yaml
analytics:
  enabled: true
  client: { app: agor-cloud-daemon, version: "1.0", debug: false }
  extras: { environment: cloud, deployment: agor-cloud-production-aws-us1a }
  plugins:
    - type: http_batch
      enabled: true
      options:
        url: https://api.segment.io/v1/batch
        headers_from_env: { Authorization: AGOR_ANALYTICS_AUTHORIZATION }
        flush_interval_ms: 1000
        max_batch_size: 50
        timeout_ms: 3000
```
- Both configured stdout and HTTP batch carry `context.app.name = client.app`, `context.app.version = String(client.version)` when present, and `context.extras = extras` (empty object if omitted). Existing client defaults remain `agor-daemon` / `dev` / debug false.
- App/extras are operator-owned initialization snapshots; caller collisions cannot replace them. The logger removes reserved and prototype-poison context keys before the real Analytics client merges options.
- `context.tenant_id` still comes exclusively from the trusted ambient runtime tenant scope, never deployment extras or a caller. Outside scope it is absent. Nonreserved caller context, identities, properties, and exclusion filters remain working.
- Extras: plain flat mapping, max 32 entries; key regex `[A-Za-z0-9_][A-Za-z0-9_.-]{0,63}`; reject `__proto__`, `constructor`, `prototype`; scalar strings <=1024 UTF-8 bytes, finite numbers, booleans. No null/arrays/objects. Operator must select nonsecret, non-PII labels; this is structural validation, not a PII detector.
- App/version strings: nonblank, <=256 UTF-8 bytes; finite numeric versions normalize to strings.

## Auth and process boundaries
- `headers_from_env` contains names only. Values resolve solely inside the HTTP transport closure, never into YAML, effective/exported config, SDK plugin config/debug state, or executor resolved-config projection.
- Each header map (`headers`, `headers_from_env`) allows 32 entries; names are HTTP tokens <=128 ASCII chars, no poison names; case-insensitive duplicates within/across maps fail. Env variable names match `[A-Z_][A-Z0-9_]*`, <=128 chars.
- Env names inherited by child processes are disallowed (shared runtime allowlist, `LC_*`, reserved trusted-launcher `AGOR_CLOUD_*`). **The proposed `AGOR_ANALYTICS_AUTHORIZATION` is supported.** Runtime env inheritance identifiers now have a shared lightweight owner; actual inheritance behavior is unchanged.
- Values allow HTAB/printable ASCII only, <=8192 bytes; env-backed values must be present and nonblank. Invalid/missing/empty/conflicting auth fails closed with bounded value-free errors. Daemon configuration falls back to disabled analytics, preserving existing failure semantics. Structural validation applies to disabled config, but disabled analytics/plugins never resolve env values.
- HTTP redirects are refused and raw fetch exceptions are not logged. Static nonsecret headers remain supported.
- Dedicated ambient analytics credentials are absent from user/tool env assembly, trusted launcher env, and executor stdin payloads. Do not separately map daemon credentials into user environments. Simple mode remains trusted-local execution, not host-account isolation.

## Validation
All HTTP delivery uses mock fetch and synthetic credentials only.
- `pnpm --filter @agor/core exec vitest run src/analytics src/config/analytics-validation.test.ts src/config/config-manager.test.ts src/config/env-resolver.test.ts` — **272 passed**.
- `pnpm --filter @agor/daemon exec vitest run src/utils/spawn-executor.resolved-config.test.ts src/utils/spawn-executor.configured.test.ts` — **76 passed**.
- `pnpm --filter @agor/core run typecheck` — passed.
- `pnpm --filter @agor/daemon exec tsc --noEmit --customConditions source` — passed.
- `pnpm lint` — passed (2884 files; 330 design-system fixture cases).
- `pnpm check:multitenancy-boundaries`, `pnpm check:daemon-filesystem-boundaries` — passed.
- Docs Prettier check/format and normal pre-commit hook — passed; no hook bypass.

Actual Analytics-client -> captured HTTP/stdout coverage includes two deployment environments, cross-tenant caller spoof attempts, no-tenant events, prototype/inherited context, metadata snapshots, identities/properties, filters, defaults/disabled behavior, valid/missing/empty/invalid/conflicting env auth, debug/error-log non-disclosure, YAML/effective config non-resolution, and executor env/payload exclusion. Config bounds have negative coverage and YAML load paths reject poison keys.

Follow-up full validation (requested after the initial PR):
- `pnpm i` — passed, no tracked dependency changes.
- `pnpm check` — **passed**, including full workspace typechecking, lint, short-ID and tenant/filesystem/realtime boundary checks, and non-docs builds.
- Relevant test commands above rerun — **272 core + 76 daemon tests passed**.
- Working tree remains clean at `b39e934773bbb3ea77b6b5a4f43ab607cf4172a0`; no additional fix commit was needed.

The earlier fresh-worktree typecheck limitations are superseded by this successful full `pnpm check`.

## Tenant/security assessment
Static metadata and destination auth are narrowly operator-owned system/global resources. Tenant event identity remains captured at the existing trusted ambient boundary before async delivery; tests attempt to replace it with a foreign tenant, and verify no identity is synthesized outside scope. No tenant-derived auth or global-to-tenant config projection was introduced.

## Runtime / Cloud rollout dependency
Minimum runtime is an Agor artifact containing **b39e934773bbb3ea77b6b5a4f43ab607cf4172a0** (or its eventual merged equivalent). There is **no assigned/published minimum release version** in this task. Roll that runtime to every relevant daemon replica before enabling these new YAML keys in `cloud-env-telemetry-tagging`; older runtimes reject them. Provision a separately rotated credential via Cloud's secret mechanism and restart to resolve it. Nothing was deployed or tested against live Segment.



## Independent review follow-up
The initial Codex review found no merge blockers or substantive correctness issues. Its one scoped improvement was accepted in `365c157e7f53093dd12c99e33139d7fa242dabdb`: logger and serializer now import one immutable operator-owned context key family (`app` / `extras`), while tenant stripping remains exclusively at the logger boundary. No payload/auth/config contract changed. Targeted validation after the refactor: 272 core tests, core no-emit typecheck, and touched-file Biome checks passed. The same reviewer completed follow-up review of `365c157e7f53093dd12c99e33139d7fa242dabdb`: **no substantive issues or merge blockers remain**. Reviewer model: `gpt-6-astra`, effort `medium`. No feedback was skipped. Applied `ai-reviewed-gpt-6-astra`.

