### PR TITLE
fix(mcp-oauth): honor advertised token_endpoint_auth_method (client_secret_post) for HubSpot

### DIFF
--- a/apps/agor-daemon/src/services/mcp-oauth-pending-flow-authority.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-pending-flow-authority.ts
@@ -81,6 +81,9 @@ function hasOnlyExpectedMaterialShape(value: unknown): value is MCPOAuthPendingF
     (material.clientSecret === undefined || typeof material.clientSecret === 'string') &&
     (material.clientRegistrationId === undefined ||
       typeof material.clientRegistrationId === 'string') &&
+    (material.tokenEndpointAuthMethod === undefined ||
+      material.tokenEndpointAuthMethod === 'client_secret_basic' ||
+      material.tokenEndpointAuthMethod === 'client_secret_post') &&
     (material.compatibilityMode === 'strict' ||
       material.compatibilityMode === 'legacy' ||
       material.compatibilityMode === 'marketplace') &&
@@ -166,6 +169,9 @@ export class MCPOAuthPendingFlowAuthority {
         ...(input.context.clientSecret ? { clientSecret: input.context.clientSecret } : {}),
         ...(input.context.clientRegistrationId
           ? { clientRegistrationId: input.context.clientRegistrationId }
+          : {}),
+        ...(input.context.tokenEndpointAuthMethod
+          ? { tokenEndpointAuthMethod: input.context.tokenEndpointAuthMethod }
           : {}),
         compatibilityMode: input.context.compatibilityMode,
         authorizationResponseIssuerParameterSupported:
@@ -305,6 +311,7 @@ export class MCPOAuthPendingFlowAuthority {
         clientId: material.clientId,
         clientSecret: material.clientSecret,
         clientRegistrationId: material.clientRegistrationId,
+        tokenEndpointAuthMethod: material.tokenEndpointAuthMethod,
         state: rawState,
         // Completion never reads this field. Do not persist or reconstruct the
         // secret-bearing authorization URL after the browser has opened it.

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.test.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.test.ts
@@ -50,6 +50,7 @@ import {
   performMCPOAuthFlow,
   resolveMCPOAuthDiscovery,
   resolveResourceMetadataUrl,
+  selectTokenEndpointAuthMethod,
   startMCPOAuthFlow,
   validateMCPOAuthMetadata,
 } from './oauth-mcp-transport';
@@ -166,6 +167,27 @@ describe('loopback OAuth callback response', () => {
 // completeMCPOAuthFlow — token exchange request contract
 // ---------------------------------------------------------------------------
 
+describe('selectTokenEndpointAuthMethod', () => {
+  it('defaults to client_secret_basic when nothing is advertised', () => {
+    expect(selectTokenEndpointAuthMethod(undefined)).toBe('client_secret_basic');
+    expect(selectTokenEndpointAuthMethod([])).toBe('client_secret_basic');
+  });
+
+  it('prefers client_secret_basic when the AS advertises both', () => {
+    expect(selectTokenEndpointAuthMethod(['client_secret_post', 'client_secret_basic'])).toBe(
+      'client_secret_basic'
+    );
+  });
+
+  it('uses client_secret_post when advertised without basic (HubSpot)', () => {
+    expect(selectTokenEndpointAuthMethod(['client_secret_post'])).toBe('client_secret_post');
+  });
+
+  it('falls back to basic when only unsupported methods are advertised', () => {
+    expect(selectTokenEndpointAuthMethod(['private_key_jwt', 'none'])).toBe('client_secret_basic');
+  });
+});
+
 describe('completeMCPOAuthFlow token exchange', () => {
   const originalFetch = globalThis.fetch;
 
@@ -236,6 +258,54 @@ describe('completeMCPOAuthFlow token exchange', () => {
         }),
       })
     );
+  });
+
+  it('sends client credentials in the body when the AS advertises client_secret_post only (HubSpot)', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ access_token: 'hubspot-token', token_type: 'bearer' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    ) as unknown as typeof fetch;
+
+    const result = await completeMCPOAuthFlow(
+      { ...context, clientSecret: 'hubspot-secret', tokenEndpointAuthMethod: 'client_secret_post' },
+      'authorization-code',
+      'state',
+      { cacheToken: false }
+    );
+
+    expect(result.access_token).toBe('hubspot-token');
+    const [, init] = (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    const headers = (init.headers ?? {}) as Record<string, string>;
+    expect(headers.Authorization).toBeUndefined();
+    const body = new URLSearchParams(String(init.body));
+    expect(body.get('client_id')).toBe('client-id');
+    expect(body.get('client_secret')).toBe('hubspot-secret');
+    expect(body.get('code_verifier')).toBe('verifier');
+  });
+
+  it('defaults a confidential client to HTTP Basic when no auth method is negotiated', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ access_token: 'basic-token' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    ) as unknown as typeof fetch;
+
+    await completeMCPOAuthFlow(
+      { ...context, clientSecret: 'basic-secret' },
+      'authorization-code',
+      'state',
+      { cacheToken: false }
+    );
+
+    const [, init] = (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    const headers = (init.headers ?? {}) as Record<string, string>;
+    expect(headers.Authorization).toBe(
+      `Basic ${Buffer.from('client-id:basic-secret').toString('base64')}`
+    );
+    expect(new URLSearchParams(String(init.body)).get('client_secret')).toBeNull();
   });
 
   it('does not log state, code, PKCE, client secret, bearer token, or secret-bearing URLs', async () => {

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.ts
@@ -173,7 +173,65 @@ export interface AuthorizationServerMetadata {
   response_types_supported?: string[];
   grant_types_supported?: string[];
   code_challenge_methods_supported?: string[];
+  token_endpoint_auth_methods_supported?: string[]; // RFC 8414
   authorization_response_iss_parameter_supported?: boolean;
+}
+
+/**
+ * How Agor presents confidential-client credentials at the token endpoint.
+ * `client_secret_basic` (HTTP Basic) is Agor's historical default and what most
+ * providers (e.g. Slack) expect; `client_secret_post` puts the credentials in
+ * the request body, which some providers (e.g. HubSpot) require exclusively.
+ */
+export type MCPOAuthTokenEndpointAuthMethod = 'client_secret_basic' | 'client_secret_post';
+
+/**
+ * Choose the token-endpoint client-authentication method for a confidential
+ * client, honoring the authorization server's advertised
+ * `token_endpoint_auth_methods_supported` (RFC 8414).
+ *
+ * Default is `client_secret_basic`: it preserves historical behavior when the
+ * server advertises nothing and is what most providers expect. We switch to
+ * `client_secret_post` only when the server advertises it but NOT Basic — e.g.
+ * HubSpot, whose token endpoint accepts `client_secret_post` only. When both
+ * are advertised, Basic wins so existing integrations are unchanged.
+ */
+export function selectTokenEndpointAuthMethod(
+  supportedMethods?: string[]
+): MCPOAuthTokenEndpointAuthMethod {
+  if (!supportedMethods || supportedMethods.length === 0) return 'client_secret_basic';
+  if (supportedMethods.includes('client_secret_basic')) return 'client_secret_basic';
+  if (supportedMethods.includes('client_secret_post')) return 'client_secret_post';
+  return 'client_secret_basic';
+}
+
+/**
+ * Attach client authentication to a token-endpoint request (authorization-code
+ * exchange or refresh). Confidential clients present the secret either as HTTP
+ * Basic (RFC 6749 §2.3.1) or in the request body (`client_secret_post`) per the
+ * negotiated method; public clients (no secret) send only `client_id` in the
+ * body. Mutates `body`/`headers` in place.
+ */
+export function applyClientAuthentication(
+  body: Record<string, string>,
+  headers: Record<string, string>,
+  clientId: string,
+  clientSecret: string | undefined,
+  method: MCPOAuthTokenEndpointAuthMethod
+): void {
+  if (!clientSecret) {
+    // Public client — send client_id in body.
+    body.client_id = clientId;
+    return;
+  }
+  if (method === 'client_secret_post') {
+    // Provider requires credentials in the request body (e.g. HubSpot).
+    body.client_id = clientId;
+    body.client_secret = clientSecret;
+    return;
+  }
+  // Default: HTTP Basic auth, which most providers expect.
+  headers.Authorization = `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`;
 }
 
 // Re-export the canonical OAuthTokenResponse from oauth-auth to avoid duplication
@@ -1041,7 +1099,8 @@ async function exchangeCodeForToken(
   clientSecret?: string,
   resourceUri?: string,
   allowLocalhostHttp = false,
-  clientRegistrationInvalidatable = false
+  clientRegistrationInvalidatable = false,
+  tokenEndpointAuthMethod: MCPOAuthTokenEndpointAuthMethod = 'client_secret_basic'
 ): Promise<OAuthTokenResponse> {
   const body: Record<string, string> = {
     grant_type: 'authorization_code',
@@ -1051,8 +1110,6 @@ async function exchangeCodeForToken(
   };
   if (resourceUri) body.resource = resourceUri;
 
-  // Build headers — use HTTP Basic auth when client_secret is available (RFC 6749 §2.3.1),
-  // fall back to body params for public clients or providers that don't support Basic auth.
   const headers: Record<string, string> = {
     'Content-Type': 'application/x-www-form-urlencoded',
     // GitHub's classic OAuth endpoint returns a form-encoded response by
@@ -1061,13 +1118,8 @@ async function exchangeCodeForToken(
     Accept: 'application/json',
   };
 
-  if (clientSecret) {
-    // Slack and other providers recommend HTTP Basic auth for credentials
-    headers.Authorization = `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`;
-  } else {
-    // Public client — send client_id in body
-    body.client_id = clientId;
-  }
+  // Present client credentials per the server's advertised auth method.
+  applyClientAuthentication(body, headers, clientId, clientSecret, tokenEndpointAuthMethod);
 
   console.log('[MCP OAuth] Starting authorization-code exchange');
 
@@ -1363,7 +1415,9 @@ export async function performMCPOAuthFlow(
       actualClientId,
       clientSecret,
       typeof resourceMetadata.resource === 'string' ? resourceMetadata.resource : undefined,
-      true
+      true,
+      false,
+      selectTokenEndpointAuthMethod(authServerMetadata.token_endpoint_auth_methods_supported)
     );
 
     console.log('[MCP OAuth] Access token received successfully');
@@ -1488,6 +1542,12 @@ export interface OAuthFlowContext {
   clientSecret?: string;
   /** Exact durable DCR epoch used by this attempt; absent for configured/local clients. */
   clientRegistrationId?: MCPOAuthClientRegistrationID;
+  /**
+   * Token-endpoint client-authentication method negotiated from the AS
+   * metadata at flow start. Optional so pre-existing durable flows (sealed
+   * before this field existed) default to `client_secret_basic`.
+   */
+  tokenEndpointAuthMethod?: MCPOAuthTokenEndpointAuthMethod;
   state: string;
   authorizationUrl: string;
   compatibilityMode: MCPOAuthRuntimeCompatibilityMode;
@@ -2078,6 +2138,9 @@ async function startMCPOAuthFlowWithAS(opts: {
     clientId: resolvedClient.clientId,
     clientSecret: resolvedClient.clientSecret,
     clientRegistrationId: resolvedClient.clientRegistrationId,
+    tokenEndpointAuthMethod: selectTokenEndpointAuthMethod(
+      authServerMetadata?.token_endpoint_auth_methods_supported
+    ),
     state,
     authorizationUrl: authUrl.toString(),
     compatibilityMode,
@@ -2346,7 +2409,8 @@ export async function completeMCPOAuthFlow(
     context.clientSecret,
     context.resourceUri,
     context.allowLocalhostHttp,
-    Boolean(context.clientRegistrationId)
+    Boolean(context.clientRegistrationId),
+    context.tokenEndpointAuthMethod ?? 'client_secret_basic'
   );
 
   console.log('[MCP OAuth] Access token received successfully');

--- a/packages/core/src/tools/mcp/oauth-refresh.test.ts
+++ b/packages/core/src/tools/mcp/oauth-refresh.test.ts
@@ -176,6 +176,76 @@ describe('refreshMCPToken', () => {
     expect(body.get('grant_type')).toBe('refresh_token');
   });
 
+  it('uses client_secret_post (credentials in body) when negotiated', async () => {
+    mockFetchOnce({ access_token: 'new-a', expires_in: 3600 });
+
+    const result = await refreshMCPToken({
+      tokenEndpoint: 'https://auth.example.com/token',
+      refreshToken: 'rt-abc',
+      clientId: 'client-123',
+      clientSecret: 'secret-xyz',
+      tokenEndpointAuthMethod: 'client_secret_post',
+    });
+
+    expect(result.access_token).toBe('new-a');
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    const [, init] = (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(init.headers.Authorization).toBeUndefined();
+    const body = new URLSearchParams(init.body as string);
+    expect(body.get('client_id')).toBe('client-123');
+    expect(body.get('client_secret')).toBe('secret-xyz');
+  });
+
+  it('retries with client_secret_post after a Basic client-auth rejection (HubSpot-style)', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: 'invalid_client' }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ access_token: 'post-a', expires_in: 3600 }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+    globalThis.fetch = fetchMock as typeof globalThis.fetch;
+
+    const result = await refreshMCPToken({
+      tokenEndpoint: 'https://auth.example.com/token',
+      refreshToken: 'rt-abc',
+      clientId: 'client-123',
+      clientSecret: 'secret-xyz',
+    });
+
+    expect(result.access_token).toBe('post-a');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [, first] = fetchMock.mock.calls[0];
+    expect(first.headers.Authorization).toBe(
+      `Basic ${Buffer.from('client-123:secret-xyz').toString('base64')}`
+    );
+    const [, second] = fetchMock.mock.calls[1];
+    expect(second.headers.Authorization).toBeUndefined();
+    const body = new URLSearchParams(second.body as string);
+    expect(body.get('client_id')).toBe('client-123');
+    expect(body.get('client_secret')).toBe('secret-xyz');
+  });
+
+  it('does not retry a public client (no secret) on invalid_client', async () => {
+    mockFetchOnce({ error: 'invalid_client' }, { status: 401 });
+
+    await expect(
+      refreshMCPToken({
+        tokenEndpoint: 'https://auth.example.com/token',
+        refreshToken: 'rt-abc',
+        clientId: 'public-client-42',
+      })
+    ).rejects.toThrow(/provider_rejected/);
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+  });
+
   it('surfaces invalid_grant as InvalidGrantError', async () => {
     mockFetchOnce(
       {

--- a/packages/core/src/tools/mcp/oauth-refresh.ts
+++ b/packages/core/src/tools/mcp/oauth-refresh.ts
@@ -16,6 +16,10 @@ import {
 } from '../../utils/safe-outbound-fetch';
 import { assertMcpGrantSubjectEntitled } from './grant-entitlement';
 import { inferOAuthTokenUrl } from './oauth-auth';
+import {
+  applyClientAuthentication,
+  type MCPOAuthTokenEndpointAuthMethod,
+} from './oauth-mcp-transport';
 import { resolveTokenExpiry } from './oauth-token-expiry';
 
 export const REFRESH_BUFFER_MS = 60_000;
@@ -104,6 +108,12 @@ export interface RefreshMCPTokenOptions {
   clientId: string;
   clientSecret?: string;
   resourceUri?: string;
+  /**
+   * Token-endpoint client-authentication method to try first. Defaults to
+   * `client_secret_basic`; `refreshMCPToken` safely retries the alternate
+   * method on an explicit client-authentication rejection.
+   */
+  tokenEndpointAuthMethod?: MCPOAuthTokenEndpointAuthMethod;
   /** Exact loopback HTTP exception for standalone development/tests only. */
   allowLocalhostHttp?: boolean;
   /** Task/session/rollout fence checked immediately before credential dispatch. */
@@ -132,59 +142,88 @@ interface OAuthRefreshRawResponse {
 export async function refreshMCPToken(
   opts: RefreshMCPTokenOptions
 ): Promise<RefreshMCPTokenResult> {
-  const body: Record<string, string> = {
-    grant_type: 'refresh_token',
-    refresh_token: opts.refreshToken,
-  };
-  if (opts.resourceUri) body.resource = opts.resourceUri;
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/x-www-form-urlencoded',
-    Accept: 'application/json',
-  };
-  if (opts.clientSecret) {
-    headers.Authorization = `Basic ${Buffer.from(`${opts.clientId}:${opts.clientSecret}`).toString('base64')}`;
-  } else {
-    body.client_id = opts.clientId;
-  }
+  // Present client credentials per the provider's auth method. Agor does not
+  // persist the method negotiated at grant time, so when a confidential
+  // client's first attempt is rejected specifically for client authentication
+  // (`invalid_client`/`unauthorized_client`) we retry once with the alternate
+  // presentation. A client-auth failure never redeems the refresh token, so the
+  // rotating credential is not consumed and the retry is safe. Providers that
+  // accept the first method (the common case) behave exactly as before.
+  const primary = opts.tokenEndpointAuthMethod ?? 'client_secret_basic';
+  const candidateMethods: MCPOAuthTokenEndpointAuthMethod[] = opts.clientSecret
+    ? primary === 'client_secret_post'
+      ? ['client_secret_post', 'client_secret_basic']
+      : ['client_secret_basic', 'client_secret_post']
+    : ['client_secret_basic']; // public client: only client_id in body, no retry
 
-  let response: Response;
-  try {
-    response = await safeOutboundFetch(opts.tokenEndpoint, {
-      method: 'POST',
+  let clientAuthRejection: OAuthRefreshExchangeError | undefined;
+  for (let attempt = 0; attempt < candidateMethods.length; attempt++) {
+    const isLastCandidate = attempt === candidateMethods.length - 1;
+    const body: Record<string, string> = {
+      grant_type: 'refresh_token',
+      refresh_token: opts.refreshToken,
+    };
+    if (opts.resourceUri) body.resource = opts.resourceUri;
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Accept: 'application/json',
+    };
+    applyClientAuthentication(
+      body,
       headers,
-      body: new URLSearchParams(body).toString(),
-      redirect: 'error',
-      timeoutMs: 15_000,
-      allowLocalhostHttp: opts.allowLocalhostHttp,
-      assertCurrent: opts.assertCurrent,
-      resolveDns: opts.resolveDns,
-    });
-  } catch (error) {
-    if (error instanceof OutboundPreDispatchAuthorityError) {
-      throw new OAuthRefreshAuthorityCancelledError(error.authorityCause);
-    }
-    throw new OAuthRefreshExchangeError('transport_ambiguous', true);
-  }
+      opts.clientId,
+      opts.clientSecret,
+      candidateMethods[attempt]
+    );
 
-  let parsed: OAuthRefreshRawResponse;
-  try {
-    parsed = (await response.json()) as OAuthRefreshRawResponse;
-  } catch {
-    throw new OAuthRefreshExchangeError('response_ambiguous', true);
+    let response: Response;
+    try {
+      response = await safeOutboundFetch(opts.tokenEndpoint, {
+        method: 'POST',
+        headers,
+        body: new URLSearchParams(body).toString(),
+        redirect: 'error',
+        timeoutMs: 15_000,
+        allowLocalhostHttp: opts.allowLocalhostHttp,
+        assertCurrent: opts.assertCurrent,
+        resolveDns: opts.resolveDns,
+      });
+    } catch (error) {
+      if (error instanceof OutboundPreDispatchAuthorityError) {
+        throw new OAuthRefreshAuthorityCancelledError(error.authorityCause);
+      }
+      throw new OAuthRefreshExchangeError('transport_ambiguous', true);
+    }
+
+    let parsed: OAuthRefreshRawResponse;
+    try {
+      parsed = (await response.json()) as OAuthRefreshRawResponse;
+    } catch {
+      throw new OAuthRefreshExchangeError('response_ambiguous', true);
+    }
+    if (parsed.error === 'invalid_grant') throw new InvalidGrantError();
+    if (parsed.error === 'invalid_client' || parsed.error === 'unauthorized_client') {
+      // Wrong credential presentation for this provider. Retry with the
+      // alternate method if one remains; otherwise surface the rejection.
+      clientAuthRejection = new OAuthRefreshExchangeError('provider_rejected', false);
+      if (!isLastCandidate) continue;
+      throw clientAuthRejection;
+    }
+    if (parsed.error) throw new OAuthRefreshExchangeError('provider_rejected', false);
+    if (!response.ok || typeof parsed.access_token !== 'string' || !parsed.access_token) {
+      throw new OAuthRefreshExchangeError('response_ambiguous', true);
+    }
+    const expiresIn = parsed.expires_in == null ? undefined : Number(parsed.expires_in);
+    return {
+      access_token: parsed.access_token,
+      refresh_token: parsed.refresh_token,
+      expires_in: Number.isFinite(expiresIn) ? expiresIn : undefined,
+      token_type: parsed.token_type,
+      scope: parsed.scope,
+    };
   }
-  if (parsed.error === 'invalid_grant') throw new InvalidGrantError();
-  if (parsed.error) throw new OAuthRefreshExchangeError('provider_rejected', false);
-  if (!response.ok || typeof parsed.access_token !== 'string' || !parsed.access_token) {
-    throw new OAuthRefreshExchangeError('response_ambiguous', true);
-  }
-  const expiresIn = parsed.expires_in == null ? undefined : Number(parsed.expires_in);
-  return {
-    access_token: parsed.access_token,
-    refresh_token: parsed.refresh_token,
-    expires_in: Number.isFinite(expiresIn) ? expiresIn : undefined,
-    token_type: parsed.token_type,
-    scope: parsed.scope,
-  };
+  // Unreachable: the loop returns or throws on every candidate.
+  throw clientAuthRejection ?? new OAuthRefreshExchangeError('provider_rejected', false);
 }
 
 type MutexKey = string;

--- a/packages/core/src/types/mcp.ts
+++ b/packages/core/src/types/mcp.ts
@@ -219,6 +219,12 @@ export interface MCPOAuthPendingFlowSealedMaterial {
   clientSecret?: string;
   /** Exact durable DCR UUID epoch used by this attempt. */
   clientRegistrationId?: MCPOAuthClientRegistrationID;
+  /**
+   * Token-endpoint client-authentication method negotiated at flow start.
+   * Optional: envelopes sealed before this field existed default to
+   * `client_secret_basic` on the exchange path.
+   */
+  tokenEndpointAuthMethod?: 'client_secret_basic' | 'client_secret_post';
   compatibilityMode: MCPOAuthRuntimeCompatibilityMode;
   /** Whether RFC 9207 says this AS will return `iss` on the callback. */
   authorizationResponseIssuerParameterSupported?: boolean;


### PR DESCRIPTION
Fixes #2725.

## What

Honor the authorization server's advertised `token_endpoint_auth_methods_supported` (RFC 8414) when presenting confidential-client credentials at the token endpoint, instead of always using `client_secret_basic`.

## Why

Agor only ever sent the client secret as HTTP Basic and never consulted the advertised auth methods:

- `packages/core/src/tools/mcp/oauth-mcp-transport.ts:1064-1070` (before) — initial code exchange
- `packages/core/src/tools/mcp/oauth-refresh.ts:144-148` (before) — refresh

Providers that accept `client_secret_post` **only** — notably **HubSpot MCP** (`token_endpoint_auth_methods_supported=["client_secret_post"]`) — reject the Basic exchange. The daemon then classifies it `provider_rejected` and the per-user OAuth callback renders "OAuth flow did not complete. Please start a new flow." (`apps/agor-daemon/src/register-services.ts:3757`, `:3795-3800`), with `oauth_authenticated` staying `false`. Previously-authenticated users also silently lapse, because refresh uses the same Basic-only auth. `oauth_compatibility_mode=legacy` does not help — it only relaxes discovery/issuer validation, never the token-endpoint auth method.

Full source trace: KB escalation `agor://kb/mcp-gateway/escalations/hubspot-mcp-oauth-callback-failure.md`.

## How

- New `selectTokenEndpointAuthMethod()` — keep `client_secret_basic` as the default (what most providers, e.g. Slack, expect and historical behavior when nothing is advertised); switch to `client_secret_post` only when the server advertises it but **not** Basic. When both are advertised, Basic wins, so existing integrations are unchanged.
- New `applyClientAuthentication()` helper shared by the code exchange and the refresh path (Basic header vs. credentials-in-body vs. public-client `client_id`).
- The method is negotiated from AS metadata at flow start, carried on `OAuthFlowContext`, and persisted in the durable pending-flow **sealed material** as an optional field — required so the exchanging replica on a Postgres/HA deployment (non-sticky callback routing) uses the right method. Old envelopes lacking the field default to Basic.
- **Refresh** does not persist the negotiated method, so it retries once with the alternate presentation on an explicit `invalid_client`/`unauthorized_client` rejection. A client-auth failure never redeems the rotating refresh token, so the retry is safe; providers that accept the first method are unaffected (single request, unchanged behavior).

## Verification

- Extended unit tests, all green (`packages/core` — 149 passing in the two touched files):
  - `selectTokenEndpointAuthMethod` (default/basic-preferred/post-only/unsupported).
  - `completeMCPOAuthFlow` sends credentials in the body under `client_secret_post` (no `Authorization` header) and still defaults to Basic otherwise.
  - `refreshMCPToken` uses body creds under `client_secret_post`, retries Basic→post on `invalid_client` (HubSpot-style), and does not retry a public client.
- `biome ci` clean on all changed files. (Note: the fresh worktree has unrelated `@agor/git` build/typecheck errors; none touch the changed files, and pre-commit `lint-staged` passed.)

Do not merge — flagged for review.
