### PR TITLE
fix(mcp): refresh expired OAuth grants before discovery

### DIFF
--- a/apps/agor-daemon/src/register-services.oauth-ha.postgres.test.ts
+++ b/apps/agor-daemon/src/register-services.oauth-ha.postgres.test.ts
@@ -33,6 +33,18 @@ const oauthFixture = vi.hoisted(() => ({
   beforeGrantLock: undefined as undefined | (() => Promise<void>),
 }));
 
+// These tests stop before MCP transport. Avoid loading the SDK's published
+// TypeScript parser in Node's test loader; constructing either client is a bug.
+const unexpectedMcpTransport = vi.hoisted(() =>
+  vi.fn(() => {
+    throw new Error('MCP transport must not be constructed before grant acquisition');
+  })
+);
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({ Client: unexpectedMcpTransport }));
+vi.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
+  StreamableHTTPClientTransport: unexpectedMcpTransport,
+}));
+
 vi.mock('@agor/core/tools/mcp/oauth-mcp-transport', async (importOriginal) => {
   const original =
     await importOriginal<typeof import('@agor/core/tools/mcp/oauth-mcp-transport')>();
@@ -334,6 +346,7 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
         .create({ mcp_server_id: machine.mcp_server_id }, params(user));
       expect(discovered).toMatchObject({
         success: false,
+        error: expect.stringContaining('No bound OAuth grant'),
         recovery: { category: 'configuration_required', action: 'review_configuration' },
       });
       const headers = await replicaB.app
@@ -354,6 +367,7 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
         );
       expect(foreign.headers[machine.mcp_server_id]).toEqual({ error: 'server_not_found' });
       expect({ starts: oauthFixture.starts, exchanges: oauthFixture.exchanges }).toEqual(before);
+      expect(unexpectedMcpTransport).not.toHaveBeenCalled();
     });
 
     it('serializes concurrent starts and completes the winner on the other replica', async () => {

--- a/apps/agor-daemon/src/register-services.oauth-ha.postgres.test.ts
+++ b/apps/agor-daemon/src/register-services.oauth-ha.postgres.test.ts
@@ -307,6 +307,55 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
       );
     });
 
+    it('reports saved machine-only configuration consistently across HA discovery and execution', async () => {
+      const machine = await runWithTenantDatabaseScope(replicaA.db, tenantId, (scoped) =>
+        new MCPServerRepository(scoped).create({
+          name: `machine-${crypto.randomUUID()}`,
+          display_name: 'Machine-only fixture',
+          transport: 'http',
+          url: 'https://mcp.provider.example.test/mcp',
+          scope: 'global',
+          enabled: true,
+          source: 'user',
+          owner_user_id: user.user_id,
+          auth: {
+            type: 'oauth',
+            oauth_mode: 'per_user',
+            oauth_grant_type: 'client_credentials',
+            oauth_client_id: 'synthetic-machine-client',
+            oauth_client_secret: 'synthetic-machine-secret',
+            oauth_token_url: 'https://provider.example.test/token',
+          },
+        })
+      );
+      const before = { starts: oauthFixture.starts, exchanges: oauthFixture.exchanges };
+      const discovered = await replicaA.app
+        .service('mcp-servers/discover')
+        .create({ mcp_server_id: machine.mcp_server_id }, params(user));
+      expect(discovered).toMatchObject({
+        success: false,
+        recovery: { category: 'configuration_required', action: 'review_configuration' },
+      });
+      const headers = await replicaB.app
+        .service('mcp-servers/oauth-auth-headers')
+        .create(
+          { mcp_server_ids: [machine.mcp_server_id] },
+          { ...params(user), provider: undefined }
+        );
+      expect(headers.headers[machine.mcp_server_id]).toMatchObject({
+        error: 'client_credentials_configuration_required',
+        recovery: { action: 'review_configuration' },
+      });
+      const foreign = await replicaB.app
+        .service('mcp-servers/oauth-auth-headers')
+        .create(
+          { mcp_server_ids: [machine.mcp_server_id] },
+          { ...params(user, `${tenantId}-foreign`), provider: undefined }
+        );
+      expect(foreign.headers[machine.mcp_server_id]).toEqual({ error: 'server_not_found' });
+      expect({ starts: oauthFixture.starts, exchanges: oauthFixture.exchanges }).toEqual(before);
+    });
+
     it('serializes concurrent starts and completes the winner on the other replica', async () => {
       const start = (replica: Replica) =>
         replica.app

--- a/apps/agor-daemon/src/register-services.oauth-sqlite.integration.test.ts
+++ b/apps/agor-daemon/src/register-services.oauth-sqlite.integration.test.ts
@@ -54,6 +54,7 @@ import {
 import { type RegisterHooksContext, registerHooks } from './register-hooks.js';
 import { createRegisteredMCPCatalogConnectService } from './register-routes.js';
 import { type RegisterServicesContext, registerMCPServices } from './register-services.js';
+import * as oauthUse from './services/mcp-oauth-use.js';
 import { createSocketIOConfig } from './setup/socketio.js';
 import { issueMCPSlackRecoveryToken } from './utils/mcp-slack-recovery-token.js';
 import {
@@ -3695,6 +3696,73 @@ describe('SQLite saved-row OAuth authority', () => {
     ).toBeNull();
   });
 
+  it.each(['client_credentials', undefined] as const)(
+    'saved machine configuration (%s) returns configuration recovery without provider work',
+    async (grantType) => {
+      const provider = await createTestProvider();
+      providers.push(provider);
+      const harness = await createHarness(provider);
+      databases.push(harness.rawDb);
+      await new MCPServerRepository(harness.rawDb).update(harness.server.mcp_server_id, {
+        auth: {
+          ...harness.server.auth!,
+          oauth_grant_type: grantType,
+          oauth_client_id: 'machine-client',
+          oauth_client_secret: 'synthetic-machine-secret',
+          oauth_token_url: `${provider.baseUrl}/token`,
+        },
+      });
+      const requestsBefore = provider.requests.length;
+      const result = await harness.app
+        .service('mcp-servers/discover')
+        .create({ mcp_server_id: harness.server.mcp_server_id }, paramsFor(harness));
+      expect(result).toMatchObject({
+        success: false,
+        recovery: { category: 'configuration_required', action: 'review_configuration' },
+      });
+      const execution = await harness.app
+        .service('mcp-servers/oauth-auth-headers')
+        .create(
+          { mcp_server_ids: [harness.server.mcp_server_id] },
+          { ...paramsFor(harness), provider: undefined }
+        );
+      expect(execution.headers[harness.server.mcp_server_id]).toMatchObject({
+        error: 'client_credentials_configuration_required',
+        recovery: { action: 'review_configuration' },
+      });
+      expect(provider.requests).toHaveLength(requestsBefore);
+    }
+  );
+
+  it('does not convert transient acquisition contention into reauth at either service boundary', async () => {
+    const provider = await createTestProvider();
+    providers.push(provider);
+    const harness = await createHarness(provider);
+    databases.push(harness.rawDb);
+    const acquire = vi
+      .spyOn(oauthUse, 'acquireMCPOAuthGrant')
+      .mockRejectedValue(new oauthUse.MCPOAuthRefreshBusyError());
+    try {
+      const result = await harness.app
+        .service('mcp-servers/discover')
+        .create({ mcp_server_id: harness.server.mcp_server_id }, paramsFor(harness));
+      expect(result).toMatchObject({ success: false, recovery: { action: 'retry' } });
+      const execution = await harness.app
+        .service('mcp-servers/oauth-auth-headers')
+        .create(
+          { mcp_server_ids: [harness.server.mcp_server_id] },
+          { ...paramsFor(harness), provider: undefined }
+        );
+      expect(execution.headers[harness.server.mcp_server_id]).toMatchObject({
+        error: 'refresh_in_progress',
+        recovery: { action: 'retry' },
+      });
+      expect(provider.requests).toHaveLength(0);
+    } finally {
+      acquire.mockRestore();
+    }
+  });
+
   it.each(['per_user', 'shared'] as const)(
     'GitLab-shaped %s callback expires then discovery rotates the durable pair',
     async (mode) => {
@@ -3702,6 +3770,11 @@ describe('SQLite saved-row OAuth authority', () => {
       providers.push(provider);
       const harness = await createHarness(provider, mode);
       databases.push(harness.rawDb);
+      // Legacy forms could save this default even for browser OAuth. A bound
+      // grant, not the form default, remains the credential authority.
+      await new MCPServerRepository(harness.rawDb).update(harness.server.mcp_server_id, {
+        auth: { ...harness.server.auth!, oauth_grant_type: 'client_credentials' },
+      });
       const started = Date.now();
       await authorizeSavedServer(harness);
       const subject = mode === 'shared' ? null : (harness.user.user_id as UserID);

--- a/apps/agor-daemon/src/register-services.oauth-sqlite.integration.test.ts
+++ b/apps/agor-daemon/src/register-services.oauth-sqlite.integration.test.ts
@@ -20,6 +20,7 @@ import {
   UserMCPOAuthTokenRepository,
   UsersRepository,
   update,
+  userMcpOauthTokens,
 } from '@agor/core/db';
 import {
   type Application,
@@ -151,6 +152,8 @@ async function createTestProvider(
     numberedTokenResponses?: boolean;
     holdRefresh?: boolean;
     invalidRefresh?: boolean;
+    gitlab?: boolean;
+    malformedRefresh?: boolean;
     rejectDynamicRegistration?: boolean;
     holdDynamicRegistration?: boolean;
     resourceScopes?: string[];
@@ -159,6 +162,7 @@ async function createTestProvider(
   } = {}
 ): Promise<TestProvider> {
   const requests: TestProvider['requests'] = [];
+  let grantRedirectUri: string | null = null;
   const tokenRequestMilestones = new Map<number, Deferred<void>>();
   const tokenReleaseGates = new Map<number, Deferred<void>>();
   const tokenRequestMilestone = (requestNumber: number): Deferred<void> => {
@@ -267,6 +271,14 @@ async function createTestProvider(
       for await (const chunk of request) body += String(chunk);
       const isRefresh = new URLSearchParams(body).get('grant_type') === 'refresh_token';
       if (isRefresh) {
+        if (options.gitlab) {
+          const form = new URLSearchParams(body);
+          expect(form.get('redirect_uri')).toBe(grantRedirectUri);
+          expect(form.get('client_id')).toBe('saved-client-id');
+          expect(form.get('resource')).toBe(`${baseUrl}/saved/mcp`);
+          // Omitted scope means the originally granted scope, not an expansion.
+          expect(form.has('scope')).toBe(false);
+        }
         refreshRequested.resolve();
         if (options.holdRefresh) await releaseRefresh.promise;
         response.writeHead(options.invalidRefresh ? 400 : 200, {
@@ -274,17 +286,20 @@ async function createTestProvider(
         });
         response.end(
           JSON.stringify(
-            options.invalidRefresh
-              ? { error: 'invalid_grant' }
-              : {
-                  access_token: 'stale-refreshed-access-token',
-                  refresh_token: 'stale-rotated-refresh-token',
-                  expires_in: 3600,
-                }
+            options.malformedRefresh
+              ? { access_token: 'synthetic-access', refresh_token: 42 }
+              : options.invalidRefresh
+                ? { error: 'invalid_grant' }
+                : {
+                    access_token: 'stale-refreshed-access-token',
+                    refresh_token: 'stale-rotated-refresh-token',
+                    expires_in: options.gitlab ? 7200 : 3600,
+                  }
           )
         );
         return;
       }
+      grantRedirectUri = new URLSearchParams(body).get('redirect_uri');
       tokenRequestCount += 1;
       const requestRelease = tokenReleaseGate(tokenRequestCount);
       tokenRequestMilestone(tokenRequestCount).resolve();
@@ -300,7 +315,7 @@ async function createTestProvider(
           refresh_token: options.numberedTokenResponses
             ? `refresh-${tokenRequestCount}`
             : 'refresh',
-          expires_in: 3600,
+          expires_in: options.gitlab ? 7200 : 3600,
         })
       );
       return;
@@ -1308,6 +1323,8 @@ describe('saved-server capability discovery', () => {
     const provider = await createTestProvider();
     providers.push(provider);
     const harness = await createHarness(provider);
+    databases.push(harness.rawDb);
+    await authorizeSavedServer(harness);
     const sentinel = 'SENTINEL_CONTEXT7_AUTH_RESPONSE';
     mcpClientTestState.connectError = Object.assign(new Error(sentinel), { code: 401 });
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
@@ -1338,6 +1355,8 @@ describe('saved-server capability discovery', () => {
     const provider = await createTestProvider();
     providers.push(provider);
     const harness = await createHarness(provider);
+    databases.push(harness.rawDb);
+    await authorizeSavedServer(harness);
     const sentinel = 'SENTINEL_MCP_EGRESS_TIMEOUT';
     mcpClientTestState.connectError = Object.assign(new Error(sentinel), { code: 'ETIMEDOUT' });
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
@@ -2380,6 +2399,11 @@ describe('SQLite saved-row OAuth authority', () => {
       const oauthStart = await harness.app
         .service('mcp-servers/oauth-start')
         .create({ mcp_server_id: harness.server.mcp_server_id }, paramsFor(harness));
+      // Keep the SDK error seam reachable without an OAuth grant: saved OAuth
+      // discovery now correctly refuses before transport when no grant exists.
+      await new MCPServerRepository(harness.rawDb).update(harness.server.mcp_server_id, {
+        auth: { type: 'none' },
+      });
       mcpClientTestState.connectError = hostile;
       const discovery = await harness.app
         .service('mcp-servers/discover')
@@ -3669,6 +3693,121 @@ describe('SQLite saved-row OAuth authority', () => {
         harness.server.mcp_server_id as MCPServerID
       )
     ).toBeNull();
+  });
+
+  it.each(['per_user', 'shared'] as const)(
+    'GitLab-shaped %s callback expires then discovery rotates the durable pair',
+    async (mode) => {
+      const provider = await createTestProvider({ gitlab: true });
+      providers.push(provider);
+      const harness = await createHarness(provider, mode);
+      databases.push(harness.rawDb);
+      const started = Date.now();
+      await authorizeSavedServer(harness);
+      const subject = mode === 'shared' ? null : (harness.user.user_id as UserID);
+      const repository = new UserMCPOAuthTokenRepository(harness.rawDb);
+      const saved = await repository.getToken(subject, harness.server.mcp_server_id as MCPServerID);
+      expect(saved?.oauth_token_expires_at?.getTime()).toBeGreaterThanOrEqual(started + 7_200_000);
+      expect(saved?.oauth_refresh_token).toBe('refresh');
+      expect(saved?.oauth_redirect_uri).toBeTruthy();
+      await update(harness.rawDb, userMcpOauthTokens)
+        .set({ oauth_token_expires_at: new Date(1) })
+        .where(eq(userMcpOauthTokens.mcp_server_id, harness.server.mcp_server_id))
+        .run();
+      mcpClientTestState.tools = [{ name: 'gitlab_list_projects' }];
+      const result = await harness.app
+        .service('mcp-servers/discover')
+        .create({ mcp_server_id: harness.server.mcp_server_id }, paramsFor(harness));
+      expect(result).toMatchObject({ success: true, capabilities: { tools: 1 } });
+      const rotated = await repository.getToken(
+        subject,
+        harness.server.mcp_server_id as MCPServerID
+      );
+      expect(rotated).toMatchObject({
+        oauth_access_token: 'stale-refreshed-access-token',
+        oauth_refresh_token: 'stale-rotated-refresh-token',
+        refresh_status: 'idle',
+        refresh_generation: 1,
+        refresh_success_generation: 1,
+      });
+      expect(rotated?.oauth_token_expires_at?.getTime()).toBeGreaterThan(Date.now() + 7_190_000);
+      expect(rotated?.grant_generation).toBe(saved?.grant_generation);
+      expect(
+        (await new MCPServerRepository(harness.rawDb).findById(harness.server.mcp_server_id))?.tools
+      ).toEqual(
+        expect.arrayContaining([expect.objectContaining({ name: 'gitlab_list_projects' })])
+      );
+    }
+  );
+
+  it.each(['invalid', 'malformed'] as const)(
+    'discovery reports reauth and never replays a %s rotating refresh',
+    async (failure) => {
+      const provider = await createTestProvider({
+        gitlab: true,
+        invalidRefresh: failure === 'invalid',
+        malformedRefresh: failure === 'malformed',
+      });
+      providers.push(provider);
+      const harness = await createHarness(provider, 'per_user');
+      databases.push(harness.rawDb);
+      await authorizeSavedServer(harness);
+      await update(harness.rawDb, userMcpOauthTokens)
+        .set({ oauth_token_expires_at: new Date(1) })
+        .where(eq(userMcpOauthTokens.mcp_server_id, harness.server.mcp_server_id))
+        .run();
+      const discover = () =>
+        harness.app
+          .service('mcp-servers/discover')
+          .create({ mcp_server_id: harness.server.mcp_server_id }, paramsFor(harness));
+      expect(await discover()).toMatchObject({
+        success: false,
+        recovery: { action: 'reauthenticate' },
+      });
+      const repository = new UserMCPOAuthTokenRepository(harness.rawDb);
+      const saved = await repository.getToken(
+        harness.user.user_id as UserID,
+        harness.server.mcp_server_id as MCPServerID
+      );
+      if (failure === 'invalid') expect(saved).toBeNull();
+      else expect(saved?.refresh_status).toBe('ambiguous');
+      const before = provider.requests.filter((r) => r.path === '/token').length;
+      expect(await discover()).toMatchObject({ success: false });
+      expect(provider.requests.filter((r) => r.path === '/token')).toHaveLength(before);
+    }
+  );
+
+  it('coalesces concurrent GitLab refreshes and quarantines a dispatch left by a dead SQLite daemon', async () => {
+    const provider = await createTestProvider({ gitlab: true, holdRefresh: true });
+    providers.push(provider);
+    const harness = await createHarness(provider, 'per_user');
+    databases.push(harness.rawDb);
+    await authorizeSavedServer(harness);
+    const refresh = () =>
+      harness.app
+        .service('mcp-servers/oauth-refresh')
+        .create({ mcp_server_id: harness.server.mcp_server_id }, paramsFor(harness));
+    const first = refresh();
+    await provider.refreshRequested.promise;
+    const second = refresh();
+    provider.releaseRefresh();
+    expect(await first).toMatchObject({ success: true });
+    expect(await second).toMatchObject({ success: true });
+    expect(provider.requests.filter((r) => r.path === '/token')).toHaveLength(2); // callback + one rotation
+    await update(harness.rawDb, userMcpOauthTokens)
+      .set({ refresh_status: 'refreshing', oauth_token_expires_at: new Date(1) })
+      .where(eq(userMcpOauthTokens.mcp_server_id, harness.server.mcp_server_id))
+      .run();
+    expect(await refresh()).toMatchObject({ success: false, error: 'needs_reauth' });
+    expect(provider.requests.filter((r) => r.path === '/token')).toHaveLength(2);
+    expect(
+      (
+        await new UserMCPOAuthTokenRepository(harness.rawDb).getToken(
+          harness.user.user_id as UserID,
+          harness.server.mcp_server_id as MCPServerID
+        )
+      )?.refresh_status
+    ).toBe('ambiguous');
   });
 
   it('does not resurrect a grant deleted by a Settings mutation during refresh', async () => {

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -88,7 +88,10 @@ import {
   OAuthCodeExchangeError,
   OAuthConfigurationError,
 } from '@agor/core/tools/mcp/oauth-mcp-transport';
-import type { RefreshAndPersistDeps } from '@agor/core/tools/mcp/oauth-refresh';
+import {
+  MissingRefreshTokenError,
+  type RefreshAndPersistDeps,
+} from '@agor/core/tools/mcp/oauth-refresh';
 import type {
   AgenticToolName,
   AuthenticatedParams,
@@ -274,12 +277,11 @@ import {
   fingerprintMCPOAuthGrantConfiguration,
   grantBindingVersionForCompatibilityMode,
   hasMCPOAuthRelevantServerConfigurationChanged,
-  isMCPOAuthGrantBoundToServer,
   lockMCPOAuthGrantConfiguration,
-  shouldVerifyMCPOAuthGrantBinding,
 } from './services/mcp-oauth-grant-binding.js';
 import { MCPOAuthPendingFlowAuthority } from './services/mcp-oauth-pending-flow-authority.js';
 import { resolveAuthenticatedServerIds } from './services/mcp-oauth-status.js';
+import { acquireMCPOAuthGrant } from './services/mcp-oauth-use.js';
 import {
   createMCPServersService,
   runWithMCPServerMutationDatabase,
@@ -5873,31 +5875,9 @@ export async function registerMCPServices(
           }
         }
       }
-      const {
-        needsRefresh,
-        refreshAndPersistToken,
-        InvalidGrantError,
-        OAuthRefreshAuthorityCancelledError,
-      } = await import('@agor/core/tools/mcp/oauth-refresh');
-
-      /**
-       * The grant owner's current standing, for the refresh paths below.
-       *
-       * A refresh is not a read: `refreshAndPersistToken` obtains and stores a
-       * *new* access token, which is issuance by the same definition the rest of
-       * this file uses. A delegated task executor already carries its user's
-       * identity; an explicit daemon service account does not. In either case,
-       * the standing that matters belongs to the user the grant is keyed on.
-       *
-       * Resolved once. Every per-user grant in one request belongs to the same
-       * user: `tokenUserId` is the caller's own id, and cross-user lookup is
-       * reserved for service accounts by `resolveForUserIdWithGate`.
-       */
-      let perUserGrantOwnerEntitled: Promise<boolean> | undefined;
-      const isPerUserGrantOwnerEntitled = (): Promise<boolean> => {
-        perUserGrantOwnerEntitled ??= isMcpGrantOwnerEntitled(db, tenantId, userId, 'per_user');
-        return perUserGrantOwnerEntitled;
-      };
+      const { OAuthRefreshAuthorityCancelledError } = await import(
+        '@agor/core/tools/mcp/oauth-refresh'
+      );
 
       await Promise.all(
         serverIds.map(async (serverId) => {
@@ -5922,132 +5902,23 @@ export async function registerMCPServices(
             }
             const tokenUserId: UserID | null = mode === 'per_user' ? (userId as UserID) : null;
 
-            const row = await runInOAuthTenantScope(db, tenantId, () =>
-              new UserMCPOAuthTokenRepository(db).getToken(tokenUserId, serverId as MCPServerID)
-            );
-            if (!row) {
+            try {
+              const grant = await acquireMCPOAuthGrant({
+                db,
+                tenantId,
+                userId: tokenUserId,
+                mcpServerId: serverId as MCPServerID,
+                validateGrant: refreshGrantValidator(tenantId, serverId as MCPServerID),
+                assertCurrent: mcpEgressAssertCurrent,
+                resolveDns: ctx.mcpOutboundDnsLookup,
+              });
+              headers[serverId] = grant
+                ? { authorization: `Bearer ${grant.oauth_access_token}` }
+                : { error: 'needs_reauth' };
+            } catch (error) {
+              if (error instanceof OAuthRefreshAuthorityCancelledError) throw error;
               headers[serverId] = { error: 'needs_reauth' };
-              return;
             }
-            const compatibilityMode = (await resolveMCPOAuthCompatibilityPolicy(server)).mode;
-            if (
-              shouldVerifyMCPOAuthGrantBinding(
-                isPostgresDatabaseHandle(db),
-                row.grant_binding_version
-              ) &&
-              !isMCPOAuthGrantBoundToServer(
-                process.env.AGOR_MASTER_SECRET!,
-                server,
-                row,
-                compatibilityMode
-              )
-            ) {
-              await runInOAuthTenantWriteScope(db, tenantId, () =>
-                new UserMCPOAuthTokenRepository(db).deleteGrantVersion(
-                  tokenUserId,
-                  serverId as MCPServerID,
-                  row.grant_generation,
-                  row.grant_binding_fingerprint
-                )
-              );
-              console.warn('[OAuth AuthHeaders] grant_rejected category=binding_mismatch');
-              headers[serverId] = { error: 'needs_reauth' };
-              return;
-            }
-            if (row.refresh_status === 'ambiguous') {
-              headers[serverId] = { error: 'needs_reauth' };
-              return;
-            }
-
-            /**
-             * Refuse to *extend* a grant whose owner no longer stands where they
-             * did, while still vending one that is already valid.
-             *
-             * That is deliberately where the line falls. A demoted user's
-             * running session keeps its MCP tools until the access token
-             * expires, then reports `needs_reauth` — an error the executor
-             * already surfaces and a person can act on, and which is literally
-             * true: re-authorizing needs member standing back. The alternative,
-             * cutting a running task off the moment its owner is demoted, fails
-             * mid-tool-call with nothing the agent or the user can do about it,
-             * and revoking a credential is not what a role change has ever meant
-             * here (#2301 — demotion is still a column write that revokes
-             * nothing).
-             *
-             * `shared` grants are out of scope: they belong to the tenant rather
-             * than to a person, are admin-only to establish, and have no owner
-             * whose demotion this could describe.
-             */
-            const refreshWouldRun =
-              row.refresh_status === 'refreshing' ||
-              (needsRefresh(row.oauth_token_expires_at) && !!row.oauth_refresh_token);
-            if (refreshWouldRun && mode === 'per_user' && !(await isPerUserGrantOwnerEntitled())) {
-              console.warn('[OAuth AuthHeaders] refresh_refused category=grant_owner_role');
-              headers[serverId] = { error: 'needs_reauth' };
-              return;
-            }
-
-            if (row.refresh_status === 'refreshing') {
-              try {
-                const observed = await refreshAndPersistToken({
-                  db,
-                  tenantId,
-                  userId: tokenUserId,
-                  mcpServerId: serverId as MCPServerID,
-                  observedRefreshVersion: {
-                    grantGeneration: row.grant_generation,
-                    grantBindingFingerprint: row.grant_binding_fingerprint,
-                    refreshGeneration: row.refresh_generation,
-                  },
-                  validateGrant: refreshGrantValidator(tenantId, serverId as MCPServerID),
-                  assertCurrent: mcpEgressAssertCurrent,
-                });
-                headers[serverId] = { authorization: `Bearer ${observed}` };
-              } catch (refreshErr) {
-                if (refreshErr instanceof OAuthRefreshAuthorityCancelledError) throw refreshErr;
-                headers[serverId] = { error: 'needs_reauth' };
-              }
-              return;
-            }
-
-            let accessToken = row.oauth_access_token;
-            if (needsRefresh(row.oauth_token_expires_at) && row.oauth_refresh_token) {
-              try {
-                accessToken = await refreshAndPersistToken({
-                  db,
-                  tenantId,
-                  userId: tokenUserId,
-                  mcpServerId: serverId as MCPServerID,
-                  observedRefreshVersion: {
-                    grantGeneration: row.grant_generation,
-                    grantBindingFingerprint: row.grant_binding_fingerprint,
-                    refreshGeneration: row.refresh_generation,
-                  },
-                  validateGrant: refreshGrantValidator(tenantId, serverId as MCPServerID),
-                  assertCurrent: mcpEgressAssertCurrent,
-                });
-              } catch (refreshErr) {
-                if (refreshErr instanceof OAuthRefreshAuthorityCancelledError) throw refreshErr;
-                if (refreshErr instanceof InvalidGrantError) {
-                  headers[serverId] = { error: 'needs_reauth' };
-                  return;
-                }
-                // A failed/ambiguous rotating-token exchange must not fall back
-                // to a stale token that may already be invalid.
-                console.warn('[OAuth AuthHeaders] refresh_failed category=reauth_or_retry');
-                headers[serverId] = { error: 'needs_reauth' };
-                return;
-              }
-            } else if (
-              !accessToken ||
-              (row.oauth_token_expires_at && row.oauth_token_expires_at <= new Date())
-            ) {
-              // Expired with no refresh_token → must re-auth.
-              headers[serverId] = { error: 'needs_reauth' };
-              return;
-            }
-
-            headers[serverId] = { authorization: `Bearer ${accessToken}` };
           } catch (err) {
             if (err instanceof OAuthRefreshAuthorityCancelledError) throw err;
             externalFailure('OAuth AuthHeaders', 'oauth', err);
@@ -6480,7 +6351,7 @@ export async function registerMCPServices(
         // compatibility code create an unpersisted token; the durable grant
         // lookup/browser-attempt path below remains authoritative.
         let authHeaders =
-          serverConfig.auth?.type === 'oauth' && isConstrainedHa(ctx.deployment)
+          serverConfig.auth?.type === 'oauth' && (serverId || isConstrainedHa(ctx.deployment))
             ? undefined
             : await runWithinOAuthBrowserReservation(browserReservation, () =>
                 resolveMCPAuthHeaders(serverConfig.auth, serverConfig.url, {
@@ -6641,55 +6512,21 @@ export async function registerMCPServices(
           // Durable token rows are the only daemon authority. The old cache
           // keyed solely by MCP origin could cross tenant/server/user grants.
           let oauthToken: string | undefined;
-          let selectedGrant: UserMCPOAuthToken | undefined;
+          let selectedGrant: UserMCPOAuthToken | null | undefined;
           const lookupUserId = serverConfig.auth?.oauth_mode === 'shared' ? null : userId;
           if (serverId) {
             selectedGrant = await runWithinOAuthBrowserReservation(browserReservation, () =>
-              runWithTenantDatabaseScope(db, tenantId, async (scopedDb) => {
-                const tokenRepo = new UserMCPOAuthTokenRepository(scopedDb);
-                const grant = await runWithinOAuthBrowserReservation(browserReservation, () =>
-                  tokenRepo.getToken(lookupUserId, serverId as MCPServerID)
-                );
-                if (!grant) return undefined;
-                const compatibilityPolicy = await runWithinOAuthBrowserReservation(
-                  browserReservation,
-                  () =>
-                    resolveMCPOAuthCompatibilityPolicy(
-                      authoritativeServer ?? {
-                        ...serverConfig,
-                        source: serverConfig.source ?? 'user',
-                      }
-                    )
-                );
-                if (
-                  shouldVerifyMCPOAuthGrantBinding(
-                    isPostgresDatabaseHandle(db),
-                    grant.grant_binding_version
-                  ) &&
-                  !isMCPOAuthGrantBoundToServer(
-                    process.env.AGOR_MASTER_SECRET!,
-                    {
-                      mcp_server_id: serverId as MCPServerID,
-                      enabled: true,
-                      transport: serverConfig.transport,
-                      url: serverConfig.url,
-                      source: serverConfig.source ?? 'user',
-                      catalog_entry_name: serverConfig.catalog_entry_name,
-                      headers: serverConfig.headers,
-                      auth: serverConfig.auth,
-                    },
-                    grant,
-                    compatibilityPolicy.mode
-                  )
-                ) {
-                  return undefined;
-                }
-                if (grant.oauth_token_expires_at && grant.oauth_token_expires_at <= new Date()) {
-                  return undefined;
-                }
-                return grant;
+              acquireMCPOAuthGrant({
+                db,
+                tenantId,
+                userId: lookupUserId,
+                mcpServerId: serverId as MCPServerID,
+                validateGrant: refreshGrantValidator(tenantId, serverId as MCPServerID),
+                assertCurrent: assertRequestAuthority,
+                resolveDns: ctx.mcpOutboundDnsLookup,
               })
             );
+            if (!selectedGrant && !browserReservation) throw new MissingRefreshTokenError();
             oauthToken = selectedGrant?.oauth_access_token;
             if (selectedGrant && discoveryAuthority) {
               discoveryAuthority = bindMCPDiscoveryOAuthGrant(

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -88,10 +88,7 @@ import {
   OAuthCodeExchangeError,
   OAuthConfigurationError,
 } from '@agor/core/tools/mcp/oauth-mcp-transport';
-import {
-  MissingRefreshTokenError,
-  type RefreshAndPersistDeps,
-} from '@agor/core/tools/mcp/oauth-refresh';
+import type { RefreshAndPersistDeps } from '@agor/core/tools/mcp/oauth-refresh';
 import type {
   AgenticToolName,
   AuthenticatedParams,
@@ -281,7 +278,12 @@ import {
 } from './services/mcp-oauth-grant-binding.js';
 import { MCPOAuthPendingFlowAuthority } from './services/mcp-oauth-pending-flow-authority.js';
 import { resolveAuthenticatedServerIds } from './services/mcp-oauth-status.js';
-import { acquireMCPOAuthGrant } from './services/mcp-oauth-use.js';
+import {
+  acquireMCPOAuthGrant,
+  MCPClientCredentialsConfigurationError,
+  MCPOAuthRefreshBusyError,
+  missingMCPOAuthGrantError,
+} from './services/mcp-oauth-use.js';
 import {
   createMCPServersService,
   runWithMCPServerMutationDatabase,
@@ -5798,7 +5800,10 @@ export async function registerMCPServices(
       data: { mcp_server_ids: string[] },
       params?: AuthenticatedParams
     ): Promise<{
-      headers: Record<string, { authorization?: string; error?: string }>;
+      headers: Record<
+        string,
+        { authorization?: string; error?: string; recovery?: MCPAuthRecovery }
+      >;
     }> {
       const userId = params?.user?.user_id;
       if (!userId && params?.provider) {
@@ -5806,7 +5811,10 @@ export async function registerMCPServices(
       }
 
       const serverIds = Array.isArray(data?.mcp_server_ids) ? data.mcp_server_ids : [];
-      const headers: Record<string, { authorization?: string; error?: string }> = {};
+      const headers: Record<
+        string,
+        { authorization?: string; error?: string; recovery?: MCPAuthRecovery }
+      > = {};
 
       if (serverIds.length === 0) {
         return { headers };
@@ -5912,12 +5920,21 @@ export async function registerMCPServices(
                 assertCurrent: mcpEgressAssertCurrent,
                 resolveDns: ctx.mcpOutboundDnsLookup,
               });
-              headers[serverId] = grant
-                ? { authorization: `Bearer ${grant.oauth_access_token}` }
-                : { error: 'needs_reauth' };
+              if (!grant) throw missingMCPOAuthGrantError(server.auth);
+              headers[serverId] = { authorization: `Bearer ${grant.oauth_access_token}` };
             } catch (error) {
               if (error instanceof OAuthRefreshAuthorityCancelledError) throw error;
-              headers[serverId] = { error: 'needs_reauth' };
+              headers[serverId] =
+                error instanceof MCPOAuthRefreshBusyError ||
+                error instanceof MCPClientCredentialsConfigurationError
+                  ? {
+                      error:
+                        error instanceof MCPOAuthRefreshBusyError
+                          ? 'refresh_in_progress'
+                          : 'client_credentials_configuration_required',
+                      recovery: classifyMCPAuthRecovery(error, { mcpServerId: serverId }),
+                    }
+                  : { error: 'needs_reauth' };
             }
           } catch (err) {
             if (err instanceof OAuthRefreshAuthorityCancelledError) throw err;
@@ -6526,7 +6543,8 @@ export async function registerMCPServices(
                 resolveDns: ctx.mcpOutboundDnsLookup,
               })
             );
-            if (!selectedGrant && !browserReservation) throw new MissingRefreshTokenError();
+            if (!selectedGrant && !browserReservation)
+              throw missingMCPOAuthGrantError(serverConfig.auth);
             oauthToken = selectedGrant?.oauth_access_token;
             if (selectedGrant && discoveryAuthority) {
               discoveryAuthority = bindMCPDiscoveryOAuthGrant(
@@ -6767,7 +6785,8 @@ export async function registerMCPServices(
         if (
           recovery.category === 'authentication_required' ||
           recovery.category === 'permission_changed' ||
-          recovery.category === 'configuration_changed'
+          recovery.category === 'configuration_changed' ||
+          recovery.category === 'configuration_required'
         ) {
           return { success: false, error: recovery.message, recovery };
         }

--- a/apps/agor-daemon/src/services/mcp-auth-recovery.test.ts
+++ b/apps/agor-daemon/src/services/mcp-auth-recovery.test.ts
@@ -3,8 +3,19 @@ import { asMCPExternalError } from '@agor/core/mcp';
 import { OAuthConfigurationError, OAuthDCRFailure } from '@agor/core/tools/mcp/oauth-mcp-transport';
 import { describe, expect, it, vi } from 'vitest';
 import { classifyMCPAuthRecovery, recoveryForOAuthAttemptFailure } from './mcp-auth-recovery';
+import { MCPClientCredentialsConfigurationError, MCPOAuthRefreshBusyError } from './mcp-oauth-use';
 
 describe('MCP auth recovery contract', () => {
+  it('distinguishes transient rotation and machine configuration from browser reauth', () => {
+    expect(classifyMCPAuthRecovery(new MCPOAuthRefreshBusyError())).toMatchObject({
+      action: 'retry',
+    });
+    expect(classifyMCPAuthRecovery(new MCPClientCredentialsConfigurationError())).toMatchObject({
+      category: 'configuration_required',
+      action: 'review_configuration',
+      message: expect.stringContaining('client-credentials-only'),
+    });
+  });
   it.each([
     [new Forbidden('SENTINEL_FORBIDDEN'), 'permission_changed', 'retry'],
     [new Conflict('SENTINEL_CONFLICT'), 'configuration_changed', 'save_and_retry'],

--- a/apps/agor-daemon/src/services/mcp-auth-recovery.ts
+++ b/apps/agor-daemon/src/services/mcp-auth-recovery.ts
@@ -2,6 +2,15 @@ import { PublicBaseUrlNotConfiguredError } from '@agor/core/config';
 import { BadRequest, Conflict, Forbidden } from '@agor/core/feathers';
 import { sanitizeMCPExternalError } from '@agor/core/mcp';
 import { OAuthConfigurationError, OAuthDCRFailure } from '@agor/core/tools/mcp/oauth-mcp-transport';
+import {
+  AmbiguousRefreshError,
+  GrantConfigurationChangedError,
+  InvalidGrantError,
+  MissingClientIdError,
+  MissingRefreshTokenError,
+  MissingTokenEndpointError,
+  OAuthRefreshExchangeError,
+} from '@agor/core/tools/mcp/oauth-refresh';
 import type { MCPAuthRecovery, MCPServerID } from '@agor/core/types';
 
 function target(mcpServerId?: string) {
@@ -11,6 +20,13 @@ function target(mcpServerId?: string) {
 }
 
 type TrustedRecoveryErrorConstructor =
+  | typeof AmbiguousRefreshError
+  | typeof InvalidGrantError
+  | typeof MissingRefreshTokenError
+  | typeof MissingClientIdError
+  | typeof MissingTokenEndpointError
+  | typeof GrantConfigurationChangedError
+  | typeof OAuthRefreshExchangeError
   | typeof Forbidden
   | typeof Conflict
   | typeof BadRequest
@@ -132,6 +148,36 @@ export function classifyMCPAuthRecovery(
       message:
         'OAuth needs a browser-reachable Agor callback URL. Configure the deployment public URL and register the callback with the provider, then retry.',
       ...(options.redirectUri ? { redirect_uri: options.redirectUri } : {}),
+    };
+  }
+
+  if (
+    [
+      AmbiguousRefreshError,
+      InvalidGrantError,
+      MissingRefreshTokenError,
+      MissingClientIdError,
+      MissingTokenEndpointError,
+      GrantConfigurationChangedError,
+    ].some((errorClass) => safeInstanceOf(error, errorClass))
+  ) {
+    return {
+      ...common,
+      category: 'authentication_required',
+      action: 'reauthenticate',
+      message:
+        'The saved OAuth grant cannot be used safely. Sign in again to reconnect this server.',
+    };
+  }
+  if (safeInstanceOf(error, OAuthRefreshExchangeError)) {
+    return {
+      ...common,
+      category: 'authentication_required',
+      action: safeOwnDataValue(error, 'ambiguous') === true ? 'reauthenticate' : 'retry',
+      message:
+        safeOwnDataValue(error, 'ambiguous') === true
+          ? 'The provider refresh outcome is unknown. Sign in again; Agor will not replay a possibly consumed refresh token.'
+          : 'The provider refused to refresh access. Retry, or review the saved OAuth client configuration.',
     };
   }
 

--- a/apps/agor-daemon/src/services/mcp-auth-recovery.ts
+++ b/apps/agor-daemon/src/services/mcp-auth-recovery.ts
@@ -12,6 +12,7 @@ import {
   OAuthRefreshExchangeError,
 } from '@agor/core/tools/mcp/oauth-refresh';
 import type { MCPAuthRecovery, MCPServerID } from '@agor/core/types';
+import { MCPClientCredentialsConfigurationError, MCPOAuthRefreshBusyError } from './mcp-oauth-use';
 
 function target(mcpServerId?: string) {
   return {
@@ -20,6 +21,8 @@ function target(mcpServerId?: string) {
 }
 
 type TrustedRecoveryErrorConstructor =
+  | typeof MCPClientCredentialsConfigurationError
+  | typeof MCPOAuthRefreshBusyError
   | typeof AmbiguousRefreshError
   | typeof InvalidGrantError
   | typeof MissingRefreshTokenError
@@ -63,6 +66,24 @@ export function classifyMCPAuthRecovery(
 ): MCPAuthRecovery {
   const common = target(options.mcpServerId);
 
+  if (safeInstanceOf(error, MCPOAuthRefreshBusyError)) {
+    return {
+      ...common,
+      category: 'authentication_required',
+      action: 'retry',
+      message:
+        'OAuth access changed during refresh. Retry to use the current grant; no additional refresh was attempted.',
+    };
+  }
+  if (safeInstanceOf(error, MCPClientCredentialsConfigurationError)) {
+    return {
+      ...common,
+      category: 'configuration_required',
+      action: 'review_configuration',
+      message:
+        'No bound OAuth grant is available. Legacy client-credential fields alone do not establish a saved machine-token connection. For browser-capable providers, configure authorization-code OAuth and reconnect. For a client-credentials-only server, use a supported bearer credential instead; browser sign-in cannot repair it.',
+    };
+  }
   if (safeInstanceOf(error, Forbidden)) {
     return {
       ...common,

--- a/apps/agor-daemon/src/services/mcp-oauth-status.test.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-status.test.ts
@@ -111,14 +111,17 @@ describe('resolveAuthenticatedServerIds', () => {
     await expect(resolveAuthenticatedServerIds(deps)).resolves.toEqual(['server-alices-private']);
   });
 
-  it('never advertises a refresh-ambiguous grant as authenticated', async () => {
-    const deps = buildDeps({
-      listShared: async () => [grantFor('server-shared', { refresh_status: 'ambiguous' })],
-      findServers: async () => [serverOwnedBy('server-shared')],
-    });
+  it.each(['ambiguous', 'refreshing'] as const)(
+    'never advertises a %s grant as authenticated',
+    async (refresh_status) => {
+      const deps = buildDeps({
+        listShared: async () => [grantFor('server-shared', { refresh_status })],
+        findServers: async () => [serverOwnedBy('server-shared')],
+      });
 
-    await expect(resolveAuthenticatedServerIds(deps)).resolves.toEqual([]);
-  });
+      await expect(resolveAuthenticatedServerIds(deps)).resolves.toEqual([]);
+    }
+  );
 
   it('never advertises an expired grant', async () => {
     const deps = buildDeps({

--- a/apps/agor-daemon/src/services/mcp-oauth-status.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-status.ts
@@ -65,7 +65,8 @@ export async function resolveAuthenticatedServerIds(deps: OAuthStatusDeps): Prom
   const tokens = [...perUserTokens, ...sharedTokens].filter(
     (token) =>
       !(token.oauth_token_expires_at && token.oauth_token_expires_at <= now) &&
-      token.refresh_status !== 'ambiguous'
+      token.refresh_status !== 'ambiguous' &&
+      token.refresh_status !== 'refreshing'
   );
   const servers = new Map(
     (await deps.findServers([...new Set(tokens.map((token) => token.mcp_server_id))])).map(

--- a/apps/agor-daemon/src/services/mcp-oauth-use.postgres.test.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-use.postgres.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Active-active refresh proofs. Run against a PostgreSQL role that is
+ * NOSUPERUSER and NOBYPASSRLS; two independent pools model two daemons.
+ */
+import http from 'node:http';
+import {
+  createDatabase,
+  createTenantScopedDatabaseProxy,
+  initializeDatabase,
+  MCPOAuthPendingFlowRepository,
+  MCPServerRepository,
+  type RawDatabase,
+  runWithTenantDatabaseScope,
+  type TenantScopeAwareDatabase,
+  UserMCPOAuthTokenRepository,
+  UsersRepository,
+} from '@agor/core/db';
+import { refreshAndPersistToken } from '@agor/core/tools/mcp/oauth-refresh';
+import type { MCPServerID, UserID } from '@agor/core/types';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { classifyMCPAuthRecovery } from './mcp-auth-recovery';
+import { acquireMCPOAuthGrant, MCPOAuthRefreshBusyError } from './mcp-oauth-use';
+
+// Hold only A's return boundary after the real provider exchange + CAS commit.
+// B uses a separate pool and the real refresher; no timing sleeps or fake rows.
+const race = vi.hoisted(() => ({
+  afterRefresh: undefined as undefined | ((db: unknown) => Promise<void>),
+}));
+vi.mock('@agor/core/tools/mcp/oauth-refresh', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@agor/core/tools/mcp/oauth-refresh')>();
+  return {
+    ...original,
+    refreshAndPersistToken: async (deps: Parameters<typeof original.refreshAndPersistToken>[0]) => {
+      const token = await original.refreshAndPersistToken(deps);
+      await race.afterRefresh?.(deps.db);
+      return token;
+    },
+  };
+});
+
+const postgresUrl = process.env.AGOR_TEST_POSTGRES_URL;
+const usesPostgresSchema = process.env.AGOR_DB_DIALECT === 'postgresql';
+const masterSecret = 'mcp-oauth-refresh-postgres-test-master-secret';
+
+interface Seed {
+  tenantId: string;
+  userId: UserID;
+  serverId: MCPServerID;
+  generation: number;
+}
+
+describe.skipIf(!postgresUrl || !usesPostgresSchema)(
+  'MCP OAuth use committed re-read across replicas (PostgreSQL)',
+  () => {
+    let rawA: RawDatabase;
+    let rawB: RawDatabase;
+    let dbA: TenantScopeAwareDatabase;
+    let dbB: TenantScopeAwareDatabase;
+    const originalMasterSecret = process.env.AGOR_MASTER_SECRET;
+    const servers: http.Server[] = [];
+
+    beforeAll(async () => {
+      process.env.AGOR_MASTER_SECRET = masterSecret;
+      rawA = createDatabase({ dialect: 'postgresql', url: postgresUrl! });
+      rawB = createDatabase({ dialect: 'postgresql', url: postgresUrl! });
+      await initializeDatabase(rawA);
+      dbA = createTenantScopedDatabaseProxy(rawA, {
+        requireScope: true,
+        label: 'OAuth refresh daemon A',
+      });
+      dbB = createTenantScopedDatabaseProxy(rawB, {
+        requireScope: true,
+        label: 'OAuth refresh daemon B',
+      });
+    });
+
+    afterAll(async () => {
+      await Promise.all(
+        servers.map(
+          (server) =>
+            new Promise<void>((resolve) => {
+              server.close(() => resolve());
+            })
+        )
+      );
+      await Promise.all([
+        (rawA as RawDatabase & { $client: { end: () => Promise<void> } }).$client.end(),
+        (rawB as RawDatabase & { $client: { end: () => Promise<void> } }).$client.end(),
+      ]);
+      if (originalMasterSecret === undefined) delete process.env.AGOR_MASTER_SECRET;
+      else process.env.AGOR_MASTER_SECRET = originalMasterSecret;
+    });
+
+    async function provider(
+      handler: (body: URLSearchParams, response: http.ServerResponse) => void | Promise<void>
+    ): Promise<{ url: string; calls: () => number }> {
+      let callCount = 0;
+      const server = http.createServer(async (request, response) => {
+        callCount += 1;
+        const chunks: Buffer[] = [];
+        for await (const chunk of request) chunks.push(Buffer.from(chunk));
+        await handler(new URLSearchParams(Buffer.concat(chunks).toString('utf8')), response);
+      });
+      servers.push(server);
+      await new Promise<void>((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(0, '127.0.0.1', resolve);
+      });
+      const address = server.address();
+      if (!address || typeof address === 'string') throw new Error('Expected TCP listener');
+      return {
+        url: `http://127.0.0.1:${address.port}/token`,
+        calls: () => callCount,
+      };
+    }
+
+    async function seed(label: string, tokenEndpoint: string): Promise<Seed> {
+      const tenantId = `oauth-refresh-${label}-${crypto.randomUUID()}`;
+      return runWithTenantDatabaseScope(dbA, tenantId, async (scoped) => {
+        const user = await new UsersRepository(scoped).create({
+          email: `${crypto.randomUUID()}@example.test`,
+          name: `Refresh ${label}`,
+        });
+        const server = await new MCPServerRepository(scoped).create({
+          name: `refresh-${label}-${crypto.randomUUID()}`,
+          display_name: `Refresh ${label}`,
+          transport: 'http',
+          url: `https://mcp.example.test/${label}`,
+          scope: 'global',
+          enabled: true,
+          source: 'user',
+          owner_user_id: user.user_id,
+          auth: {
+            type: 'oauth',
+            oauth_mode: 'per_user',
+            oauth_client_id: 'configured-client',
+            oauth_token_url: tokenEndpoint,
+          },
+        });
+        const generation = await new MCPOAuthPendingFlowRepository(scoped).allocateGrantGeneration({
+          tenantId,
+          mcpServerId: server.mcp_server_id as MCPServerID,
+          oauthMode: 'per_user',
+          subjectUserId: user.user_id as UserID,
+        });
+        await new UserMCPOAuthTokenRepository(scoped, masterSecret).saveToken(
+          user.user_id as UserID,
+          server.mcp_server_id as MCPServerID,
+          {
+            accessToken: `expired-access-${label}`,
+            refreshToken: `refresh-${label}-0`,
+            clientId: 'configured-client',
+            expiresAt: new Date(Date.now() - 60_000),
+            grantBinding: {
+              generation,
+              version: 1,
+              fingerprint: 'a'.repeat(64),
+              metadataUri: `https://mcp.example.test/${label}/.well-known/oauth-protected-resource`,
+              resourceUri: `https://mcp.example.test/${label}`,
+              issuer: 'https://provider.example.test',
+              authorizationEndpoint: 'https://provider.example.test/authorize',
+              tokenEndpoint,
+              redirectUri: 'https://agor.example.test/mcp-servers/oauth-callback',
+            },
+          }
+        );
+        return {
+          tenantId,
+          userId: user.user_id as UserID,
+          serverId: server.mcp_server_id as MCPServerID,
+          generation,
+        };
+      });
+    }
+
+    it.each(['completed', 'refreshing'] as const)(
+      'handles a newer %s rotation without reauthentication',
+      async (state) => {
+        let ordinal = 0;
+        let release!: () => void;
+        const held = new Promise<void>((resolve) => {
+          release = resolve;
+        });
+        let started!: () => void;
+        const secondStarted = new Promise<void>((resolve) => {
+          started = resolve;
+        });
+        const tokenProvider = await provider(async (body, response) => {
+          const current = ++ordinal;
+          expect(body.get('refresh_token')).toBe(
+            current === 1 ? `refresh-${state}-0` : 'rotated-refresh-1'
+          );
+          if (current === 2) {
+            started();
+            if (state === 'refreshing') await held;
+          }
+          response.writeHead(200, { 'content-type': 'application/json' });
+          response.end(
+            JSON.stringify({
+              access_token: `rotated-access-${current}`,
+              refresh_token: `rotated-refresh-${current}`,
+              token_type: 'Bearer',
+              expires_in: 7200,
+            })
+          );
+        });
+        const bound = await seed(state, tokenProvider.url);
+        const deps = {
+          db: dbA,
+          tenantId: bound.tenantId,
+          userId: bound.userId,
+          mcpServerId: bound.serverId,
+          validateGrant: async () => true,
+          allowLocalhostHttpDevelopment: true,
+        };
+        let second: Promise<string> | undefined;
+        race.afterRefresh = async (db) => {
+          if (db !== dbA) return;
+          race.afterRefresh = undefined;
+          second = refreshAndPersistToken({
+            ...deps,
+            db: dbB,
+            observedRefreshVersion: {
+              grantGeneration: bound.generation,
+              grantBindingFingerprint: 'a'.repeat(64),
+              refreshGeneration: 1,
+            },
+          });
+          if (state === 'completed') await second;
+          else await secondStarted;
+        };
+        try {
+          if (state === 'completed') {
+            const acquired = await acquireMCPOAuthGrant(deps);
+            expect(acquired).toMatchObject({
+              refresh_generation: 2,
+              refresh_success_generation: 2,
+              refresh_status: 'idle',
+              oauth_access_token: 'rotated-access-2',
+            });
+          } else {
+            const error = await acquireMCPOAuthGrant(deps).catch((error) => error);
+            expect(error).toBeInstanceOf(MCPOAuthRefreshBusyError);
+            expect(classifyMCPAuthRecovery(error).action).toBe('retry');
+          }
+        } finally {
+          release();
+          race.afterRefresh = undefined;
+          await second;
+        }
+        const acquired = await acquireMCPOAuthGrant({ ...deps, db: dbB });
+        expect(acquired).toMatchObject({
+          refresh_generation: 2,
+          refresh_success_generation: 2,
+          refresh_status: 'idle',
+          oauth_access_token: 'rotated-access-2',
+        });
+        // Re-read never exchanges the previous rotating credential again.
+        expect(tokenProvider.calls()).toBe(2);
+        expect(
+          await acquireMCPOAuthGrant({ ...deps, tenantId: `${bound.tenantId}-foreign` })
+        ).toBeNull();
+        expect(tokenProvider.calls()).toBe(2);
+      }
+    );
+  }
+);

--- a/apps/agor-daemon/src/services/mcp-oauth-use.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-use.ts
@@ -1,0 +1,74 @@
+import { runWithTenantDatabaseScope, UserMCPOAuthTokenRepository } from '@agor/core/db';
+import { assertMcpGrantSubjectEntitled } from '@agor/core/tools/mcp/grant-entitlement';
+import {
+  AmbiguousRefreshError,
+  GrantConfigurationChangedError,
+  MissingRefreshTokenError,
+  needsRefresh,
+  type RefreshAndPersistDeps,
+  refreshAndPersistToken,
+} from '@agor/core/tools/mcp/oauth-refresh';
+
+/**
+ * One use-time boundary for execution and capability discovery. Never call
+ * from inventory: obtaining a usable grant can rotate provider credentials.
+ * External I/O stays outside short tenant database units, and the returned
+ * row is the exact committed grant (needed by discovery's publication fence).
+ */
+export async function acquireMCPOAuthGrant(
+  deps: Omit<RefreshAndPersistDeps, 'observedRefreshVersion'>
+) {
+  const read = () =>
+    runWithTenantDatabaseScope(deps.db, deps.tenantId, async (db) => {
+      const grant = await new UserMCPOAuthTokenRepository(db).getToken(
+        deps.userId,
+        deps.mcpServerId
+      );
+      if (grant && !(await deps.validateGrant(grant, db))) {
+        throw new GrantConfigurationChangedError();
+      }
+      return grant;
+    });
+  const grant = await read();
+  if (!grant) return null;
+  if (grant.refresh_status === 'ambiguous') throw new AmbiguousRefreshError();
+  if (
+    grant.refresh_status === 'refreshing' ||
+    (needsRefresh(grant.oauth_token_expires_at) && grant.oauth_refresh_token)
+  ) {
+    await runWithTenantDatabaseScope(deps.db, deps.tenantId, (db) =>
+      assertMcpGrantSubjectEntitled({
+        db,
+        tenantId: deps.tenantId,
+        subjectUserId: deps.userId,
+        oauthMode: deps.userId === null ? 'shared' : 'per_user',
+      })
+    );
+    const accessToken = await refreshAndPersistToken({
+      ...deps,
+      observedRefreshVersion: {
+        grantGeneration: grant.grant_generation,
+        grantBindingFingerprint: grant.grant_binding_fingerprint,
+        refreshGeneration: grant.refresh_generation,
+      },
+    });
+    const committed = await read();
+    if (
+      !committed ||
+      committed.grant_generation !== grant.grant_generation ||
+      committed.grant_binding_fingerprint !== grant.grant_binding_fingerprint ||
+      committed.refresh_status !== 'idle' ||
+      committed.oauth_access_token !== accessToken
+    ) {
+      throw new GrantConfigurationChangedError();
+    }
+    return committed;
+  }
+  if (
+    !grant.oauth_access_token ||
+    (grant.oauth_token_expires_at && grant.oauth_token_expires_at.getTime() <= Date.now())
+  ) {
+    throw new MissingRefreshTokenError();
+  }
+  return grant;
+}

--- a/apps/agor-daemon/src/services/mcp-oauth-use.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-use.ts
@@ -8,6 +8,35 @@ import {
   type RefreshAndPersistDeps,
   refreshAndPersistToken,
 } from '@agor/core/tools/mcp/oauth-refresh';
+import type { MCPAuth } from '@agor/core/types';
+
+/** A live newer rotation is contention, not lost authorization. */
+export class MCPOAuthRefreshBusyError extends Error {
+  constructor() {
+    super('OAuth access changed during refresh. Retry using the current grant.');
+    this.name = 'MCPOAuthRefreshBusyError';
+  }
+}
+
+/** Ephemeral machine tokens are not durable browser grants. */
+export class MCPClientCredentialsConfigurationError extends Error {
+  constructor() {
+    super('Saved client-credentials OAuth requires a supported authentication configuration.');
+    this.name = 'MCPClientCredentialsConfigurationError';
+  }
+}
+
+export function missingMCPOAuthGrantError(auth: MCPAuth): Error {
+  // Legacy forms defaulted an omitted grant type to client_credentials. Do not
+  // mint a machine token here: a missing row can also be a retired browser grant.
+  if (
+    auth.oauth_grant_type === 'client_credentials' ||
+    (!auth.oauth_grant_type && auth.oauth_client_id && auth.oauth_client_secret)
+  ) {
+    return new MCPClientCredentialsConfigurationError();
+  }
+  return new MissingRefreshTokenError();
+}
 
 /**
  * One use-time boundary for execution and capability discovery. Never call
@@ -57,10 +86,24 @@ export async function acquireMCPOAuthGrant(
       !committed ||
       committed.grant_generation !== grant.grant_generation ||
       committed.grant_binding_fingerprint !== grant.grant_binding_fingerprint ||
-      committed.refresh_status !== 'idle' ||
-      committed.oauth_access_token !== accessToken
+      committed.refresh_generation < grant.refresh_generation
     ) {
       throw new GrantConfigurationChangedError();
+    }
+    if (committed.refresh_status === 'ambiguous') throw new AmbiguousRefreshError();
+    // Another replica may have claimed/completed the next rotation after our
+    // exchange committed. Never vend the superseded token or replay a refresh.
+    // A successful newer idle row is authoritative; an active/failed newer
+    // claim is retryable contention, not a configuration/reauthentication error.
+    if (
+      committed.refresh_status !== 'idle' ||
+      committed.refresh_success_generation !== committed.refresh_generation ||
+      !committed.oauth_access_token ||
+      (committed.oauth_access_token !== accessToken &&
+        committed.refresh_success_generation <= grant.refresh_generation) ||
+      (committed.oauth_token_expires_at && committed.oauth_token_expires_at.getTime() <= Date.now())
+    ) {
+      throw new MCPOAuthRefreshBusyError();
     }
     return committed;
   }

--- a/apps/agor-docs/content/guide/mcp-servers.mdx
+++ b/apps/agor-docs/content/guide/mcp-servers.mdx
@@ -15,6 +15,31 @@ Catalog's pre-connect readiness is advisory from catalog and saved-connection da
 
 For unsupported schemes, configure the server in **Settings → MCP Servers**. Custom headers still support alternatives such as Datadog API/application-key pairs; Catalog's Datadog entry uses Datadog's recommended browser OAuth flow instead of asking users to manage a long-lived PAT or SAT. That card targets Datadog's US1 MCP endpoint. Other Datadog sites need their regional endpoint configured manually, and an organisation may need to allow-list the Agor callback under **MCP OAuth Redirect URLs** before sign-in completes.
 
+### Expiring OAuth access and refresh
+
+**Connected** means the saved access grant is currently usable according to its stored
+expiry and configuration binding; it is not a live provider health check. **Refresh needed**
+means access has expired and a refresh credential is stored. Agor attempts refresh just before
+use, including **Refresh tools** and saved-server connection tests, without opening a sign-in
+window. Inventory reads never contact providers. A successful refresh atomically replaces the
+access token and any rotated refresh token; an omitted refresh token preserves the old one.
+
+GitLab normally issues access tokens lasting two hours (`expires_in: 7200`). This is the
+provider's access-token lifetime, not an Agor daily sign-in limit. Agor sends the grant's
+original redirect URI and client credentials when refreshing. A valid stored refresh grant
+can renew access without user interaction.
+
+If the token endpoint definitively rejects the grant/client, Agor retires that exact grant.
+If an exchange may have consumed a rotating refresh token but its result was lost or malformed,
+Agor quarantines it instead of replaying it. Use **Connect** or **Reconnect** in the server's
+settings to sign in again. Temporary, unambiguous provider rejections preserve the grant for
+retry; a missing refresh token or incompatible saved client may also require sign-in.
+
+Existing bound grants with valid refresh credentials can recover on their next use after an
+upgrade. A missing original redirect/client, revoked grant, or quarantined/lost rotation may
+need one new sign-in. Upgrading cannot recover a token pair the provider issued but Agor never
+received. Do not disconnect a working refreshable grant merely because access expired.
+
 ### Recovering a provider-deleted OAuth client (administrators)
 
 If sign-in repeatedly fails at the provider with an unknown/deleted client, ordinary reconnect may keep selecting the same saved Dynamic Client Registration (DCR). Agor automatically retires that exact registration only when the provider's token endpoint returns a structured `invalid_client` or `unauthorized_client` error. A browser/authorization-page error alone does not authorize retirement.

--- a/apps/agor-docs/content/guide/mcp-servers.mdx
+++ b/apps/agor-docs/content/guide/mcp-servers.mdx
@@ -40,6 +40,29 @@ upgrade. A missing original redirect/client, revoked grant, or quarantined/lost 
 need one new sign-in. Upgrading cannot recover a token pair the provider issued but Agor never
 received. Do not disconnect a working refreshable grant merely because access expired.
 
+### Saved client-credentials configurations
+
+Client credentials (machine-to-machine OAuth) and browser authorization-code grants are
+not interchangeable. **Test Authentication** and direct standalone core integrations retain
+their legacy client-credentials exchange, but it does not persist a browser grant or establish
+that a saved server is usable for tasks. Daemon-backed execution and HA discovery require a
+bound durable OAuth grant. Saved standalone discovery now follows the same boundary rather
+than minting an untracked machine token. This is a compatibility change for installations
+that previously used standalone **Refresh tools** with client credentials alone.
+
+When no durable grant exists for a client-credentials configuration, discovery reports
+**Review configuration**, not browser reauthentication. Configure authorization-code OAuth if
+the provider supports it, or use a provider-supported bearer credential. A machine-only
+provider cannot be repaired by repeatedly opening browser sign-in. Configured client IDs and
+secrets can also belong to browser OAuth; an existing bound grant continues to work regardless
+of the legacy form's grant-type default. Agor never falls back to machine-token minting after
+a browser grant fails or is retired.
+
+A newer refresh on another daemon may temporarily require retrying a request; it does not
+require replacing a healthy grant. For rotating credentials, even a crash after the durable
+dispatch fence but before network dispatch can require one sign-in: Agor cannot safely prove
+that the provider did not consume the token and will not replay it.
+
 ### Recovering a provider-deleted OAuth client (administrators)
 
 If sign-in repeatedly fails at the provider with an unknown/deleted client, ordinary reconnect may keep selecting the same saved Dynamic Client Registration (DCR). Agor automatically retires that exact registration only when the provider's token endpoint returns a structured `invalid_client` or `unauthorized_client` error. A browser/authorization-page error alone does not authorize retirement.

--- a/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.height.browser.test.tsx
+++ b/apps/agor-ui/src/components/BoardTeammatePanel/BoardTeammatePanel.height.browser.test.tsx
@@ -250,21 +250,27 @@ it.each([
       ...makeGatewaySessions(gatewayCount),
     ]);
     const scrollers = () => [...container.querySelectorAll<HTMLElement>('.ant-tree-list-holder')];
-    await waitFor(() => {
-      expect(scrollers()).toHaveLength(2);
-      for (const [index, count] of [manualCount, gatewayCount].entries()) {
-        const tree = scrollers()[index];
-        if (count <= 2) {
-          const section = tree.closest('.ant-collapse')!;
-          // Only the Collapse body padding may follow the rendered short tree.
-          expect(
-            section.getBoundingClientRect().bottom - tree.getBoundingClientRect().bottom
-          ).toBeLessThan(20);
-        } else {
-          expect(tree.clientHeight).toBeGreaterThan(500);
+    // Initial allocation also waits for Collapse motion and ResizeObserver
+    // redistribution. Use the same bounded convergence window as live growth
+    // below; an intermediate equal split must not satisfy the geometry checks.
+    await waitFor(
+      () => {
+        expect(scrollers()).toHaveLength(2);
+        for (const [index, count] of [manualCount, gatewayCount].entries()) {
+          const tree = scrollers()[index];
+          if (count <= 2) {
+            const section = tree.closest('.ant-collapse')!;
+            // Only the Collapse body padding may follow the rendered short tree.
+            expect(
+              section.getBoundingClientRect().bottom - tree.getBoundingClientRect().bottom
+            ).toBeLessThan(20);
+          } else {
+            expect(tree.clientHeight).toBeGreaterThan(500);
+          }
         }
-      }
-    });
+      },
+      { timeout: 5_000 }
+    );
     // Realtime growth must remove the short-tree cap; later shrink must restore it.
     await act(async () => {
       agorStore.setState({

--- a/apps/agor-ui/src/components/Marketplace/CredentialsTab.test.tsx
+++ b/apps/agor-ui/src/components/Marketplace/CredentialsTab.test.tsx
@@ -51,7 +51,7 @@ describe('Marketplace credential metadata', () => {
     const active = screen.getByText('Active server').closest('tr');
     expect(active).not.toBeNull();
     expect(within(active!).getByText('OAuth')).toBeInTheDocument();
-    expect(within(active!).getByText('Connected')).toBeInTheDocument();
+    expect(within(active!).getByText('Access expired')).toBeInTheDocument();
     expect(within(active!).getAllByText(new Date(TIMESTAMP).toLocaleString())).toHaveLength(2);
     fireEvent.click(
       screen.getByRole('button', {
@@ -65,7 +65,7 @@ describe('Marketplace credential metadata', () => {
     const statuses = [
       ['active', 'Connected', 'success', 'Settings'],
       ['configured', 'Credential stored', 'default', 'Settings'],
-      ['refreshable', 'Connected', 'success', 'Settings'],
+      ['refreshable', 'Refresh needed', 'warning', 'Settings'],
       ['refreshing', 'Refreshing', 'processing', 'Settings'],
       ['reauthentication_required', 'Reconnect required', 'error', 'Reconnect'],
       ['not_connected', 'Sign-in required', 'warning', 'Connect'],

--- a/apps/agor-ui/src/components/Marketplace/Marketplace.layout.browser.test.tsx
+++ b/apps/agor-ui/src/components/Marketplace/Marketplace.layout.browser.test.tsx
@@ -5,7 +5,7 @@
  * cover the browser result at the desktop, phone, and short-landscape viewports
  * configured in `vitest.browser.config.ts`, without screenshot pixel churn.
  */
-import type { MCPCatalogEntry, MCPMarketplaceOverview } from '@agor/core/types';
+import type { MCPCatalogEntry, MCPMarketplaceOverview, MCPServerID } from '@agor/core/types';
 import type { AgorClient, User } from '@agor-live/client';
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { ConfigProvider } from 'antd';
@@ -21,6 +21,8 @@ import {
   MARKETPLACE_CATALOG_DRAWER_WIDTH,
   MARKETPLACE_SERVER_DRAWER_WIDTH,
 } from './marketplaceLayout';
+import { marketplaceCredentialPresentation } from './marketplacePresentation';
+import { ServerSettingsDrawer } from './ServerSettingsDrawer';
 import { SessionsTab } from './SessionsTab';
 
 const CATALOG_ENTRY: MCPCatalogEntry = {
@@ -388,6 +390,78 @@ describe('Catalog responsive layout (real browser)', () => {
     const manage = screen.getByRole('button', { name: /OAuth connection/ });
     expect(document.querySelector('.ant-table-content')).toBeNull();
     expectReachableInViewport(manage);
+  });
+
+  it('shows expired GitLab refresh pending, then actionable reauth without claiming Connected', async () => {
+    const server = {
+      mcp_server_id: 'gitlab' as MCPServerID,
+      name: 'GitLab',
+      source: 'user',
+      transport: 'http',
+      enabled: true,
+      tools: [],
+      session_count: 0,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    } satisfies MCPMarketplaceOverview['servers'][number];
+    const reconnect = vi.fn();
+    const refreshTools = vi.fn();
+    const props = {
+      server,
+      attachments: [],
+      cursorAttached: false,
+      canRefresh: true,
+      canChangeTools: true,
+      canReconnect: true,
+      canRemove: true,
+      busy: new Set<string>(),
+      onClose: vi.fn(),
+      onAfterOpenChange: vi.fn(),
+      onReconnectOAuth: reconnect,
+      onRefreshTools: refreshTools,
+      onToggleTool: vi.fn(),
+      onRemove: vi.fn(),
+    };
+    const renewable = {
+      mcp_server_id: 'gitlab' as MCPServerID,
+      server_name: 'GitLab',
+      method: 'oauth',
+      status: 'expired',
+      detail_status: 'refreshable',
+      expires_at: new Date(1).toISOString(),
+    } satisfies MCPMarketplaceOverview['credentials'][number];
+    const view = render(
+      <ServerSettingsDrawer
+        {...props}
+        credential={renewable}
+        connection={marketplaceCredentialPresentation(renewable)}
+      />
+    );
+    expect(await screen.findByText(/OAuth.*Refresh needed/)).toBeVisible();
+    expect(screen.queryByText(/OAuth.*Connected/)).not.toBeInTheDocument();
+    expect(refreshTools).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh tools' }));
+    expect(refreshTools).toHaveBeenCalledTimes(1);
+    const failed = {
+      ...renewable,
+      status: 'attention',
+      detail_status: 'reauthentication_required',
+    } as const;
+    view.rerender(
+      <ServerSettingsDrawer
+        {...props}
+        credential={failed}
+        connection={marketplaceCredentialPresentation(failed)}
+      />
+    );
+    const reconnectButton = await screen.findByRole('button', { name: 'Reconnect GitLab account' });
+    await waitFor(() => {
+      reconnectButton.scrollIntoView({ block: 'center', inline: 'nearest' });
+      expectReachableInViewport(reconnectButton);
+    });
+    fireEvent.click(reconnectButton);
+    expect(reconnect).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText(/OAuth.*Connected/)).not.toBeInTheDocument();
   });
 
   it('keeps the primary My Servers action directly reachable on a phone', async () => {

--- a/apps/agor-ui/src/components/Marketplace/MyServersTab.test.tsx
+++ b/apps/agor-ui/src/components/Marketplace/MyServersTab.test.tsx
@@ -684,7 +684,7 @@ describe('Marketplace server inventory and settings', () => {
     expect(drawer.getAllByLabelText('GitHub: read_wiki_contents on')).toHaveLength(1);
     const refreshTools = drawer.getByText('Refresh tools').closest('button');
     expect(refreshTools).toBeEnabled();
-    expect(mocked.refresh).not.toHaveBeenCalled();
+    expect(mocked.refresh).toHaveBeenCalledTimes(1);
 
     const close = drawer.getByLabelText('Close');
     fireEvent.click(close);
@@ -851,7 +851,7 @@ describe('Marketplace server inventory and settings', () => {
 
     await waitFor(() => expect(error).toHaveBeenCalledWith('Provider is unavailable'));
     expect(success).not.toHaveBeenCalled();
-    expect(refresh).not.toHaveBeenCalled();
+    expect(refresh).toHaveBeenCalledTimes(1);
   });
 
   it('fails closed when member policy permits reuse but not configuration', async () => {

--- a/apps/agor-ui/src/components/Marketplace/MyServersTab.tsx
+++ b/apps/agor-ui/src/components/Marketplace/MyServersTab.tsx
@@ -474,10 +474,12 @@ export const MyServersTab: React.FC<MyServersTabProps> = ({
           next.delete(key);
           busyRef.current = next;
           setBusy(next);
+          // Refresh may rotate or retire a grant even when discovery fails.
+          void refresh();
         }
       }
     },
-    [client, guard]
+    [client, guard, refresh]
   );
 
   const toggleTool = useCallback(

--- a/apps/agor-ui/src/components/Marketplace/marketplacePresentation.test.ts
+++ b/apps/agor-ui/src/components/Marketplace/marketplacePresentation.test.ts
@@ -1,5 +1,5 @@
 import type { MCPMarketplaceCredential } from '@agor/core/types';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   formatMarketplaceDate,
   marketplaceCredentialActionLabel,
@@ -80,6 +80,36 @@ describe('Marketplace presentation vocabulary', () => {
       detail:
         'Your credential is stored securely. The remote provider verifies it when this server is used.',
     });
+  });
+
+  it('never labels an active projection Connected after its known expiry', () => {
+    const now = Date.parse('2026-09-09T12:00:00Z');
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(now);
+    try {
+      const credential: MCPMarketplaceCredential = {
+        mcp_server_id: 'server-1',
+        server_name: 'GitLab',
+        method: 'oauth',
+        status: 'active',
+        detail_status: 'active',
+        expires_at: new Date(now).toISOString(),
+      };
+      expect(marketplaceCredentialPresentation(credential)).toEqual({
+        label: 'Access expired',
+        badge: 'warning',
+        detail:
+          'Access has expired. Refresh status to check whether the saved grant can be renewed.',
+      });
+      expect(marketplaceCredentialActionLabel(credential)).toBe('Settings');
+      expect(
+        marketplaceCredentialPresentation({
+          ...credential,
+          expires_at: new Date(now + 1).toISOString(),
+        }).label
+      ).toBe('Connected');
+    } finally {
+      clock.mockRestore();
+    }
   });
 
   it('returns a safe dash for absent or invalid dates', () => {

--- a/apps/agor-ui/src/components/Marketplace/marketplacePresentation.ts
+++ b/apps/agor-ui/src/components/Marketplace/marketplacePresentation.ts
@@ -48,6 +48,14 @@ export function marketplaceCredentialPresentation(
 
   switch (credentialDetailStatus(credential)) {
     case 'active':
+      if (credential.expires_at && Date.parse(credential.expires_at) <= Date.now()) {
+        return {
+          label: 'Access expired',
+          badge: 'warning',
+          detail:
+            'Access has expired. Refresh status to check whether the saved grant can be renewed.',
+        };
+      }
       return {
         label: 'Connected',
         badge: 'success',
@@ -62,15 +70,16 @@ export function marketplaceCredentialPresentation(
       };
     case 'refreshable':
       return {
-        label: 'Connected',
-        badge: 'success',
-        detail: 'Access will refresh securely when this server is used.',
+        label: 'Refresh needed',
+        badge: 'warning',
+        detail:
+          'Access has expired. Agor will try the saved refresh grant when this server is used.',
       };
     case 'refreshing':
       return {
         label: 'Refreshing',
         badge: 'processing',
-        detail: 'Agor is refreshing this connection. No new sign-in is needed.',
+        detail: 'Agor is refreshing this connection. Wait for the result.',
       };
     case 'reauthentication_required':
       return {

--- a/apps/agor-ui/src/components/Marketplace/useMarketplaceOverview.test.tsx
+++ b/apps/agor-ui/src/components/Marketplace/useMarketplaceOverview.test.tsx
@@ -1,4 +1,4 @@
-import type { MCPMarketplaceOverview } from '@agor/core/types';
+import type { MCPMarketplaceOverview, MCPServerID } from '@agor/core/types';
 import type { AgorClient } from '@agor-live/client';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
@@ -49,6 +49,62 @@ describe('useMarketplaceOverview live recovery', () => {
 
     expect(result.current.loading).toBe(true);
     expect(result.current.overview.servers).toEqual([]);
+  });
+
+  it('revalidates expiry using inventory only, and cancels the timer on identity change', async () => {
+    vi.useFakeTimers();
+    try {
+      const find = vi.fn(
+        async (): Promise<MCPMarketplaceOverview> => ({
+          servers: [],
+          attachments: [],
+          generated_at: new Date().toISOString(),
+          credentials: [
+            {
+              mcp_server_id: 'gitlab' as MCPServerID,
+              server_name: 'GitLab',
+              method: 'oauth',
+              status: 'active',
+              detail_status: 'active',
+              expires_at: new Date(Date.now() + 7200_000).toISOString(),
+            },
+          ],
+        })
+      );
+      const service = vi.fn((path: string) => (path === 'mcp-marketplace' ? { find } : emitter()));
+      const client = { service, io: emitter() } as unknown as AgorClient;
+      const { rerender, unmount } = renderHook(
+        ({ userId }) =>
+          useMarketplaceOverview({
+            client,
+            connected: true,
+            connecting: false,
+            authGeneration: 1,
+            userId,
+            role: 'member',
+          }),
+        { initialProps: { userId: 'alice' as string | undefined } }
+      );
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(find).toHaveBeenCalledTimes(1);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(7200_025);
+      });
+      expect(find).toHaveBeenCalledTimes(2);
+      expect(
+        service.mock.calls.filter(([path]) => path.includes('discover') || path.includes('refresh'))
+      ).toEqual([]);
+      rerender({ userId: undefined });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(7200_025);
+      });
+      expect(find).toHaveBeenCalledTimes(2);
+      unmount();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('refetches for authoritative row events and window focus', async () => {

--- a/apps/agor-ui/src/components/Marketplace/useMarketplaceOverview.ts
+++ b/apps/agor-ui/src/components/Marketplace/useMarketplaceOverview.ts
@@ -97,6 +97,23 @@ export function useMarketplaceOverview(input: {
   }, [ready, refresh]);
 
   useEffect(() => {
+    if (!ready) return;
+    const now = Date.now();
+    const deadlines = overview.credentials
+      .filter((credential) => (credential.detail_status ?? credential.status) === 'active')
+      .map((credential) => Date.parse(credential.expires_at ?? ''))
+      .filter((expiry) => Number.isFinite(expiry) && expiry > now);
+    if (!deadlines.length) return;
+    // Inventory reads only: never contact a provider to keep a badge fresh.
+    // Bound setTimeout's signed-32-bit range for unusually long-lived grants.
+    const timer = setTimeout(
+      () => void refresh(),
+      Math.min(Math.min(...deadlines) - now + 25, 2_147_483_647)
+    );
+    return () => clearTimeout(timer);
+  }, [overview, ready, refresh]);
+
+  useEffect(() => {
     if (!client || !ready) return;
     let timer: ReturnType<typeof setTimeout> | undefined;
     const schedule = () => {

--- a/packages/core/src/db/repositories/user-mcp-oauth-tokens.ts
+++ b/packages/core/src/db/repositories/user-mcp-oauth-tokens.ts
@@ -751,6 +751,30 @@ export class UserMCPOAuthTokenRepository {
     }
   }
 
+  /** SQLite has one daemon, but its dispatch fence must survive a restart. */
+  async setStandaloneRefreshState(
+    userId: UserID | null,
+    serverId: MCPServerID,
+    expected: MCPOAuthRefreshVersion,
+    from: 'idle' | 'refreshing',
+    to: 'refreshing' | 'idle' | 'ambiguous'
+  ): Promise<boolean> {
+    if (this.postgres) throw new RepositoryError('Standalone refresh state requires SQLite');
+    const result = await update(this.db, userMcpOauthTokens)
+      .set({ refresh_status: to, updated_at: new Date() })
+      .where(
+        and(
+          matchKey(userId, serverId),
+          eq(userMcpOauthTokens.grant_generation, expected.grantGeneration),
+          eq(userMcpOauthTokens.refresh_generation, expected.refreshGeneration),
+          eq(userMcpOauthTokens.refresh_status, from),
+          sql`${userMcpOauthTokens.grant_binding_fingerprint} IS NOT DISTINCT FROM ${expected.grantBindingFingerprint ?? null}`
+        )
+      )
+      .run();
+    return result.rowsAffected === 1;
+  }
+
   /**
    * Commit a standalone/SQLite refresh only onto the exact grant which was
    * verified before the provider exchange. This is deliberately update-only:
@@ -760,7 +784,7 @@ export class UserMCPOAuthTokenRepository {
   async completeStandaloneRefresh(
     userId: UserID | null,
     serverId: MCPServerID,
-    expected: Pick<MCPOAuthRefreshVersion, 'grantGeneration' | 'grantBindingFingerprint'>,
+    expected: MCPOAuthRefreshVersion,
     input: { accessToken: string; refreshToken?: string; expiresAt: Date | null }
   ): Promise<boolean> {
     if (this.postgres) {
@@ -773,12 +797,17 @@ export class UserMCPOAuthTokenRepository {
           oauth_access_token: input.accessToken,
           oauth_token_expires_at: input.expiresAt,
           ...(input.refreshToken !== undefined ? { oauth_refresh_token: input.refreshToken } : {}),
+          refresh_status: 'idle',
+          refresh_generation: expected.refreshGeneration + 1,
+          refresh_success_generation: expected.refreshGeneration + 1,
           updated_at: new Date(),
         })
         .where(
           and(
             matchKey(userId, serverId),
             eq(userMcpOauthTokens.grant_generation, expected.grantGeneration),
+            eq(userMcpOauthTokens.refresh_generation, expected.refreshGeneration),
+            eq(userMcpOauthTokens.refresh_status, 'refreshing'),
             sql`${userMcpOauthTokens.grant_binding_fingerprint} IS NOT DISTINCT FROM ${fingerprint}`
           )
         )

--- a/packages/core/src/tools/mcp/oauth-refresh.postgres.test.ts
+++ b/packages/core/src/tools/mcp/oauth-refresh.postgres.test.ts
@@ -229,6 +229,9 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
         expect(body.get('grant_type')).toBe('refresh_token');
         expect(body.get('refresh_token')).toBe('refresh-concurrent-0');
         expect(body.get('resource')).toBe('https://mcp.example.test/concurrent');
+        expect(body.get('redirect_uri')).toBe(
+          'https://agor.example.test/mcp-servers/oauth-callback'
+        );
         await new Promise((resolve) => setTimeout(resolve, 150));
         response.writeHead(200, { 'content-type': 'application/json' });
         response.end(
@@ -292,6 +295,43 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
         )
       ).toBe(true);
     });
+
+    it.each(['mixed-error', 'invalid-expiry'] as const)(
+      'quarantines a GitLab-shaped %s response across replicas without replay',
+      async (shape) => {
+        const tokenProvider = await provider((_body, response) => {
+          response.writeHead(200, { 'content-type': 'application/json' });
+          response.end(
+            JSON.stringify({
+              access_token: 'synthetic-next-access',
+              refresh_token: 'synthetic-rotated-refresh',
+              ...(shape === 'mixed-error'
+                ? { error: { unsafe: 'synthetic-error' } }
+                : { expires_in: 'invalid' }),
+            })
+          );
+        });
+        const bound = await seed(`malformed-${shape}`, tokenProvider.url);
+        const refresh = (db: TenantScopeAwareDatabase) =>
+          refreshAndPersistToken({
+            db,
+            tenantId: bound.tenantId,
+            userId: bound.userId,
+            mcpServerId: bound.serverId,
+            observedRefreshVersion: initialRefreshVersion(bound),
+            validateGrant: async () => true,
+            allowLocalhostHttpDevelopment: true,
+          });
+        await expect(refresh(dbA)).rejects.toMatchObject({ ambiguous: true });
+        await expect(refresh(dbB)).rejects.toBeInstanceOf(AmbiguousRefreshError);
+        expect(tokenProvider.calls()).toBe(1);
+        const saved = await runWithTenantDatabaseScope(dbB, bound.tenantId, (db) =>
+          new UserMCPOAuthTokenRepository(db, masterSecret).getToken(bound.userId, bound.serverId)
+        );
+        expect(saved?.refresh_status).toBe('ambiguous');
+        expect(saved?.oauth_refresh_token).toBe(`refresh-malformed-${shape}-0`);
+      }
+    );
 
     it('refuses completion when authoritative server configuration changes during exchange', async () => {
       let configurationStillValid = true;

--- a/packages/core/src/tools/mcp/oauth-refresh.test.ts
+++ b/packages/core/src/tools/mcp/oauth-refresh.test.ts
@@ -73,12 +73,14 @@ import {
 const {
   mockGetToken,
   mockCompleteStandaloneRefresh,
+  mockSetStandaloneRefreshState,
   mockDeleteGrantVersion,
   mockFindById,
   mockUserFindById,
 } = vi.hoisted(() => ({
   mockGetToken: vi.fn(),
   mockCompleteStandaloneRefresh: vi.fn(),
+  mockSetStandaloneRefreshState: vi.fn(),
   mockDeleteGrantVersion: vi.fn(),
   mockFindById: vi.fn(),
   // Persisting a refreshed token now requires the grant's subject to still be
@@ -93,6 +95,7 @@ vi.mock('../../db/repositories', () => ({
     return {
       getToken: mockGetToken,
       completeStandaloneRefresh: mockCompleteStandaloneRefresh,
+      setStandaloneRefreshState: mockSetStandaloneRefreshState,
       deleteGrantVersion: mockDeleteGrantVersion,
     };
   },
@@ -174,6 +177,62 @@ describe('refreshMCPToken', () => {
     expect(body.get('client_id')).toBe('public-client-42');
     expect(body.get('refresh_token')).toBe('rt-abc');
     expect(body.get('grant_type')).toBe('refresh_token');
+  });
+
+  it.each([
+    null,
+    [],
+    { access_token: 'synthetic', error: {} },
+    { access_token: 'synthetic', refresh_token: 'rotated', error: 'server_error' },
+    { access_token: 'synthetic', refresh_token: 42 },
+    { access_token: 'synthetic', expires_in: 'nonsense' },
+    { access_token: 'synthetic', expires_in: 0 },
+    { access_token: 'synthetic', expires_in: null },
+    { access_token: 'synthetic', expires_in: true },
+  ])(
+    'quarantines malformed or mixed token responses rather than allowing replay: %j',
+    async (response) => {
+      mockFetchOnce(response);
+      await expect(
+        refreshMCPToken({
+          tokenEndpoint: 'https://gitlab.example.test/oauth/token',
+          clientId: 'synthetic-client',
+          refreshToken: 'synthetic-refresh',
+        })
+      ).rejects.toMatchObject({ category: 'response_ambiguous', ambiguous: true });
+    }
+  );
+
+  it('sends the original GitLab redirect with client authentication and preserves its rotating pair', async () => {
+    mockFetchOnce({
+      access_token: 'synthetic-next-access',
+      refresh_token: 'synthetic-next-refresh',
+      expires_in: 7200,
+      token_type: 'bearer',
+      created_at: 1788950000,
+    });
+    await expect(
+      refreshMCPToken({
+        tokenEndpoint: 'https://gitlab.example.test/oauth/token',
+        clientId: 'synthetic-client',
+        clientSecret: 'synthetic-secret',
+        refreshToken: 'synthetic-old-refresh',
+        redirectUri: 'https://agor.example.test/mcp-servers/oauth-callback',
+        resourceUri: 'https://gitlab.example.test/api/v4/mcp',
+      })
+    ).resolves.toMatchObject({
+      access_token: 'synthetic-next-access',
+      refresh_token: 'synthetic-next-refresh',
+      expires_in: 7200,
+    });
+    const [, init] = vi.mocked(globalThis.fetch).mock.calls[0];
+    const form = new URLSearchParams(init?.body as string);
+    expect(form.get('redirect_uri')).toBe('https://agor.example.test/mcp-servers/oauth-callback');
+    expect(form.get('resource')).toBe('https://gitlab.example.test/api/v4/mcp');
+    expect((init?.headers as Record<string, string> | undefined)?.Authorization).toBe(
+      `Basic ${Buffer.from('synthetic-client:synthetic-secret').toString('base64')}`
+    );
+    expect(form.has('scope')).toBe(false);
   });
 
   it('surfaces invalid_grant as InvalidGrantError', async () => {
@@ -335,6 +394,7 @@ describe('refreshAndPersistToken', () => {
 
     mockGetToken.mockReset();
     mockCompleteStandaloneRefresh.mockReset().mockResolvedValue(true);
+    mockSetStandaloneRefreshState.mockReset().mockResolvedValue(true);
     mockDeleteGrantVersion.mockReset();
     mockFindById.mockReset();
 
@@ -382,7 +442,7 @@ describe('refreshAndPersistToken', () => {
     expect(mockCompleteStandaloneRefresh).toHaveBeenCalledWith(
       USER_ID,
       SERVER_ID,
-      { grantGeneration: 0, grantBindingFingerprint: undefined },
+      { grantGeneration: 0, grantBindingFingerprint: undefined, refreshGeneration: 0 },
       {
         accessToken: 'new-a',
         expiresAt: expect.any(Date), // resolved from expires_in: 3600 → ~now+1h
@@ -459,7 +519,7 @@ describe('refreshAndPersistToken', () => {
     expect(mockCompleteStandaloneRefresh).toHaveBeenCalledWith(
       USER_ID,
       SERVER_ID,
-      { grantGeneration: 7, grantBindingFingerprint: 'binding-7' },
+      { grantGeneration: 7, grantBindingFingerprint: 'binding-7', refreshGeneration: 0 },
       expect.objectContaining({ accessToken: 'stale-refresh-result' })
     );
   });
@@ -676,6 +736,45 @@ describe('refreshAndPersistToken', () => {
     ).rejects.toBeInstanceOf(MissingClientIdError);
 
     expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('never joins another tenant refresh flight for the same subject and server IDs', async () => {
+    mockGetToken.mockResolvedValue({
+      user_id: USER_ID,
+      mcp_server_id: SERVER_ID,
+      oauth_access_token: 'synthetic-old',
+      oauth_refresh_token: 'synthetic-refresh',
+      oauth_client_id: 'synthetic-client',
+    });
+    mockFindById.mockResolvedValue({
+      auth: { oauth_token_url: 'https://provider.example.test/token' },
+    });
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            access_token: 'synthetic-next',
+            expires_in: 7200,
+          }),
+          { headers: { 'content-type': 'application/json' } }
+        )
+    );
+    await Promise.all(
+      ['tenant-a', 'tenant-b'].map((tenantId) =>
+        refreshAndPersistToken({
+          db: { run: () => undefined } as unknown as Parameters<
+            typeof refreshAndPersistToken
+          >[0]['db'],
+          tenantId,
+          userId: USER_ID,
+          mcpServerId: SERVER_ID,
+          observedRefreshVersion: observedVersion(),
+          validateGrant: async () => true,
+        })
+      )
+    );
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+    expect(mockCompleteStandaloneRefresh).toHaveBeenCalledTimes(2);
   });
 
   it('mutex: concurrent refreshes for same key collapse to ONE HTTP call', async () => {

--- a/packages/core/src/tools/mcp/oauth-refresh.ts
+++ b/packages/core/src/tools/mcp/oauth-refresh.ts
@@ -104,6 +104,8 @@ export interface RefreshMCPTokenOptions {
   clientId: string;
   clientSecret?: string;
   resourceUri?: string;
+  /** Exact redirect used to issue this grant (required by GitLab on refresh). */
+  redirectUri?: string;
   /** Exact loopback HTTP exception for standalone development/tests only. */
   allowLocalhostHttp?: boolean;
   /** Task/session/rollout fence checked immediately before credential dispatch. */
@@ -137,6 +139,7 @@ export async function refreshMCPToken(
     refresh_token: opts.refreshToken,
   };
   if (opts.resourceUri) body.resource = opts.resourceUri;
+  if (opts.redirectUri) body.redirect_uri = opts.redirectUri;
   const headers: Record<string, string> = {
     'Content-Type': 'application/x-www-form-urlencoded',
     Accept: 'application/json',
@@ -172,12 +175,48 @@ export async function refreshMCPToken(
   } catch {
     throw new OAuthRefreshExchangeError('response_ambiguous', true);
   }
-  if (parsed.error === 'invalid_grant') throw new InvalidGrantError();
-  if (parsed.error) throw new OAuthRefreshExchangeError('provider_rejected', false);
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new OAuthRefreshExchangeError('response_ambiguous', true);
+  }
+  if (parsed.error !== undefined) {
+    // Only an unambiguous error response proves no token pair was issued.
+    // Mixed success/error or malformed error JSON may have consumed a
+    // rotating token and must never release its dispatch fence for replay.
+    if (
+      response.ok ||
+      typeof parsed.error !== 'string' ||
+      !parsed.error ||
+      parsed.access_token !== undefined ||
+      parsed.refresh_token !== undefined
+    ) {
+      throw new OAuthRefreshExchangeError('response_ambiguous', true);
+    }
+    if (['invalid_grant', 'invalid_client', 'unauthorized_client'].includes(parsed.error)) {
+      throw new InvalidGrantError();
+    }
+    throw new OAuthRefreshExchangeError('provider_rejected', false);
+  }
   if (!response.ok || typeof parsed.access_token !== 'string' || !parsed.access_token) {
     throw new OAuthRefreshExchangeError('response_ambiguous', true);
   }
+  if (
+    (parsed.refresh_token !== undefined &&
+      (typeof parsed.refresh_token !== 'string' || !parsed.refresh_token)) ||
+    (parsed.token_type !== undefined &&
+      (typeof parsed.token_type !== 'string' || parsed.token_type.toLowerCase() !== 'bearer'))
+  ) {
+    throw new OAuthRefreshExchangeError('response_ambiguous', true);
+  }
   const expiresIn = parsed.expires_in == null ? undefined : Number(parsed.expires_in);
+  if (
+    parsed.expires_in !== undefined &&
+    ((typeof parsed.expires_in !== 'number' && typeof parsed.expires_in !== 'string') ||
+      !Number.isSafeInteger(expiresIn) ||
+      expiresIn! <= 0 ||
+      !Number.isFinite(new Date(Date.now() + expiresIn! * 1000).getTime()))
+  ) {
+    throw new OAuthRefreshExchangeError('response_ambiguous', true);
+  }
   return {
     access_token: parsed.access_token,
     refresh_token: parsed.refresh_token,
@@ -199,8 +238,12 @@ export function __resetRefreshMutexForTests(): void {
 export function __refreshMutexSizeForTests(): number {
   return _inFlightRefreshes.size;
 }
-function mutexKey(userId: UserID | null, serverId: MCPServerID): MutexKey {
-  return `${userId ?? '<shared>'}:${serverId}`;
+function mutexKey(deps: RefreshAndPersistDeps): MutexKey {
+  return JSON.stringify([
+    deps.tenantId ?? getCurrentTenantId() ?? '<standalone>',
+    deps.userId,
+    deps.mcpServerId,
+  ]);
 }
 
 export interface RefreshAndPersistDeps {
@@ -402,6 +445,7 @@ async function refreshPostgres(deps: RefreshAndPersistDeps): Promise<string> {
       clientId: row.oauth_client_id,
       clientSecret: row.oauth_client_secret,
       resourceUri: row.oauth_resource_uri,
+      redirectUri: row.oauth_redirect_uri,
       allowLocalhostHttp: deps.allowLocalhostHttpDevelopment,
       assertCurrent: deps.assertCurrent,
       resolveDns: deps.resolveDns,
@@ -503,16 +547,34 @@ async function loadObservedStandaloneGrant(
 
 async function refreshStandalone(
   deps: RefreshAndPersistDeps,
-  observedVersion: Pick<MCPOAuthRefreshVersion, 'grantGeneration' | 'grantBindingFingerprint'>
+  observedVersion: MCPOAuthRefreshVersion
 ): Promise<string> {
   const userTokenRepo = new UserMCPOAuthTokenRepository(deps.db as Database);
   const exactGrantVersion = {
     grantGeneration: observedVersion.grantGeneration,
     grantBindingFingerprint: observedVersion.grantBindingFingerprint,
+    refreshGeneration: observedVersion.refreshGeneration,
   };
   // Repeat the caller-bound check inside the mutex owner. The saved row may
   // have changed after the pre-mutex validation but before this promise ran.
   const row = await loadObservedStandaloneGrant(deps, exactGrantVersion);
+  if (row.refresh_status === 'ambiguous') throw new AmbiguousRefreshError();
+  // No in-process owner exists here. A persisted dispatch from a previous
+  // daemon may have consumed the rotating token; never replay it.
+  if (row.refresh_status === 'refreshing') {
+    await userTokenRepo.setStandaloneRefreshState(
+      deps.userId,
+      deps.mcpServerId,
+      exactGrantVersion,
+      'refreshing',
+      'ambiguous'
+    );
+    throw new AmbiguousRefreshError();
+  }
+  if (row.refresh_generation > observedVersion.refreshGeneration) {
+    return row.oauth_access_token;
+  }
+
   if (!row.oauth_refresh_token) throw new MissingRefreshTokenError();
   const server = await new MCPServerRepository(deps.db as Database).findById(deps.mcpServerId);
   const clientId = row.oauth_client_id ?? server?.auth?.oauth_client_id;
@@ -520,6 +582,16 @@ async function refreshStandalone(
   let tokenEndpoint = row.oauth_token_endpoint ?? server?.auth?.oauth_token_url;
   if (!tokenEndpoint && server?.url) tokenEndpoint = inferOAuthTokenUrl(server.url);
   if (!tokenEndpoint) throw new MissingTokenEndpointError();
+  if (
+    !(await userTokenRepo.setStandaloneRefreshState(
+      deps.userId,
+      deps.mcpServerId,
+      exactGrantVersion,
+      'idle',
+      'refreshing'
+    ))
+  )
+    throw new GrantConfigurationChangedError();
   try {
     const result = await refreshMCPToken({
       tokenEndpoint,
@@ -527,6 +599,7 @@ async function refreshStandalone(
       clientId,
       clientSecret: row.oauth_client_secret ?? server?.auth?.oauth_client_secret,
       resourceUri: row.oauth_resource_uri,
+      redirectUri: row.oauth_redirect_uri,
       allowLocalhostHttp: true,
       assertCurrent: deps.assertCurrent,
       resolveDns: deps.resolveDns,
@@ -561,6 +634,18 @@ async function refreshStandalone(
       if (deleted) notifyInvalidGrant(deps);
       else throw new GrantConfigurationChangedError();
     }
+    if (!(error instanceof InvalidGrantError)) {
+      const retrySafe =
+        error instanceof OAuthRefreshAuthorityCancelledError ||
+        (error instanceof OAuthRefreshExchangeError && !error.ambiguous);
+      await userTokenRepo.setStandaloneRefreshState(
+        deps.userId,
+        deps.mcpServerId,
+        exactGrantVersion,
+        'refreshing',
+        retrySafe ? 'idle' : 'ambiguous'
+      );
+    }
     throw error;
   }
 }
@@ -576,7 +661,7 @@ export async function refreshAndPersistToken(deps: RefreshAndPersistDeps): Promi
   // user/server mutex. A caller authorized against an old row must not learn,
   // refresh, or invalidate the replacement row occupying the same subject.
   await loadObservedStandaloneGrant(deps, expected);
-  const key = mutexKey(deps.userId, deps.mcpServerId);
+  const key = mutexKey(deps);
   const existing = _inFlightRefreshes.get(key);
   if (existing) {
     if (!exactGrantVersionsMatch(existing.version, expected)) {


### PR DESCRIPTION
## Summary

Fix the expired OAuth grant path used by **Refresh tools**, share execution/discovery's JIT acquisition, send the grant's original redirect URI on refresh, and stop describing expired-but-refreshable access as Connected. Add rotating-token response validation and restart-safe SQLite dispatch fencing; preserve PostgreSQL encrypted CAS authority.

No live credentials were inspected/decrypted, no account was disconnected/reconnected, and no provider mutations were sent. All provider exchanges below were synthetic test fixtures. **Datadog was unavailable**: this session's authoritative configured MCP-server catalog was empty. The supplied live GitLab report is evidence of the symptom, not a captured provider response.

## Root cause and reconstructed behavior

Started from and re-fetched current main `9dbfec9526ac7c1b40c29cfb74c1b568fd2a7bad`.

1. **Discovery bypassed JIT refresh.** `/mcp-servers/oauth-auth-headers` refreshed before task use, but saved-server discovery separately loaded a grant and discarded it when expired. Without an explicit browser reservation, its fallback could not obtain a grant, then attempted MCP initialization without usable OAuth authorization. It never tried the stored refresh credential. Saved SQLite OAuth could additionally enter the legacy auth-header resolver before consulting the authoritative grant.
2. **The refresh request omitted `redirect_uri`.** Current bound grants already persist the exact original redirect, but neither PostgreSQL nor SQLite passed it to `refreshMCPToken`. GitLab explicitly documents that it must match the original authorization redirect.
3. **Presentation collapsed distinct states.** #2565's projection already distinguished expired/refreshable access, but its presentation deliberately labeled that state **Connected**, with a promise about future refresh that the discovery path did not fulfill. The legacy authenticated-ID read also admitted `refreshing` grants. An unchanged open inventory did not revalidate at expiry.

These are code-proven causes, not a claim that the live grant's refresh token is revoked or that a particular error body was observed. No token metadata from that user's row was queried.

### What was already correct, and what changes

| Boundary | Finding / disposition |
| --- | --- |
| Callback | Standard GitLab `expires_in: 7200` and `refresh_token` already persist correctly, alongside client ID/secret, token endpoint, resource and original redirect binding. No speculative callback migration. |
| Before use | Execution had a 60-second JIT buffer. Execution and saved discovery now share `acquireMCPOAuthGrant`, with short tenant DB units around reads/validation and no provider I/O inside them. Discovery binds the exact committed row before publishing tools. Known saved OAuth without a grant fails closed before MCP transport. |
| Rotation | PostgreSQL already atomically seals/writes the returned pair behind exact grant/refresh/claim CAS and RLS. Omitted refresh token preserves its predecessor. SQLite now persists dispatch state before I/O, fences completion by refresh generation, and refuses replay of an orphaned dispatch after restart. |
| Refresh request | Uses stored client ID/secret, discovered token endpoint, protected resource, and now original `redirect_uri`. Public clients send `client_id`; the currently supported confidential-client route is Basic. Scope remains omitted, preserving originally granted scope per RFC 6749 §6 rather than expanding it. |
| Responses | Normal GitLab JSON/rotated pair/7200-second TTL is accepted. Malformed token/error/expiry responses and mixed success/error payloads are ambiguous, never retry-safe. Structured definitive grant/client rejection retires only the exact grant. Unambiguous other provider errors preserve it for retry. |
| Status/recovery | Expired renewable access is **Refresh needed**; ambiguous/binding-invalid grants require reauth. Inventory does not probe providers. An expiry timer re-reads inventory, and discovery re-reads it even on failure. Stale active projections also stop saying Connected after their known expiry. Existing Connect/Reconnect controls remain the recovery route. |

## History / interaction with related work

Reviewed merged #2647 (durable DCR/pending callback/config binding), #2565 (Catalog presentation), #2234 (HA refresh CAS), #1047 (JIT lifecycle), #1410 (token endpoint persistence), #2491 (marketplace compatibility), #2553 (safe recovery), #2558/#2566 (egress authority), and #2650 (saved discovery diagnostics/persistence).

- **#2576 remains open.** Its Google offline-consent/non-rotating refresh retry work is separate. This patch does not transplant its provider-specific ambiguity relaxation or replay MCP tool requests after a 401. Rotating GitLab credentials remain fail-closed.
- **#2550 remains open.** `client_secret_post` is not an end-to-end supported persisted method on current main. That broader auth-method migration is not partially transplanted or falsely claimed fixed here. GitLab-shaped tests cover the existing public and Basic routes.
- **#2714 remains open.** It changes DCR diagnostics/setup policy, not refresh grant persistence. Preserve its nominal diagnostic identity and provider gates when resolving the nearby recovery import/guide overlap; this patch does not relax DCR/issuer/resource/callback checks or reset registrations. Also noted open #2716's overlapping policy/recovery presentation files.

## Provider lifetime and upgrade recovery

GitLab's normal **two-hour access-token lifetime is not an Agor daily sign-in limit**. Its refresh grant can renew expired access and rotates both tokens. Existing bound grants with a valid saved refresh credential can recover automatically on next use after upgrading—**do not disconnect them merely because access expired**. A revoked/missing refresh grant, absent original client/redirect, or lost/quarantined rotation can require one new sign-in. An upgrade cannot recover a token pair that was issued but never received. The live account's precise recoverability remains unverified.

Official references: [GitLab OAuth API](https://docs.gitlab.com/api/oauth2/), [GitLab provider lifetime](https://docs.gitlab.com/integration/oauth_provider/), [RFC 6749 §6](https://www.rfc-editor.org/rfc/rfc6749.html#section-6), [MCP authorization](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization).

## Correctness / security review

GPT-6 Astra completed independent review and follow-up. Fixed its malformed-error replay blocker, supplied-expiry validation, and status/deadline findings. Final production review: **no remaining blockers**; final test results follow below. Only `ai-reviewed-gpt-6-astra` is applied.

Tenant/user/shared-subject selection, trusted tenant propagation, PostgreSQL encryption/RLS, configuration binding, exact-generation CAS, pre-dispatch authority checks, and no-token logging are preserved. SQLite flight identity now includes tenant. No schema migration or weakening of HA behavior.

## Validation

Final passing runs (test fixtures only):

- Full core: **4,413 passed / 147 gated skips** (208 passing files).
- Full daemon: **4,419 passed / 211 gated skips** (348 passing files); final focused discovery/OAuth suite **99 passed**, and final status suite **11 passed**.
- All Marketplace UI: **191 passed**; final modified UI subset **45 passed**.
- Chromium: **52 passed**, including GitLab expiry → definitive refresh failure → Reconnect across desktop/tablet/phone/short-height viewports.
- PostgreSQL/RLS Docker runner: **318 passed / 0 failed / 0 skipped** across 67 files, plus interruption cleanup. Includes two-replica rotating refresh, original redirect, malformed response/no replay, and tenant-negative coverage.
- Explicit source **no-emit TypeScript checks passed** for core, daemon, and UI. The canonical `pnpm typecheck` invokes dependency builds through Turbo; that graph was stopped and replaced with source-only checks to respect the workspace no-build rule. Supplemental checks of normally excluded tests found **25 existing daemon / 20 existing UI diagnostics**, matched against current-main baseline with zero new diagnostics.
- Full lint: **2,894 files**, plus **330 frontend design-system fixtures**. Tenancy, filesystem, realtime, short-ID, and CI-coverage boundary checks passed. Normal commit hooks passed; no hook was bypassed.

Initial runs exposed and corrected outdated discovery fixtures and two new test-mock mistakes. An unchanged daemon hook timeout and PostgreSQL knowledge-embedding timeout passed on rerun (the final PostgreSQL run used concurrency 2); no timeout or assertion was weakened. Hosted CI is also **green** at `9a588d165906dc5e537ac9b583a13933525d65ed`: [full CI](https://github.com/preset-io/agor/actions/runs/34355032081) (lint/policies, typecheck/build, core/daemon/both UI shards/CLI/support tests, Redis HA, browser layout), [PostgreSQL non-superuser RLS](https://github.com/preset-io/agor/actions/runs/34355032209), docs, image build, and packaged-install smoke all passed. Only conditional agent integrations and main-image promotion were skipped. No merge or main-image promotion occurred.

## Safe live verification after deployment

1. On the existing install, open My Servers/Settings without reconnecting. Check only the redacted status, known expiry, and available action; loading inventory must not contact GitLab.
2. If **Refresh needed**, choose **Refresh tools** once. This intentionally exercises refresh after deployment; expect tools and Connected after the atomic rotation. Do not copy tokens, authorization headers, callback query strings, client material, or provider bodies into logs/issues.
3. Reopen or refresh inventory and verify durable status on another browser/replica. After the next real expiry, repeat a normal use to verify another rotation without sign-in. Avoid deliberately concurrent live refresh experiments; concurrency is covered synthetically.
4. If **Connect/Reconnect required**, follow the explicit sign-in action once. For a definitively invalid client, use the documented administrator recovery if ordinary sign-in cannot recover. For ambiguous rotation, do not retry the old refresh credential manually.
5. Safe telemetry may record only closed outcomes and whether tools were discovered. No production verification or deployment certification is claimed by this PR.

Do not merge automatically.


## Independent Fable review follow-up

Addressed findings from the independent Fable review of `9a588d165906dc5e537ac9b583a13933525d65ed`. No live credentials, provider mutations, or reconnects were used.

| Finding | Disposition |
| --- | --- |
| **1 — saved client-credentials compatibility/recovery** | **Real gap; configuration recovery fixed, implicit minting intentionally not restored.** Traced `oauth-auth.ts`, `jwt-auth.ts`, executor hydration/scoping, the form's default/persistence, test-auth, saved discovery and execution. Standalone discovery previously supported a temporary machine token; daemon-backed execution already rejected fallback after empty hydration, and HA discovery already required durable grants. Legacy `client_credentials` defaults also appear on browser configurations, and an absent row may be a definitively retired browser grant. Restoring fallback would silently switch authorization flows after rejection. Saved discovery now deliberately follows execution's durable-grant boundary. Missing explicit machine/legacy credential configurations receive **configuration_required / review_configuration**, including safe structured execution recovery, not `needs_reauth`. Copy distinguishes browser-capable reconnect from machine-only unsupported configuration. Existing bound browser grants remain authoritative even with the legacy form default. Legacy Test Authentication/direct standalone core exchanges are unchanged. The guide explicitly documents the standalone compatibility change and supported alternatives; this is **not** a claim that machine-token execution is now supported. SQLite and PostgreSQL service regressions cover discovery/execution, no provider exchange, and foreign-tenant rejection. |
| **2 — newer concurrent HA rotation** | **Fixed.** The post-refresh reread accepts a successfully committed, unexpired, same-grant newer idle rotation. A newer active/failed/expired snapshot returns retryable contention (`refresh_in_progress` for execution; recovery action `retry` for discovery), not configuration drift or reauthentication. Replacement/invalid-binding grants and quarantined outcomes still fail closed. No additional exchange is initiated by the reread. Two independent PostgreSQL pools deterministically start or complete B's second real rotation after A commits and before A rereads, assert exactly two exchanges with the correct successive rotating credentials, and prove another tenant cannot read or trigger work. |
| **3 — crash after fence, before dispatch** | **No behavioral change.** Durable dispatch must precede network I/O. A crash in that gap is indistinguishable from a dispatched-but-lost result, so quarantine may conservatively require one sign-in. Replaying would risk consuming an already-used rotating credential. Added durable guide clarification. |
| **4 — invalid_client / unauthorized_client retirement** | **No change.** Only well-formed, unambiguous token-endpoint rejection is definitive, and retirement is exact-grant fenced. Provider prose, mixed success/error bodies and ambiguous transport outcomes do not authorize this retirement. Treating a definitive client rejection as an ordinary reusable grant would misrepresent usability. |
| **5 — strict success response validation** | **No change.** Agor can only safely vend supported Bearer access and a usable supplied lifetime. Malformed/non-supported successes may have already rotated the provider credential; treating them as unknown-expiry success or retrying the predecessor is unsafe. Omitted expiry retains the existing unknown-expiry policy; normal GitLab shapes remain covered. No claim of arbitrary-provider compatibility. |
| **6 — original redirect sent to all providers** | **No change.** Preserve the original grant context rather than adding a GitLab hostname exception. GitLab requires the original redirect. RFC 6749 **§3.2** (token endpoint, not §3.1) requires ignoring unrecognized parameters. Endpoint/resource/client/redirect binding and egress checks remain unchanged. |
| **7 — binding mismatch no longer eagerly deletes on use** | **No change.** Acquisition refuses mismatched grants before dispatch; inventory also refuses to call them usable. Retaining the encrypted row cannot authorize stale use and avoids deleting state during read/use. Explicit manual refresh retains its existing retirement behavior; bound reconnect atomically replaces the row. This asymmetry is intentional, not a credential fallback. |

Also added the missing direct **active-but-known-expired** presentation unit: the expiry boundary renders **Access expired**, warning, and Settings—not Connected or a speculative Reconnect action.

References: [GitLab refresh API](https://docs.gitlab.com/api/oauth2/), [RFC 6749 token endpoint](https://www.rfc-editor.org/rfc/rfc6749.html#section-3.2), [RFC 6749 refresh](https://www.rfc-editor.org/rfc/rfc6749.html#section-6).

### Follow-up validation

Head: `80b952732425d445090786d8580633b45560c951` (two additive commits; explicit push lease against `9a588d165906dc5e537ac9b583a13933525d65ed`, no history rewritten).

Final local runs:
- Full core: **4,413 passed / 147 gated skips**.
- Full daemon: **4,424 passed / 214 gated skips**; focused SQLite/service recovery **90 passed**.
- Relevant UI: **195 passed** (Marketplace plus recovery alert); direct presentation unit **7 passed**.
- Full Chromium: **332 passed across 76 viewport projects**; focused affected browser surfaces **76 passed across 20 projects**.
- Full PostgreSQL/RLS: **321 passed / 0 failed / 0 skipped across 68 files**, plus interruption cleanup. Focused HA/configuration/two-pool acquisition tests **11 passed**.
- Source no-emit TypeScript checks passed for daemon/UI; full lint **2,895 files + 330 design-system fixtures**, tenancy/filesystem/realtime/short-ID/CI-coverage boundaries, normal commit hooks and diff whitespace checks passed.

**Hosted CI is green at this exact head:** [CI](https://github.com/preset-io/agor/actions/runs/34361825553) (typecheck/build, lint/policy, complete core/daemon/both UI shards/CLI/support, Redis HA, Chromium), [PostgreSQL non-superuser/RLS](https://github.com/preset-io/agor/actions/runs/34361825502) (**321/321**), docs, image build and packaged-install smoke. Only conditional agent integrations/main promotion were skipped. No merge or main promotion.

Validation history: initial tests exposed missing configuration-recovery propagation (fixed) and a PostgreSQL test-loader SDK import obstacle (fixed with a fail-if-constructed transport mock, matching the existing SQLite harness). Unchanged Catalog-modal and knowledge-embedding timeout failures passed reruns; no timeout or assertion was relaxed. The first broad browser attempt was interrupted after stale dynamic imports; refreshing only the test cache yielded the full 332-test pass. The shared worktree volume was nearly full, so the regenerated test cache was placed on `/tmp`; unrelated files were not removed. The first hosted daemon attempt hit the unchanged Slack recovery-token forgery fixture: changing a final base64 character can preserve decoded bytes. Verified that mechanism using synthetic bytes, left the unrelated test/production files unchanged, and the failed-job rerun passed at the same SHA.

GPT-6 Astra independently re-reviewed the changes and found no new correctness/security blockers. Its two copy corrections were applied (legacy fields do not prove machine-only configuration; retryable contention does not prove another refresh remains active). Only the current Astra review label is applied. No merge requested or performed.
