### PR TITLE
perf: avoid unused credential work and unblock owner profile reads

### DIFF
--- a/apps/agor-daemon/src/services/users.credentials.test.ts
+++ b/apps/agor-daemon/src/services/users.credentials.test.ts
@@ -1,6 +1,7 @@
 import { UsersRepository } from '@agor/core/db';
-import type { UserID } from '@agor/core/types';
+import type { AuthenticatedParams, UserID } from '@agor/core/types';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as encryption from '../../../../packages/core/src/db/encryption';
 import { dbTest } from '../../../../packages/core/src/db/test-helpers';
 import { UsersService } from './users';
 
@@ -10,6 +11,94 @@ afterEach(() => {
 });
 
 describe('UsersService credential reader delegation', () => {
+  dbTest.skipIf(process.env.AGOR_BENCH_PUBLIC_VALUES !== '1')(
+    'benchmarks owner DTO decryption responsiveness',
+    async ({ db }) => {
+      vi.stubEnv('AGOR_MASTER_SECRET', 'synthetic-public-benchmark-key');
+      const repository = new UsersRepository(db);
+      const service = new UsersService(db);
+      const user = await repository.create({ email: 'benchmark@example.invalid' });
+      await repository.setToolConfigField(
+        user.user_id,
+        'codex',
+        'OPENAI_BASE_URL',
+        'https://codex.invalid'
+      );
+      await repository.setToolConfigField(
+        user.user_id,
+        'claude-code',
+        'ANTHROPIC_BASE_URL',
+        'https://claude.invalid'
+      );
+      const samples = [];
+      for (let round = 0; round < 8; round++) {
+        let last = performance.now();
+        let maxTickGapMs = 0;
+        const tick = () => {
+          const now = performance.now();
+          maxTickGapMs = Math.max(maxTickGapMs, now - last);
+          last = now;
+        };
+        const timer = setInterval(tick, 5);
+        try {
+          const start = performance.now();
+          const result = await service.get(user.user_id, { user } as AuthenticatedParams);
+          const elapsedMs = performance.now() - start;
+          tick();
+          expect(result.agentic_tools_public_values?.codex?.OPENAI_BASE_URL).toBe(
+            'https://codex.invalid'
+          );
+          if (round) samples.push({ elapsedMs, maxTickGapMs });
+        } finally {
+          clearInterval(timer);
+        }
+      }
+      process.stdout.write(`Owner DTO real SQLite + 2 public fields: ${JSON.stringify(samples)}\n`);
+    }
+  );
+
+  dbTest(
+    'self-only public values use async decryption without leaking to other readers',
+    async ({ db }) => {
+      vi.stubEnv('AGOR_MASTER_SECRET', 'synthetic-public-values-key');
+      const repository = new UsersRepository(db);
+      const service = new UsersService(db);
+      const own = await repository.create({ email: 'public-own@example.invalid' });
+      const other = await repository.create({ email: 'public-other@example.invalid' });
+      await repository.setToolConfigField(own.user_id, 'codex', 'OPENAI_API_KEY', 'private-key');
+      await repository.setToolConfigField(
+        own.user_id,
+        'codex',
+        'OPENAI_BASE_URL',
+        'https://private-host.invalid'
+      );
+      const sync = vi.spyOn(encryption, 'decryptApiKey');
+      const open = vi.spyOn(encryption, 'decryptApiKeyAsync');
+      const params = { user: own } as AuthenticatedParams;
+      expect((await service.get(own.user_id, params)).agentic_tools_public_values).toEqual({
+        codex: { OPENAI_BASE_URL: 'https://private-host.invalid' },
+      });
+      expect(open).toHaveBeenCalledTimes(1);
+      expect(sync).not.toHaveBeenCalled();
+      open.mockClear();
+      const patched = await service.patch(own.user_id, { preferences: { theme: 'dark' } }, params);
+      expect(patched.agentic_tools_public_values).toEqual({
+        codex: { OPENAI_BASE_URL: 'https://private-host.invalid' },
+      });
+      expect(open).toHaveBeenCalledTimes(1); // Final DTO only, not the internal merge input.
+      open.mockClear();
+      expect(
+        (await service.get(own.user_id, { user: other } as AuthenticatedParams))
+          .agentic_tools_public_values
+      ).toBeUndefined();
+      expect((await service.get(own.user_id)).agentic_tools_public_values).toBeUndefined();
+      expect(open).not.toHaveBeenCalled();
+      vi.stubEnv('AGOR_MASTER_SECRET', 'wrong-public-values-key');
+      expect((await service.get(own.user_id, params)).agentic_tools_public_values).toBeUndefined();
+      expect(sync).not.toHaveBeenCalled();
+    }
+  );
+
   dbTest(
     'preserves values, user/tool isolation, and missing/corrupt result contracts',
     async ({ db }) => {

--- a/apps/agor-daemon/src/services/users.ts
+++ b/apps/agor-daemon/src/services/users.ts
@@ -35,7 +35,7 @@ import {
   boards,
   branches,
   compare,
-  decryptApiKey,
+  decryptApiKeyAsync,
   deleteFrom,
   encryptApiKey,
   eq,
@@ -94,7 +94,7 @@ import type {
 import {
   AGENTIC_TOOL_NAMES,
   canAssignUserRole,
-  extractAgenticToolsPublicValues,
+  extractAgenticToolsPublicValuesAsync,
   hasMinimumRole,
   hasRoleAuthorityOver,
   isAgenticToolName,
@@ -818,9 +818,10 @@ export class UsersService {
       limit === undefined ? rows.slice(skip) : rows.slice(skip, skip + Math.max(limit, 0));
 
     const includeAuthMetadata = shouldIncludeAuthMetadata(params, includePassword);
-    const results = pageRows.map((row) =>
-      this.rowToUser(row, includePassword, requesterId, includeAuthMetadata)
-    );
+    const results = [];
+    for (const row of pageRows) {
+      results.push(await this.rowToUser(row, includePassword, requesterId, includeAuthMetadata));
+    }
 
     return {
       total,
@@ -1080,12 +1081,9 @@ export class UsersService {
       data.default_agentic_selection ||
       data.default_mcp_server_ids !== undefined
     ) {
-      const current = this.rowToUser(
-        authority.target,
-        false,
-        (params as AuthenticatedParams | undefined)?.user?.user_id as UserID | undefined,
-        shouldIncludeAuthMetadata(params)
-      );
+      // Internal merge inputs need metadata, not owner-only presentation values.
+      // Decrypt public values only for the final response, after the update.
+      const current = await this.rowToUser(authority.target, false, undefined, false);
       const currentRow = authority.target;
       const currentData = currentRow?.data as {
         avatar_url?: string;
@@ -1540,7 +1538,7 @@ export class UsersService {
     const requesterId = (params as AuthenticatedParams | undefined)?.user?.user_id as
       | UserID
       | undefined;
-    const user = this.rowToUser(
+    const user = await this.rowToUser(
       authority.target,
       false,
       requesterId,
@@ -1702,7 +1700,7 @@ export class UsersService {
       path: 'users',
       event: 'patched',
       id: userId,
-      data: this.rowToUser(row, false, undefined, false),
+      data: await this.rowToUser(row, false, undefined, false),
       params,
     });
   }
@@ -1832,7 +1830,12 @@ export class UsersService {
       primary_agentic_tool?: AgenticToolName;
     };
     if (currentData.primary_agentic_tool !== undefined) {
-      return this.rowToUser(currentRow, false, userId, shouldIncludeAuthMetadata(params)) as User;
+      return (await this.rowToUser(
+        currentRow,
+        false,
+        userId,
+        shouldIncludeAuthMetadata(params)
+      )) as User;
     }
 
     const updatedRow = await update(this.db, users)
@@ -1859,12 +1862,17 @@ export class UsersService {
         event: 'patched',
         id: userId,
         // Owner-only decrypted presentation values must never ride a broadcast.
-        data: this.rowToUser(updatedRow, false, undefined, false),
+        data: await this.rowToUser(updatedRow, false, undefined, false),
         params,
       });
     }
 
-    return this.rowToUser(effectiveRow, false, userId, shouldIncludeAuthMetadata(params)) as User;
+    return (await this.rowToUser(
+      effectiveRow,
+      false,
+      userId,
+      shouldIncludeAuthMetadata(params)
+    )) as User;
   }
 
   private requireMemberCaller(params: Params | undefined, action: string): UserID {
@@ -1892,12 +1900,12 @@ export class UsersService {
    *   including admins viewing someone else's profile — public values are
    *   omitted, since base URLs can leak internal hostnames.
    */
-  private rowToUser(
+  private async rowToUser(
     row: typeof users.$inferSelect,
     includePassword = false,
     requesterId?: UserID,
     includeAuthMetadata = true
-  ): (User | InternalUser) & { password?: string } {
+  ): Promise<(User | InternalUser) & { password?: string }> {
     const data = row.data as {
       avatar_url?: string;
       avatar?: string;
@@ -1953,7 +1961,7 @@ export class UsersService {
       // secrets are NEVER on the whitelist; see `AGENTIC_TOOLS_PUBLIC_FIELDS`.
       agentic_tools_public_values:
         requesterId === row.user_id
-          ? extractAgenticToolsPublicValues(data.agentic_tools, decryptApiKey)
+          ? await extractAgenticToolsPublicValuesAsync(data.agentic_tools, decryptApiKeyAsync)
           : undefined,
       // Return env var metadata (presence + scope), NOT actual values
       env_vars: envVarMetadata,

--- a/packages/core/src/config/env-resolver.postgres.test.ts
+++ b/packages/core/src/config/env-resolver.postgres.test.ts
@@ -12,12 +12,14 @@ import {
   RepoRepository,
   SessionEnvSelectionRepository,
   SessionRepository,
+  TenantAgenticToolSettingsRepository,
   UsersRepository,
 } from '../db/repositories';
 import { users } from '../db/schema';
 import { createTenantScopedDatabaseProxy, runWithTenantDatabaseScope } from '../db/tenant-scope';
 import { generateId } from '../lib/ids';
 import { resolveUserEnvironment } from './env-resolver';
+import { resolveApiKey } from './key-resolver';
 
 const postgresUrl = process.env.AGOR_TEST_POSTGRES_URL;
 const usesPostgresSchema = process.env.AGOR_DB_DIALECT === 'postgresql';
@@ -172,6 +174,39 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
           {}
         );
       });
+    });
+
+    it('keeps workspace-selected provider credentials tenant-bound and observes rotation', async () => {
+      const tenantA = `provider-a-${generateId()}` as TenantID;
+      const tenantB = `provider-b-${generateId()}` as TenantID;
+      const scopedDb = createTenantScopedDatabaseProxy(rawA, {
+        requireScope: true,
+        label: 'provider-policy',
+      });
+      for (const [tenant, value] of [
+        [tenantA, 'credential-a'],
+        [tenantB, 'credential-b'],
+      ] as const) {
+        await runWithTenantDatabaseScope(scopedDb, tenant, async (db) => {
+          await new TenantAgenticToolSettingsRepository(db).patch('codex', {
+            resolution_policy: 'tenant_preferred',
+            connection: { OPENAI_API_KEY: value },
+          });
+        });
+      }
+      const resolve = (tenant: TenantID) =>
+        runWithTenantDatabaseScope(scopedDb, tenant, (db) =>
+          resolveApiKey('OPENAI_API_KEY', { db, tool: 'codex' })
+        );
+      expect(await resolve(tenantA)).toMatchObject({ apiKey: 'credential-a', source: 'tenant' });
+      expect(await resolve(tenantB)).toMatchObject({ apiKey: 'credential-b', source: 'tenant' });
+      await runWithTenantDatabaseScope(scopedDb, tenantA, async (db) => {
+        await new TenantAgenticToolSettingsRepository(db).patch('codex', {
+          connection: { OPENAI_API_KEY: 'rotated-a' },
+        });
+      });
+      expect(await resolve(tenantA)).toMatchObject({ apiKey: 'rotated-a' });
+      expect(await resolve(tenantB)).toMatchObject({ apiKey: 'credential-b' });
     });
 
     it('serializes selection replacement across replica connections', async () => {

--- a/packages/core/src/config/key-resolver.test.ts
+++ b/packages/core/src/config/key-resolver.test.ts
@@ -147,6 +147,58 @@ describe('resolveApiKey — per-tool credential scoping', () => {
     });
   });
 
+  for (const policy of ['tenant_required', 'tenant_preferred'] as const) {
+    dbTest(`${policy} does not read or decrypt an unused user connection`, async ({ db }) => {
+      const userId = await createUserWithToolCreds(db, {
+        codex: {
+          OPENAI_API_KEY: encryptApiKey('unused-user-key'),
+          OPENAI_BASE_URL: encryptApiKey('https://unused.invalid/v1'),
+        },
+      });
+      await new TenantAgenticToolSettingsRepository(db).patch('codex', {
+        resolution_policy: policy,
+        connection: { OPENAI_API_KEY: 'tenant-key' },
+      });
+      const reads = vi.spyOn(wrapper, 'select');
+      const open = vi.spyOn(encryption, 'decryptApiKeyAsync');
+      expect(await resolveApiKey('OPENAI_API_KEY', { userId, db, tool: 'codex' })).toMatchObject({
+        apiKey: 'tenant-key',
+        source: 'tenant',
+      });
+      expect(reads).toHaveBeenCalledTimes(1);
+      expect(open).toHaveBeenCalledTimes(1); // Only the tenant settings document.
+    });
+  }
+
+  dbTest(
+    'tenant-preferred rechecks settings and retains the user fallback and corruption contract',
+    async ({ db }) => {
+      const userId = await createUserWithToolCreds(db, {
+        codex: { OPENAI_API_KEY: encryptApiKey('user-key') },
+      });
+      const settings = new TenantAgenticToolSettingsRepository(db);
+      await settings.patch('codex', {
+        resolution_policy: 'tenant_preferred',
+        connection: { OPENAI_API_KEY: 'tenant-key' },
+      });
+      const resolve = () => resolveApiKey('OPENAI_API_KEY', { userId, db, tool: 'codex' });
+      expect(await resolve()).toMatchObject({ apiKey: 'tenant-key', source: 'tenant' });
+      await settings.patch('codex', {
+        connection: { OPENAI_API_KEY: null, OPENAI_BASE_URL: 'https://tenant.invalid' },
+      });
+      expect(await resolve()).toMatchObject({ apiKey: 'user-key', source: 'user' });
+      const native = encryption.decryptApiKeyAsync;
+      vi.spyOn(encryption, 'decryptApiKeyAsync').mockImplementation(async (value) => {
+        const plain = await native(value);
+        if (plain === 'user-key') throw new Error('synthetic corrupt user field');
+        return plain;
+      });
+      expect(await resolve()).toMatchObject({ source: 'user', decryptionFailed: true });
+      await settings.patch('codex', { resolution_policy: 'tenant_required' });
+      expect(await resolve()).toMatchObject({ source: 'none', apiKey: undefined });
+    }
+  );
+
   dbTest('required policies fail closed instead of using the other scope', async ({ db }) => {
     const userId = await createUserWithToolCreds(db, {
       codex: { OPENAI_API_KEY: encryptApiKey('user-key') },
@@ -281,6 +333,32 @@ describe('resolveApiKey — per-tool credential scoping', () => {
         source: 'user',
         decryptionFailed: true,
       });
+    }
+  );
+
+  dbTest.skipIf(process.env.AGOR_BENCH_PROVIDER_READ !== '1')(
+    'benchmarks tenant-selected provider resolution',
+    async ({ db }) => {
+      const userId = await createUserWithToolCreds(db, {
+        codex: {
+          OPENAI_API_KEY: encryptApiKey('unused-user-key'),
+          OPENAI_BASE_URL: encryptApiKey('https://unused.invalid'),
+        },
+      });
+      await new TenantAgenticToolSettingsRepository(db).patch('codex', {
+        resolution_policy: 'tenant_preferred',
+        connection: { OPENAI_API_KEY: 'workspace-key' },
+      });
+      const elapsedMs = [];
+      for (let round = 0; round < 8; round++) {
+        const start = performance.now();
+        const result = await resolveApiKey('OPENAI_API_KEY', { userId, db, tool: 'codex' });
+        expect(result.apiKey).toBe('workspace-key');
+        if (round) elapsedMs.push(performance.now() - start);
+      }
+      process.stdout.write(
+        `Tenant-selected resolution, real SQLite, 1 settings document + 2 unused user fields: ${JSON.stringify(elapsedMs)}\n`
+      );
     }
   );
 

--- a/packages/core/src/config/tenant-agentic-tool-resolver.ts
+++ b/packages/core/src/config/tenant-agentic-tool-resolver.ts
@@ -162,11 +162,21 @@ export async function resolveProviderConnection(
   // reads/decryptions of the same settings document separated by user hydration.
   const settings = repository ? await repository.find(canonical) : null;
   const policy = settings?.resolution_policy ?? DEFAULT_PROVIDER_RESOLUTION_POLICY;
+  const tenantConnection = settings?.connection ?? null;
+  // Do not read/decrypt a user's credentials when policy cannot select them.
+  // A preferred workspace connection only short-circuits when it has a usable
+  // credential; incomplete workspace configuration must retain the user fallback.
+  const needsUser =
+    policy !== 'tenant_required' &&
+    !(
+      policy === 'tenant_preferred' &&
+      tenantConnection &&
+      hasCredential(canonical, tenantConnection)
+    );
   const user =
-    context.userId && context.db
+    needsUser && context.userId && context.db
       ? await resolveUserConnection(canonical, context.userId, context.db)
       : null;
-  const tenantConnection = settings?.connection ?? null;
   const userCandidate = user
     ? {
         source: 'user' as const,

--- a/packages/core/src/types/user.test.ts
+++ b/packages/core/src/types/user.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from 'vitest';
 import {
   canAssignUserRole,
   compareRoleAuthority,
+  extractAgenticToolsPublicValuesAsync,
   hasMinimumRole,
   hasRoleAuthorityOver,
   normalizeRole,
@@ -67,5 +68,33 @@ describe('role authority ordering', () => {
     expect(hasRoleAuthorityOver('not-a-role', ROLES.VIEWER)).toBe(false);
     expect(hasRoleAuthorityOver('not-a-role', 'not-a-role')).toBe(false);
     expect(canAssignUserRole('not-a-role', 'not-a-role')).toBe(false);
+  });
+});
+
+describe('owner-authorized public credential values', () => {
+  it('opens only whitelisted fields sequentially and omits async failures per field', async () => {
+    const calls: string[] = [];
+    let active = 0;
+    let peak = 0;
+    const result = await extractAgenticToolsPublicValuesAsync(
+      {
+        codex: { OPENAI_API_KEY: 'secret', OPENAI_BASE_URL: 'bad-url' },
+        'claude-code': { ANTHROPIC_API_KEY: 'other-secret', ANTHROPIC_BASE_URL: 'good-url' },
+      },
+      async (value) => {
+        calls.push(value);
+        peak = Math.max(peak, ++active);
+        try {
+          await Promise.resolve();
+          if (value === 'bad-url') throw new Error('synthetic corrupt field');
+          return 'https://example.invalid';
+        } finally {
+          active--;
+        }
+      }
+    );
+    expect(calls).toEqual(['bad-url', 'good-url']);
+    expect(peak).toBe(1);
+    expect(result).toEqual({ 'claude-code': { ANTHROPIC_BASE_URL: 'https://example.invalid' } });
   });
 });

--- a/packages/core/src/types/user.ts
+++ b/packages/core/src/types/user.ts
@@ -363,10 +363,10 @@ export type AgenticToolsPublicValues = {
  * The caller is responsible for the self-only authorization check — this
  * helper assumes the requester is already authorized to see the values.
  */
-export function extractAgenticToolsPublicValues(
+export async function extractAgenticToolsPublicValuesAsync(
   stored: StoredAgenticTools | undefined,
-  decrypt: (ciphertext: string) => string
-): AgenticToolsPublicValues | undefined {
+  decrypt: (ciphertext: string) => Promise<string>
+): Promise<AgenticToolsPublicValues | undefined> {
   if (!stored) return undefined;
   const out: Record<string, Record<string, string>> = {};
   for (const [tool, fields] of Object.entries(stored) as Array<
@@ -380,7 +380,7 @@ export function extractAgenticToolsPublicValues(
       const ciphertext = fields[field as string];
       if (!ciphertext) continue;
       try {
-        plaintext[field as string] = decrypt(ciphertext);
+        plaintext[field as string] = await decrypt(ciphertext);
       } catch {
         // Silently skip undecryptable values; the boolean status flag will
         // still indicate presence so the user can clear and re-set.


### PR DESCRIPTION
## Summary
Follow-up to #2709 and #2712, based on merged main `9dbfec95`. Two small credential-read improvements rather than a speculative rewrite of every slow endpoint:

1. **Skip unused user credentials during provider resolution.** `tenant_required` never reads the user connection; `tenant_preferred` skips it only when the workspace connection has a usable credential. Incomplete workspace connections still fall back, and relevant corrupt user connections still fail closed. Each invocation reads current workspace settings: no cross-request/user/tenant cache.
2. **Remove remaining synchronous KDF work from owner-profile presentation.** Saved public base URLs used by self-profile/settings reads now use the existing async decryption helper, sequentially. The DTO mapper and event producers await materialization. Other users (including administrators) and broadcasts still receive no owner-only values. Preference updates no longer decrypt public values for their internal merge input and then again for the response.

No encryption format, KDF parameters, JWT validation, authorization/RLS, pagination, or credential-presence semantics change. This does **not** move encryption writes or every legacy credential path off the event loop.

## Evidence and rollout boundaries
Read-only Datadog investigation: `service:agor-daemon env:sandbox`, host `agor-2`; recent retained traces sampled in **2026-09-09 08:15–08:40 UTC**, process `579196`. Retained diversity samples are examples, not a latency population.

At **08:47 UTC**, sandbox health still reported build **`0721b0e27`**, built `06:37:55 UTC`, deployment `e7de02dc-6109-4f36-9a57-09e8eef3a738`. #2712 merged at `08:22:52 UTC` but its deployment was **not observed**. The screenshot's one-request slow inventories are not evidence of a current-version regression.

Prior profiles showed worker-pool contention after moving KDF work off the main loop; this motivates eliminating unnecessary KDFs rather than increasing concurrency. Source inspection found provider policy selected the workspace credential **after** opening unused user fields. The remaining self-profile synchronous path was established from source and reproduced locally; we have not attributed a percentage of production stalls to it.

Representative follow-up traces and what they **do not** establish:
- [check-auth, 08:31:45 UTC](https://app.datadoghq.com/apm/trace/6aa119710000000046cdeaee8ac13703): request 1,245 ms; Claude subprocess span 1,377 ms outlives it. Two settings reads remain. Native/provider probing is not equivalent to blocked daemon CPU, and nested durations must not be added. This PR is not a claim that the native probe becomes fast.
- [board-objects, 08:32:30 UTC](https://app.datadoghq.com/apm/trace/6aa1199e000000001179a79f04954869): request 1,002 ms, query spans 562/954 ms. Their overlap/queueing means durations are not additive; SQL is reported as non-parsable. Investigate plans/driver boundaries rather than guessing this is a JavaScript serialization bottleneck.

## Local before/after measurements
Real SQLite and real scrypt/AES, synthetic credentials, same checkout/container. Benchmarks were run against actual base source and changed source, restoring edited files afterward. One warmup plus seven samples; numbers are medians. Sequential runs are not a controlled production load test.

| Fixture | Before | After | Interpretation |
|---|---:|---:|---|
| Workspace-selected provider resolution, 1 settings document + 2 unused user fields | 103.21 ms | 36.62 ms | ~65% less elapsed work in this fixture |
| Same resolver's deterministic read/KDF counts | 2 SELECTs / 3 decryptions | 1 SELECT / 1 decryption | No unused user read or key derivation |
| Owner DTO with 2 saved base URLs: elapsed | 67.25 ms | 68.13 ms | Essentially unchanged request cost |
| Same DTO: maximum 5-ms timer gap per run, median across runs | 67.27 ms | 5.18 ms | Event-loop responsiveness, **not** throughput gain |

Reproduce optional fixtures:
```sh
AGOR_BENCH_PROVIDER_READ=1 pnpm --filter @agor/core exec vitest run src/config/key-resolver.test.ts -t 'benchmarks tenant-selected'
AGOR_BENCH_PUBLIC_VALUES=1 pnpm --filter @agor/daemon exec vitest run src/services/users.credentials.test.ts -t 'benchmarks owner DTO'
```
No production benchmarking, load generation, database writes, or profiler tuning. Rich profiling remains enabled.

## Validation
- `pnpm i --frozen-lockfile` passed.
- `pnpm check` passed (rerun on final diff before commit).
- Core provider/environment/native/strip suites: **57 passed**, 2 opt-in benchmarks skipped; type utilities: **10 passed**.
- Ten relevant daemon user/auth suites: **121 passed**, 1 opt-in benchmark skipped. Focused credential suite rerun after the preference-update assertion: **3 passed**.
- Disposable PostgreSQL with verified **NOSUPERUSER / NOBYPASSRLS**: user authority **8 passed**; environment tenant/user/session isolation plus workspace credential rotation **3 passed**.
- New regressions cover query/decryption counts, workspace policy changes, fallback/corruption behavior, async per-field omission, sequential work, owner-only disclosure and no duplicate decryption during preference updates.

## Deferred opportunities / next measurement
1. **Gateway inventories:** still hydrate credentials; page/filter pushdown may remove work for unreturned rows. Need actual cardinality/query shape and post-#2712 evidence. Do not replace authenticated decryption with presence flags that misreport corrupt credentials.
2. **Board objects / sessions:** get representative plans and matched inventory sizes. Sessions already has SQL pagination and batched relationship enrichment; do not duplicate #2689 or force a new response shape based on a one-request sample.
3. **Check-auth:** enablement and provider resolution still reread settings; a shared request-scoped boundary could remove this, but a public mutable settings cache is not warranted. Distinguish native probes from API-key paths.
4. **OAuth status polling:** examine active-tab/request amplification and duplicate grant/server reads without weakening revocation or latest-request-wins behavior.
5. **Profiler:** source-map filesystem scanning is a separate observed overhead. Keep rich profiles per operator decision; do not hide it or claim application work explains all CPU.
6. **MCP:** individual `mcp.tool` spans already exist. Per-request registration has measurable but relatively small profile presence; avoid sharing context-bound handlers across users. Do not relabel arbitrary payload values as endpoint resources.

After rollout, confirm build/runtime first; compare stable matched windows excluding restart, recording request counts/mix, event-loop stall frequency (e.g. >250 ms / >1 s), endpoint p50/p95 and worker-pool pressure. Neither local benchmarks nor this PR assert a deployed improvement. No merge or deployment performed.

### CI note
The first final-head CI run passed core, PostgreSQL/RLS, UI, typecheck/build and policy checks; daemon tests had **4,406 passes and one timeout** in unchanged `sessions.branch-archive.test.ts` (1,001-session fixture, 10-second limit). That suite passed locally in 5.66 seconds of test execution. The failed-job rerun passed on the identical commit. All final GitHub checks are now successful or intentionally skipped; no timeout increase, skipped assertion or error suppression was introduced.
