### PR TITLE
perf: trace daemon contention and unblock session deep links

### DIFF
--- a/apps/agor-daemon/src/setup/database.test.ts
+++ b/apps/agor-daemon/src/setup/database.test.ts
@@ -13,6 +13,7 @@ const configMocks = vi.hoisted(() => ({
 
 const dbMocks = vi.hoisted(() => ({
   checkMigrationStatus: vi.fn(),
+  configureSecretKeyDerivationTracing: vi.fn(),
   createDatabaseAsync: vi.fn(),
   createTenantScopedDatabaseProxy: vi.fn(),
   runWithSystemDatabaseScope: vi.fn(),
@@ -22,6 +23,12 @@ const dbMocks = vi.hoisted(() => ({
 const adminMocks = vi.hoisted(() => ({
   runFirstRunAdminBootstrap: vi.fn(),
   logFirstRunAdminBootstrap: vi.fn(),
+}));
+
+const tracingMocks = vi.hoisted(() => ({ resolveDatadogTracer: vi.fn() }));
+vi.mock('@agor/core/tracing/datadog', async (importOriginal) => ({
+  ...(await importOriginal()),
+  ...tracingMocks,
 }));
 
 vi.mock('node:fs/promises', async (importOriginal) => ({
@@ -47,6 +54,7 @@ describe('initializeDatabase logging', () => {
   beforeEach(() => {
     const rawDb = {};
     const scopedDb = {};
+    tracingMocks.resolveDatadogTracer.mockReturnValue(null);
 
     logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     fsMocks.access.mockResolvedValue(undefined);
@@ -70,6 +78,22 @@ describe('initializeDatabase logging', () => {
     vi.clearAllMocks();
     vi.unstubAllEnvs();
     logSpy.mockRestore();
+  });
+
+  it('uses the same startup APM gate and tracer for database and crypto timing', async () => {
+    const tracer = { trace: vi.fn() };
+    tracingMocks.resolveDatadogTracer.mockReturnValue(tracer);
+    const url = 'file::memory:';
+    await initializeDatabase(url, { skipFirstRunAdminBootstrap: true, traceServices: 'off' });
+    expect(tracingMocks.resolveDatadogTracer).not.toHaveBeenCalled();
+    expect(dbMocks.configureSecretKeyDerivationTracing).toHaveBeenLastCalledWith(null);
+    await initializeDatabase(url, {
+      skipFirstRunAdminBootstrap: true,
+      traceServices: 'entrypoint',
+    });
+    expect(tracingMocks.resolveDatadogTracer).toHaveBeenCalledTimes(1);
+    expect(dbMocks.configureSecretKeyDerivationTracing).toHaveBeenLastCalledWith(tracer);
+    expect(dbMocks.createDatabaseAsync).toHaveBeenLastCalledWith({ url }, { tracer });
   });
 
   it.each([
@@ -103,6 +127,7 @@ describe('initializeDatabase logging', () => {
       for (const sentinel of sentinels) expect(logged).not.toContain(sentinel);
 
       expect(dbMocks.createDatabaseAsync).toHaveBeenCalledWith({ url });
+      expect(dbMocks.configureSecretKeyDerivationTracing).toHaveBeenCalledWith(null);
       expect(dbMocks.checkMigrationStatus).toHaveBeenCalledTimes(1);
       expect(dbMocks.seedInitialData).not.toHaveBeenCalled();
     }

--- a/apps/agor-daemon/src/setup/database.ts
+++ b/apps/agor-daemon/src/setup/database.ts
@@ -13,6 +13,7 @@ import type { ApmTraceServiceDepth } from '@agor/core/config';
 import { ensureAgorHome, getAgorHome } from '@agor/core/config';
 import {
   checkMigrationStatus,
+  configureSecretKeyDerivationTracing,
   createDatabaseAsync,
   createTenantScopedDatabaseProxy,
   detectDialectFromUrl,
@@ -144,6 +145,7 @@ export async function initializeDatabase(
   // path free of per-query and startup module-resolution overhead.
   const tracingEnabled = (options.traceServices ?? 'off') !== 'off';
   const tracer = tracingEnabled ? resolveDatadogTracer(createRequire(import.meta.url)) : null;
+  configureSecretKeyDerivationTracing(tracer);
 
   // Create database with foreign keys enabled
   const databaseConfig = {

--- a/apps/agor-docs/content/guide/config-yaml.mdx
+++ b/apps/agor-docs/content/guide/config-yaml.mdx
@@ -517,6 +517,37 @@ these tags. Tool spans measure handler execution, not pre-handler SDK validation
 an MCP result containing `isError: true` remains a returned result rather than
 an exception. Use the protocol response to assess application success.
 
+Both enabled depths also expose capacity-related waits without per-request logs:
+
+- `postgres.transaction` covers a root transaction from acquisition through
+  commit/rollback. `db.transaction.acquire_ms` measures the interval until its
+  callback starts, including pool queueing, connection establishment, BEGIN and
+  transaction setup—not pure database lock wait. `db.pool.max` records the
+  configured connection limit. Its child `postgres.transaction.work` covers the
+  callback body. Nested savepoints are not counted as new pool acquisitions.
+- `crypto.scrypt` covers async secret-key derivation from submission through
+  completion, including native worker queueing and execution—not pure queue
+  wait. `crypto.pending_at_submit` counts other outstanding Agor derivations,
+  not all work in Node's shared pool. `crypto.in_tenant_transaction` identifies
+  derivations started inside a tenant database transaction, which can keep a
+  connection occupied while waiting. `crypto.envelope` is `legacy` or `bound`.
+  `crypto.configured_pool_size` records the startup `UV_THREADPOOL_SIZE` setting
+  (Node defaults to 4); it is not a measurement of active worker threads.
+
+These added tags contain no credentials, ciphertext, salts, bindings, or
+user/session/tenant IDs. Counts are process-wide capacity observations. The
+spans share the existing APM sampling and delivery path; a parent transaction
+and its nested work/crypto/query spans must not be summed as independent time.
+Acquisition failures have no `acquire_ms` value because the callback never ran.
+
+For long service spans with short SQL spans, inspect transaction acquisition
+first. For long transaction bodies, inspect nested crypto and other work before
+increasing either pool. PostgreSQL connections default to 10 per client unless
+`database.postgresql.pool.max` is configured. The separate libuv pool is shared
+by async crypto, filesystem and some DNS operations. A larger
+`UV_THREADPOOL_SIZE` must be set before starting Node; more workers can improve
+throughput with spare CPU/memory, but do not remove the work or its resource cost.
+
 `AGOR_APM_TRACE_SERVICES` (`off`, `entrypoint`, or `full`) overrides the YAML
 value so depth can be changed without editing config. Like all metrics
 settings, this is resolved into the daemon's immutable startup snapshot and

--- a/apps/agor-ui/src/hooks/useAgorData.test.tsx
+++ b/apps/agor-ui/src/hooks/useAgorData.test.tsx
@@ -90,7 +90,8 @@ function makeMockClient(seed: Record<string, unknown[]> = {}) {
       const key = `${name}:get`;
       fetchCounts.set(key, (fetchCounts.get(key) ?? 0) + 1);
       fetchArguments.set(key, [...(fetchArguments.get(key) ?? []), id]);
-      return Promise.resolve(seed[key] ?? null);
+      const gate = fetchHooks.get(key)?.(fetchCounts.get(key)!);
+      return Promise.resolve(gate).then(() => seed[key] ?? null);
     }),
     on: (event: string, fn: Listener) => {
       let svc = serviceListeners.get(name);
@@ -143,7 +144,7 @@ function makeMockClient(seed: Record<string, unknown[]> = {}) {
     // `method` is invoked (receives the 1-based call count). The hook fires
     // BEFORE the returned promise resolves, so emitting a live event here lands
     // a write DURING the fetch window — exactly the race the hydration guards.
-    onFetch: (name: string, method: 'findAll' | 'find', fn: (call: number) => unknown) =>
+    onFetch: (name: string, method: 'findAll' | 'find' | 'get', fn: (call: number) => unknown) =>
       fetchHooks.set(`${name}:${method}`, fn),
     fetchCount: (name: string, method: 'findAll' | 'find' | 'get') =>
       fetchCounts.get(`${name}:${method}`) ?? 0,
@@ -247,7 +248,7 @@ describe('useAgorData — socket-event bailouts', () => {
     }
   });
 
-  it('heals a cold mobile session outside the recent slice before resolving board scope', async () => {
+  it('opens a cold mobile session without waiting for a stalled branch get', async () => {
     const boardId = '01a012d8-1b9b-7909-b6f4-2024dfc7c51e';
     const sessionId = '01a012d8-4f50-7c32-9daa-6e3f70819b2c';
     const branchId = '01a012d8-3e4f-7b21-8c99-5d2e6f708a1b';
@@ -258,24 +259,43 @@ describe('useAgorData — socket-event bailouts', () => {
     });
     const directBranch = makeBranch({ branch_id: branchId, board_id: boardId });
     const boardObject = makeBoardObject({ board_id: boardId, branch_id: branchId });
-    const { client, fetchArguments } = makeMockClient({
+    const { client, fetchArguments, fetchCount, onFetch } = makeMockClient({
       sessions: [],
       boards: [{ board_id: boardId, slug: 'delivery' }],
+      branches: [directBranch],
       'sessions:get': directSession,
       'branches:get': directBranch,
       'board-objects': [boardObject],
     });
+    onFetch('branches', 'get', () => new Promise(() => {}));
     window.history.pushState({}, '', `/m/session/${sessionId}`);
 
     const { result } = renderHook(() => useAgorData(client, { directSessionId: sessionId }));
     await waitForInitialLoad(result);
 
     expect(agorStore.getState().sessionById.get(sessionId)).toMatchObject({ branch_id: branchId });
+    expect(fetchCount('branches', 'get')).toBe(0);
+    expect(agorStore.getState().branchById.get(branchId)).toMatchObject({ board_id: boardId });
     expect(agorStore.getState().boardObjectById.get('bo-1')).toMatchObject({ board_id: boardId });
     expect(fetchArguments('board-objects', 'findAll')).toContainEqual({
       query: expect.objectContaining({ board_id: boardId }),
     });
     window.history.pushState({}, '', '/');
+  });
+
+  it('opens a legacy session without board metadata or granting access to its missing branch', async () => {
+    const session = makeSession({ session_id: 'legacy-session', branch_id: 'hidden-branch' });
+    const { client, onFetch, fetchCount } = makeMockClient({
+      sessions: [],
+      branches: [],
+      'sessions:get': session,
+    });
+    onFetch('branches', 'get', () => new Promise(() => {}));
+    const { result } = renderHook(() => useAgorData(client, { directSessionId: 'legacy-session' }));
+    await waitForInitialLoad(result);
+    expect(agorStore.getState().sessionById.has('legacy-session')).toBe(true);
+    expect(agorStore.getState().branchById.has('hidden-branch')).toBe(false);
+    expect(fetchCount('branches', 'get')).toBe(0);
   });
 
   it('hydrates a direct archived session by id without broadening active board lists', async () => {

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -662,17 +662,18 @@ export function useAgorData(
         ]);
         if (!authorityIsCurrent()) return false;
 
-        // Branches healed into first paint by a direct deep link — the URL
-        // session's branch, or a `/w/<id>` branch link. They seed `branchById`
+        // Branches healed into first paint by a `/w/<id>` branch link. They seed `branchById`
         // ahead of the board-scoped branch fetch so the displayed board can be
         // resolved and its target card paints immediately.
         const healedBranches: Branch[] = [];
 
         // Direct /s/<id>/ opens should work for archived sessions without broadening
         // the recent-session slice. If it missed the URL target, fetch just that
-        // session by ID/short ID. Its branch is only hydrated when it is still
-        // active; adding archived branches to `branchById` would make board-object
-        // joins render archived cards back onto active boards.
+        // session by ID/short ID. Do not await a separate branches.get here:
+        // sessions carry branch_board_id for board resolution, and the scoped
+        // branch batch / authority-fenced background hydration below loads active
+        // branches. Optional branch enrichment must not block session first paint.
+        // Older responses without branch_board_id use global background hydration.
         if (
           directSessionId &&
           !hasIdMatchingPrefix(directSessionId, sessionsList, (s) => s.session_id)
@@ -683,19 +684,6 @@ export function useAgorData(
               .get(directSessionId)) as Session;
             if (!sessionsList.some((s) => s.session_id === directSession.session_id)) {
               sessionsList.push(directSession);
-            }
-            if (!directSession.archived && directSession.branch_id) {
-              try {
-                const directBranch = (await client
-                  .service('branches')
-                  .get(directSession.branch_id)) as Branch;
-                if (!directBranch.archived) {
-                  healedBranches.push(directBranch);
-                }
-              } catch {
-                // The session can still open; it just won't be able to switch/recenter
-                // if the branch is inaccessible or gone.
-              }
             }
           } catch {
             // Leave normal URL resolution to report/not-heal unresolved session links.

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -1240,17 +1240,17 @@ export type ApmTraceServiceDepth = (typeof APM_TRACE_SERVICE_DEPTHS)[number];
  * The tracer itself is loaded process-wide (single-step / `NODE_OPTIONS`
  * injection), which already auto-instruments HTTP, Express, Postgres, and
  * Redis. These settings govern Agor's custom tracing layers: the FeathersJS
- * service-method layer and the postgres.js Drizzle query shim, both of which
- * dd-trace has no native plugin for. `off` disables both custom layers.
+ * service-method layer, postgres.js Drizzle queries/transactions, async secret
+ * key derivation, and MCP admission/tool handlers. `off` disables these layers.
  */
 export interface AgorApmSettings {
   /**
    * Depth of custom Agor tracing. Defaults to `off`.
    *
-   * PostgreSQL query tracing is enabled for either `entrypoint` or `full` and
+   * PostgreSQL and async key-derivation tracing are enabled for `entrypoint` or `full` and
    * disabled for `off`. The depth only affects FeathersJS service spans.
    *
-   * - `off`: neither custom tracing layer is registered — zero custom tracing
+   * - `off`: no custom tracing layer is registered — zero custom tracing
    *   overhead (including no database shim patch and no tracer resolution).
    * - `entrypoint`: one span per top-level request; nested service-to-service
    *   fan-out is suppressed (mirrors the StatsD metrics hook). Cheap and

--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -292,7 +292,7 @@ function createPostgresDatabase(
     // postgres.js plugin, so without this the daemon's DB layer is invisible in
     // Datadog. Best-effort and additive — a no-op unless the daemon injected a
     // tracer, and it can never break a query (see postgres-tracing.ts).
-    instrumentDrizzlePostgresForTracing(db, { tracer });
+    instrumentDrizzlePostgresForTracing(db, { tracer, poolMax: options.max });
     return db;
   } catch (error) {
     throw new DatabaseConnectionError(

--- a/packages/core/src/db/encryption.ts
+++ b/packages/core/src/db/encryption.ts
@@ -1,4 +1,5 @@
-import { createCipheriv, createDecipheriv, randomBytes, scrypt, scryptSync } from 'node:crypto';
+import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from 'node:crypto';
+import { deriveSecretKeyAsync } from './secret-key-derivation';
 
 const ALGORITHM = 'aes-256-gcm';
 const KEY_LENGTH = 32;
@@ -88,12 +89,7 @@ export async function decryptApiKeyAsync(ciphertext: string, secret?: string): P
 
   try {
     const envelope = parseEnvelope(ciphertext);
-    const key = await new Promise<Buffer>((resolve, reject) => {
-      scrypt(masterSecret, envelope.salt, KEY_LENGTH, (error, derivedKey) => {
-        if (error) reject(error);
-        else resolve(derivedKey);
-      });
-    });
+    const key = await deriveSecretKeyAsync(masterSecret, envelope.salt, 'legacy');
     return decryptEnvelope(envelope, key);
   } catch {
     throw new Error('Secret decryption failed');

--- a/packages/core/src/db/index.ts
+++ b/packages/core/src/db/index.ts
@@ -53,6 +53,7 @@ export * from './repositories';
 export * from './sanitize-error';
 export * from './schema';
 export { type DatabaseDialect, detectDialectFromUrl, getDatabaseDialect } from './schema-factory';
+export { configureSecretKeyDerivationTracing } from './secret-key-derivation';
 // Session guard utilities (defensive programming for deleted sessions)
 export * from './session-guard';
 // Tenant database lifecycle primitives. Filesystem-backed portability operations

--- a/packages/core/src/db/oauth-secret-envelope.ts
+++ b/packages/core/src/db/oauth-secret-envelope.ts
@@ -1,4 +1,5 @@
-import { createCipheriv, createDecipheriv, randomBytes, scrypt, scryptSync } from 'node:crypto';
+import { createCipheriv, createDecipheriv, randomBytes, scryptSync } from 'node:crypto';
+import { deriveSecretKeyAsync } from './secret-key-derivation';
 
 const PREFIX = 'agor-mcp-oauth';
 const FORMAT_VERSION = 'v1';
@@ -83,12 +84,7 @@ export async function openBoundSecretAsync(
   binding: string
 ): Promise<string> {
   const parsed = parseEnvelope(envelope, masterSecret, purpose);
-  const key = await new Promise<Buffer>((resolve, reject) => {
-    scrypt(masterSecret, parsed.salt, KEY_LENGTH, (error, derivedKey) => {
-      if (error) reject(error);
-      else resolve(derivedKey);
-    });
-  });
+  const key = await deriveSecretKeyAsync(masterSecret, parsed.salt, 'bound');
   return decryptEnvelope(parsed, key, purpose, binding);
 }
 

--- a/packages/core/src/db/postgres-tracing.integration.postgres.test.ts
+++ b/packages/core/src/db/postgres-tracing.integration.postgres.test.ts
@@ -2,6 +2,7 @@ import { sql } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { isPostgresDatabase } from './database-wrapper';
 import { type DatadogTracer, instrumentDrizzlePostgresForTracing } from './postgres-tracing';
 import * as postgresSchema from './schema.postgres';
 import { runWithTenantDatabaseScope } from './tenant-scope';
@@ -81,9 +82,8 @@ describe.skipIf(!url)('postgres-tracing against real Drizzle postgres.js', () =>
     });
     await ready;
     const second = runWithTenantDatabaseScope(db, tenantB, async (scoped) => {
-      const rows = await (scoped as typeof db).execute(
-        sql`select current_setting('agor.tenant_id') as tenant`
-      );
+      if (!isPostgresDatabase(scoped)) throw new Error('PostgreSQL test requires PostgreSQL');
+      const rows = await scoped.execute(sql`select current_setting('agor.tenant_id') as tenant`);
       expect((rows as unknown as { tenant: string }[])[0].tenant).toBe(tenantB);
       await expect(
         runWithTenantDatabaseScope(db, tenantA, async () => undefined)

--- a/packages/core/src/db/postgres-tracing.integration.postgres.test.ts
+++ b/packages/core/src/db/postgres-tracing.integration.postgres.test.ts
@@ -4,6 +4,7 @@ import postgres from 'postgres';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { type DatadogTracer, instrumentDrizzlePostgresForTracing } from './postgres-tracing';
 import * as postgresSchema from './schema.postgres';
+import { runWithTenantDatabaseScope } from './tenant-scope';
 
 /**
  * Validates the tracing shim against the REAL drizzle-orm/postgres-js internals
@@ -14,11 +15,16 @@ import * as postgresSchema from './schema.postgres';
 const url = process.env.AGOR_TEST_POSTGRES_URL;
 
 describe.skipIf(!url)('postgres-tracing against real Drizzle postgres.js', () => {
-  const calls: { resource?: string }[] = [];
+  const calls: { resource?: string; tags: Record<string, unknown> }[] = [];
   const tracer: DatadogTracer = {
     trace(_name, opts, fn) {
-      calls.push({ resource: opts.resource });
-      return fn();
+      const call = { resource: opts.resource, tags: { ...opts.tags } };
+      calls.push(call);
+      return fn({
+        setTag: (key, value) => {
+          call.tags[key] = value;
+        },
+      });
     },
   };
 
@@ -57,9 +63,48 @@ describe.skipIf(!url)('postgres-tracing against real Drizzle postgres.js', () =>
     expect(calls.some((c) => (c.resource ?? '').includes('13'))).toBe(true);
   });
 
-  // NOTE: transaction-sub-session coverage (the prototype patch reaching the
-  // scoped session drizzle creates for a transactional callback) is proven in
-  // the unit suite (postgres-tracing.test.ts). We don't open a real transaction
-  // here to avoid the raw-Drizzle-transaction multitenancy boundary check for a
-  // test that touches no tenant data.
+  it('records queued acquisition on a one-connection pool and preserves tenant boundaries', async () => {
+    calls.length = 0;
+    const tenantA = '11111111-1111-4111-8111-111111111111';
+    const tenantB = '22222222-2222-4222-8222-222222222222';
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let entered!: () => void;
+    const ready = new Promise<void>((resolve) => {
+      entered = resolve;
+    });
+    const first = runWithTenantDatabaseScope(db, tenantA, async () => {
+      entered();
+      await held;
+    });
+    await ready;
+    const second = runWithTenantDatabaseScope(db, tenantB, async (scoped) => {
+      const rows = await (scoped as typeof db).execute(
+        sql`select current_setting('agor.tenant_id') as tenant`
+      );
+      expect((rows as unknown as { tenant: string }[])[0].tenant).toBe(tenantB);
+      await expect(
+        runWithTenantDatabaseScope(db, tenantA, async () => undefined)
+      ).rejects.toThrow();
+    });
+    try {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      const transactions = calls.filter((call) => call.resource === 'postgres.transaction');
+      expect(transactions).toHaveLength(2);
+      expect(transactions[0].tags['db.transaction.acquire_ms']).toBeGreaterThanOrEqual(0);
+      expect(transactions[1].tags).not.toHaveProperty('db.transaction.acquire_ms');
+      expect(calls.filter((call) => call.resource === 'postgres.transaction.work')).toHaveLength(1);
+    } finally {
+      release();
+      await Promise.all([first, second]);
+    }
+    expect(calls.filter((call) => call.resource === 'postgres.transaction.work')).toHaveLength(2);
+    expect(
+      calls.filter((call) => call.resource === 'postgres.transaction')[1].tags[
+        'db.transaction.acquire_ms'
+      ]
+    ).toBeGreaterThanOrEqual(0);
+  });
 });

--- a/packages/core/src/db/postgres-tracing.ts
+++ b/packages/core/src/db/postgres-tracing.ts
@@ -1,4 +1,5 @@
 import type { DatadogTracer } from '../tracing/datadog';
+import { instrumentPostgresTransactions } from './postgres-transaction-tracing';
 
 export type { DatadogTracer };
 
@@ -21,10 +22,12 @@ export type { DatadogTracer };
  * driver directly, bypassing `prepareQuery`. Agor's normal query paths do not
  * use them, so they are intentionally out of scope; the real-Drizzle regression
  * test asserts the covered paths and fails loudly if the chokepoint moves.
+ * Root transactions additionally get acquisition/setup timing and a body span
+ * via postgres-transaction-tracing.ts; BEGIN/COMMIT bypass prepareQuery.
  *
  * Safety contract: this is best-effort and additive. Any failure to resolve the
  * tracer, reach the Drizzle internals, install the patch, OR run the per-query
- * wrapper leaves the query untouched — it can never break, slow, duplicate, or
+ * wrapper leaves the query untouched — it must never break, duplicate, or
  * change a query. Worst case is "no DB spans".
  */
 
@@ -139,11 +142,12 @@ interface DrizzleSessionLike {
  */
 export function instrumentDrizzlePostgresForTracing(
   db: unknown,
-  options: { tracer?: DatadogTracer | null } = {}
+  options: { tracer?: DatadogTracer | null; poolMax?: number } = {}
 ): boolean {
   try {
     const tracer = options.tracer ?? null;
     if (!tracer) return false;
+    instrumentPostgresTransactions(db, tracer, options.poolMax);
 
     // The session is shared by prototype across the top-level db AND every
     // transaction sub-session, so patching the prototype covers transactional

--- a/packages/core/src/db/postgres-transaction-tracing.test.ts
+++ b/packages/core/src/db/postgres-transaction-tracing.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import type { DatadogTracer } from '../tracing/datadog';
+import { instrumentPostgresTransactions } from './postgres-transaction-tracing';
+import { getCurrentTenantId, runWithTenantContext } from './tenant-context';
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function recordingTracer() {
+  const calls: { name: string; tags: Record<string, unknown>; finished: boolean }[] = [];
+  const tracer: DatadogTracer = {
+    trace(name, options, fn) {
+      const call = { name, tags: { ...options.tags }, finished: false };
+      calls.push(call);
+      const result = fn({
+        setTag: (key, value) => {
+          call.tags[key] = value;
+        },
+      });
+      void Promise.resolve(result).then(
+        () => {
+          call.finished = true;
+        },
+        () => {
+          call.finished = true;
+        }
+      );
+      return result;
+    },
+  };
+  return { tracer, calls };
+}
+
+describe('PostgreSQL transaction timing', () => {
+  it('separates acquisition, callback work and commit without changing the transaction', async () => {
+    const acquire = deferred();
+    const work = deferred();
+    const commit = deferred();
+    const entered = deferred();
+    const bodyDone = deferred();
+    const tx = {};
+    const options = { isolationLevel: 'read committed' };
+    const { tracer, calls } = recordingTracer();
+    let transactions = 0;
+    const db = {
+      async transaction(callback: (handle: object) => Promise<string>, config: object) {
+        expect(this).toBe(db);
+        expect(config).toBe(options);
+        transactions++;
+        await acquire.promise;
+        const result = await callback(tx);
+        bodyDone.resolve();
+        await commit.promise;
+        return result;
+      },
+    };
+    instrumentPostgresTransactions(db, tracer, 10);
+    instrumentPostgresTransactions(db, tracer, 10);
+    const result = db.transaction(async (handle) => {
+      expect(handle).toBe(tx);
+      entered.resolve();
+      await work.promise;
+      return 'result';
+    }, options);
+    expect(calls.map((c) => c.name)).toEqual(['postgres.transaction']);
+    expect(calls[0].tags).not.toHaveProperty('db.transaction.acquire_ms');
+    acquire.resolve();
+    await entered.promise;
+    expect(calls[0].tags['db.transaction.acquire_ms']).toBeGreaterThanOrEqual(0);
+    expect(calls[0].tags['db.pool.max']).toBe(10);
+    expect(calls[1].name).toBe('postgres.transaction.work');
+    work.resolve();
+    await bodyDone.promise;
+    expect(calls[1].finished).toBe(true);
+    expect(calls[0].finished).toBe(false);
+    commit.resolve();
+    await expect(result).resolves.toBe('result');
+    expect(calls[0].finished).toBe(true);
+    expect(transactions).toBe(1);
+  });
+
+  it('preserves concurrent tenant context and rejects a cross-tenant switch', async () => {
+    const { tracer } = recordingTracer();
+    const db = {
+      async transaction(callback: () => Promise<void>) {
+        return callback();
+      },
+    };
+    instrumentPostgresTransactions(db, tracer);
+    await Promise.all(
+      ['tenant-a', 'tenant-b'].map((tenant) =>
+        runWithTenantContext(tenant, () =>
+          db.transaction(async () => {
+            await Promise.resolve();
+            expect(getCurrentTenantId()).toBe(tenant);
+            const foreign = tenant === 'tenant-a' ? 'tenant-b' : 'tenant-a';
+            expect(() => runWithTenantContext(foreign, () => undefined)).toThrow(
+              'Cannot enter tenant context'
+            );
+          })
+        )
+      )
+    );
+  });
+
+  it('propagates acquisition, body, and commit errors without retrying', async () => {
+    for (const stage of ['acquire', 'body', 'commit']) {
+      const failure = new Error(stage);
+      let transactions = 0;
+      const db = {
+        async transaction(callback: () => Promise<void>) {
+          transactions++;
+          if (stage === 'acquire') throw failure;
+          await callback();
+          throw failure;
+        },
+      };
+      instrumentPostgresTransactions(db, recordingTracer().tracer);
+      await expect(
+        db.transaction(async () => {
+          if (stage === 'body') throw failure;
+        })
+      ).rejects.toBe(failure);
+      expect(transactions).toBe(1);
+    }
+  });
+
+  it('leaves frozen handles alone', () => {
+    const transaction = () => 'unchanged';
+    const db = Object.freeze({ transaction });
+    expect(() => instrumentPostgresTransactions(db, recordingTracer().tracer)).not.toThrow();
+    expect(db.transaction).toBe(transaction);
+  });
+});

--- a/packages/core/src/db/postgres-transaction-tracing.ts
+++ b/packages/core/src/db/postgres-transaction-tracing.ts
@@ -1,0 +1,48 @@
+import { performance } from 'node:perf_hooks';
+import { type DatadogTracer, setSpanTag, traceBestEffort } from '../tracing/datadog';
+
+const installed = new WeakSet<object>();
+
+/**
+ * Instrument the raw root database, not a tenant proxy or a shared prototype.
+ * postgres.js executes BEGIN before invoking Drizzle's transaction callback;
+ * prepareQuery instrumentation cannot see that acquisition/BEGIN interval.
+ * Nested savepoints are not new pool acquisitions and are not wrapped here.
+ */
+export function instrumentPostgresTransactions(
+  db: unknown,
+  tracer: DatadogTracer,
+  poolMax?: number
+): void {
+  try {
+    if (!db || typeof db !== 'object' || installed.has(db)) return;
+    const target = db as { transaction?: (...args: unknown[]) => unknown };
+    const original = target.transaction;
+    if (typeof original !== 'function') return;
+    target.transaction = function (this: unknown, ...args: unknown[]) {
+      const callback = args[0];
+      if (typeof callback !== 'function') return original.apply(this, args);
+      const tags = {
+        'db.system': 'postgresql',
+        ...(poolMax === undefined ? {} : { 'db.pool.max': poolMax }),
+      };
+      return traceBestEffort(tracer, 'postgres.transaction', tags, (span) => {
+        const started = performance.now();
+        return original.apply(this, [
+          function (this: unknown, ...callbackArgs: unknown[]) {
+            // Includes pool queueing, establishing a connection and BEGIN (and
+            // Drizzle transaction setup). It is NOT pure server lock wait.
+            setSpanTag(span, 'db.transaction.acquire_ms', performance.now() - started);
+            return traceBestEffort(tracer, 'postgres.transaction.work', tags, () =>
+              callback.apply(this, callbackArgs)
+            );
+          },
+          ...args.slice(1),
+        ]);
+      });
+    };
+    installed.add(db);
+  } catch {
+    // A frozen/incompatible handle only loses this optional instrumentation.
+  }
+}

--- a/packages/core/src/db/secret-key-derivation.test.ts
+++ b/packages/core/src/db/secret-key-derivation.test.ts
@@ -1,0 +1,139 @@
+import { scrypt } from 'node:crypto';
+import { afterEach, expect, it, vi } from 'vitest';
+import type { DatadogTracer } from '../tracing/datadog';
+import type { Database } from './client';
+import { openBoundSecretAsync, sealBoundSecret } from './oauth-secret-envelope';
+import { configureSecretKeyDerivationTracing, deriveSecretKeyAsync } from './secret-key-derivation';
+import { getCurrentTenantId, runWithTenantContext, tenantDatabaseScope } from './tenant-context';
+
+vi.mock('node:crypto', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:crypto')>();
+  return { ...actual, scrypt: vi.fn(actual.scrypt) };
+});
+
+afterEach(() => {
+  configureSecretKeyDerivationTracing(null);
+  vi.mocked(scrypt).mockReset();
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+it('retains authenticated envelope binding with tracing enabled', async () => {
+  const actual = await vi.importActual<typeof import('node:crypto')>('node:crypto');
+  vi.mocked(scrypt).mockImplementation(actual.scrypt);
+  configureSecretKeyDerivationTracing({
+    trace(_name, _options, fn) {
+      return fn();
+    },
+  });
+  const envelope = sealBoundSecret(
+    'synthetic-token',
+    'synthetic-master',
+    'access-token',
+    'tenant-a:row'
+  );
+  await expect(
+    openBoundSecretAsync(envelope, 'synthetic-master', 'access-token', 'tenant-a:row')
+  ).resolves.toBe('synthetic-token');
+  await expect(
+    openBoundSecretAsync(envelope, 'synthetic-master', 'access-token', 'tenant-b:row')
+  ).rejects.toThrow();
+});
+
+it('records only bounded capacity/context tags and restores pending count after success or failure', async () => {
+  const callbacks: ((error: Error | null, key: Buffer) => void)[] = [];
+  vi.mocked(scrypt).mockImplementation(((
+    _secret: unknown,
+    _salt: unknown,
+    _length: unknown,
+    callback: (error: Error | null, key: Buffer) => void
+  ) => {
+    callbacks.push(callback);
+  }) as typeof scrypt);
+  const calls: Record<string, unknown>[] = [];
+  const tracer: DatadogTracer = {
+    trace(name, options, fn) {
+      expect(name).toBe('crypto.scrypt');
+      calls.push(options.tags!);
+      return fn();
+    },
+  };
+  vi.stubEnv('UV_THREADPOOL_SIZE', '8');
+  configureSecretKeyDerivationTracing(tracer);
+  const key = Buffer.alloc(32, 2);
+  const first = runWithTenantContext('tenant-a', () =>
+    tenantDatabaseScope.run(
+      {
+        kind: 'tenant',
+        tenantId: 'tenant-a',
+        transactionActive: true,
+        db: {} as Database,
+        postCommitCallbacks: [],
+        afterCommitCallbacks: [],
+      },
+      async () => {
+        const result = await deriveSecretKeyAsync(
+          'sensitive-master',
+          Buffer.from('sensitive-salt'),
+          'legacy'
+        );
+        expect(getCurrentTenantId()).toBe('tenant-a');
+        expect(() => runWithTenantContext('tenant-b', () => undefined)).toThrow(
+          'Cannot enter tenant context'
+        );
+        return result;
+      }
+    )
+  );
+  const second = runWithTenantContext('tenant-b', () =>
+    deriveSecretKeyAsync('another-master', Buffer.alloc(16), 'bound')
+  );
+  const failure = new Error('synthetic failure');
+  const rejected = expect(second).rejects.toBe(failure);
+  expect(calls).toEqual([
+    {
+      'crypto.envelope': 'legacy',
+      'crypto.pending_at_submit': 0,
+      'crypto.in_tenant_transaction': true,
+      'crypto.configured_pool_size': 8,
+    },
+    {
+      'crypto.envelope': 'bound',
+      'crypto.pending_at_submit': 1,
+      'crypto.in_tenant_transaction': false,
+      'crypto.configured_pool_size': 8,
+    },
+  ]);
+  callbacks[0](null, key);
+  callbacks[1](failure, Buffer.alloc(0));
+  await expect(first).resolves.toBe(key);
+  await rejected;
+  const third = deriveSecretKeyAsync('sensitive-master', Buffer.from('sensitive-salt'), 'legacy');
+  expect(calls[2]['crypto.pending_at_submit']).toBe(0);
+  callbacks[2](null, key);
+  await third;
+  expect(callbacks).toHaveLength(3); // No secret/key caching or deduplication.
+  expect(JSON.stringify(calls)).not.toMatch(/sensitive|tenant-a|tenant-b|another-master/);
+});
+
+it('keeps the native KDF operational when disabled or when the tracer throws', async () => {
+  const key = Buffer.alloc(32);
+  vi.mocked(scrypt).mockImplementation(((
+    _secret: unknown,
+    _salt: unknown,
+    _length: unknown,
+    callback: (error: Error | null, key: Buffer) => void
+  ) => {
+    callback(null, key);
+  }) as typeof scrypt);
+  vi.mocked(scrypt).mockClear();
+  configureSecretKeyDerivationTracing(null);
+  await expect(deriveSecretKeyAsync('test', Buffer.alloc(16), 'legacy')).resolves.toBe(key);
+  configureSecretKeyDerivationTracing({
+    trace() {
+      throw new Error('tracer unavailable');
+    },
+  });
+  await expect(deriveSecretKeyAsync('test', Buffer.alloc(16), 'bound')).resolves.toBe(key);
+  expect(scrypt).toHaveBeenCalledTimes(2);
+});

--- a/packages/core/src/db/secret-key-derivation.ts
+++ b/packages/core/src/db/secret-key-derivation.ts
@@ -1,0 +1,68 @@
+import { scrypt } from 'node:crypto';
+import { type DatadogTracer, traceBestEffort } from '../tracing/datadog';
+import { getCurrentTenantDatabaseScope } from './tenant-context';
+
+interface DerivationTracing {
+  tracer: DatadogTracer;
+  pending: number;
+  configuredPoolSize?: number;
+}
+
+let tracing: DerivationTracing | null = null;
+
+/** Daemon startup only; shares the existing custom-APM gate and optional tracer. */
+export function configureSecretKeyDerivationTracing(tracer: DatadogTracer | null): void {
+  const configured = Number(process.env.UV_THREADPOOL_SIZE ?? 4);
+  tracing = tracer
+    ? {
+        tracer,
+        pending: 0,
+        configuredPoolSize:
+          Number.isSafeInteger(configured) && configured > 0 ? configured : undefined,
+      }
+    : null;
+}
+
+/**
+ * One async KDF, unchanged cryptography. APM records submit-to-callback time,
+ * not pure queue time: Node does not expose when the native worker starts.
+ * Pending counts cover these Agor KDFs only, not other libuv work. They are
+ * process-global capacity observations, never tenant authorization state.
+ * No input, salt, key, plaintext, binding, or resource identity is tagged.
+ */
+export function deriveSecretKeyAsync(
+  secret: string,
+  salt: Buffer,
+  envelope: 'legacy' | 'bound'
+): Promise<Buffer> {
+  const derive = () =>
+    new Promise<Buffer>((resolve, reject) => {
+      scrypt(secret, salt, 32, (error, key) => {
+        if (error) reject(error);
+        else resolve(key);
+      });
+    });
+  const state = tracing;
+  if (!state) return derive();
+  const scope = getCurrentTenantDatabaseScope();
+  return traceBestEffort(
+    state.tracer,
+    'crypto.scrypt',
+    {
+      'crypto.envelope': envelope,
+      'crypto.pending_at_submit': state.pending,
+      'crypto.in_tenant_transaction': scope?.kind === 'tenant' && scope.transactionActive,
+      ...(state.configuredPoolSize === undefined
+        ? {}
+        : { 'crypto.configured_pool_size': state.configuredPoolSize }),
+    },
+    async () => {
+      state.pending++;
+      try {
+        return await derive();
+      } finally {
+        state.pending--;
+      }
+    }
+  );
+}

--- a/packages/core/src/tracing/datadog.test.ts
+++ b/packages/core/src/tracing/datadog.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { resolveDatadogTracer } from './datadog';
+import { type DatadogTracer, resolveDatadogTracer, setSpanTag, traceBestEffort } from './datadog';
 
 describe('resolveDatadogTracer', () => {
   const validTracer = { trace: () => undefined };
@@ -31,5 +31,64 @@ describe('resolveDatadogTracer', () => {
     ).toBe(validTracer);
     expect(resolveDatadogTracer(notFound)).toBeNull();
     expect(resolveDatadogTracer(() => ({}))).toBeNull(); // no callable .trace
+  });
+});
+
+describe('best-effort tracing', () => {
+  it('runs work once when disabled or tracing throws before/after invocation', async () => {
+    const tracers: (DatadogTracer | null)[] = [
+      null,
+      {
+        trace() {
+          throw new Error('tracer failed');
+        },
+      },
+      {
+        trace(_name, _options, fn) {
+          fn();
+          throw new Error('tracer failed');
+        },
+      },
+    ];
+    for (const tracer of tracers) {
+      let runs = 0;
+      await expect(
+        traceBestEffort(tracer, 'test', {}, async () => {
+          runs++;
+          return 42;
+        })
+      ).resolves.toBe(42);
+      expect(runs).toBe(1);
+    }
+  });
+
+  it('preserves sync and async work errors, and ignores tag failures', async () => {
+    const failure = new Error('work failed');
+    const tracer: DatadogTracer = {
+      trace(_name, _options, fn) {
+        return fn();
+      },
+    };
+    expect(() =>
+      traceBestEffort(tracer, 'test', {}, () => {
+        throw failure;
+      })
+    ).toThrow(failure);
+    await expect(
+      traceBestEffort(tracer, 'test', {}, async () => {
+        throw failure;
+      })
+    ).rejects.toBe(failure);
+    expect(() =>
+      setSpanTag(
+        {
+          setTag() {
+            throw new Error('tag failed');
+          },
+        },
+        'test',
+        1
+      )
+    ).not.toThrow();
   });
 });

--- a/packages/core/src/tracing/datadog.ts
+++ b/packages/core/src/tracing/datadog.ts
@@ -14,12 +14,57 @@
  */
 
 /** Minimal surface of the dd-trace singleton we depend on. */
+export interface DatadogSpan {
+  setTag(name: string, value: unknown): unknown;
+}
+
 export interface DatadogTracer {
   trace<T>(
     name: string,
     options: { resource?: string; type?: string; tags?: Record<string, unknown> },
-    fn: () => T
+    fn: (span?: DatadogSpan) => T
   ): T;
+}
+
+/** Instrumentation must not prevent, retry, or replace the underlying work. */
+export function traceBestEffort<T>(
+  tracer: DatadogTracer | null,
+  name: string,
+  tags: Record<string, unknown>,
+  work: (span?: DatadogSpan) => T
+): T {
+  if (!tracer) return work();
+  let ran = false;
+  let failed = false;
+  let failure: unknown;
+  let result: T;
+  const invoke = (span?: DatadogSpan): T => {
+    ran = true;
+    try {
+      result = work(span);
+      return result;
+    } catch (error) {
+      failed = true;
+      failure = error;
+      throw error;
+    }
+  };
+  try {
+    return tracer.trace(name, { resource: name, tags }, invoke);
+  } catch {
+    if (failed) throw failure;
+    if (ran) return result!;
+    return invoke();
+  }
+}
+
+/** Optional tracer bridges and tag failures must not affect application work. */
+export function setSpanTag(span: DatadogSpan | undefined, name: string, value: unknown): void {
+  try {
+    span?.setTag(name, value);
+  } catch {
+    // Best-effort telemetry only.
+  }
 }
 
 /**

--- a/scripts/check-multitenancy-boundaries.mjs
+++ b/scripts/check-multitenancy-boundaries.mjs
@@ -209,6 +209,10 @@ const checks = [
       // capabilities use a second transaction path so their RLS GUC is local
       // to one pooled connection checkout and cannot leak after discovery.
       'packages/core/src/db/tenant-scope.ts': 2,
+      // Pure in-memory transaction doubles exercise tracing timing/failure
+      // semantics. They never access a database; the real PostgreSQL tracing
+      // test goes through runWithTenantDatabaseScope instead.
+      'packages/core/src/db/postgres-transaction-tracing.test.ts': 3,
       // Test-only security harness deliberately invokes every direct libsql
       // and Drizzle transaction surface to prove the literal-memory client
       // coordinator cannot be bypassed. No application database access lives


### PR DESCRIPTION
## Summary
- Add durable, opt-in APM visibility into root PostgreSQL transaction acquisition/setup and callback work, plus async secret-key derivation latency and outstanding KDF counts. Reuse the existing `metrics.apm.trace_services` gate and optional tracer; no new operational logs or pool-size changes.
- Remove a redundant blocking `branches.get` during cold **session** deep-link bootstrap. Session `branch_board_id` already resolves the displayed board; existing authorized board-scoped/background branch hydration supplies the records. Legacy session responses fall back to background hydration. Direct branch links and backend authorization are unchanged.
- Document timing semantics, configuration, overhead, and interpretation in the existing configuration guide.

## Evidence and scope
Recent sandbox `branches.get` traces reached tens of seconds, with most elapsed time outside recorded SQL. Example: https://app.datadoghq.com/apm/trace/6aa183360000000038d3da9142569f25 . The current SQL shim misses transaction acquisition/BEGIN. Database pool is operator-configured to **50** in this environment; crypto uses Node's default **4** unless overridden (live crypto override not verified).

The normal branch-read path does not hydrate credentials. Shared capacity contention is a hypothesis, not a proven root cause. This PR illuminates it and removes one unnecessary UI dependency; it does not claim to cure all backend latency or all session loading waits.

## Instrumentation contract
- `postgres.transaction`: root transaction through settlement; `db.transaction.acquire_ms` includes queueing, connection establishment, BEGIN and setup. Child `postgres.transaction.work` covers the callback, not commit/rollback. `db.pool.max` records the configured limit.
- `crypto.scrypt`: submit-to-completion, **not pure queue wait**. Pending counts cover Agor KDFs, not all libuv work. Tags identify legacy/bound envelope, configured worker count, and whether derivation starts inside a tenant transaction.
- No credential/plaintext/ciphertext/salt/binding or tenant/user/session identifiers added to tags. No secret caching, relaxed authorization or cryptography changes.
- Tracing is disabled by default. Enabled tracing adds two spans/root transaction and one/async KDF, using existing APM sampling/export. Real Datadog tracer CPU/export overhead has **not** been measured locally; sampling does not eliminate all span-creation cost.

## Validation
- **132 focused tests passed**: 51 UI, 46 core, 35 daemon.
- UI regression: a never-resolving branch get cannot block cold mobile session bootstrap; authorized scoped hydration still supplies the branch.
- UI negative coverage: legacy session without board metadata remains loadable without inventing access to an unavailable branch; existing archive and authority-scope tests pass.
- Core: transaction timing/lifecycle and failure preservation, exactly-once work when tracing fails, concurrent tenant-context preservation and rejected cross-tenant switches, bound-envelope negative test with tracing enabled.
- Added real-PostgreSQL one-connection queue/tenant-scope integration test. **Not run locally**: no configured isolated `AGOR_TEST_POSTGRES_URL`; the PostgreSQL integration lane must validate it.
- Biome, documentation formatting, and multitenancy boundary check pass. Existing unrelated repos.ts baseline-improvement notice remains.
- No local builds or deployment; no pool settings changed.

## Rollout
Deploy with existing pool settings first, inspect acquisition/body/crypto spans, and monitor instrumentation overhead. Only then run a controlled crypto worker trial (e.g. 4 to 8), leaving the DB pool at 50. Keep rollback/configuration changes separate from the measurement baseline.
