### PR TITLE
feat(apm): expose MCP tools as measured server operations

### DIFF
--- a/apps/agor-daemon/src/mcp/register-tool-proxy.ts
+++ b/apps/agor-daemon/src/mcp/register-tool-proxy.ts
@@ -21,6 +21,9 @@ import type { McpServer } from '@modelcontextprotocol/server';
  * function's signature.
  */
 
+/** Progressive execution facade, shared by registration and instrumentation. */
+export const MCP_EXECUTE_TOOL_NAME = 'agor_execute_tool';
+
 export type ToolConfig = Record<string, unknown>;
 export type ToolHandler = (args: unknown, extra?: unknown) => unknown;
 export type RegisterTool = (name: string, config: ToolConfig, handler: ToolHandler) => unknown;

--- a/apps/agor-daemon/src/mcp/server.test.ts
+++ b/apps/agor-daemon/src/mcp/server.test.ts
@@ -3,6 +3,7 @@ import { request as httpRequest } from 'node:http';
 import { promisify } from 'node:util';
 import { resolveMultiTenancyConfig } from '@agor/core/config';
 import { getCurrentTenantId, SessionRepository } from '@agor/core/db';
+import type { DatadogTracer } from '@agor/core/tracing/datadog';
 import { Server as SdkServer } from '@modelcontextprotocol/server';
 import type { Request, Response } from 'express';
 import express from 'express';
@@ -189,8 +190,8 @@ describe('POST /mcp token source', () => {
   });
 
   it('attributes admission failures without recording the credential or arbitrary method', async () => {
-    const { resolveTracerModule } = await import('../tracing/feathers.js');
-    const tracingModule = await import('../tracing/feathers.js');
+    const { resolveTracerModule } = await import('../tracing/datadog.js');
+    const tracingModule = await import('../tracing/datadog.js');
     const calls: unknown[] = [];
     vi.spyOn(tracingModule, 'resolveTracerModule').mockReturnValue({
       trace(name, options, work) {
@@ -461,7 +462,7 @@ describe('POST /mcp with personal API keys', () => {
     'traces the registered tool with search=$search facade=$facade',
     async ({ search, facade }) => {
       await mockPersonalApiKeyUser();
-      const tracingModule = await import('../tracing/feathers.js');
+      const tracingModule = await import('../tracing/datadog.js');
       const calls: { name: string; resource?: string }[] = [];
       vi.spyOn(tracingModule, 'resolveTracerModule').mockReturnValue({
         trace(name, options, work) {
@@ -509,7 +510,6 @@ describe('POST /mcp with personal API keys', () => {
       );
       expect(calls).toEqual([
         { name: 'mcp.request', resource: 'tools/call' },
-        ...(facade ? [{ name: 'mcp.tool', resource: 'agor_execute_tool' }] : []),
         { name: 'mcp.tool', resource: 'agor_users_get_current' },
       ]);
     }
@@ -1103,6 +1103,14 @@ describe('POST /mcp with personal API keys', () => {
   });
 
   it('interoperates end-to-end with the v2 TypeScript client in modern auto-negotiation mode', async () => {
+    const tracingModule = await import('../tracing/datadog.js');
+    const trace = vi.fn<(name: string, options: Parameters<DatadogTracer['trace']>[1]) => void>();
+    vi.spyOn(tracingModule, 'resolveTracerModule').mockReturnValue({
+      trace(name, options, work) {
+        trace(name, options);
+        return work();
+      },
+    });
     await mockPersonalApiKeyUser();
     const getUser = vi.fn(async () => ({
       user_id: 'user-1',
@@ -1241,9 +1249,16 @@ describe('POST /mcp with personal API keys', () => {
           user_id: 'user-1',
         });
       },
-      { multi_tenancy: undefined },
+      { multi_tenancy: undefined, metrics: { apm: { trace_services: 'entrypoint' } } },
       /* toolSearchEnabled */ true
     );
+    const toolCalls = trace.mock.calls.filter(([name]) => name === 'mcp.tool');
+    expect(toolCalls).toHaveLength(1);
+    expect(toolCalls[0]?.[1]).toEqual({
+      resource: 'agor_users_get_current',
+      measured: true,
+      tags: { 'mcp.tool': 'agor_users_get_current', 'span.kind': 'server' },
+    });
   });
 
   it('rejects a modern request that omits the required per-request metadata envelope', async () => {
@@ -1515,6 +1530,14 @@ describe('POST /mcp with personal API keys', () => {
   });
 
   it('rejects cross-tenant Agor session context on a fresh stateless request', async () => {
+    const tracingModule = await import('../tracing/datadog.js');
+    const trace = vi.fn<(name: string, options: Parameters<DatadogTracer['trace']>[1]) => void>();
+    vi.spyOn(tracingModule, 'resolveTracerModule').mockReturnValue({
+      trace(name, options, work) {
+        trace(name, options);
+        return work();
+      },
+    });
     await mockPersonalApiKeyUser();
     const getUser = vi.fn(async (_userId: string, params: { tenant: { tenant_id: string } }) => ({
       user_id: 'user-1',
@@ -1551,12 +1574,14 @@ describe('POST /mcp with personal API keys', () => {
         );
       },
       {
+        metrics: { apm: { trace_services: 'entrypoint' } },
         multi_tenancy: {
           mode: 'required_from_auth',
           trusted_header: 'x-agor-tenant-id',
         },
       }
     );
+    expect(trace).toHaveBeenCalled();
   });
 
   it('re-authorizes a signed token Session binding on every stateless POST', async () => {
@@ -1628,6 +1653,14 @@ describe('POST /mcp with personal API keys', () => {
   });
 
   it('keeps authenticated user, tenant, and Agor session context isolated under concurrency', async () => {
+    const tracingModule = await import('../tracing/datadog.js');
+    const trace = vi.fn<(name: string, options: Parameters<DatadogTracer['trace']>[1]) => void>();
+    vi.spyOn(tracingModule, 'resolveTracerModule').mockReturnValue({
+      trace(name, options, work) {
+        trace(name, options);
+        return work();
+      },
+    });
     await mockPersonalApiKeyUser();
     const getUser = vi.fn(async (userId: string, params: { tenant: { tenant_id: string } }) => ({
       user_id: userId,
@@ -1688,11 +1721,13 @@ describe('POST /mcp with personal API keys', () => {
         expect(getSession).toHaveBeenCalledTimes(expected.length);
       },
       {
+        metrics: { apm: { trace_services: 'entrypoint' } },
         multi_tenancy: {
           mode: 'required_from_auth',
           trusted_header: 'x-agor-tenant-id',
         },
       }
     );
+    expect(trace).toHaveBeenCalled();
   });
 });

--- a/apps/agor-daemon/src/mcp/server.ts
+++ b/apps/agor-daemon/src/mcp/server.ts
@@ -376,7 +376,7 @@ function createMcpServer(
     );
 
     // Register search/detail/execute as the complete visible MCP catalog.
-    registerSearchTools(tracing.toolProxy(server), registry, dispatcher);
+    registerSearchTools(tracing.toolProxy(server, dispatcher), registry, dispatcher);
 
     // Keep the advertised catalog to the three progressive-discovery facade
     // tools without removing direct tools/call compatibility. This uses the

--- a/apps/agor-daemon/src/mcp/tool-registry.ts
+++ b/apps/agor-daemon/src/mcp/tool-registry.ts
@@ -11,6 +11,8 @@
 
 import type { Tool, ToolAnnotations } from '@modelcontextprotocol/server';
 
+import { MCP_EXECUTE_TOOL_NAME } from './register-tool-proxy.js';
+
 export interface ToolEntry {
   name: string;
   description: string;
@@ -66,7 +68,11 @@ export function formatDomainDescriptionsForInstructions(): string {
 }
 
 /** Tools always visible in `tools/list` even when search mode is enabled. */
-const ALWAYS_VISIBLE = new Set(['agor_search_tools', 'agor_get_tool_details', 'agor_execute_tool']);
+const ALWAYS_VISIBLE = new Set([
+  'agor_search_tools',
+  'agor_get_tool_details',
+  MCP_EXECUTE_TOOL_NAME,
+]);
 
 export class ToolRegistry {
   private tools: Map<string, ToolEntry> = new Map();

--- a/apps/agor-daemon/src/mcp/tools/search.test.ts
+++ b/apps/agor-daemon/src/mcp/tools/search.test.ts
@@ -1,9 +1,62 @@
+import type { DatadogTracer } from '@agor/core/tracing/datadog';
 import type { McpServer } from '@modelcontextprotocol/server';
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
-import { ToolDispatcher } from '../register-tool-proxy.js';
+import {
+  type ToolHandler as RegisteredToolHandler,
+  ToolDispatcher,
+  toolDispatcherProxy,
+} from '../register-tool-proxy.js';
 import { ToolRegistry } from '../tool-registry.js';
+import { createMcpTracing } from '../tracing.js';
 import { registerSearchTools } from './search.js';
+
+it('traces facade validation and unknown targets without exporting arbitrary tool names', async () => {
+  const calls: { resource?: string; tags: Record<string, unknown> }[] = [];
+  const tracer: DatadogTracer = {
+    trace(_name, options, work) {
+      const tags = { ...options.tags };
+      calls.push({ resource: options.resource, tags });
+      return work({
+        setTag: (key, value) => {
+          tags[key] = value;
+        },
+      });
+    },
+  };
+  const tracing = createMcpTracing('entrypoint', { tracer });
+  const handlers = new Map<string, RegisteredToolHandler>();
+  const server = {
+    registerTool: (name: string, _config: unknown, handler: RegisteredToolHandler) =>
+      handlers.set(name, handler),
+  } as unknown as McpServer;
+  const dispatcher = new ToolDispatcher();
+  const target = vi.fn(async () => ({ content: [] }));
+  tracing.toolProxy(toolDispatcherProxy(server, dispatcher)).registerTool(
+    'agor_test',
+    {
+      inputSchema: z.object({ limit: z.number() }),
+    },
+    target
+  );
+  registerSearchTools(tracing.toolProxy(server, dispatcher), new ToolRegistry(), dispatcher);
+  const execute = handlers.get('agor_execute_tool')!;
+  await execute({ tool_name: 'agor_test', arguments: { limit: 'secret invalid input' } });
+  await execute({ tool_name: 'secret unknown tool', arguments: {} });
+  expect(target).not.toHaveBeenCalled();
+  expect(calls).toEqual(
+    ['agor_test', 'agor_execute_tool'].map((resource) => ({
+      resource,
+      tags: {
+        'mcp.tool': resource,
+        'span.kind': 'server',
+        'mcp.outcome': 'tool_error',
+        error: true,
+      },
+    }))
+  );
+  expect(JSON.stringify(calls)).not.toContain('secret');
+});
 
 vi.mock('../server.js', () => ({
   coerceJsonRecord: (value: unknown) => {

--- a/apps/agor-daemon/src/mcp/tools/search.ts
+++ b/apps/agor-daemon/src/mcp/tools/search.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from '@modelcontextprotocol/server';
 import { z } from 'zod';
 import type { DispatchableTool } from '../register-tool-proxy.js';
-import { ToolDispatcher } from '../register-tool-proxy.js';
+import { MCP_EXECUTE_TOOL_NAME, ToolDispatcher } from '../register-tool-proxy.js';
 import { mcpPositiveIntWithDefault, mcpRequiredString } from '../schema.js';
 import { coerceJsonRecord, textResult } from '../server.js';
 import { ToolRegistry } from '../tool-registry.js';
@@ -232,7 +232,7 @@ export function registerSearchTools(
   );
 
   server.registerTool(
-    'agor_execute_tool',
+    MCP_EXECUTE_TOOL_NAME,
     {
       description:
         'Execute one Agor MCP tool by name. Expected shape: { "tool_name": "agor_sessions_list", "arguments": { ... } }. Use agor_search_tools to find tools and agor_get_tool_details for the exact schema.',
@@ -286,7 +286,7 @@ export function registerSearchTools(
         const result = await tool.handler(toolArgs, requestContext);
         return result as { content: Array<{ type: 'text'; text: string }> };
       } catch (error) {
-        const failure = mcpValidationFailure(error, toolName ?? 'agor_execute_tool');
+        const failure = mcpValidationFailure(error, toolName ?? MCP_EXECUTE_TOOL_NAME);
         if (failure) return failure;
         return {
           content: [

--- a/apps/agor-daemon/src/mcp/tracing.test.ts
+++ b/apps/agor-daemon/src/mcp/tracing.test.ts
@@ -17,6 +17,127 @@ function recordingTracer() {
 }
 
 describe('MCP tracing', () => {
+  it('keeps one measured server span per facade call, async parentage and caller isolation', async () => {
+    const active = new AsyncLocalStorage<string>();
+    const tenant = new AsyncLocalStorage<string>();
+    const calls: { resource: string; parent?: string; tags: Record<string, unknown> }[] = [];
+    const tracer: DatadogTracer = {
+      trace(_name, options, work) {
+        const tags = { ...options.tags };
+        calls.push({ resource: options.resource!, parent: active.getStore(), tags });
+        expect(options.measured).toBe(true);
+        return active.run(options.resource!, () =>
+          work({
+            setTag: (key, value) => {
+              tags[key] = value;
+            },
+          })
+        );
+      },
+    };
+    const tracing = createMcpTracing('entrypoint', { tracer });
+    const handlers = new Map<string, ToolHandler>();
+    const server = {
+      registerTool: (name: string, _config: unknown, handler: ToolHandler) =>
+        handlers.set(name, handler),
+    } as unknown as McpServer;
+    const dispatcher = new ToolDispatcher();
+    const failure = new Error('secret exception');
+    tracing
+      .toolProxy(toolDispatcherProxy(server, dispatcher))
+      .registerTool('agor_test', {}, async () => {
+        await Promise.resolve();
+        expect(active.getStore()).toBe('agor_test');
+        if (tenant.getStore() === 'tenant-b') throw failure;
+        return { content: [], tenant: tenant.getStore() };
+      });
+    tracing.toolProxy(server, dispatcher).registerTool('agor_execute_tool', {}, async () => {
+      try {
+        return await dispatcher.get('agor_test')!.handler({ secret: 'private args' });
+      } catch {
+        return { isError: true, content: [{ type: 'text' as const, text: 'secret result' }] };
+      }
+    });
+    const results = await Promise.all(
+      ['tenant-a', 'tenant-b'].map((id) =>
+        tenant.run(id, () =>
+          active.run(id, () => handlers.get('agor_execute_tool')!({ tool_name: 'agor_test' }))
+        )
+      )
+    );
+    expect(results).toEqual([
+      { content: [], tenant: 'tenant-a' },
+      { isError: true, content: [{ type: 'text', text: 'secret result' }] },
+    ]);
+    expect(calls).toEqual([
+      {
+        resource: 'agor_test',
+        parent: 'tenant-a',
+        tags: { 'mcp.tool': 'agor_test', 'span.kind': 'server', 'mcp.outcome': 'success' },
+      },
+      {
+        resource: 'agor_test',
+        parent: 'tenant-b',
+        tags: {
+          'mcp.tool': 'agor_test',
+          'span.kind': 'server',
+          'mcp.outcome': 'exception',
+          error: true,
+        },
+      },
+    ]);
+    expect(active.getStore()).toBeUndefined();
+    expect(tenant.getStore()).toBeUndefined();
+    expect(JSON.stringify(calls.map((call) => call.tags))).not.toMatch(/secret|tenant/);
+  });
+
+  it('records safe errors without exposing exceptions to the tracer, even when instrumentation fails', async () => {
+    for (const mode of ['normal', 'before', 'after', 'tag'] as const) {
+      const tags: Record<string, unknown>[] = [];
+      const tracer: DatadogTracer = {
+        trace(_name, _options, work) {
+          if (mode === 'before') throw new Error('tracer failed');
+          const data: Record<string, unknown> = {};
+          tags.push(data);
+          const result = work({
+            setTag: (key, value) => {
+              if (mode === 'tag') throw new Error('tag failed');
+              data[key] = value;
+            },
+          });
+          if (mode === 'after') throw new Error('tracer failed');
+          // The traced callback must resolve, never hand the tracer a raw error.
+          Promise.resolve(result).catch(() => {
+            throw new Error('raw error reached tracer');
+          });
+          return result;
+        },
+      };
+      const handlers = new Map<string, ToolHandler>();
+      const server = {
+        registerTool: (name: string, _config: unknown, handler: ToolHandler) =>
+          handlers.set(name, handler),
+      } as unknown as McpServer;
+      const proxy = createMcpTracing('full', { tracer }).toolProxy(server);
+      const failure = new Error('secret credential');
+      const reject = vi.fn(() => {
+        throw failure;
+      });
+      proxy.registerTool('agor_fail', {}, reject);
+      await expect(handlers.get('agor_fail')!({})).rejects.toBe(failure);
+      expect(reject).toHaveBeenCalledTimes(1);
+      const result = { isError: true, content: [{ type: 'text' as const, text: 'secret output' }] };
+      proxy.registerTool('agor_result', {}, async () => result);
+      expect(await handlers.get('agor_result')!({})).toBe(result);
+      if (mode === 'normal')
+        expect(tags).toEqual([
+          { 'mcp.outcome': 'exception', error: true },
+          { 'mcp.outcome': 'tool_error', error: true },
+        ]);
+      expect(JSON.stringify(tags)).not.toContain('secret');
+    }
+  });
+
   it('does not resolve a tracer when tracing is off', () => {
     const resolveTracer = vi.fn();
     const tracing = createMcpTracing('off', { resolveTracer });
@@ -43,6 +164,7 @@ describe('MCP tracing', () => {
       'tools/list',
       'initialize',
       'server/discover',
+      'resources/read',
       'private-data',
     ]) {
       tracing.request(
@@ -57,6 +179,7 @@ describe('MCP tracing', () => {
       'tools/list',
       'initialize',
       'server/discover',
+      'resources/read',
       'other',
       'batch',
       'other',
@@ -93,7 +216,11 @@ describe('MCP tracing', () => {
     expect(calls).toEqual(
       Array.from({ length: 2 }, () => ({
         name: 'mcp.tool',
-        options: { resource: 'agor_boards_get', tags: { 'mcp.tool': 'agor_boards_get' } },
+        options: {
+          resource: 'agor_boards_get',
+          measured: true,
+          tags: { 'mcp.tool': 'agor_boards_get', 'span.kind': 'server' },
+        },
       }))
     );
     expect(JSON.stringify(calls)).not.toMatch(/secret|sensitive/);

--- a/apps/agor-daemon/src/mcp/tracing.ts
+++ b/apps/agor-daemon/src/mcp/tracing.ts
@@ -1,8 +1,14 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
 import type { ApmTraceServiceDepth } from '@agor/core/config';
-import type { DatadogTracer } from '@agor/core/tracing/datadog';
+import { type DatadogTracer, setSpanTag, traceBestEffort } from '@agor/core/tracing/datadog';
 import type { McpServer } from '@modelcontextprotocol/server';
-import { resolveTracerModule } from '../tracing/feathers.js';
-import { wrapRegisterTool } from './register-tool-proxy.js';
+import { resolveTracerModule } from '../tracing/datadog.js';
+import {
+  MCP_EXECUTE_TOOL_NAME,
+  type ToolDispatcher,
+  type ToolHandler,
+  wrapRegisterTool,
+} from './register-tool-proxy.js';
 
 /** Bounded protocol labels, not client-provided method strings or request IDs. */
 const REQUEST_METHODS = new Set([
@@ -11,6 +17,9 @@ const REQUEST_METHODS = new Set([
   'server/discover',
   'tools/list',
   'tools/call',
+  'resources/list',
+  'resources/templates/list',
+  'resources/read',
   'notifications/initialized',
   'notifications/cancelled',
 ]);
@@ -24,9 +33,10 @@ function requestMethod(body: unknown): string {
 /**
  * One request span includes admission; tool spans cover only registered handlers.
  * Both direct tools/call and the execute facade must register through toolProxy
- * BEFORE the dispatcher captures the handler. The facade and target are nested
- * spans, not independent requests. No args, results, tenant/user IDs or secrets
- * enter tags. Registration names are server-authored and bounded by the catalog.
+ * BEFORE the dispatcher captures the handler. A facade invocation uses its
+ * registered target's resource and suppresses only that exact delegated wrapper.
+ * No args, results, tenant/user IDs or secrets enter tags. Target names are
+ * accepted only after lookup in the request-local registered dispatcher.
  */
 export function createMcpTracing(
   depth: ApmTraceServiceDepth,
@@ -39,25 +49,91 @@ export function createMcpTracing(
         ? options.tracer
         : (options.resolveTracer ?? resolveTracerModule)();
 
+  // Independent of authenticated tenant context; never used for authorization.
+  const delegation = tracer
+    ? new AsyncLocalStorage<
+        | {
+            handler: ToolHandler;
+            exception: boolean;
+            consumed: boolean;
+          }
+        | undefined
+      >()
+    : null;
+
   return {
     request<T>(body: unknown, work: () => T): T {
       if (!tracer) return work();
       const method = requestMethod(body);
-      return tracer.trace(
-        'mcp.request',
-        { resource: method, tags: { 'mcp.method': method } },
-        work
-      );
+      return traceBestEffort(tracer, 'mcp.request', { 'mcp.method': method }, work, {
+        resource: method,
+      });
     },
-    toolProxy(server: McpServer): McpServer {
+    toolProxy(server: McpServer, dispatcher?: ToolDispatcher): McpServer {
       if (!tracer) return server;
-      return wrapRegisterTool(server, (register, name, config, handler) =>
-        register(name, config, (args, extra) =>
-          tracer.trace('mcp.tool', { resource: name, tags: { 'mcp.tool': name } }, () =>
-            handler(args, extra)
-          )
-        )
-      );
+      return wrapRegisterTool(server, (register, name, config, handler) => {
+        const invoke: ToolHandler = async (args, extra) => {
+          const parent = delegation?.getStore();
+          if (parent?.handler === invoke && !parent.consumed) {
+            parent.consumed = true;
+            // Consume the delegation only for this call. Genuine nested calls
+            // (including the same tool) must still receive their own spans.
+            return delegation!.run(undefined, async () => {
+              try {
+                return await handler(args, extra);
+              } catch (error) {
+                parent.exception = true;
+                throw error;
+              }
+            });
+          }
+
+          const candidate =
+            name === MCP_EXECUTE_TOOL_NAME && args && typeof args === 'object'
+              ? (args as { tool_name?: unknown }).tool_name
+              : undefined;
+          const target = typeof candidate === 'string' ? dispatcher?.get(candidate) : undefined;
+          const resource = target ? (candidate as string) : name;
+          const outcome = await traceBestEffort(
+            tracer,
+            'mcp.tool',
+            {
+              'mcp.tool': resource,
+              'span.kind': 'server',
+            },
+            async (span) => {
+              const state = target
+                ? { handler: target.handler, exception: false, consumed: false }
+                : undefined;
+              try {
+                const result = await delegation!.run(state, () => handler(args, extra));
+                const isError =
+                  !!result &&
+                  typeof result === 'object' &&
+                  (result as { isError?: unknown }).isError === true;
+                setSpanTag(
+                  span,
+                  'mcp.outcome',
+                  state?.exception ? 'exception' : isError ? 'tool_error' : 'success'
+                );
+                if (isError || state?.exception) setSpanTag(span, 'error', true);
+                return { ok: true as const, result };
+              } catch (error) {
+                setSpanTag(span, 'mcp.outcome', 'exception');
+                setSpanTag(span, 'error', true);
+                // dd-trace automatically records thrown errors' messages/stacks.
+                // Keep arbitrary error content out of this span while preserving
+                // the exact rejection for the SDK/caller outside the callback.
+                return { ok: false as const, error };
+              }
+            },
+            { resource, measured: true }
+          );
+          if (!outcome.ok) throw outcome.error;
+          return outcome.result;
+        };
+        return register(name, config, invoke);
+      });
     },
   };
 }

--- a/apps/agor-daemon/src/tracing/datadog.test.ts
+++ b/apps/agor-daemon/src/tracing/datadog.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { resolveTracerModule } from './datadog.js';
+
+describe('resolveTracerModule', () => {
+  const validTracer = { trace: () => Promise.resolve() };
+  const notFound = (id: string) => {
+    throw Object.assign(new Error(`Cannot find module '${id}'`), { code: 'MODULE_NOT_FOUND' });
+  };
+
+  it('returns dd-trace-api when present, without consulting dd-trace', () => {
+    const seen: string[] = [];
+    const resolved = resolveTracerModule((id) => {
+      seen.push(id);
+      if (id === 'dd-trace-api') return validTracer;
+      throw new Error('should not be reached');
+    });
+    expect(resolved).toBe(validTracer);
+    expect(seen).toEqual(['dd-trace-api']);
+  });
+
+  it('falls back to dd-trace when dd-trace-api is absent', () => {
+    const resolved = resolveTracerModule((id) => (id === 'dd-trace' ? validTracer : notFound(id)));
+    expect(resolved).toBe(validTracer);
+  });
+
+  it('unwraps a default export', () => {
+    const resolved = resolveTracerModule((id) =>
+      id === 'dd-trace-api' ? { default: validTracer } : notFound(id)
+    );
+    expect(resolved).toBe(validTracer);
+  });
+
+  it('skips a module without a callable trace() and returns null when both absent', () => {
+    expect(resolveTracerModule(() => ({}))).toBeNull();
+    expect(resolveTracerModule(notFound)).toBeNull();
+  });
+});

--- a/apps/agor-daemon/src/tracing/datadog.ts
+++ b/apps/agor-daemon/src/tracing/datadog.ts
@@ -1,0 +1,24 @@
+import { createRequire } from 'node:module';
+import { type DatadogTracer, resolveDatadogTracer } from '@agor/core/tracing/datadog';
+
+const requireFromDaemon = createRequire(import.meta.url);
+
+/**
+ * Resolve the process-wide APM tracer without initializing it.
+ *
+ * The tracer is preloaded ahead of application code by Datadog single-step
+ * instrumentation (`NODE_OPTIONS`). It is an OPTIONAL runtime dependency that
+ * Agor never declares as a hard dep or bundles (declaring it as a peer makes
+ * pnpm auto-install its native modules, defeating the point). So this returns
+ * `null` unless the operator has installed `dd-trace` — or the lightweight
+ * `dd-trace-api` bridge — into the daemon's module tree, or single-step
+ * provides it. `dd-trace-api` is tried first because it is Datadog's supported
+ * entry point for custom instrumentation under single-step; both expose the
+ * same `tracer.trace()` surface. Treated like `hot-shots` for StatsD: present →
+ * used, absent → no-op (loudly, at registration).
+ */
+export function resolveTracerModule(
+  requireFn: (id: string) => unknown = requireFromDaemon
+): DatadogTracer | null {
+  return resolveDatadogTracer(requireFn);
+}

--- a/apps/agor-daemon/src/tracing/feathers.test.ts
+++ b/apps/agor-daemon/src/tracing/feathers.test.ts
@@ -2,7 +2,7 @@ import { feathers } from '@agor/core/feathers';
 import type { HookContext } from '@agor/core/types';
 import { describe, expect, it, vi } from 'vitest';
 import { FEATHERS_INSTRUMENTATION_REASON } from '../utils/feathers-instrumentation.js';
-import { createFeathersTracingHook, type DatadogTracer, resolveTracerModule } from './feathers.js';
+import { createFeathersTracingHook, type DatadogTracer } from './feathers.js';
 
 interface TracedCall {
   name: string;
@@ -306,40 +306,5 @@ describe('Feathers tracing hook', () => {
     expect(tracer.spans).toHaveLength(1);
     expect(tracer.spans[0]?.finished).toBe(true);
     expect(tracer.spans[0]?.error).toBe(boom);
-  });
-});
-
-describe('resolveTracerModule', () => {
-  const validTracer = { trace: () => Promise.resolve() };
-  const notFound = (id: string) => {
-    throw Object.assign(new Error(`Cannot find module '${id}'`), { code: 'MODULE_NOT_FOUND' });
-  };
-
-  it('returns dd-trace-api when present, without consulting dd-trace', () => {
-    const seen: string[] = [];
-    const resolved = resolveTracerModule((id) => {
-      seen.push(id);
-      if (id === 'dd-trace-api') return validTracer;
-      throw new Error('should not be reached');
-    });
-    expect(resolved).toBe(validTracer);
-    expect(seen).toEqual(['dd-trace-api']);
-  });
-
-  it('falls back to dd-trace when dd-trace-api is absent', () => {
-    const resolved = resolveTracerModule((id) => (id === 'dd-trace' ? validTracer : notFound(id)));
-    expect(resolved).toBe(validTracer);
-  });
-
-  it('unwraps a default export', () => {
-    const resolved = resolveTracerModule((id) =>
-      id === 'dd-trace-api' ? { default: validTracer } : notFound(id)
-    );
-    expect(resolved).toBe(validTracer);
-  });
-
-  it('skips a module without a callable trace() and returns null when both absent', () => {
-    expect(resolveTracerModule(() => ({}))).toBeNull();
-    expect(resolveTracerModule(notFound)).toBeNull();
   });
 });

--- a/apps/agor-daemon/src/tracing/feathers.ts
+++ b/apps/agor-daemon/src/tracing/feathers.ts
@@ -13,9 +13,6 @@ import {
 
 import { resolveTracerModule } from './datadog.js';
 
-// Compatibility export for existing daemon integrations.
-export { resolveTracerModule } from './datadog.js';
-
 type AroundNext = () => Promise<void>;
 
 export type { DatadogTracer };

--- a/apps/agor-daemon/src/tracing/feathers.ts
+++ b/apps/agor-daemon/src/tracing/feathers.ts
@@ -1,7 +1,6 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
-import { createRequire } from 'node:module';
 import type { ApmTraceServiceDepth } from '@agor/core/config';
-import { type DatadogTracer, resolveDatadogTracer } from '@agor/core/tracing/datadog';
+import type { DatadogTracer } from '@agor/core/tracing/datadog';
 import type { HookContext } from '@agor/core/types';
 import {
   type FeathersInstrumentationOptions,
@@ -11,6 +10,11 @@ import {
   readFeathersInstrumentationReason,
   readTaggedFeathersCustomMethod,
 } from '../utils/feathers-instrumentation.js';
+
+import { resolveTracerModule } from './datadog.js';
+
+// Compatibility export for existing daemon integrations.
+export { resolveTracerModule } from './datadog.js';
 
 type AroundNext = () => Promise<void>;
 
@@ -36,28 +40,6 @@ export interface FeathersTracingOptions extends FeathersInstrumentationOptions {
  * adds cost without insight, so it is excluded by default at every depth.
  */
 export const DEFAULT_EXCLUDED_SERVICE_PATHS = ['health'] as const;
-
-const requireFromDaemon = createRequire(import.meta.url);
-
-/**
- * Resolve the process-wide APM tracer without initializing it.
- *
- * The tracer is preloaded ahead of application code by Datadog single-step
- * instrumentation (`NODE_OPTIONS`). It is an OPTIONAL runtime dependency that
- * Agor never declares as a hard dep or bundles (declaring it as a peer makes
- * pnpm auto-install its native modules, defeating the point). So this returns
- * `null` unless the operator has installed `dd-trace` — or the lightweight
- * `dd-trace-api` bridge — into the daemon's module tree, or single-step
- * provides it. `dd-trace-api` is tried first because it is Datadog's supported
- * entry point for custom instrumentation under single-step; both expose the
- * same `tracer.trace()` surface. Treated like `hot-shots` for StatsD: present →
- * used, absent → no-op (loudly, at registration).
- */
-export function resolveTracerModule(
-  requireFn: (id: string) => unknown = requireFromDaemon
-): DatadogTracer | null {
-  return resolveDatadogTracer(requireFn);
-}
 
 /**
  * App-level `around` hook that wraps every Feathers service method in a

--- a/apps/agor-docs/content/guide/config-yaml.mdx
+++ b/apps/agor-docs/content/guide/config-yaml.mdx
@@ -505,17 +505,35 @@ metrics:
   ingestion cost); PostgreSQL query spans are also enabled. Intended for active
   investigation, not steady state.
 
-Both enabled depths also add an `mcp.request` span covering MCP admission and
-protocol handling, plus `mcp.tool` spans for registered tool handlers. Filter by
-`mcp.method` to separate protocol methods and by `mcp.tool` to identify the actual
-Agor tool. Calls through `agor_execute_tool` have nested facade and target-tool
-spans; do not sum those durations as independent requests. Method labels are
-bounded (`other` for unknown/malformed methods, `batch` for arrays), and tool
-names come from server registration, never arbitrary request arguments.
+Both enabled depths add an `mcp.request` span covering MCP admission and
+protocol handling, plus one measured `mcp.tool` server-operation span per logical
+tool invocation. The service remains `agor-daemon`; the resource is the registered
+tool name. Select **All server operations** (or `mcp.tool`) on the Datadog service
+page to inspect per-tool latency distributions, throughput, errors, and time.
+The existing HTTP primary operation, `POST /mcp` resource, and Feathers spans
+are unchanged; tool spans remain nested in the same trace.
+
+Calls through `agor_execute_tool` use the registered target's resource, without
+an additional facade span. Unknown targets retain `agor_execute_tool` as a bounded
+fallback. Search and detail tools remain separate resources. `mcp.outcome` is
+`success`, `tool_error` (returned `isError: true`), or `exception`; both failure
+outcomes set the span error flag without copying error messages or stacks.
+Results and exceptions delivered to callers are unchanged.
+
+Filter transport spans by `mcp.method` to separate initialization, discovery,
+tool listing/calling, and resource methods. Method labels are bounded (`other`
+for unknown/malformed methods, `batch` for arrays); resource URIs are never tags.
 Arguments, results, credentials and user/session/tenant IDs are not added to
-these tags. Tool spans measure handler execution, not pre-handler SDK validation;
-an MCP result containing `isError: true` remains a returned result rather than
-an exception. Use the protocol response to assess application success.
+these spans. Tool spans include facade argument validation but not pre-handler
+SDK validation, and end at handler completion, not SSE flush or completion of
+background work initiated by the tool. HTTP status alone does not establish
+tool success.
+
+Tracing inherits the operator's sampling settings; it does not force retention
+or add per-call logs. Aggregate logical invocations using `mcp.tool` only, not
+HTTP, transport, and nested Feathers spans together. Existing lower-layer
+instrumentation has its own error/tag policies; this does not redact all spans
+in a trace.
 
 Both enabled depths also expose capacity-related waits without per-request logs:
 

--- a/packages/core/src/tracing/datadog.test.ts
+++ b/packages/core/src/tracing/datadog.test.ts
@@ -37,10 +37,10 @@ describe('resolveDatadogTracer', () => {
 describe('best-effort tracing', () => {
   it('forwards explicit resource and measurement without changing the operation or tags', () => {
     const tags = { 'span.kind': 'server' };
+    const calls: { name: string; options: Parameters<DatadogTracer['trace']>[1] }[] = [];
     const tracer: DatadogTracer = {
       trace(name, options, work) {
-        expect(name).toBe('mcp.tool');
-        expect(options).toEqual({ resource: 'agor_test', measured: true, tags });
+        calls.push({ name, options });
         return work();
       },
     };
@@ -50,6 +50,12 @@ describe('best-effort tracing', () => {
         measured: true,
       })
     ).toBe(42);
+    expect(calls).toEqual([
+      {
+        name: 'mcp.tool',
+        options: { resource: 'agor_test', measured: true, tags },
+      },
+    ]);
   });
 
   it('runs work once when disabled or tracing throws before/after invocation', async () => {

--- a/packages/core/src/tracing/datadog.test.ts
+++ b/packages/core/src/tracing/datadog.test.ts
@@ -35,6 +35,23 @@ describe('resolveDatadogTracer', () => {
 });
 
 describe('best-effort tracing', () => {
+  it('forwards explicit resource and measurement without changing the operation or tags', () => {
+    const tags = { 'span.kind': 'server' };
+    const tracer: DatadogTracer = {
+      trace(name, options, work) {
+        expect(name).toBe('mcp.tool');
+        expect(options).toEqual({ resource: 'agor_test', measured: true, tags });
+        return work();
+      },
+    };
+    expect(
+      traceBestEffort(tracer, 'mcp.tool', tags, () => 42, {
+        resource: 'agor_test',
+        measured: true,
+      })
+    ).toBe(42);
+  });
+
   it('runs work once when disabled or tracing throws before/after invocation', async () => {
     const tracers: (DatadogTracer | null)[] = [
       null,

--- a/packages/core/src/tracing/datadog.ts
+++ b/packages/core/src/tracing/datadog.ts
@@ -21,7 +21,12 @@ export interface DatadogSpan {
 export interface DatadogTracer {
   trace<T>(
     name: string,
-    options: { resource?: string; type?: string; tags?: Record<string, unknown> },
+    options: {
+      resource?: string;
+      type?: string;
+      measured?: boolean;
+      tags?: Record<string, unknown>;
+    },
     fn: (span?: DatadogSpan) => T
   ): T;
 }
@@ -31,7 +36,8 @@ export function traceBestEffort<T>(
   tracer: DatadogTracer | null,
   name: string,
   tags: Record<string, unknown>,
-  work: (span?: DatadogSpan) => T
+  work: (span?: DatadogSpan) => T,
+  options: { resource?: string; measured?: boolean } = {}
 ): T {
   if (!tracer) return work();
   let ran = false;
@@ -50,7 +56,7 @@ export function traceBestEffort<T>(
     }
   };
   try {
-    return tracer.trace(name, { resource: name, tags }, invoke);
+    return tracer.trace(name, { resource: name, ...options, tags }, invoke);
   } catch {
     if (failed) throw failure;
     if (ran) return result!;


### PR DESCRIPTION
## Summary

Expose logical MCP tool invocations as measured `mcp.tool` server operations in the existing `agor-daemon` APM service. This targets the **All server operations** resource/endpoints view without renaming `POST /mcp`, changing the primary operation, or creating a synthetic service.

- Tag logical tool spans with `span.kind: server`, explicit measurement, and bounded registered-tool resources.
- Resolve progressive `agor_execute_tool` calls to the registered target, suppressing only the corresponding delegated wrapper; retain separate discovery/detail operations and a bounded fallback for unknown targets.
- Record returned `isError` outcomes and exceptions without copying raw exception content into MCP tool tags; preserve results, rejection identity, and exactly-once application work when instrumentation fails.
- Keep admission/protocol spans separate, including bounded resource-method labels, and move optional tracer resolution into a neutral daemon tracing module.
- Preserve async parentage and authenticated tenant context; update the existing tracing configuration guide.

## Validation

- [x] `pnpm i`
- [x] `pnpm check` (typechecks, lint, boundary checks, and builds)
- [x] 108 focused tests passed: MCP tracing, real server/protocol, progressive discovery, Feathers tracing, and core Datadog helpers.
- Tracing-enabled cross-tenant session denial and concurrent caller-context isolation.
- Off/missing tracer passthrough, instrumentation failures, safe error tagging, and unknown-target/input-validation coverage.

## Operational notes

Live Datadog inspection confirmed existing per-tool latency distributions/hit metrics, but MCP tool spans lacked the `span.kind: server` classification already present on Feathers spans.

No deployment or Datadog configuration changes are included. After an authorized deployment, verify that tool resources appear under **agor-daemon → All server operations**, with distributions and time statistics, while existing HTTP/Feathers resources remain intact. Sampling remains operator-controlled; downstream instrumentation retains its own tag/error policies.

This branch is independent of PR #2722's gateway lean-read work.
