### PR TITLE
docs: add reusable agentic QA protocol and templates

### DIFF
--- a/context/README.md
+++ b/context/README.md
@@ -51,6 +51,7 @@ Step-by-step implementation guides referenced from code.
 - [`frontend.md`](guidelines/frontend.md) — AntD-first components, theme tokens, accessibility, and exact-color exceptions.
 - [`logging.md`](guidelines/logging.md) — Safe, bounded operational logging and its boundary with analytics, telemetry, and usage accounting.
 - [`testing.md`](guidelines/testing.md) — Vitest patterns and conventions.
+- [`agentic-qa.md`](guidelines/agentic-qa.md) — repeatable feature QA, evidence, and regression promotion; [templates and profiles](../qa/README.md).
 - [`toasts.md`](guidelines/toasts.md) — Toast/message pattern. Always `useThemedMessage()` — never static `message.x()`.
 - [`onboarding-design.md`](guidelines/onboarding-design.md) — Onboarding wizard: goal-over-role framing, the locked goal cards, and composable-block recs.
 

--- a/context/guidelines/agentic-qa.md
+++ b/context/guidelines/agentic-qa.md
@@ -1,0 +1,106 @@
+# Agentic QA protocol
+
+Use this protocol for agent-driven feature validation and regression discovery.
+Start at [qa/README.md](../../qa/README.md) for templates and environment profiles.
+It complements [automated testing conventions](testing.md); it does not replace them.
+
+## Define the claim before execution
+
+1. Map the requested feature or diff to stable scenario IDs and adjacent risks.
+2. Read the relevant product guide, accepted requirement, canonical types, and code.
+   Requirements define intended behavior; code locates enforcement and observation
+   points. If they conflict, record the ambiguity instead of copying a bug into the
+   expected result. Continue independent checks while resolving it.
+3. Choose the smallest test layer that proves each claim: unit/component,
+   service/database, browser component, or running application. Name mocked boundaries.
+4. Assess [tenant ownership and isolation](../concepts/multitenancy.md). Select
+   applicable negative cases across API, realtime, async work, files, and cleanup.
+   A hidden control alone does not prove denied access. Review this assessment again
+   against the final change and evidence.
+5. Record applicable permission, multiplayer, persistence, lifecycle, recovery,
+   execution-mode, and accessibility/layout variations. Explain exclusions briefly;
+   do not expand every scenario into every possible combination.
+
+## Preflight
+
+- Record the scenario revision, checkout revision and relevant uncommitted changes,
+  target URLs, environment profile, database dialect, execution mode, browser/viewport,
+  and agent/tool versions when they affect reproducibility. Never record credentials.
+- Verify that the running target belongs to the intended checkout. A reachable health
+  endpoint alone does not prove revision identity or application readiness.
+- Establish fixture ownership, independent authenticated actors, expected initial state,
+  observation tools, and a cleanup procedure before mutating data. Use disposable,
+  run-owned resources; never reset a shared database as a convenience.
+- Use the documented environment workflow. Respect the repository's user-managed watch
+  mode: do not start background processes or build the application without authorization.
+- Identify external calls, paid execution, and irreversible side effects. Stay within
+  the authorized environment and task scope; missing required access is a blocker.
+- Set a time/action budget for exploration, condition-based timeouts, and a bounded
+  reproduction/retry budget before running. Budget exhaustion leaves unfinished checks
+  explicitly untested; it is not evidence of success.
+
+## Execute and observe
+
+Run each required scenario from its declared starting state. Exercise the named
+interface: an API mutation cannot substitute for the UI action being tested. APIs
+and existing fixtures may prepare data or independently verify the result.
+
+Use semantic browser locators and condition-based waits. Inspect screenshots for
+visual claims and retain traces or focused event/network evidence for failures.
+Confirm persistence and side effects at their authoritative boundary when the scenario
+requires them. For multiplayer, use independent authenticated clients. For runtime
+changes, follow [task lifecycle invariants](../concepts/task-runtime-state.md): a badge
+or live heartbeat is not proof of SDK progress or verified termination.
+
+After prescribed checks, investigate the scenario's exploration charter. Record new
+hypotheses and findings separately from required coverage. Preserve the first failure
+before retrying, fixing, or resetting. Reset relevant state between trials, and record
+every attempt; a later success does not erase an intermittent failure.
+
+## Verdict and failure handling
+
+Assign a verdict per scenario **and environment/variation**, with evidence references:
+
+| Verdict        | Meaning                                                                |
+| -------------- | ---------------------------------------------------------------------- |
+| `pass`         | All required outcomes were observed with the specified evidence.       |
+| `fail`         | Evidence demonstrates a violated requirement.                          |
+| `blocked`      | A known prerequisite prevents completion; name it and the next action. |
+| `inconclusive` | Execution or evidence cannot establish the outcome reliably.           |
+| `not_run`      | No execution was attempted; explain the omission.                      |
+
+Classify failures separately as product, test/harness, environment, or unresolved.
+Do not call a suspected harness problem a product pass. A required check that skips,
+times out without sufficient evidence, or lacks its required environment stays incomplete.
+Report verdict counts and unresolved gaps; never summarize a partially executed scope
+as fully validated. Record intermittent results even when a later attempt passes.
+
+Reproduce a defect within the agreed budget and capture expected versus actual behavior,
+minimal steps, affected actors, and evidence. Fix within the authorized scope under the
+normal development workflow; keep diagnosis, source repair, and verification distinct.
+Never weaken assertions, accept a new visual baseline, change requirements, or skip a
+broken test merely to obtain a passing result. Locator/wait/fixture repairs must preserve
+the claim and explain why the failure belonged to the harness.
+
+## Preserve regressions and finish
+
+- Link a confirmed reproducible defect to the smallest useful automated regression test
+  and the stable scenario ID. Prefer existing colocated suites; add a full application
+  test only when that boundary is needed. Record a follow-up if automation is blocked.
+- Where feasible, prove the regression check fails before the fix and passes after it
+  in an isolated environment. Do not introduce deliberate faults into a shared runtime.
+- Update the specification when accepted behavior changes, preserving IDs for the same
+  contract. The feature author maintains it and the reviewer checks its proof limits.
+- Clean up only resources owned by this run, including sessions/processes started for it.
+  Verify cleanup and record leftovers or intentional retention separately from verdicts.
+- Use the [run result template](../../qa/templates/run-result.md). Keep routine reports,
+  traces, screenshots, and logs in issue/PR attachments or CI artifacts, not tracked
+  repository reports. Sanitize evidence before sharing: exclude secrets, auth state,
+  private data, and credential-bearing URLs; use an access-appropriate artifact destination.
+
+## Design references
+
+The protocol combines [specification by example](https://martinfowler.com/bliki/SpecificationByExample.html),
+[human-readable browser test plans](https://playwright.dev/docs/test-agents), and
+[outcome-based agent evaluation](https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents).
+These inform the approach; the repository contracts above govern execution.

--- a/context/guidelines/testing.md
+++ b/context/guidelines/testing.md
@@ -2,6 +2,9 @@
 
 **Vitest with co-located test files.**
 
+For agent-driven feature validation, exploration, evidence, and regression promotion,
+follow the [agentic QA protocol](agentic-qa.md) and [QA templates](../../qa/README.md).
+
 ---
 
 ## Philosophy

--- a/qa/README.md
+++ b/qa/README.md
@@ -1,0 +1,63 @@
+# Agentic QA
+
+Reusable specifications describe what must work, which environment can prove it,
+and what evidence an agent must collect. Follow the
+[QA protocol](../context/guidelines/agentic-qa.md) before executing them.
+
+## Start here
+
+1. Copy the [scenario template](templates/scenario.md) into
+   `qa/specs/<feature>/<scenario>.md` when a feature is selected. Create that directory
+   with the first real specification; templates alone are not coverage.
+2. Replace placeholders, link an accepted requirement, select applicable variations,
+   and resolve the required environment/setup before calling the scenario executable.
+3. Use the [local environment profile](environments/local.md) to identify existing
+   test layers and missing runtime prerequisites. It is an inventory, not a readiness receipt.
+4. Execute under the protocol and publish a [run result](templates/run-result.md)
+   with evidence in the issue/PR or CI artifacts.
+5. Link useful regression tests from the specification. Existing automated tests remain
+   colocated with source under [testing conventions](../context/guidelines/testing.md).
+
+## Conventions and ownership
+
+- IDs use `QA-<feature>-<number>`, for example `QA-catalog-001`. Keep IDs stable across
+  filename changes; use a new ID when replacing the behavioral contract.
+- YAML frontmatter is descriptive metadata, not an executable schema or runner API.
+  `status` is `draft`, `ready`, or `retired`; `risk` is `critical`, `high`, or `normal`.
+  `ready` means prerequisites and expectations are specified, not that testing passed.
+- `profiles` names documented profile IDs. The local profile defines `local-component`
+  and `local-app`; selecting either still requires its preflight checks for each run.
+- Feature authors maintain scenarios with behavior changes. Reviewers check requirements,
+  applicable boundaries, evidence quality, and linked regression coverage.
+- Keep durable specs, profiles, templates, and shared helpers here. Keep transient results
+  outside the tracked tree; do not put authentication state or fixture secrets in specs.
+
+## Template walkthrough (documentation only)
+
+The existing [Catalog keyboard browser test](../apps/agor-ui/src/components/Marketplace/MCPCatalogModal.browser.test.tsx)
+named `opens from the header with Enter/Space, searches, closes with Escape, tears down and restores focus`
+illustrates how to fill the template:
+
+| Field               | Mapping from the existing test                                                                                                                                                                              |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Intent              | Keyboard users can open, search, close, and reopen the Catalog.                                                                                                                                             |
+| Profile/surface     | `local-component`; real browser, fixture client, mounted Catalog harness.                                                                                                                                   |
+| Actors/ownership    | One fixture client; no real authenticated tenant or persisted resources.                                                                                                                                    |
+| Preconditions       | Render the harness with a fresh client; visible header trigger; configured Chromium viewport.                                                                                                               |
+| Actions             | Open with Enter; search for a missing provider; clear; select Credentials; close with Escape; reopen with Space.                                                                                            |
+| Expected evidence   | Dialog in viewport; no-match message; results restored; stable dialog height across tab switch; listeners removed and trigger focused after close; Catalog tab selected after reopening; route remains `/`. |
+| Variations          | Use the existing browser configuration's viewport instances. Real auth, tenant isolation, persistence, and provider connection need separate scenarios.                                                     |
+| Exploration charter | In a future QA run, investigate focus loss across repeated close/reopen actions within a declared budget. This is additional coverage, not an assertion already made by this test.                          |
+| Cleanup             | The suite unmounts rendered components; its listener assertion checks teardown.                                                                                                                             |
+| Regression link     | Link the test above and its exact test name.                                                                                                                                                                |
+
+This mapping demonstrates template fit by reading an existing test. It is not a run
+result or a newly approved product requirement. A production scenario must also link
+its accepted behavior source; this component test cannot establish full application QA.
+
+## Pilot follow-ups
+
+After feature selection, start with three representative journeys: persisted behavior,
+permissions/multiplayer, and execution lifecycle. Use them to refine setup and evidence
+before adding seed/reset helpers, a full application runner, new CI lanes, additional
+environment profiles, or a reusable skill. None of those is provisioned by this scaffold.

--- a/qa/environments/local.md
+++ b/qa/environments/local.md
@@ -1,0 +1,75 @@
+# Local QA environment profile
+
+This inventory describes repository-supported mechanisms. Every run must verify its
+own prerequisites; this document does not certify an active environment as ready.
+
+## Profile IDs and proof limits
+
+| ID                | Use                                                                                                              | Limits                                                                                                                                                                        |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `local-component` | Existing unit/component or real-browser component suites, with each scenario naming its layer and mocks.         | Does not prove deployed UI/daemon integration, real authentication, persistence, or executor behavior across mocked boundaries.                                               |
+| `local-app`       | A user-managed running UI and daemon belonging to the intended checkout, with scenario-specific disposable data. | Not provisioned here. Verify actual configuration and access; local SQLite/simple mode cannot establish PostgreSQL RLS, Linux sandbox containment, or multi-replica behavior. |
+
+## Existing checks
+
+Run from the repository root, after confirming dependencies are installed. Commands
+below execute foreground test suites; the browser component runner owns its temporary
+test server. They do not start the product's development environment.
+
+```bash
+# Focused existing UI component test: replace the file with the selected test.
+pnpm --filter agor-ui exec vitest run src/components/Marketplace/MCPCatalogModal.test.tsx
+
+# Focused real-browser component example, across configured viewport instances.
+pnpm --filter agor-ui exec vitest run --config vitest.browser.config.ts src/components/Marketplace/MCPCatalogModal.browser.test.tsx
+```
+
+Check the selected test path, installed dependencies, and required browser binary
+before execution. If Chromium is missing, report browser setup as a prerequisite;
+the documented installation command is `pnpm --filter agor-ui exec playwright install chromium`.
+The [browser configuration](../../apps/agor-ui/vitest.browser.config.ts) owns viewport
+definitions. [CI](../../.github/workflows/ci.yml) runs the browser suite separately from
+the standard UI suite; component coverage is not a full application lane.
+
+The [database fixture](../../packages/core/src/db/test-helpers.ts) creates a per-test
+temporary SQLite file and initializes its schema. It does not reset the running daemon
+database or establish authenticated tenant-boundary coverage by itself. For PostgreSQL
+and RLS proof, use the disposable runner described in
+[testing guidelines](../../context/guidelines/testing.md#postgresql-integration-suites),
+with that environment recorded separately. Never point it at a shared application database.
+
+## Running application preflight (`local-app`)
+
+The operator manages daemon and UI watch processes. Follow [repository instructions](../../AGENTS.md)
+and the [architecture guide](../../apps/agor-docs/content/guide/architecture.mdx).
+Do not infer ports from defaults or start/restart services to make preflight pass.
+
+Before a scenario can run, establish:
+
+1. The actual UI and daemon URLs, successful health/authenticated application checks,
+   and evidence tying the running target to the intended checkout and revision.
+2. The actual database dialect, execution mode, tenant configuration, and any required
+   external services. Record settings by name/value only when safe; omit credentials.
+3. Disposable actors with the required roles/tenants, independently authenticated
+   browser contexts for multiplayer checks, and access to authoritative observations.
+4. A repeatable scenario-specific fixture setup and cleanup procedure, with run-owned
+   resource IDs. Verify the starting state before every independent attempt.
+5. For execution claims, a functioning executor and explicit real/mocked provider setup;
+   for isolation claims, an environment that actually enforces the boundary being tested.
+
+Resolve missing prerequisites through documented setup within the authorized scope.
+If that is unavailable, record `blocked` with the missing requirement and continue
+other checks whose prerequisites are satisfied. Do not invent an environment reset.
+
+## Fixtures and missing infrastructure
+
+[Demo fixture loading](../../scripts/load-fixtures.ts) inserts fake data without git,
+network, or executor activity. It is useful for presentation scenarios but is not a
+general reset mechanism, authenticated multi-user seed, or execution fixture. Inspect
+its target configuration and confirm that mutations fit the existing task authorization
+before use.
+
+This scaffold supplies no full application runner, universal reset command, multi-tenant
+login fixture, runtime revision probe, or executor provisioning. Define those seams from
+the pilot scenarios before adding shared helpers. Reuse existing test fixtures and
+documented runtime workflows where they already prove the required boundary.

--- a/qa/templates/run-result.md
+++ b/qa/templates/run-result.md
@@ -1,0 +1,51 @@
+# QA run: {run ID}
+
+Publish the completed result in the issue/PR or CI artifacts, not as a tracked report.
+Sanitize attachments and links before sharing. Use aliases for actors and resources;
+omit secrets, authentication state, private data, and credential-bearing URLs.
+
+## Scope and environment
+
+- Requested scope and scenario IDs/revisions: {references}
+- Checkout revision and relevant uncommitted changes: {identity}
+- Target/profile: {sanitized URLs, proof target uses intended checkout, profile ID}
+- Runtime: {dialect, execution mode, replicas, real/mocked dependencies}
+- Browser/viewport and relevant agent/tool versions: {versions}
+- Actors/fixture state and preflight evidence: {aliases, ownership, checks}
+- Start/end time and execution/exploration/retry limits: {values}
+
+## Results
+
+Verdicts: `pass`, `fail`, `blocked`, `inconclusive`, `not_run`.
+Report each required profile/variation separately, including ones not executed.
+
+| Scenario / profile / variation | Verdict | Attempt(s), including first failure | Evidence references                | Gap or next action |
+| ------------------------------ | ------- | ----------------------------------- | ---------------------------------- | ------------------ |
+| {ID / profile / case}          | not_run | {none, or attempt IDs}              | {assertion/trace/state references} | {reason}           |
+
+- Counts by verdict: {counts; reconcile with the selected scope}
+- Intermittent outcomes: {all failures and retries, even after later success}
+- Untested scope and proof limits: {explicit omissions; no extrapolated claims}
+
+## Findings and reproduction
+
+For each finding, include severity/impact, classification (`product`, `test/harness`,
+`environment`, `unresolved`), expected versus actual behavior, minimal reproduction,
+affected actors, and sanitized evidence. Identify the attempt and revision observed.
+List exploratory discoveries separately from required scenario failures.
+
+## Repairs and regression evidence
+
+- Changes: {source or harness repair, rationale, revision; or none}
+- Reverification: {new attempts and evidence; preserve original failure}
+- Regression test: {path/test name and scenario ID; before/after result or proof gap}
+- Follow-ups: {remaining automation or specification gaps}
+
+## Cleanup
+
+- Run-owned resources and cleanup checks: {removed/verified, or no resources created}
+- Leftovers/intentional retention: {reason and responsible owner; or none}
+- Cleanup failures: {evidence and next action; or none}
+
+State the conclusion proportionately: a passing subset is not a fully validated feature,
+and successful scenario assertions do not imply successful cleanup.

--- a/qa/templates/scenario.md
+++ b/qa/templates/scenario.md
@@ -1,0 +1,67 @@
+---
+id: QA-feature-001
+status: draft
+risk: normal
+profiles: []
+surfaces: []
+regression_tests: []
+---
+
+# Scenario: {observable user outcome}
+
+Copy to `qa/specs/{feature}/{scenario}.md`. Replace all placeholders before setting
+`status: ready`. Follow the QA protocol linked from `qa/README.md`.
+
+## Intent and requirement
+
+- Accepted requirement: {guide/issue section and relevant contract}
+- User outcome: {what this protects and impact of failure}
+- Related scenarios/source boundaries: {stable IDs and relevant code paths}
+
+## Actors and preconditions
+
+- Actors: {identities by alias, roles, tenants, ownership and independent clients}
+- Resources: {tenant-owned / derived / explicit system-global classification}
+- Environment: {profile IDs; configuration, dialect, execution mode, viewport}
+- Setup: {existing fixture/helper or exact repeatable setup actions; no secrets}
+- Initial state: {observable conditions and how to verify them}
+- Dependencies and observation access: {real versus mocked services; missing setup}
+- Scope: {allowed mutations/external calls and run-owned resource identifiers}
+- Limits: {condition timeouts, reproduction attempts, exploration time/actions}
+
+## Actions and required evidence
+
+| Step | Actor and interface  | Action              | Required outcome, including forbidden side effects | Evidence/check and timeout  |
+| ---- | -------------------- | ------------------- | -------------------------------------------------- | --------------------------- |
+| 1    | {actor; UI/API/etc.} | {meaningful action} | {observable assertion}                             | {authoritative observation} |
+
+Specify persistence, other-client updates, and runtime evidence when needed. UI
+confirmation alone does not prove those outcomes. Avoid implementation-specific click
+scripts unless the exact interaction is the requirement. Missing required evidence
+prevents a pass.
+
+## Applicable variations
+
+For each applicable dimension, specify concrete steps/outcomes here or link a separate
+scenario. Record a short reason for exclusions; an empty checklist is not coverage.
+
+| Dimension                       | Applicable cases or exclusion reason                | Scenario/step reference |
+| ------------------------------- | --------------------------------------------------- | ----------------------- |
+| Permissions and foreign tenants | {allowed/denied actors and boundary assertions}     | {reference}             |
+| Multiplayer and concurrency     | {independent clients; competing actions; reconnect} | {reference}             |
+| Persistence and lifecycle       | {reload; cancellation; late events; cleanup}        | {reference}             |
+| Failure and recovery            | {dependency failure; retry; partial completion}     | {reference}             |
+| Execution and infrastructure    | {mock/live provider; dialect; mode; replicas}       | {reference}             |
+| Keyboard and layout             | {focus; viewport; overflow}                         | {reference}             |
+
+## Exploration charter
+
+Investigate {specific failure hypotheses} within the limits above. Record additional
+findings separately; exploration does not replace required steps or expand authorization.
+
+## Cleanup and regression maintenance
+
+- Cleanup: {exact run-owned resources, removal procedure and verification}
+- Retention/failure handling: {what remains if cleanup fails; how to report it}
+- Regression mapping: {existing test path plus test name, or explicit automation gap}
+- Maintenance: {feature owner; linked requirement change when expectations change}


### PR DESCRIPTION
## Linked issue

No linked issue.

## Summary

Add a reusable QA protocol, scenario and run-result templates, and a local environment profile. Link the entry point from the existing testing guidelines and agent orientation.

## Why / context

Feature validation needs repeatable success criteria, explicit environment requirements, and evidence that future runs can use to detect regressions. The protocol distinguishes completed checks from blocked or untested scope and preserves failures across retries.

## Implementation notes

The scaffold defines stable scenario IDs, applicable permission and tenant-boundary checks, evidence requirements, cleanup, and regression-test promotion. A walkthrough maps an existing Catalog keyboard test to the template and explicitly limits its claim to component coverage. The local profile separates existing test mechanisms from runtime prerequisites that still need verification.

## Validation / test plan

- [x] Reviewed all seven changed documentation files against existing tests, fixtures, configuration, and repository conventions.
- [x] Checked formatting, staged whitespace, 22 local documentation links, and the focused test path.
- [x] Commit hooks passed.
- Application tests and builds were not run: this change adds documentation only. The walkthrough is a source-reading exercise, not application validation.

## Screenshots / demos

Not applicable; no product UI changes.

## Risks / rollout / rollback

No runtime, data, dependency, or CI changes. Environment profiles describe proof limits rather than asserting readiness. The first feature pilot should refine the protocol; rollback is removal of the documentation and entry-point links.

## Out of scope / follow-ups

Select three representative feature journeys, then establish any missing setup and observation helpers. Full application automation, new CI lanes, additional environment profiles, and a reusable skill remain follow-ups after the pilot.
