### PR TITLE
perf: slim OAuth and gateway display reads, stop idle grant polling

### DIFF
--- a/apps/agor-daemon/src/adapters/drizzle.ts
+++ b/apps/agor-daemon/src/adapters/drizzle.ts
@@ -101,7 +101,7 @@ export class DrizzleService<
   emit?: (event: string, ...args: any[]) => boolean;
 
   /** Extract resolved tenant context from Feathers params. */
-  private getTenant(params?: P): TenantContext | undefined {
+  protected getTenant(params?: P): TenantContext | undefined {
     return (params as (P & { tenant?: TenantContext }) | undefined)?.tenant;
   }
 
@@ -110,7 +110,7 @@ export class DrizzleService<
    * fixtures that do not expose tenant_id are treated as visible so existing
    * single-tenant unit tests keep working; migrated DB rows always carry it.
    */
-  private rowBelongsToTenant(row: T, tenant: TenantContext | undefined): boolean {
+  protected rowBelongsToTenant(row: T, tenant: TenantContext | undefined): boolean {
     if (!tenant) return true;
     const record = row as Record<string, unknown>;
     if (!('tenant_id' in record)) return true;

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -5700,9 +5700,10 @@ export async function registerMCPServices(
         const serverRepo = new MCPServerRepository(db);
         const authenticatedServerIds = await resolveAuthenticatedServerIds({
           viewer: { user_id: userId as UserID, role: params?.user?.role },
-          listForUser: (id) => userTokenRepo.listForUser(id),
-          listShared: () => userTokenRepo.listShared(),
+          listForUser: (id) => userTokenRepo.listStatusForSubject(id),
+          listShared: () => userTokenRepo.listStatusForSubject(null),
           findServer: (serverId) => serverRepo.findById(serverId),
+          findServers: (serverIds) => serverRepo.findByIds(serverIds),
           requireGrantBinding: true,
           isGrantBoundToServer: (server, grant) =>
             isMCPOAuthGrantAuthorizedForServer(db, server, grant),

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -5702,7 +5702,6 @@ export async function registerMCPServices(
           viewer: { user_id: userId as UserID, role: params?.user?.role },
           listForUser: (id) => userTokenRepo.listStatusForSubject(id),
           listShared: () => userTokenRepo.listStatusForSubject(null),
-          findServer: (serverId) => serverRepo.findById(serverId),
           findServers: (serverIds) => serverRepo.findByIds(serverIds),
           requireGrantBinding: true,
           isGrantBoundToServer: (server, grant) =>

--- a/apps/agor-daemon/src/services/executor-callback-boundaries.test.ts
+++ b/apps/agor-daemon/src/services/executor-callback-boundaries.test.ts
@@ -1,5 +1,9 @@
 import { Readable } from 'node:stream';
-import { describe, expect, it, vi } from 'vitest';
+import { GatewayChannelRepository } from '@agor/core/db';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+afterEach(() => vi.restoreAllMocks());
+
 import { gatewaySlackUploadExecutorCommandId } from '../auth/executor-command-ids.js';
 import { ArtifactsService } from './artifacts.js';
 import { GatewayChannelsService } from './gateway-channels.js';
@@ -68,7 +72,7 @@ describe('executor callback boundaries', () => {
   });
 
   it('rejects Slack uploads from a normal member', async () => {
-    const service = new GatewayChannelsService(null as never);
+    const service = new GatewayChannelsService({ run: vi.fn() } as never);
 
     await expect(
       service.uploadFileStreamFromExecutor(
@@ -96,8 +100,11 @@ describe('executor callback boundaries', () => {
     [{ channel_type: 'github' }, 'not configured for Slack'],
     [{ config: { ...gatewayChannel.config, allowed_channel_ids: ['C999'] } }, 'not an allowed'],
   ])('revalidates mutable Slack policy: %j', async (patch, message) => {
-    const service = new GatewayChannelsService(null as never);
-    vi.spyOn(service, 'get').mockResolvedValue({ ...gatewayChannel, ...patch } as never);
+    const service = new GatewayChannelsService({ run: vi.fn() } as never);
+    vi.spyOn(GatewayChannelRepository.prototype, 'findById').mockResolvedValue({
+      ...gatewayChannel,
+      ...patch,
+    } as never);
 
     await expect(
       service.uploadFileStreamFromExecutor(
@@ -114,8 +121,10 @@ describe('executor callback boundaries', () => {
   });
 
   it('enforces the upload limit again at the daemon callback', async () => {
-    const service = new GatewayChannelsService(null as never);
-    vi.spyOn(service, 'get').mockResolvedValue(gatewayChannel as never);
+    const service = new GatewayChannelsService({ run: vi.fn() } as never);
+    vi.spyOn(GatewayChannelRepository.prototype, 'findById').mockResolvedValue(
+      gatewayChannel as never
+    );
 
     await expect(
       service.uploadFileStreamFromExecutor(
@@ -135,8 +144,10 @@ describe('executor callback boundaries', () => {
     ['session_id', 'gateway.slack-file-upload:wrong:scope'],
     ['branch_id', '019fa07c-b353-7a6b-abd9-9adf1017b990'],
   ])('rejects a Slack callback with a mismatched %s claim', async (claim, value) => {
-    const service = new GatewayChannelsService(null as never);
-    vi.spyOn(service, 'get').mockResolvedValue(gatewayChannel as never);
+    const service = new GatewayChannelsService({ run: vi.fn() } as never);
+    vi.spyOn(GatewayChannelRepository.prototype, 'findById').mockResolvedValue(
+      gatewayChannel as never
+    );
 
     await expect(
       service.uploadFileStreamFromExecutor(

--- a/apps/agor-daemon/src/services/gateway-channels.agentic-config.test.ts
+++ b/apps/agor-daemon/src/services/gateway-channels.agentic-config.test.ts
@@ -24,6 +24,29 @@ beforeAll(() => {
 });
 
 describe('GatewayChannelsService exact agentic configuration', () => {
+  dbTest(
+    'display find/get retain metadata and sentinels while runtime reads retain secrets',
+    async ({ db }) => {
+      const { data, owner } = await channelData(db);
+      const repo = new GatewayChannelRepository(db);
+      const created = await repo.create({
+        ...data,
+        created_by: owner.user_id,
+        config: { bot_token: 'synthetic-bot', app_token: 'synthetic-app' },
+      });
+      const service = new GatewayChannelsService(db);
+      const params = { user: owner, query: { id: created.id, $limit: 1 } } as never;
+      const result = await service.find(params);
+      const records = Array.isArray(result) ? result : result.data;
+      expect(records).toHaveLength(1);
+      expect(records[0].config.bot_token).toBe(GATEWAY_REDACTED_SENTINEL);
+      const display = await service.get(created.id, params);
+      expect(display.config.app_token).toBe(GATEWAY_REDACTED_SENTINEL);
+      expect(display.name).toBe(created.name);
+      expect((await repo.findById(created.id))?.config.bot_token).toBe('synthetic-bot');
+    }
+  );
+
   it('rejects My default when execution-owner alignment is unstable', async () => {
     await expect(
       new GatewayChannelsService({} as TenantScopeAwareDatabase).create({

--- a/apps/agor-daemon/src/services/gateway-channels.discord-verification.test.ts
+++ b/apps/agor-daemon/src/services/gateway-channels.discord-verification.test.ts
@@ -85,6 +85,7 @@ function makeService() {
   const findById = vi.fn(async () => channel);
   const channelRepo = {
     findById,
+    findDisplayById: vi.fn(async () => channel),
     updateWithVerifiedDiscordInstallation,
   } as unknown as GatewayChannelRepository;
   const repository = {

--- a/apps/agor-daemon/src/services/gateway-channels.postgres.test.ts
+++ b/apps/agor-daemon/src/services/gateway-channels.postgres.test.ts
@@ -343,6 +343,11 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
       const readError = await runWithTenantContext(otherTenant, () =>
         serviceB.get(channel.id)
       ).catch((error) => error);
+      const foreignList = await runWithTenantContext(otherTenant, () => serviceB.find());
+      expect(Array.isArray(foreignList) ? foreignList : foreignList.data).toEqual([]);
+      const ownDisplay = await runWithTenantContext(ownerTenant, () => serviceB.get(channel.id));
+      expect(ownDisplay.config.bot_token).not.toBe(channel.config.bot_token);
+      expect(ownDisplay.config.bot_token).toBe('••••••••');
       const patchError = await runWithTenantContext(otherTenant, () =>
         serviceB.patch(channel.id, { config: { guild_id: '888888888888888888' } })
       ).catch((error) => error);

--- a/apps/agor-daemon/src/services/gateway-channels.ts
+++ b/apps/agor-daemon/src/services/gateway-channels.ts
@@ -13,7 +13,7 @@ import {
   runWithTenantDatabaseScope,
   type TenantScopeAwareDatabase,
 } from '@agor/core/db';
-import { BadRequest, Forbidden, NotAuthenticated } from '@agor/core/feathers';
+import { BadRequest, Forbidden, NotAuthenticated, NotFound } from '@agor/core/feathers';
 import {
   evaluateDiscordConnectionVerification,
   getConnector,
@@ -219,12 +219,22 @@ export class GatewayChannelsService extends DrizzleService<
     });
   }
 
+  protected async fetchData(): Promise<GatewayChannel[]> {
+    return this.channelRepo.findDisplayAll();
+  }
+
   async find(params?: Params) {
     return this.withTenantDatabase(params, () => super.find(params));
   }
 
   async get(id: string, params?: Params) {
-    return this.withTenantDatabase(params, () => super.get(id, params));
+    return this.withTenantDatabase(params, async () => {
+      const channel = await this.channelRepo.findDisplayById(id);
+      if (!channel || !this.rowBelongsToTenant(channel, this.getTenant(params))) {
+        throw new NotFound(`GatewayChannel not found: ${id}`);
+      }
+      return channel;
+    });
   }
 
   async patch(id: NullableId, data: GatewayChannelPatchData, params?: Params) {
@@ -395,7 +405,14 @@ export class GatewayChannelsService extends DrizzleService<
       throw new Forbidden('Executor token is not scoped to this Slack upload');
     }
 
-    const gatewayChannel = (await this.get(data.gatewayChannelId, params)) as GatewayChannel;
+    // This trusted execution path needs actual connector credentials, unlike
+    // public list/detail reads. Finish the DB phase before calling Slack.
+    const gatewayChannel = await this.withTenantDatabase(params, () =>
+      this.channelRepo.findById(data.gatewayChannelId)
+    );
+    if (!gatewayChannel || !this.rowBelongsToTenant(gatewayChannel, this.getTenant(params))) {
+      throw new NotFound('Gateway channel not found');
+    }
     if (!gatewayChannel.enabled) {
       throw new Forbidden('Gateway channel is disabled');
     }

--- a/apps/agor-daemon/src/services/gateway.test.ts
+++ b/apps/agor-daemon/src/services/gateway.test.ts
@@ -847,7 +847,9 @@ describe('GatewayService multi-tenant process state', () => {
     );
     const mapping = makeMapping({ channel_id: tenantAChannel.id });
     const channelRepo = {
-      findAll: vi.fn(async () => (getCurrentTenantId() === 'tenant-a' ? [tenantAChannel] : [])),
+      findDisplayAll: vi.fn(async () =>
+        getCurrentTenantId() === 'tenant-a' ? [tenantAChannel] : []
+      ),
       findById: vi.fn(async () => tenantAChannel),
       updateLastMessage: vi.fn(async () => undefined),
     };

--- a/apps/agor-daemon/src/services/gateway.ts
+++ b/apps/agor-daemon/src/services/gateway.ts
@@ -1170,7 +1170,7 @@ export class GatewayService {
     const tenantId = requireCurrentTenantId(
       'Missing tenant context while refreshing gateway channel state'
     );
-    const channels = await this.channelRepo.findAll();
+    const channels = await this.channelRepo.findDisplayAll();
     if (channels.some((ch) => ch.enabled)) {
       this.activeChannelTenants.add(tenantId);
     } else {

--- a/apps/agor-daemon/src/services/mcp-oauth-grant-authority.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-grant-authority.ts
@@ -26,7 +26,7 @@ type GrantAuthorityDatabase = TenantScopeAwareDatabase | TenantScopedDatabase;
 export async function isMCPOAuthGrantAuthorizedForServer(
   db: GrantAuthorityDatabase,
   server: MCPServer,
-  grant: UserMCPOAuthToken
+  grant: MCPOAuthGrantAuthorityRecord
 ): Promise<boolean> {
   if (!server.enabled) return false;
   return isMCPOAuthGrantIdentityAuthorizedForServer(db, server, grant);

--- a/apps/agor-daemon/src/services/mcp-oauth-status.test.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-status.test.ts
@@ -22,7 +22,7 @@ function buildDeps(overrides: Partial<OAuthStatusDeps> = {}): OAuthStatusDeps {
     viewer: { user_id: BOB, role: 'member' },
     listForUser: async () => [],
     listShared: async () => [],
-    findServer: async () => null,
+    findServers: async () => [],
     requireGrantBinding: false,
     isGrantBoundToServer: () => true,
     ...overrides,
@@ -35,29 +35,26 @@ describe('resolveAuthenticatedServerIds', () => {
       serverOwnedBy('visible'),
       serverOwnedBy('private', ALICE),
     ]);
-    const findServer = vi.fn();
     const result = await resolveAuthenticatedServerIds(
       buildDeps({
         listForUser: async () => [grantFor('visible')],
         listShared: async () => [grantFor('visible'), grantFor('private')],
         findServers,
-        findServer,
       })
     );
     expect(result).toEqual(['visible']);
     expect(findServers).toHaveBeenCalledExactlyOnceWith(['visible', 'private']);
-    expect(findServer).not.toHaveBeenCalled();
   });
 
   it.each(['listForUser', 'listShared'] as const)(
     'propagates %s envelope failures without returning partial status',
     async (failedList) => {
       const error = new Error('Unsupported bound secret envelope');
-      const findServer = vi.fn(async () => serverOwnedBy('server-valid'));
+      const findServers = vi.fn(async () => [serverOwnedBy('server-valid')]);
       const deps = buildDeps({
         listForUser: async () => [grantFor('server-valid')],
         listShared: async () => [grantFor('server-valid')],
-        findServer,
+        findServers,
         [failedList]: async () => {
           throw error;
         },
@@ -66,7 +63,7 @@ describe('resolveAuthenticatedServerIds', () => {
       // The endpoint catches this and returns an empty authenticated set. A
       // projection must not silently turn a failed list into partial success.
       await expect(resolveAuthenticatedServerIds(deps)).rejects.toBe(error);
-      expect(findServer).not.toHaveBeenCalled();
+      expect(findServers).not.toHaveBeenCalled();
     }
   );
 
@@ -77,7 +74,7 @@ describe('resolveAuthenticatedServerIds', () => {
     // one place its id is handed out.
     const deps = buildDeps({
       listShared: async () => [grantFor('server-alices-private')],
-      findServer: async () => serverOwnedBy('server-alices-private', ALICE),
+      findServers: async () => [serverOwnedBy('server-alices-private', ALICE)],
     });
 
     await expect(resolveAuthenticatedServerIds(deps)).resolves.toEqual([]);
@@ -86,7 +83,7 @@ describe('resolveAuthenticatedServerIds', () => {
   it('names a shared server to any member', async () => {
     const deps = buildDeps({
       listShared: async () => [grantFor('server-shared')],
-      findServer: async () => serverOwnedBy('server-shared'),
+      findServers: async () => [serverOwnedBy('server-shared')],
     });
 
     await expect(resolveAuthenticatedServerIds(deps)).resolves.toEqual(['server-shared']);
@@ -96,7 +93,7 @@ describe('resolveAuthenticatedServerIds', () => {
     const deps = buildDeps({
       viewer: { user_id: ALICE, role: 'member' },
       listForUser: async () => [grantFor('server-alices-private')],
-      findServer: async () => serverOwnedBy('server-alices-private', ALICE),
+      findServers: async () => [serverOwnedBy('server-alices-private', ALICE)],
     });
 
     await expect(resolveAuthenticatedServerIds(deps)).resolves.toEqual(['server-alices-private']);
@@ -108,7 +105,7 @@ describe('resolveAuthenticatedServerIds', () => {
     const deps = buildDeps({
       viewer: { user_id: BOB, role: 'admin' },
       listShared: async () => [grantFor('server-alices-private')],
-      findServer: async () => serverOwnedBy('server-alices-private', ALICE),
+      findServers: async () => [serverOwnedBy('server-alices-private', ALICE)],
     });
 
     await expect(resolveAuthenticatedServerIds(deps)).resolves.toEqual(['server-alices-private']);
@@ -117,7 +114,7 @@ describe('resolveAuthenticatedServerIds', () => {
   it('never advertises a refresh-ambiguous grant as authenticated', async () => {
     const deps = buildDeps({
       listShared: async () => [grantFor('server-shared', { refresh_status: 'ambiguous' })],
-      findServer: async () => serverOwnedBy('server-shared'),
+      findServers: async () => [serverOwnedBy('server-shared')],
     });
 
     await expect(resolveAuthenticatedServerIds(deps)).resolves.toEqual([]);
@@ -129,7 +126,7 @@ describe('resolveAuthenticatedServerIds', () => {
       listShared: async () => [
         grantFor('server-shared', { oauth_token_expires_at: new Date('2026-01-01T00:00:00.000Z') }),
       ],
-      findServer: async () => serverOwnedBy('server-shared'),
+      findServers: async () => [serverOwnedBy('server-shared')],
     });
 
     await expect(resolveAuthenticatedServerIds(deps)).resolves.toEqual([]);
@@ -141,7 +138,7 @@ describe('resolveAuthenticatedServerIds', () => {
       requireGrantBinding: true,
       isGrantBoundToServer,
       listShared: async () => [grantFor('server-shared')],
-      findServer: async () => serverOwnedBy('server-shared'),
+      findServers: async () => [serverOwnedBy('server-shared')],
     });
 
     await expect(resolveAuthenticatedServerIds(deps)).resolves.toEqual([]);
@@ -151,7 +148,7 @@ describe('resolveAuthenticatedServerIds', () => {
   it('says nothing about a grant whose server is gone', async () => {
     const deps = buildDeps({
       listShared: async () => [grantFor('server-deleted')],
-      findServer: async () => null,
+      findServers: async () => [],
     });
 
     await expect(resolveAuthenticatedServerIds(deps)).resolves.toEqual([]);

--- a/apps/agor-daemon/src/services/mcp-oauth-status.test.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-status.test.ts
@@ -30,6 +30,25 @@ function buildDeps(overrides: Partial<OAuthStatusDeps> = {}): OAuthStatusDeps {
 }
 
 describe('resolveAuthenticatedServerIds', () => {
+  it('batch reads distinct servers and retains private-server visibility checks', async () => {
+    const findServers = vi.fn(async () => [
+      serverOwnedBy('visible'),
+      serverOwnedBy('private', ALICE),
+    ]);
+    const findServer = vi.fn();
+    const result = await resolveAuthenticatedServerIds(
+      buildDeps({
+        listForUser: async () => [grantFor('visible')],
+        listShared: async () => [grantFor('visible'), grantFor('private')],
+        findServers,
+        findServer,
+      })
+    );
+    expect(result).toEqual(['visible']);
+    expect(findServers).toHaveBeenCalledExactlyOnceWith(['visible', 'private']);
+    expect(findServer).not.toHaveBeenCalled();
+  });
+
   it.each(['listForUser', 'listShared'] as const)(
     'propagates %s envelope failures without returning partial status',
     async (failedList) => {

--- a/apps/agor-daemon/src/services/mcp-oauth-status.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-status.ts
@@ -28,8 +28,7 @@ export interface OAuthStatusDeps {
   viewer: OAuthStatusViewer;
   listForUser(userId: UserID): Promise<MCPOAuthGrantStatusRecord[]>;
   listShared(): Promise<MCPOAuthGrantStatusRecord[]>;
-  findServers?(serverIds: MCPServerID[]): Promise<MCPServer[]>;
-  findServer(serverId: string): Promise<MCPServer | null>;
+  findServers(serverIds: MCPServerID[]): Promise<MCPServer[]>;
   /**
    * Whether to recompute each grant's binding to its server's configuration.
    * The daemon may keep this false for a legacy caller; production enables it
@@ -68,25 +67,18 @@ export async function resolveAuthenticatedServerIds(deps: OAuthStatusDeps): Prom
       !(token.oauth_token_expires_at && token.oauth_token_expires_at <= now) &&
       token.refresh_status !== 'ambiguous'
   );
-  const servers = deps.findServers
-    ? new Map(
-        (await deps.findServers([...new Set(tokens.map((token) => token.mcp_server_id))])).map(
-          (server) => [server.mcp_server_id, server]
-        )
-      )
-    : undefined;
+  const servers = new Map(
+    (await deps.findServers([...new Set(tokens.map((token) => token.mcp_server_id))])).map(
+      (server) => [server.mcp_server_id, server]
+    )
+  );
   const authenticatedServerIds = new Set<MCPServerID>();
   for (const token of tokens) {
-    if (token.oauth_token_expires_at && token.oauth_token_expires_at <= now) continue;
-    if (token.refresh_status === 'ambiguous') continue;
-
-    const server = servers
-      ? servers.get(token.mcp_server_id)
-      : await deps.findServer(token.mcp_server_id);
+    const server = servers.get(token.mcp_server_id);
     if (!server || !isVisibleTo(server, deps.viewer)) continue;
 
-    // Durable status is authoritative. A realtime hint or stale row must never
-    // make the UI advertise a grant which the request path would refuse to use.
+    // Verify saved configuration binding rather than trusting realtime hints.
+    // Execution separately validates token material and provider acceptance.
     if (deps.requireGrantBinding && !(await deps.isGrantBoundToServer(server, token))) continue;
 
     authenticatedServerIds.add(token.mcp_server_id);

--- a/apps/agor-daemon/src/services/mcp-oauth-status.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-status.ts
@@ -14,7 +14,7 @@
  * leaves here.
  */
 
-import type { UserMCPOAuthToken } from '@agor/core/db';
+import type { MCPOAuthGrantStatusRecord } from '@agor/core/db';
 import { isMCPServerUsableBy } from '@agor/core/mcp';
 import type { MCPServer, MCPServerID, UserID } from '@agor/core/types';
 import { hasMinimumRole, ROLES } from '@agor/core/types';
@@ -26,8 +26,9 @@ export interface OAuthStatusViewer {
 
 export interface OAuthStatusDeps {
   viewer: OAuthStatusViewer;
-  listForUser(userId: UserID): Promise<UserMCPOAuthToken[]>;
-  listShared(): Promise<UserMCPOAuthToken[]>;
+  listForUser(userId: UserID): Promise<MCPOAuthGrantStatusRecord[]>;
+  listShared(): Promise<MCPOAuthGrantStatusRecord[]>;
+  findServers?(serverIds: MCPServerID[]): Promise<MCPServer[]>;
   findServer(serverId: string): Promise<MCPServer | null>;
   /**
    * Whether to recompute each grant's binding to its server's configuration.
@@ -35,7 +36,10 @@ export interface OAuthStatusDeps {
    * and lets the verifier grandfather only historical unbound SQLite rows.
    */
   requireGrantBinding: boolean;
-  isGrantBoundToServer(server: MCPServer, grant: UserMCPOAuthToken): boolean | Promise<boolean>;
+  isGrantBoundToServer(
+    server: MCPServer,
+    grant: MCPOAuthGrantStatusRecord
+  ): boolean | Promise<boolean>;
   now?: Date;
 }
 
@@ -59,12 +63,26 @@ export async function resolveAuthenticatedServerIds(deps: OAuthStatusDeps): Prom
     deps.listShared(),
   ]);
 
+  const tokens = [...perUserTokens, ...sharedTokens].filter(
+    (token) =>
+      !(token.oauth_token_expires_at && token.oauth_token_expires_at <= now) &&
+      token.refresh_status !== 'ambiguous'
+  );
+  const servers = deps.findServers
+    ? new Map(
+        (await deps.findServers([...new Set(tokens.map((token) => token.mcp_server_id))])).map(
+          (server) => [server.mcp_server_id, server]
+        )
+      )
+    : undefined;
   const authenticatedServerIds = new Set<MCPServerID>();
-  for (const token of [...perUserTokens, ...sharedTokens]) {
+  for (const token of tokens) {
     if (token.oauth_token_expires_at && token.oauth_token_expires_at <= now) continue;
     if (token.refresh_status === 'ambiguous') continue;
 
-    const server = await deps.findServer(token.mcp_server_id);
+    const server = servers
+      ? servers.get(token.mcp_server_id)
+      : await deps.findServer(token.mcp_server_id);
     if (!server || !isVisibleTo(server, deps.viewer)) continue;
 
     // Durable status is authoritative. A realtime hint or stale row must never

--- a/apps/agor-docs/content/guide/mcp-servers.mdx
+++ b/apps/agor-docs/content/guide/mcp-servers.mdx
@@ -35,6 +35,16 @@ Use your existing authenticated API client and the saved server's `mcp_server_id
 
 DCR requests identify standalone HTTP loopback callbacks as `native` and public HTTPS callbacks as `web`. That choice is part of the durable credential binding, so a registration created under an older or different binding is not reused. HA activation and upgrades still require the public callback origin and offline cutover described in [Daemon HA](/guide/daemon-ha).
 
+### Saved OAuth status
+
+OAuth badges reflect the last saved-grant check, refreshed when the UI loads or
+reconnects and after explicit OAuth actions/events. Idle tabs do not scan all
+grants on a timer. The badge is not a live provider-health guarantee: credentials
+can expire or be revoked between observations. Runtime credential resolution
+independently validates the effective session servers (attached and enabled global
+servers), and refreshes credentials when needed. A provider timeout is not proof
+that authentication has been revoked.
+
 ### Capability metadata
 
 Remote tool, resource, and prompt descriptions are untrusted optional free text. Agor keeps every valid capability name and schema, but deterministically shortens descriptions that exceed the per-field or aggregate safe metadata budget. **Test Connection** (or **Save & Test Connection** for a saved/OAuth server) reports when this happened. Malformed names, schemas, or non-string descriptions still fail validation instead of being silently repaired. The same bounded tool descriptions are stored for display and applied by the mediated MCP egress path used in `compatibility` and `enforced` gateway modes.

--- a/apps/agor-docs/content/guide/message-gateway.mdx
+++ b/apps/agor-docs/content/guide/message-gateway.mdx
@@ -6,6 +6,12 @@ heroImage: '/screenshots/marketing/agor-marketing-slack-thread.png'
 
 # Message Gateway
 
+Gateway channel lists and detail reads return saved metadata with secret-presence
+placeholders; they do not decrypt credentials or environment-variable values. A
+placeholder means a value is stored, not that it is valid. Connector execution
+and explicit connection tests load credentials separately and validate them when
+used.
+
 <div style={{ marginTop: '16px', marginBottom: '24px', padding: '16px 20px', border: '1px solid #4a90c0', borderRadius: '8px', backgroundColor: 'rgba(74, 144, 192, 0.08)' }}>
 
 **Security: Think Before Enabling**

--- a/apps/agor-ui/src/hooks/useAgorData.test.tsx
+++ b/apps/agor-ui/src/hooks/useAgorData.test.tsx
@@ -225,6 +225,24 @@ function deferred() {
   return { promise, resolve };
 }
 
+it('does not rescan OAuth grants on an idle 60-second timer', async () => {
+  const { client, fetchCount } = makeMockClient();
+  const { result, unmount } = renderHook(() => useAgorData(client));
+  try {
+    await waitForInitialLoad(result);
+    await waitFor(() => expect(fetchCount('mcp-servers/oauth-status', 'find')).toBeGreaterThan(0));
+    const initial = fetchCount('mcp-servers/oauth-status', 'find');
+    vi.useFakeTimers();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(180_000);
+    });
+    expect(fetchCount('mcp-servers/oauth-status', 'find')).toBe(initial);
+  } finally {
+    unmount();
+    vi.useRealTimers();
+  }
+});
+
 describe('useAgorData — socket-event bailouts', () => {
   it('scopes the real cold mobile board load before fetching board entities', async () => {
     const boardId = '01a012d8-1b9b-7909-b6f4-2024dfc7c51e';

--- a/apps/agor-ui/src/hooks/useAgorData.ts
+++ b/apps/agor-ui/src/hooks/useAgorData.ts
@@ -37,8 +37,6 @@ import {
 } from '@agor-live/client';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
-const MCP_OAUTH_STATUS_POLL_INTERVAL_MS = 60_000;
-
 import {
   bumpFirstPaintMergeRevisions,
   bumpRevision,
@@ -416,9 +414,9 @@ export function useAgorData(
   const oauthStatusRequestGenerationRef = useRef(0);
 
   /**
-   * One latest-request-wins coordinator for initial hydration, polling, and
+   * One latest-request-wins coordinator for initial hydration and
    * realtime OAuth hints. A later request invalidates every earlier response,
-   * preventing an old poll from overwriting a newer disconnect/re-auth result.
+   * preventing an old read from overwriting a newer disconnect/re-auth result.
    */
   const refetchOAuthDurableState = useCallback(
     async (requestAuthorityScope: string, mcpServerId?: string): Promise<boolean> => {
@@ -1246,20 +1244,9 @@ export function useAgorData(
   // after teardown. Generation bump = cancellation; see `runHydration`.
   useEffect(() => () => cancelAllHydrations(), []);
 
-  // OAuth status is intentionally separate from generic MCP server reads so
-  // listing servers never loads credentials. Poll the non-secret status path
-  // as well as reacting to OAuth events; otherwise a grant that expires while
-  // a tab is idle could remain displayed as authenticated indefinitely.
-  useEffect(() => {
-    if (!client || !enabled || !authorityScopeKey) return;
-    const pollAuthorityScope = authorityScopeKey;
-    const interval = window.setInterval(() => {
-      void refetchOAuthDurableState(pollAuthorityScope).catch(() => {
-        // Transient disconnects are handled by the next poll/realtime refetch.
-      });
-    }, MCP_OAUTH_STATUS_POLL_INTERVAL_MS);
-    return () => window.clearInterval(interval);
-  }, [authorityScopeKey, client, enabled, refetchOAuthDurableState]);
+  // Auth badges reflect the last durable observation. Refresh on bootstrap,
+  // reconnect and explicit OAuth events, not on an idle-tab timer. Execution
+  // independently resolves credentials; this UI snapshot never authorizes use.
 
   // If the user navigates to /s/<id>/ after the initial active-session fetch,
   // load that one session by ID as well. This keeps direct links to archived

--- a/apps/agor-ui/src/utils/mcpAuth.ts
+++ b/apps/agor-ui/src/utils/mcpAuth.ts
@@ -6,9 +6,9 @@ import type { MCPServer } from '@agor-live/client';
  * OAuth authentication has one non-secret source of truth:
  * `userAuthenticatedMcpServerIds`, populated from the dedicated
  * `/mcp-servers/oauth-status` resource. Generic server reads deliberately do
- * not load per-user grants. Realtime OAuth events and a periodic status poll
- * refresh the Set so an expired or invalid grant is removed without exposing
- * its token or expiry through the ordinary server resource.
+ * not load per-user grants. Bootstrap, reconnect and explicit OAuth events
+ * refresh this last-observed snapshot. It is not a live provider-health check
+ * or execution authorization; execution resolves credentials independently.
  *
  * Bearer/JWT rows can intentionally remain saved after an explicit secret
  * clear. Their redacted sentinel counts as a configured saved value; absence

--- a/packages/core/src/db/repositories/gateway-channels.reads.test.ts
+++ b/packages/core/src/db/repositories/gateway-channels.reads.test.ts
@@ -59,6 +59,42 @@ afterEach(() => {
 });
 
 describe('gateway credential hydration', () => {
+  it('display list and detail redact without any KDF and retain tenant identity', async () => {
+    const id = '00000000-0000-4000-8000-000000000001';
+    query.rows = [row(id)];
+    const open = vi.spyOn(encryption, 'decryptApiKeyAsync');
+    const repo = new GatewayChannelRepository({} as Database);
+    const [display] = await repo.findDisplayAll();
+    expect(display).toMatchObject({
+      config: { bot_token: '••••••••', app_token: '••••••••', label: 'public' },
+      agentic_config: { envVars: [{ key: 'API_KEY', value: '••••••••' }] },
+      channel_key: '••••••••',
+    });
+    expect(Object.getOwnPropertyDescriptor(display, 'tenant_id')).toMatchObject({
+      value: 'tenant-a',
+      enumerable: false,
+    });
+    expect(await repo.findDisplayById(id)).toEqual(display);
+    expect(open).not.toHaveBeenCalled();
+    expect((await repo.findById(id))?.config.bot_token).toBe('bot');
+    expect(open).toHaveBeenCalledTimes(3);
+  });
+
+  it('display normalizes legacy env maps and never exposes unreadable stored material', async () => {
+    query.rows = [
+      {
+        ...row(),
+        config: { bot_token: 'invalid-ciphertext' },
+        agentic_config: { envVars: { LEGACY: 'invalid-ciphertext' } },
+      },
+    ];
+    const open = vi.spyOn(encryption, 'decryptApiKeyAsync');
+    const [display] = await new GatewayChannelRepository({} as Database).findDisplayAll();
+    expect(display.agentic_config?.envVars).toEqual([{ key: 'LEGACY', value: '••••••••' }]);
+    expect(JSON.stringify(display)).not.toContain('invalid-ciphertext');
+    expect(open).not.toHaveBeenCalled();
+  });
+
   it('discovers IDs with one narrow query and no credential decryption', async () => {
     const first = '00000000-0000-4000-8000-000000000001';
     query.rows = [row(first), row('second')];

--- a/packages/core/src/db/repositories/gateway-channels.ts
+++ b/packages/core/src/db/repositories/gateway-channels.ts
@@ -539,7 +539,7 @@ export class GatewayChannelRepository
     const storedAgenticConfig = (row.agentic_config as Record<string, unknown> | null) ?? null;
     // Normalize legacy env maps before using the shared transport redactor.
     // Never open a credential merely to replace it with a display sentinel.
-    const displayAgenticConfig = storedAgenticConfig && {
+    const displayAgenticConfig: Record<string, unknown> | null = storedAgenticConfig && {
       ...storedAgenticConfig,
       ...(storedAgenticConfig.envVars && !Array.isArray(storedAgenticConfig.envVars)
         ? {

--- a/packages/core/src/db/repositories/gateway-channels.ts
+++ b/packages/core/src/db/repositories/gateway-channels.ts
@@ -15,6 +15,7 @@ import type {
   UUID,
 } from '@agor/core/types';
 import { and, asc, eq, gt, inArray, isNull, like, lte, or, sql } from 'drizzle-orm';
+import { redactGatewayChannelSecrets } from '../../gateway/redaction';
 import { generateId } from '../../lib/ids';
 import { isAgenticToolDefaultConfigurationReference } from '../../types/agentic-tool-preset';
 import {
@@ -533,41 +534,52 @@ export class GatewayChannelRepository
   /**
    * Convert database row to GatewayChannel type
    */
-  private async rowToChannel(row: GatewayChannelRow): Promise<GatewayChannel> {
+  private async rowToChannel(row: GatewayChannelRow, displayOnly = false): Promise<GatewayChannel> {
     const config = row.config as Record<string, unknown>;
-    const agenticConfig = await decryptAgenticConfig(
-      (row.agentic_config as Record<string, unknown> | null) ?? null
-    );
+    const storedAgenticConfig = (row.agentic_config as Record<string, unknown> | null) ?? null;
+    // Normalize legacy env maps before using the shared transport redactor.
+    // Never open a credential merely to replace it with a display sentinel.
+    const displayAgenticConfig = storedAgenticConfig && {
+      ...storedAgenticConfig,
+      ...(storedAgenticConfig.envVars && !Array.isArray(storedAgenticConfig.envVars)
+        ? {
+            envVars: Object.entries(storedAgenticConfig.envVars as Record<string, unknown>).map(
+              ([key, value]) => ({ key, value })
+            ),
+          }
+        : {}),
+    };
+    const agenticConfig = displayOnly
+      ? displayAgenticConfig
+      : await decryptAgenticConfig(storedAgenticConfig);
 
-    return attachHiddenTenant(
-      {
-        id: row.id as GatewayChannelID,
-        created_by: row.created_by,
-        name: row.name,
-        channel_type: row.channel_type as ChannelType,
-        target_branch_id: row.target_branch_id as UUID,
-        agor_user_id: (row.agor_user_id as UUID | null) ?? null,
-        provider_installation_id: row.provider_installation_id ?? null,
-        provider_config_generation: row.provider_config_generation ?? 1,
-        channel_key: row.channel_key,
-        config: await decryptConfig(config),
-        agentic_config: agenticConfig
-          ? ({
-              ...(agenticConfig as unknown as PersistedGatewayAgenticConfig),
-              presetId:
-                (row.agentic_tool_preset_id as PersistedGatewayAgenticConfig['presetId']) ??
-                (agenticConfig.presetId as PersistedGatewayAgenticConfig['presetId']) ??
-                undefined,
-            } as PersistedGatewayAgenticConfig)
-          : null,
-        mcp_server_ids: row.mcp_server_ids ?? undefined,
-        enabled: Boolean(row.enabled),
-        created_at: new Date(row.created_at).toISOString(),
-        updated_at: new Date(row.updated_at).toISOString(),
-        last_message_at: row.last_message_at ? new Date(row.last_message_at).toISOString() : null,
-      },
-      row
-    );
+    const channel: GatewayChannel = {
+      id: row.id as GatewayChannelID,
+      created_by: row.created_by,
+      name: row.name,
+      channel_type: row.channel_type as ChannelType,
+      target_branch_id: row.target_branch_id as UUID,
+      agor_user_id: (row.agor_user_id as UUID | null) ?? null,
+      provider_installation_id: row.provider_installation_id ?? null,
+      provider_config_generation: row.provider_config_generation ?? 1,
+      channel_key: row.channel_key,
+      config: displayOnly ? config : await decryptConfig(config),
+      agentic_config: agenticConfig
+        ? ({
+            ...(agenticConfig as unknown as PersistedGatewayAgenticConfig),
+            presetId:
+              (row.agentic_tool_preset_id as PersistedGatewayAgenticConfig['presetId']) ??
+              (agenticConfig.presetId as PersistedGatewayAgenticConfig['presetId']) ??
+              undefined,
+          } as PersistedGatewayAgenticConfig)
+        : null,
+      mcp_server_ids: row.mcp_server_ids ?? undefined,
+      enabled: Boolean(row.enabled),
+      created_at: new Date(row.created_at).toISOString(),
+      updated_at: new Date(row.updated_at).toISOString(),
+      last_message_at: row.last_message_at ? new Date(row.last_message_at).toISOString() : null,
+    };
+    return attachHiddenTenant(displayOnly ? redactGatewayChannelSecrets(channel) : channel, row);
   }
 
   private async rowsToChannels(rows: GatewayChannelRow[]): Promise<GatewayChannel[]> {
@@ -796,6 +808,15 @@ export class GatewayChannelRepository
    * Find gateway channel by ID (supports short ID)
    */
   async findById(id: string): Promise<GatewayChannel | null> {
+    return this.readById(id, false);
+  }
+
+  /** Transport-safe detail: presence is not proof of credential validity. */
+  async findDisplayById(id: string): Promise<GatewayChannel | null> {
+    return this.readById(id, true);
+  }
+
+  private async readById(id: string, displayOnly: boolean): Promise<GatewayChannel | null> {
     try {
       const fullId = await this.resolveId(id);
       const row = await select(this.db)
@@ -803,7 +824,7 @@ export class GatewayChannelRepository
         .where(eq(gatewayChannels.id, fullId))
         .one();
 
-      return row ? await this.rowToChannel(row) : null;
+      return row ? await this.rowToChannel(row, displayOnly) : null;
     } catch (error) {
       if (error instanceof EntityNotFoundError) return null;
       if (error instanceof AmbiguousIdError) throw error;
@@ -817,6 +838,13 @@ export class GatewayChannelRepository
   /**
    * Find all gateway channels
    */
+  async findDisplayAll(): Promise<GatewayChannel[]> {
+    const rows = await select(this.db).from(gatewayChannels).all();
+    const channels: GatewayChannel[] = [];
+    for (const row of rows) channels.push(await this.rowToChannel(row, true));
+    return channels;
+  }
+
   async findAll(): Promise<GatewayChannel[]> {
     try {
       const rows = await select(this.db).from(gatewayChannels).all();

--- a/packages/core/src/db/repositories/mcp-servers.ts
+++ b/packages/core/src/db/repositories/mcp-servers.ts
@@ -610,6 +610,37 @@ export class MCPServerRepository
     }
   }
 
+  /** Tenant-scoped batch read; callers must still enforce per-user visibility. */
+  async findByIds(ids: readonly MCPServerID[]): Promise<MCPServer[]> {
+    try {
+      const uniqueIds = [...new Set(ids)];
+      const rows: MCPServerRow[] = [];
+      for (
+        let offset = 0;
+        offset < uniqueIds.length;
+        offset += MCPServerRepository.AUTHORITY_READ_BATCH_SIZE
+      ) {
+        const batch = uniqueIds.slice(
+          offset,
+          offset + MCPServerRepository.AUTHORITY_READ_BATCH_SIZE
+        );
+        if (batch.length === 0) continue;
+        rows.push(
+          ...(await select(this.db)
+            .from(mcpServers)
+            .where(inArray(mcpServers.mcp_server_id, batch))
+            .all())
+        );
+      }
+      return rows.map((row) => this.rowToMCPServer(row));
+    } catch (error) {
+      throw new RepositoryError(
+        `Failed to find MCP servers by IDs: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
+  }
+
   /**
    * Find all MCP servers
    */

--- a/packages/core/src/db/repositories/user-mcp-oauth-tokens.reads.postgres.test.ts
+++ b/packages/core/src/db/repositories/user-mcp-oauth-tokens.reads.postgres.test.ts
@@ -103,6 +103,20 @@ describe.skipIf(!url || process.env.AGOR_DB_DIALECT !== 'postgresql')(
                 oauth_refresh_token: 'synthetic-refresh',
               },
             ]);
+            const status = await repo.listStatusForSubject(own.user);
+            expect(status).toHaveLength(1);
+            expect(status[0]).not.toHaveProperty('oauth_access_token');
+            expect(status[0]).not.toHaveProperty('oauth_refresh_token');
+            await expect(repo.listStatusForSubject(foreign.user)).resolves.toEqual([]);
+            const sharedStatus = await repo.listStatusForSubject(null);
+            expect(sharedStatus).toHaveLength(1);
+            expect(sharedStatus[0].mcp_server_id).toBe(own.server);
+            const servers = await new MCPServerRepository(scoped).findByIds([
+              own.server,
+              foreign.server,
+              own.server,
+            ]);
+            expect(servers.map((server) => server.mcp_server_id)).toEqual([own.server]);
             expect(personal).toHaveLength(1);
             expect(shared).toHaveLength(1);
             await expect(repo.listForUser(foreign.user)).resolves.toEqual([]);

--- a/packages/core/src/db/repositories/user-mcp-oauth-tokens.reads.test.ts
+++ b/packages/core/src/db/repositories/user-mcp-oauth-tokens.reads.test.ts
@@ -63,6 +63,12 @@ dbTest(
     expect(
       await repo.listAuthorityForUserAndSharedByServerIds(other, [server.mcp_server_id])
     ).toHaveLength(1);
+    await expect(repo.listStatusForSubject(other)).resolves.toEqual([]);
+    const status = await repo.listStatusForSubject(owner);
+    expect(status).toHaveLength(1);
+    expect(status[0]).not.toHaveProperty('oauth_access_token');
+    expect(status[0]).not.toHaveProperty('oauth_refresh_token');
+    expect(await repo.listStatusForSubject(null)).toHaveLength(1);
     await repo.deleteToken(owner, server.mcp_server_id);
     await expect(repo.listForUser(owner)).resolves.toEqual([]);
     await expect(repo.getCatalogGrantAuthority(owner, server.mcp_server_id)).resolves.toBeNull();

--- a/packages/core/src/db/repositories/user-mcp-oauth-tokens.status.test.ts
+++ b/packages/core/src/db/repositories/user-mcp-oauth-tokens.status.test.ts
@@ -77,6 +77,46 @@ beforeEach(() => {
 });
 
 describe('OAuth status grant read integrity and cost', () => {
+  it('status opens only client binding material, never access or refresh tokens', async () => {
+    query.rows = [
+      {
+        ...grant(),
+        oauth_access_token: 'corrupt-unread-access',
+        oauth_refresh_token: 'corrupt-unread-refresh',
+      },
+    ];
+    const open = vi.spyOn(envelope, 'openBoundSecretAsync');
+    const repo = new UserMCPOAuthTokenRepository({} as Database, master);
+    const records = await repo.listStatusForSubject(userId);
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({ oauth_client_id: 'client', oauth_client_secret: 'secret' });
+    expect(records[0]).not.toHaveProperty('oauth_access_token');
+    expect(records[0]).not.toHaveProperty('oauth_refresh_token');
+    expect(Object.keys(query.projections[0]!)).not.toContain('oauth_access_token');
+    expect(Object.keys(query.projections[0]!)).not.toContain('oauth_refresh_token');
+    expect(open).toHaveBeenCalledTimes(2);
+  });
+
+  it('status filters expired and ambiguous grants before opening client material', async () => {
+    query.rows = [
+      { ...grant(), oauth_token_expires_at: new Date('2000-01-01'), oauth_client_secret: 'unread' },
+      { ...grant(), refresh_status: 'ambiguous', oauth_client_secret: 'unread' },
+    ];
+    const open = vi.spyOn(envelope, 'openBoundSecretAsync');
+    await expect(
+      new UserMCPOAuthTokenRepository({} as Database, master).listStatusForSubject(userId)
+    ).resolves.toEqual([]);
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it('status still rejects client material transplanted across tenants', async () => {
+    query.rows = [grant()];
+    query.tenantId = 'tenant-b';
+    await expect(
+      new UserMCPOAuthTokenRepository({} as Database, master).listStatusForSubject(userId)
+    ).rejects.toThrow();
+  });
+
   it('awaits fields and rows serially, preserves order, and never caches a read', async () => {
     query.rows = [grant(), { ...grant(), created_at: new Date('2026-02-01T00:00:00Z') }];
     let active = 0;

--- a/packages/core/src/db/repositories/user-mcp-oauth-tokens.status.test.ts
+++ b/packages/core/src/db/repositories/user-mcp-oauth-tokens.status.test.ts
@@ -25,7 +25,9 @@ vi.mock('../database-wrapper', () => ({
           ? Object.fromEntries(
               Object.keys(projection).map((key) => [
                 key,
-                key === 'has_access_token' ? row.oauth_access_token != null : row[key],
+                key === 'has_access_token'
+                  ? row.oauth_access_token != null && row.oauth_access_token !== ''
+                  : row[key],
               ])
             )
           : row
@@ -108,6 +110,18 @@ describe('OAuth status grant read integrity and cost', () => {
     ).resolves.toEqual([]);
     expect(open).not.toHaveBeenCalled();
   });
+
+  it.each([null, ''])(
+    'status excludes access token %s before opening client material',
+    async (accessToken) => {
+      query.rows = [{ ...grant(), oauth_access_token: accessToken, oauth_client_secret: 'unread' }];
+      const open = vi.spyOn(envelope, 'openBoundSecretAsync');
+      await expect(
+        new UserMCPOAuthTokenRepository({} as Database, master).listStatusForSubject(userId)
+      ).resolves.toEqual([]);
+      expect(open).not.toHaveBeenCalled();
+    }
+  );
 
   it('status still rejects client material transplanted across tenants', async () => {
     query.rows = [grant()];

--- a/packages/core/src/db/repositories/user-mcp-oauth-tokens.ts
+++ b/packages/core/src/db/repositories/user-mcp-oauth-tokens.ts
@@ -100,6 +100,10 @@ type MCPOAuthGrantAuthorityRow = Pick<
   | 'oauth_redirect_uri'
 >;
 
+/** Status authority excludes access and refresh token plaintext. */
+export type MCPOAuthGrantStatusRecord = MCPOAuthGrantAuthorityRecord &
+  Pick<UserMCPOAuthToken, 'oauth_token_expires_at' | 'refresh_status'>;
+
 /** Input shape for `saveToken`. */
 export interface SaveTokenInput {
   accessToken: string;
@@ -1021,6 +1025,54 @@ export class UserMCPOAuthTokenRepository {
         error
       );
     }
+  }
+
+  /** Read saved-grant status without opening access/refresh tokens. */
+  async listStatusForSubject(userId: UserID | null): Promise<MCPOAuthGrantStatusRecord[]> {
+    const rows = await select(this.db, {
+      has_access_token: sql<boolean>`${userMcpOauthTokens.oauth_access_token} is not null and ${userMcpOauthTokens.oauth_access_token} <> ''`,
+      user_id: userMcpOauthTokens.user_id,
+      mcp_server_id: userMcpOauthTokens.mcp_server_id,
+      oauth_client_id: userMcpOauthTokens.oauth_client_id,
+      oauth_client_secret: userMcpOauthTokens.oauth_client_secret,
+      grant_generation: userMcpOauthTokens.grant_generation,
+      grant_binding_version: userMcpOauthTokens.grant_binding_version,
+      grant_binding_fingerprint: userMcpOauthTokens.grant_binding_fingerprint,
+      oauth_metadata_uri: userMcpOauthTokens.oauth_metadata_uri,
+      oauth_resource_uri: userMcpOauthTokens.oauth_resource_uri,
+      oauth_issuer: userMcpOauthTokens.oauth_issuer,
+      oauth_authorization_endpoint: userMcpOauthTokens.oauth_authorization_endpoint,
+      oauth_token_endpoint: userMcpOauthTokens.oauth_token_endpoint,
+      oauth_redirect_uri: userMcpOauthTokens.oauth_redirect_uri,
+      oauth_token_expires_at: userMcpOauthTokens.oauth_token_expires_at,
+      refresh_status: userMcpOauthTokens.refresh_status,
+    })
+      .from(userMcpOauthTokens)
+      .where(
+        userId === null
+          ? isNull(userMcpOauthTokens.user_id)
+          : eq(userMcpOauthTokens.user_id, userId)
+      )
+      .all();
+    const records: MCPOAuthGrantStatusRecord[] = [];
+    const now = new Date();
+    for (const row of rows) {
+      const expiresAt = row.oauth_token_expires_at
+        ? new Date(row.oauth_token_expires_at)
+        : undefined;
+      if (
+        !row.has_access_token ||
+        row.refresh_status === 'ambiguous' ||
+        (expiresAt && expiresAt <= now)
+      )
+        continue;
+      records.push({
+        ...(await this.mapAuthorityRow(row)),
+        oauth_token_expires_at: expiresAt,
+        refresh_status: row.refresh_status as UserMCPOAuthToken['refresh_status'],
+      });
+    }
+    return records;
   }
 
   async listForUser(userId: UserID): Promise<UserMCPOAuthToken[]> {


### PR DESCRIPTION
## Summary
- Stop the UI's recurring 60-second full OAuth-status scan. Refresh the last-observed saved-grant snapshot on initial load, reconnect, and explicit OAuth actions/events instead.
- Add a narrow status projection that never loads/decrypts access or refresh token values. Filter missing-access-token, expired, and ambiguous grants before opening client material needed for binding verification.
- Batch server reads instead of per-grant lookups; preserve caller visibility and grant-binding verification.
- Document last-observed status semantics. Runtime credential resolution remains independent of UI badges.

## Evidence
A deployed `mcp-servers/oauth-status.find` trace took 1,004ms: main transaction acquisition was 2.7ms, transaction work 992ms, and 12 scrypt operations ran inside that transaction. Individual SQL calls were roughly 2–5ms.
https://app.datadoghq.com/apm/trace/6aa1b44f0000000029fb6f5cd7bc6160

This removes unnecessary crypto work and recurring requests, not all crypto or transaction coupling. Client identity/secret material still participates in grant binding and is decrypted where required. No pool sizes change.

## Semantics and security
- Status is a saved-grant observation, not proof of live provider health or access-token envelope integrity. Actual execution independently validates credentials and handles refresh.
- Existing full snapshot response and store application semantics remain unchanged. Targeted `.get()`/partial updates and universal last-call-to-badge reporting are explicitly out of scope.
- Tenant-owned grants retain trusted tenant scope/RLS; per-user/shared selection, server visibility, expiry, ambiguous refresh state, and binding checks remain.
- Full credential reads are unchanged; only status stops opening access/refresh envelopes.

## Validation
- 74 focused tests passed: 20 core, 18 daemon, 36 UI (one opt-in benchmark skipped).
- Coverage: no access/refresh token projection or decryption; early expiry/ambiguous filtering; client-envelope cross-tenant rejection; subject isolation; batch lookup/visibility; no recurring idle OAuth poll.
- Added PostgreSQL RLS coverage for status and batch server reads; not run locally because no isolated PostgreSQL test URL is configured. CI must validate this lane.
- Biome, multitenancy boundary check, and normal commit hooks passed; documentation formatted.
- No deployment performed; broader typecheck/build validation left to CI.


## Gateway display-read extension
- Gateway service list/detail and metadata-only runtime state refresh now use explicit display repository reads with zero secret KDFs. Runtime credential reads remain unchanged. The trusted Slack executor-upload path explicitly loads credentials rather than using display get.
- Shared redaction preserves saved-value sentinels, legacy environment maps, and hidden tenant identity. Adapter tenant-check helpers become protected so the detail override reuses the same checks.
- Evidence: gateway-channels.find took 4.23s with 83 serial scrypt spans totaling 4.17s; inventory SQL was 5.7ms and main transaction acquisition 8.5ms: https://app.datadoghq.com/apm/trace/6aa1be170000000029063fa1ed7b4f29
- No generic enrichment flag or blanket repository findAll behavior change. SQL pagination remains a follow-up; current in-memory filters/pagination are preserved.
- Added zero-KDF display, runtime-credential preservation, legacy/corrupt stored-value redaction, service display behavior and PostgreSQL foreign-tenant list/detail coverage. PostgreSQL integration cannot run locally without the configured test database; CI remains required.
- Review label removed for this expanded scope; same Codex reviewer will re-review. No deployment performed.

Gateway validation: 150 focused tests passed (144 daemon, 6 core); real PostgreSQL cases and opt-in benchmarks skipped locally. Biome and multitenancy boundary checks passed.
