### PR TITLE
fix(analytics): unify Segment Track events under agor_event

### DIFF
--- a/apps/agor-docs/content/faq.mdx
+++ b/apps/agor-docs/content/faq.mdx
@@ -698,6 +698,12 @@ When ongoing telemetry is enabled, Agor sends lightweight install and aggregate 
 
 Agor does **not** send prompts, messages, repo names or remotes, file paths, user emails or names, branch/session/task IDs, code, tool output, secrets, tokens, or raw custom model names.
 
+The outbound Segment Track name is `agor_event`; `properties.event_type` retains
+semantic names such as `daemon.start` and `usage.daily_summary`. See the
+[analytics rollout notes](/guide/config-yaml#segment-event-naming-and-rollout)
+for the breaking rename and warehouse limitations. This does not change consent
+or the collected fields.
+
 You can inspect the setting with `agor telemetry`. Change it in deployment-owned
 `config.yaml`, or use an environment override:
 

--- a/apps/agor-docs/content/guide/config-yaml.mdx
+++ b/apps/agor-docs/content/guide/config-yaml.mdx
@@ -333,6 +333,50 @@ options to the analytics client.
 Only use non-secret, non-PII deployment labels. Bounds are structural validation,
 not a PII detector; operators own field selection and destination access/retention.
 
+### Segment event naming and rollout
+
+Both built-in analytics transports now emit `type: 'track'`, `event: 'agor_event'`,
+and `properties.event_type` containing the original semantic name (for example,
+`task.completed`). Community telemetry uses the same wire convention but retains
+its separate opt-in and privacy rules. The canonical original name wins over a
+caller-supplied `properties.event_type`; other properties, including nested values,
+keep their current shape. Internal event names and app analytics remain unchanged;
+`exclude_events` still matches original names, not `agor_event`.
+
+This is a **breaking outbound rename**, including stdout and non-Segment HTTP
+consumers. Segment's [Track spec](https://www.twilio.com/docs/segment/connections/spec/track)
+distinguishes the protocol `type` from the `event` name. `event_type` is not a
+listed common reserved Track property or warehouse column; validate destination-specific
+rules before rollout. Do not substitute `agor_event` for the protocol `track` type.
+
+Segment's [warehouse schema](https://www.twilio.com/docs/segment/connections/storage/warehouses/schema)
+creates event-specific tables within each source schema. New Track events therefore
+target `<source>.agor_event` in the standard warehouse mapping (alongside `tracks`).
+This does not combine sources/schemas or Identify, Page, Group, or other method tables.
+The connector flattens nested objects but generally stringifies arrays; a constant
+name does not guarantee arbitrary JSON becomes flat columns. Reserved column collisions
+(such as `id`, `event`, or `user_id`), normalized-name collisions, inferred types,
+column limits, and destination mappings still require review. Agor adds no flattening.
+
+Rollout checklist (operator work, not performed automatically):
+
+- Update destination action mappings, filters, transformations, and tracking plans
+  to accept `agor_event` and branch on `properties.event_type` for semantic actions.
+- Review downstream queries/dashboards and property types across previously separate
+  events; retain original-name Agor exclusion filters.
+- Record the cutover for every replica/source. Buffered events from an older process
+  retain the older payload; newly converted events use the new name. There is no dual-write.
+- Keep historical tables. A rename does not consolidate them; if needed, separately
+  authorize a historical UNION/view with aligned columns/types and deduplication.
+  See Segment's [historical data FAQ](https://www.twilio.com/docs/segment/connections/storage/warehouses/faq).
+- Validate destination delivery and schema after the separately authorized rollout.
+  No warehouse migration, backfill, live destination configuration, or dashboard edit
+  is included in this change.
+
+These transports use best-effort in-memory batches, not a persisted event outbox;
+failed HTTP batches are not retried. This rename does not change those guarantees
+or introduce event IDs/message IDs that the existing adapters did not send.
+
 ### HTTP authentication from daemon environment
 
 `options.headers_from_env` maps HTTP header names to **environment variable names**.

--- a/packages/core/src/analytics/analytics.test.ts
+++ b/packages/core/src/analytics/analytics.test.ts
@@ -145,6 +145,8 @@ describe('analytics logger', () => {
 describe('analytics plugins', () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
   });
 
   it('stdout emits Segment-like track JSON', () => {
@@ -167,9 +169,9 @@ describe('analytics plugins', () => {
     expect(log).toHaveBeenCalledTimes(1);
     expect(JSON.parse(log.mock.calls[0][0] as string)).toEqual({
       type: 'track',
-      event: 'session.created',
+      event: 'agor_event',
       userId: 'user-1',
-      properties: { session_id: 'session-1' },
+      properties: { session_id: 'session-1', event_type: 'session.created' },
       context: { source: 'test' },
       timestamp: '2026-01-01T00:00:00.000Z',
     });
@@ -210,9 +212,9 @@ describe('analytics plugins', () => {
       batch: [
         {
           type: 'track',
-          event: 'task.completed',
+          event: 'agor_event',
           userId: 'user-1',
-          properties: { task_id: 'task-1', duration_ms: 123 },
+          properties: { task_id: 'task-1', duration_ms: 123, event_type: 'task.completed' },
           context: {},
           timestamp: '2026-01-01T00:00:00.000Z',
         },
@@ -251,7 +253,7 @@ describe('analytics plugins', () => {
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
     const [, secondInit] = fetchMock.mock.calls[1] as unknown as [string, RequestInit];
     expect(JSON.parse(secondInit.body as string).batch).toEqual([
-      expect.objectContaining({ event: 'second' }),
+      expect.objectContaining({ event: 'agor_event', properties: { event_type: 'second' } }),
     ]);
   });
 

--- a/packages/core/src/analytics/delivery.test.ts
+++ b/packages/core/src/analytics/delivery.test.ts
@@ -92,6 +92,9 @@ describe('actual Analytics client delivery', () => {
         expect(init?.headers).toMatchObject({ Authorization: SECRET, 'x-source': 'agor' });
         expect(init?.redirect).toBe('error');
         const event = JSON.parse(init?.body as string).batch[0];
+        expect(event.type).toBe('track');
+        expect(event.event).toBe('agor_event');
+        expect(event.properties.event_type).toBe(tenant ? 'task.completed' : 'daemon.event');
         expect(event.context).toEqual({
           source: 'caller',
           app: { name: `agor-${environment}-daemon`, version: '1' },
@@ -177,12 +180,18 @@ describe('actual Analytics client delivery', () => {
 
   it('does not resolve missing credentials for disabled analytics or plugins', async () => {
     vi.stubEnv(ENV_NAME, undefined);
-    expect((await createAnalyticsLogger({ ...settings(), enabled: false })).isEnabled()).toBe(
-      false
-    );
+    const fetchMock = vi.fn<typeof fetch>();
+    vi.stubGlobal('fetch', fetchMock);
+    const disabled = await createAnalyticsLogger({ ...settings(), enabled: false });
+    expect(disabled.isEnabled()).toBe(false);
+    disabled.track('task.completed');
     const config = settings();
     for (const plugin of config.plugins ?? []) plugin.enabled = false;
-    expect((await createAnalyticsLogger(config)).isEnabled()).toBe(true);
+    const logger = await createAnalyticsLogger(config);
+    expect(logger.isEnabled()).toBe(true);
+    logger.track('task.completed');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('fails closed on a static/env header collision without sending or logging either value', async () => {

--- a/packages/core/src/analytics/plugins.ts
+++ b/packages/core/src/analytics/plugins.ts
@@ -9,6 +9,7 @@ import type {
   AgorAnalyticsSettings,
   AgorAnalyticsStdoutPluginSettings,
 } from '../config/types.js';
+import { segmentTrackFields } from './segment.js';
 import { OPERATOR_OWNED_ANALYTICS_CONTEXT_KEYS, type ResolvedAnalyticsPlugin } from './types.js';
 
 interface AnalyticsTrackPayload {
@@ -55,8 +56,7 @@ export function toSegmentLikeTrack(
 
   const event: Record<string, unknown> = {
     type: 'track',
-    event: payload.event,
-    properties: payload.properties ?? {},
+    ...segmentTrackFields(payload.event, payload.properties),
     context: {
       ...Object.fromEntries(
         Object.entries(payload.options?.context ?? {}).filter(

--- a/packages/core/src/analytics/segment.test.ts
+++ b/packages/core/src/analytics/segment.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createOpenSourceTelemetryLogger } from '../telemetry/logger.js';
+import { createHttpBatchAnalyticsPlugin, createStdoutAnalyticsPlugin } from './plugins.js';
+import { SEGMENT_TRACK_EVENT_NAME } from './segment.js';
+
+const timestamp = '2026-01-01T00:00:00.000Z';
+
+describe('unified Segment Track boundary', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+    vi.useRealTimers();
+  });
+
+  it('maps two queued operator events without mutating internal records or metadata', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(timestamp);
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response(null));
+    vi.stubGlobal('fetch', fetchMock);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const http = createHttpBatchAnalyticsPlugin({
+      type: 'http_batch',
+      enabled: true,
+      options: { url: 'https://example.test/batch', max_batch_size: 10, flush_interval_ms: 100 },
+    });
+    const stdout = createStdoutAnalyticsPlugin({ type: 'stdout', enabled: true });
+    const records = ['task.created', 'task.completed'].map((event) => ({
+      event,
+      properties: Object.freeze({
+        event_type: 'caller-conflict',
+        action: 'synthetic-action',
+        event_id: 'synthetic-event-id',
+        nested: { count: 2, tags: ['safe'] },
+      }),
+      options: { userId: 'user-1', anonymousId: 'anon-1', context: { tenant_id: 'tenant-a' } },
+      meta: { ts: Date.parse(timestamp) },
+    }));
+    const snapshot = structuredClone(records);
+    for (const record of records) {
+      http?.track?.({ payload: record });
+      stdout.track?.(record); // Both supported SDK wrapper and direct payload shapes.
+    }
+    expect(fetchMock).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(100);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const body = JSON.parse(fetchMock.mock.calls[0][1]?.body as string);
+    expect(body).toEqual({
+      sentAt: '2026-01-01T00:00:00.100Z',
+      batch: records.map((record) => ({
+        type: 'track',
+        event: SEGMENT_TRACK_EVENT_NAME,
+        properties: { ...record.properties, event_type: record.event },
+        userId: 'user-1',
+        anonymousId: 'anon-1',
+        context: { tenant_id: 'tenant-a' },
+        timestamp,
+      })),
+    });
+    expect(body.batch.map((event: { event: string }) => event.event)).toEqual([
+      'agor_event',
+      'agor_event',
+    ]);
+    expect(log.mock.calls.map(([value]) => JSON.parse(value as string))).toEqual(body.batch);
+    expect(records).toEqual(snapshot);
+    await http?.flush?.();
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it('retains best-effort failure behavior without retries or duplicate events', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 503 }));
+    vi.stubGlobal('fetch', fetchMock);
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const plugin = createHttpBatchAnalyticsPlugin({
+      type: 'http_batch',
+      enabled: true,
+      options: { url: 'https://example.test/batch', max_batch_size: 10 },
+    });
+    plugin?.track?.({ event: 'task.completed' });
+    await plugin?.flush?.();
+    await vi.advanceTimersByTimeAsync(5000);
+    await plugin?.flush?.();
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(JSON.parse(fetchMock.mock.calls[0][1]?.body as string).batch).toEqual([
+      expect.objectContaining({
+        event: 'agor_event',
+        properties: { event_type: 'task.completed' },
+      }),
+    ]);
+  });
+
+  it('maps the alternate telemetry HTTP path after redaction, retaining anonymous identity', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(timestamp);
+    vi.stubEnv('AGOR_TELEMETRY', '1');
+    vi.stubEnv('DO_NOT_TRACK', undefined);
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response(null));
+    vi.stubGlobal('fetch', fetchMock);
+    const logger = createOpenSourceTelemetryLogger({
+      telemetry: {
+        enabled: true,
+        instance_id: 'install-1',
+        endpoint: 'https://example.test/batch',
+      },
+    });
+    const properties = Object.freeze({
+      event_type: 'caller-conflict',
+      action: 'synthetic-action',
+      prompt: 'must-not-leave',
+      nested: { count: 2, token: 'must-not-leave' },
+    });
+    for (const event of ['daemon.start', 'daemon.active'] as const) {
+      logger.track({ event, properties, timestamp });
+    }
+    await logger.flush();
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(JSON.parse(fetchMock.mock.calls[0][1]?.body as string)).toEqual({
+      sentAt: timestamp,
+      batch: ['daemon.start', 'daemon.active'].map((event_type) => ({
+        type: 'track',
+        event: 'agor_event',
+        anonymousId: 'install-1',
+        properties: { event_type, action: 'synthetic-action', nested: { count: 2 } },
+        timestamp,
+        context: { app: 'agor', telemetry: 'open-source' },
+      })),
+    });
+    expect(properties.event_type).toBe('caller-conflict');
+    expect(properties.nested.token).toBe('must-not-leave');
+  });
+
+  it.each(['DO_NOT_TRACK', 'AGOR_TELEMETRY'] as const)(
+    'honors the %s telemetry kill switch',
+    async (key) => {
+      vi.stubEnv('AGOR_TELEMETRY', '1');
+      vi.stubEnv('DO_NOT_TRACK', undefined);
+      vi.stubEnv(key, key === 'DO_NOT_TRACK' ? '1' : '0');
+      const fetchMock = vi.fn<typeof fetch>();
+      vi.stubGlobal('fetch', fetchMock);
+      const logger = createOpenSourceTelemetryLogger({
+        telemetry: {
+          enabled: true,
+          instance_id: 'install-1',
+          endpoint: 'https://example.test/batch',
+        },
+      });
+      logger.track({ event: 'daemon.start', properties: {} });
+      await logger.flush();
+      expect(logger.isEnabled()).toBe(false);
+      expect(fetchMock).not.toHaveBeenCalled();
+    }
+  );
+});

--- a/packages/core/src/analytics/segment.ts
+++ b/packages/core/src/analytics/segment.ts
@@ -1,0 +1,13 @@
+/** Shared wire name for operator analytics and opt-in community telemetry. */
+export const SEGMENT_TRACK_EVENT_NAME = 'agor_event';
+
+/** Keep semantic names internal; reserve event_type only on the outbound copy. */
+export function segmentTrackFields(
+  eventType: string | undefined,
+  properties: Record<string, unknown> = {}
+): { event: string; properties: Record<string, unknown> } {
+  return {
+    event: SEGMENT_TRACK_EVENT_NAME,
+    properties: { ...properties, event_type: eventType },
+  };
+}

--- a/packages/core/src/telemetry/logger.ts
+++ b/packages/core/src/telemetry/logger.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import { segmentTrackFields } from '../analytics/segment.js';
 import type { AgorConfig } from '../config/types.js';
 import type {
   OpenSourceTelemetryConfig,
@@ -151,9 +152,8 @@ export class BatchedOpenSourceTelemetryLogger implements OpenSourceTelemetryLogg
     try {
       const payload: SegmentTrackPayload = {
         type: 'track',
-        event: input.event,
+        ...segmentTrackFields(input.event, sanitizeTelemetryProperties(input.properties)),
         anonymousId: this.config.instanceId,
-        properties: sanitizeTelemetryProperties(input.properties),
         timestamp: input.timestamp ?? new Date().toISOString(),
         context: { app: 'agor', telemetry: 'open-source' },
       };

--- a/packages/core/src/telemetry/telemetry.test.ts
+++ b/packages/core/src/telemetry/telemetry.test.ts
@@ -92,9 +92,9 @@ describe('open-source telemetry payload hygiene', () => {
     expect(transport.batches).toHaveLength(1);
     expect(transport.batches[0].batch[0]).toMatchObject({
       type: 'track',
-      event: 'install.completed',
+      event: 'agor_event',
       anonymousId: 'instance-1',
-      properties: { ongoing_telemetry_enabled: true },
+      properties: { ongoing_telemetry_enabled: true, event_type: 'install.completed' },
     });
     vi.useRealTimers();
   });


### PR DESCRIPTION
## Summary

Implement Max's request: one outbound Segment Track name, `agor_event`, with the original semantic name in `properties.event_type`. No dual-write.

A small shared boundary helper is used by operator analytics (`http_batch` and its stdout mirror) and the alternate opt-in community telemetry batch path. Original names win over conflicting caller properties on a fresh property object. Protocol `type` remains `track`.

## Trace / scope

- Operator producers: task lifecycle, branch creation, session create hook/scheduler, and primary-teammate repository → `analyticsLogger.track(originalName, curatedProperties, identity)` → exclusion filter and trusted tenant context → Analytics SDK → shared Segment-like converter → stdout / in-memory HTTP batch.
- Community producers: CLI install/test, daemon start/active/upgrade, and daily usage aggregation → telemetry logger → existing property sanitizer → shared wire mapping → in-memory batch → `SegmentHttpTelemetryTransport`.
- There is no persisted analytics event table/outbox or `event_type` analytics column in the current schemas. Durable task/session/branch records and usage accounting remain unchanged; the leaderboard queries task data rather than Segment. No internal event enums/names or producer calls changed.
- Both transports are best-effort; failed HTTP batches are not retried or durably replayed today. Timed, size-triggered and in-flight-queued sends use the same conversion. Existing summary/heartbeat deduplication and scheduler winner guards are untouched.
- Neither adapter currently emits a Segment `messageId`; this PR does not add IDs, change timestamps/identity/context, broaden collection, flatten data, or change transport/retry semantics. Existing event-ID properties remain intact. No additional event sends or payload logging.
- Repo search found no Segment tracking-plan/destination mapping definitions to edit. Existing consumers are tests, config guidance and the telemetry FAQ; those are updated. External consumers require the rollout work below.

## Synthetic before / after

Before (one batch member):
```json
{"type":"track","event":"task.completed","userId":"user-1","anonymousId":"anon-1","properties":{"task_id":"task-1","duration_ms":123},"context":{"tenant_id":"tenant-a"},"timestamp":"2026-01-01T00:00:00.000Z"}
```
After:
```json
{"type":"track","event":"agor_event","userId":"user-1","anonymousId":"anon-1","properties":{"task_id":"task-1","duration_ms":123,"event_type":"task.completed"},"context":{"tenant_id":"tenant-a"},"timestamp":"2026-01-01T00:00:00.000Z"}
```
`task.created` likewise emits `event: "agor_event"`, but `properties.event_type: "task.created"`. Telemetry retains anonymous install identity and sanitization.

## Warehouse verification / breaking rename

Verified official [Track spec](https://www.twilio.com/docs/segment/connections/spec/track), [warehouse schemas](https://www.twilio.com/docs/segment/connections/storage/warehouses/schema), and [warehouse FAQ](https://www.twilio.com/docs/segment/connections/storage/warehouses/faq):

- Segment `event`, not protocol `type`, selects the custom event table. Under standard mapping future events target `<source>.agor_event` (plus the common `tracks` table).
- `event_type` is not listed among common reserved Track properties or warehouse columns. Destination-specific mappings still need verification. Reserved column collisions can discard properties; name normalization and inferred types can collide.
- Objects are connector-flattened and arrays generally stringified. One name does not promise arbitrary flat JSON columns. No destructive flattening here.
- This cannot merge historical tables, distinct source schemas, or Identify/Page/Group tables.

### Rollout checklist — separately authorized operator work

- [ ] Update destination action mappings, filters, transformations and tracking plans for `agor_event`; use `properties.event_type` to distinguish actions.
- [ ] Review property type compatibility/column limits across formerly separate events and downstream queries/dashboards. Agor exclusions still use original semantic names.
- [ ] Record per-replica/source cutover. Old-process buffered payloads keep old names; newly converted batches use the new name. No dual-write or automatic replay.
- [ ] Retain historical tables; separately authorize a historical UNION/view with aligned types and deduplication if needed.
- [ ] Validate warehouse schema and delivery after the separately authorized deployment.

No merge, deployment, live Segment events/configuration, credentials, warehouse ETL/backfill/migration, or dashboard changes were performed.

## Tenancy / privacy review

Operator egress is deployment-configured system infrastructure carrying tenant-derived curated data. The existing logger rejects caller-spoofed tenant/app/extras context and preserves trusted ambient identity; no queries, routing, access controls or tenant boundaries change. Existing mocked delivery tests verify foreign tenant context cannot override trusted identity and that no tenant is invented outside scope. Telemetry remains a separate opt-in anonymous path with recursive redaction and unchanged kill switches. Mapping only copies the already-collected semantic name into a reserved outbound property.

## Validation

- PASS: `pnpm --filter @agor/core exec vitest run src/analytics src/telemetry` — 35 tests, 4 files.
- PASS: `pnpm --filter @agor/daemon exec vitest run src/services/tasks.analytics.test.ts src/utils/analytics-payloads.test.ts src/utils/open-source-telemetry-heartbeat.test.ts src/utils/open-source-telemetry-config.test.ts` — 8 tests, 4 files.
- New deterministic mocked-fetch tests cover two semantic types sharing the wire name, exact metadata/property preservation, nonmutation/conflict precedence, timer batching, no retry/duplicate on failure, telemetry redaction and both kill switches. Existing tests cover in-flight queued delivery, actual SDK filtering, disabled plugins/analytics, credential-safe failure and trusted tenant context.
- PASS: `pnpm check` — repository typecheck, lint, short-ID/multitenancy/filesystem/realtime boundary guards, and non-docs builds.
- PASS: normal pre-commit hook (no bypass). Initial lint-staged backup failed due to the host PWD mount alias; rerunning with PWD matched to the working directory succeeded.
- Commit: `d61d101515a48f0ca58a89d783506af59ebb8062`.
- Limits: no live destination/warehouse validation; full repository test suite and PostgreSQL integration suites not run. No durable-outbox or messageId preservation test is claimed because these send paths have neither.
