### PR TITLE
perf(gateway): avoid duplicate credential hydration during listener discovery

### DIFF
--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -4826,12 +4826,12 @@ export class GatewayService {
 
     const refs = this.listenerDiscoveryTenantId
       ? await this.runWithListenerTenantIdentity(this.listenerDiscoveryTenantId, async () => {
-          const channels = await this.channelRepo.findEnabledListenerCandidates(
+          const channelIds = await this.channelRepo.findEnabledListenerCandidateIds(
             GATEWAY_LISTENER_SCAN_BATCH,
             this.listenerDiscoveryCursor?.channel_id
           );
-          return channels.map((channel) => ({
-            channel_id: channel.id,
+          return channelIds.map((channelId) => ({
+            channel_id: channelId,
             tenant_id: this.listenerDiscoveryTenantId!,
           }));
         })

--- a/packages/core/src/db/gateway-listener-ha.postgres.test.ts
+++ b/packages/core/src/db/gateway-listener-ha.postgres.test.ts
@@ -317,11 +317,11 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)('gateway listener HA (Postg
     expect(refs).toContainEqual({ channel_id: discord.channel.id, tenant_id: tenantA });
 
     await runWithTenantDatabaseScope(db, tenantA, async (scoped) => {
-      const candidates = await new GatewayChannelRepository(scoped).findEnabledListenerCandidates(
+      const candidates = await new GatewayChannelRepository(scoped).findEnabledListenerCandidateIds(
         100
       );
-      expect(candidates.some((channel) => channel.id === a.channel.id)).toBe(true);
-      expect(candidates.some((channel) => channel.id === discord.channel.id)).toBe(true);
+      expect(candidates.includes(a.channel.id)).toBe(true);
+      expect(candidates.includes(discord.channel.id)).toBe(true);
 
       await new GatewayChannelRepository(scoped).claimListener({
         channelId: a.channel.id,
@@ -343,6 +343,9 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)('gateway listener HA (Postg
     });
 
     await runWithTenantDatabaseScope(db, tenantB, async (scoped) => {
+      expect(
+        await new GatewayChannelRepository(scoped).findEnabledListenerCandidateIds(100)
+      ).not.toContain(a.channel.id);
       expect(await new GatewayChannelRepository(scoped).findById(a.channel.id)).toBeNull();
       expect(
         await new GatewayChannelRepository(scoped).claimListener({

--- a/packages/core/src/db/gateway-listener-ha.postgres.test.ts
+++ b/packages/core/src/db/gateway-listener-ha.postgres.test.ts
@@ -303,7 +303,7 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)('gateway listener HA (Postg
     const tenantA = `gateway-a-${generateId()}` as TenantID;
     const tenantB = `gateway-b-${generateId()}` as TenantID;
     const a = await seedChannel(db, tenantA);
-    await seedChannel(db, tenantB);
+    const b = await seedChannel(db, tenantB);
     const discord = await seedChannel(db, tenantA, { channelType: 'discord' });
 
     const refs = await runWithSystemDatabaseScope(
@@ -343,9 +343,13 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)('gateway listener HA (Postg
     });
 
     await runWithTenantDatabaseScope(db, tenantB, async (scoped) => {
-      expect(
-        await new GatewayChannelRepository(scoped).findEnabledListenerCandidateIds(100)
-      ).not.toContain(a.channel.id);
+      const candidates = await new GatewayChannelRepository(scoped).findEnabledListenerCandidateIds(
+        100
+      );
+      expect(candidates).toContain(b.channel.id);
+      // Use an unclaimed foreign channel: a held lease would independently
+      // exclude the row and mask a missing tenant boundary.
+      expect(candidates).not.toContain(discord.channel.id);
       expect(await new GatewayChannelRepository(scoped).findById(a.channel.id)).toBeNull();
       expect(
         await new GatewayChannelRepository(scoped).claimListener({

--- a/packages/core/src/db/repositories/gateway-channels.reads.test.ts
+++ b/packages/core/src/db/repositories/gateway-channels.reads.test.ts
@@ -2,16 +2,27 @@ import { setImmediate as nextTurn } from 'node:timers/promises';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Database } from '../client';
 import * as encryption from '../encryption';
+import { gatewayChannels } from '../schema';
 import { GatewayChannelRepository } from './gateway-channels';
 
-const query = vi.hoisted(() => ({ rows: [] as Record<string, unknown>[], selects: 0 }));
+const query = vi.hoisted(() => ({
+  rows: [] as Record<string, unknown>[],
+  selects: 0,
+  projection: undefined as unknown,
+}));
 vi.mock('../database-wrapper', async (importOriginal) => {
   const original = await importOriginal<typeof import('../database-wrapper')>();
   return {
     ...original,
-    select: () => {
+    select: (_db: unknown, projection: unknown) => {
+      query.projection = projection;
       query.selects++;
-      const result = { all: async () => query.rows, one: async () => query.rows[0] };
+      const result = {
+        all: async () => query.rows,
+        one: async () => query.rows[0],
+        orderBy: () => result,
+        limit: () => result,
+      };
       return { from: () => ({ ...result, where: () => result }) };
     },
   };
@@ -48,6 +59,21 @@ afterEach(() => {
 });
 
 describe('gateway credential hydration', () => {
+  it('discovers IDs with one narrow query and no credential decryption', async () => {
+    const first = '00000000-0000-4000-8000-000000000001';
+    query.rows = [row(first), row('second')];
+    const open = vi.spyOn(encryption, 'decryptApiKeyAsync');
+    const repo = new GatewayChannelRepository({} as Database);
+    expect(await repo.findEnabledListenerCandidateIds(2)).toEqual([first, 'second']);
+    expect(query.projection).toEqual({ id: gatewayChannels.id });
+    expect(query.selects).toBe(1);
+    expect(open).not.toHaveBeenCalled();
+    // Discovery is not a credential cache: the later authoritative read opens
+    // the current row, including all three secret fields.
+    await repo.findById(first);
+    expect(open).toHaveBeenCalledTimes(3);
+  });
+
   it('opens rows and fields serially, preserves order and hidden tenant, and does not cache', async () => {
     query.rows = [row('second'), row('first')];
     let active = 0;
@@ -120,6 +146,30 @@ describe('gateway credential hydration', () => {
       expect(logs).toHaveBeenCalledTimes(2);
       expect(JSON.stringify(logs.mock.calls)).not.toContain('corrupt:');
     }
+  );
+
+  it.skipIf(process.env.AGOR_BENCH_GATEWAY_DISCOVERY !== '1')(
+    'benchmarks discovery hydration versus ID projection with real crypto',
+    async () => {
+      query.rows = Array.from({ length: 6 }, (_, i) => row(String(i)));
+      const repo = new GatewayChannelRepository({} as Database);
+      const samples: Record<string, number[]> = { hydrated: [], ids: [] };
+      for (let round = 0; round < 4; round++) {
+        for (const mode of round % 2 ? ['ids', 'hydrated'] : ['hydrated', 'ids']) {
+          const start = performance.now();
+          const result =
+            mode === 'ids'
+              ? await repo.findEnabledListenerCandidateIds(6)
+              : (await repo.findAll()).map((channel) => channel.id);
+          expect(result).toEqual(['0', '1', '2', '3', '4', '5']);
+          if (round) samples[mode].push(performance.now() - start);
+        }
+      }
+      process.stdout.write(
+        `Discovery-only benchmark, mock SQL / real crypto, ms: ${JSON.stringify(samples)}\n`
+      );
+    },
+    30000
   );
 
   it.skipIf(process.env.AGOR_BENCH_GATEWAY_READ !== '1')(

--- a/packages/core/src/db/repositories/gateway-channels.test.ts
+++ b/packages/core/src/db/repositories/gateway-channels.test.ts
@@ -55,6 +55,38 @@ async function seedBranch(db: Database) {
 }
 
 describe('GatewayChannelRepository', () => {
+  dbTest(
+    'listener discovery preserves enabled filtering, ID order and keyset pagination',
+    async ({ db }) => {
+      const branch = await seedBranch(db);
+      const repo = new GatewayChannelRepository(db);
+      const channels = [];
+      for (const enabled of [true, false, true]) {
+        channels.push(
+          await repo.create({
+            name: `Discovery ${channels.length}`,
+            created_by: generateId() as UUID,
+            target_branch_id: branch.branch_id as UUID,
+            enabled,
+            config: { bot_token: 'bot-test', app_token: 'app-test' },
+          })
+        );
+      }
+      const expected = channels
+        .filter((channel) => channel.enabled)
+        .map((channel) => channel.id)
+        .sort();
+      expect(await repo.findEnabledListenerCandidateIds(1)).toEqual(expected.slice(0, 1));
+      expect(await repo.findEnabledListenerCandidateIds(1, expected[0])).toEqual(expected.slice(1));
+      expect(await repo.findEnabledListenerCandidateIds(1, expected[1])).toEqual([]);
+      for (const limit of [0, -1, 1.5, 1001]) {
+        await expect(repo.findEnabledListenerCandidateIds(limit)).rejects.toThrow(
+          'between 1 and 1000'
+        );
+      }
+    }
+  );
+
   dbTest('create throws when created_by is missing', async ({ db }) => {
     const repo = new GatewayChannelRepository(db);
     await expect(repo.create({ name: 'Test Channel' })).rejects.toThrow(

--- a/packages/core/src/db/repositories/gateway-channels.ts
+++ b/packages/core/src/db/repositories/gateway-channels.ts
@@ -493,11 +493,14 @@ export class GatewayChannelRepository
     return result.rowsAffected > 0;
   }
 
-  /** Bounded tenant-local candidates for static PostgreSQL deployments. */
-  async findEnabledListenerCandidates(
+  /**
+   * Bounded tenant-local discovery, without loading credentials. The listener
+   * worker reloads each candidate under tenant scope before claiming/starting it.
+   */
+  async findEnabledListenerCandidateIds(
     limit = 25,
     afterId?: GatewayChannelID
-  ): Promise<GatewayChannel[]> {
+  ): Promise<GatewayChannelID[]> {
     if (!Number.isInteger(limit) || limit <= 0 || limit > 1_000) {
       throw new RepositoryError('Gateway listener candidate limit must be between 1 and 1000');
     }
@@ -511,34 +514,20 @@ export class GatewayChannelRepository
     const auditedProvider = isPostgresDatabase(this.db)
       ? inArray(gatewayChannels.channel_type, [...DURABLE_GATEWAY_LISTENER_CHANNEL_TYPES])
       : undefined;
-    const candidates: GatewayChannel[] = [];
-    let rawAfterId = afterId;
-    while (candidates.length < limit) {
-      const rows = await select(this.db)
-        .from(gatewayChannels)
-        .where(
-          and(
-            eq(gatewayChannels.enabled, true),
-            auditedProvider,
-            claimable,
-            rawAfterId ? gt(gatewayChannels.id, rawAfterId) : undefined
-          )
+    const rows = await select(this.db, { id: gatewayChannels.id })
+      .from(gatewayChannels)
+      .where(
+        and(
+          eq(gatewayChannels.enabled, true),
+          auditedProvider,
+          claimable,
+          afterId ? gt(gatewayChannels.id, afterId) : undefined
         )
-        .orderBy(asc(gatewayChannels.id))
-        .limit(limit)
-        .all();
-
-      for (const row of rows as GatewayChannelRow[]) {
-        candidates.push(await this.rowToChannel(row));
-        if (candidates.length === limit) break;
-      }
-
-      if (rows.length < limit || candidates.length === limit) break;
-      const last = rows.at(-1) as GatewayChannelRow | undefined;
-      if (!last) break;
-      rawAfterId = last.id as GatewayChannelID;
-    }
-    return candidates;
+      )
+      .orderBy(asc(gatewayChannels.id))
+      .limit(limit)
+      .all();
+    return (rows as Pick<GatewayChannelRow, 'id'>[]).map((row) => row.id as GatewayChannelID);
   }
 
   /**


### PR DESCRIPTION
## Summary

Remove redundant credential hydration from tenant-local gateway listener discovery. Discovery now selects only ordered, bounded channel IDs; the worker still reloads each candidate under its tenant scope before listener validation/claim/start. No credential cache, KDF parameter changes, concurrency increases, or profiler configuration changes.

## Why this change

Post-#2709 investigation found real worker-pool contention in `agor-daemon`, `env:sandbox`, host `agor-2`, runtime `b5fcefbf-711c-4092-8dc5-9ad3f212838f`. The deployed build was verified as `0721b0e27` with restart near 06:46 UTC on 2026-09-09. A later 07:15:52–07:16:58 UTC profile timeline recorded 371 crypto operations / 13.81 seconds of async activity versus 375 filesystem operations / 0.26 seconds. These overlapping operation durations are not exclusive CPU or queue-wait measurements; profile coverage was about 78% for that interval.

Source inspection established a narrower, deterministic redundancy: `reconcileListenersOnce` hydrated full candidates, discarded all fields except IDs, then called `findById` to hydrate selected candidates again. This change removes that first hydration. **Telemetry motivates reducing unnecessary crypto, but does not attribute the observed pool contention to this discovery path or establish its fleet-wide frequency.** Benefit depends on eligible candidate count; no candidates means little benefit. The global/system discovery path already uses reference projections and is unchanged.

## Implementation and boundaries

- Rename the internal repository method to `findEnabledListenerCandidateIds`, returning branded IDs rather than full channels.
- Preserve enabled/provider/claimability predicates, database-clock lease expiry, ascending ID order, exclusive keyset cursor and limit validation.
- Remove a redundant loop: every selected row previously became a candidate, so one SQL LIMIT page already satisfied its behavior.
- Preserve scoped database ownership and all downstream fresh reads, listener validation, claim/fencing and revocation checks.
- Discovery intentionally no longer opens/logs corrupt credentials. The authoritative per-candidate hydration retains its existing corruption handling before listener startup. Invalid credentials are not treated as usable merely because an ID was discovered.
- No public API response changes. SQLite repository behavior and PostgreSQL/RLS are exercised.

## Local measurement

Synthetic six-channel fixture, three encrypted fields/channel, real native async crypto and mocked SQL; one warmup plus three alternating samples. Discovery stage only, not full startup/endpoint latency:

| Path | Samples (ms) | Median | Discovery KDF calls |
|---|---|---:|---:|
| Prior hydrated discovery (equivalent full-row mapper) | 602.69, 661.52, 603.39 | 603.39 ms | 18 |
| ID-only discovery | 0.175, 0.347, 0.139 | 0.175 ms | 0 |

The later authoritative read still performs needed decryptions. This benchmark excludes database cost, provider startup and worker-pool interference. No timing thresholds in CI. Reproduce with `AGOR_BENCH_GATEWAY_DISCOVERY=1 pnpm --filter @agor/core exec vitest run src/db/repositories/gateway-channels.reads.test.ts`.

## Validation

- `pnpm i --frozen-lockfile`: passed, already up to date.
- Core gateway repository suites: 27 passed (existing optional benchmark skipped); subsequent benchmark suite 5 passed, 1 skipped.
- Daemon gateway suite: 119 passed.
- Disposable PostgreSQL gateway HA suite: 5 passed under NOSUPERUSER/NOBYPASSRLS role, including cross-tenant discovery negative coverage. Container cleaned up.
- `pnpm check`: passed (typecheck, lint/policy checks and build).
- Initial regression fixture accidentally used a short ID against a nonfiltering query mock; corrected to canonical UUID. Initial typecheck exposed the database wrapper's untyped result; added a narrow schema-derived result annotation. Neither failure was bypassed.

## Deferred / rollout validation

- Profiler source-map traversal is a separate operational issue, not an application optimization in this PR.
- OAuth inventory polling/concurrency remains a stronger live endpoint lead, but no stale status cache or unverified pool-sizing change is included.
- After a separately authorized rollout, compare matched candidate cardinality, scan frequency, KDF operations, worker queueing and listener acquisition/recovery latency; verify disable/revoke/corrupt-credential behavior. No production load generation or mutations were performed. This follow-up is not deployed.

Base: latest main `43ac72e75e47a91c8c3dd8b2f3944e3b0238cdec`, on a fresh Git branch after #2709 was merged.
