### PR TITLE
Support Asana MCP V2 with configured OAuth clients

### DIFF
--- a/apps/agor-daemon/src/register-services.oauth-sqlite.integration.test.ts
+++ b/apps/agor-daemon/src/register-services.oauth-sqlite.integration.test.ts
@@ -1305,6 +1305,72 @@ describe('configured-client catalog OAuth through registered services', () => {
     return { provider, harness, member, memberParams, start, tokens, readGrant };
   }
 
+  it.each([undefined, 'strict', 'legacy'] as const)(
+    'requests ordinary sign-in for a canonical configured browser client with no grant (%s)',
+    async (compatibility) => {
+      const { provider, harness, memberParams } = await configuredFixture();
+      const repo = new MCPServerRepository(harness.rawDb);
+      const saved = await repo.findById(harness.server.mcp_server_id);
+      await repo.update(harness.server.mcp_server_id, {
+        auth: { ...saved!.auth!, oauth_compatibility_mode: compatibility },
+      });
+      const result = await harness.app
+        .service('mcp-servers/discover')
+        .create({ mcp_server_id: harness.server.mcp_server_id }, memberParams);
+      expect(result).toMatchObject({
+        success: false,
+        recovery: { category: 'authentication_required', action: 'reauthenticate' },
+      });
+      const execution = await harness.app
+        .service('mcp-servers/oauth-auth-headers')
+        .create(
+          { mcp_server_ids: [harness.server.mcp_server_id] },
+          { ...memberParams, provider: undefined }
+        );
+      expect(execution.headers[harness.server.mcp_server_id]).toEqual({ error: 'needs_reauth' });
+      expect(provider.requests).toHaveLength(0);
+    }
+  );
+
+  it.each(['headers', 'endpoint', 'provenance', 'machine_grant', 'removed_entry'] as const)(
+    'does not infer browser recovery from configured credentials with %s drift',
+    async (drift) => {
+      const { provider, harness, memberParams } = await configuredFixture();
+      const repo = new MCPServerRepository(harness.rawDb);
+      const saved = await repo.findById(harness.server.mcp_server_id);
+      if (drift === 'removed_entry') vi.mocked(loadCatalog).mockResolvedValue([]);
+      else {
+        await repo.update(harness.server.mcp_server_id, {
+          ...(drift === 'headers' ? { headers: { 'X-Custom': 'fixture' } } : {}),
+          ...(drift === 'endpoint' ? { url: `${provider.savedMcpUrl}/edited` } : {}),
+          ...(drift === 'provenance'
+            ? { source: 'user' as const, catalog_entry_name: undefined }
+            : {}),
+          ...(drift === 'machine_grant'
+            ? { auth: { ...saved!.auth!, oauth_grant_type: 'client_credentials' as const } }
+            : {}),
+        });
+      }
+      const result = await harness.app
+        .service('mcp-servers/discover')
+        .create({ mcp_server_id: harness.server.mcp_server_id }, memberParams);
+      expect(result).toMatchObject({
+        success: false,
+        recovery: { category: 'configuration_required', action: 'review_configuration' },
+      });
+      const execution = await harness.app
+        .service('mcp-servers/oauth-auth-headers')
+        .create(
+          { mcp_server_ids: [harness.server.mcp_server_id] },
+          { ...memberParams, provider: undefined }
+        );
+      expect(execution.headers[harness.server.mcp_server_id]).toMatchObject({
+        error: 'client_credentials_configuration_required',
+      });
+      expect(provider.requests).toHaveLength(0);
+    }
+  );
+
   it('lets a member sign in without DCR, persists exact binding and refreshes the same client/resource', async () => {
     const { provider, harness, member, memberParams, start, tokens, readGrant } =
       await configuredFixture();

--- a/apps/agor-daemon/src/register-services.oauth-sqlite.integration.test.ts
+++ b/apps/agor-daemon/src/register-services.oauth-sqlite.integration.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import http, { type Server as HttpServer } from 'node:http';
 import { resolveMcpOAuthCallbackOrigin } from '@agor/core/config';
 import {
@@ -132,6 +133,7 @@ type TestProvider = {
     authorization?: string;
     transientHeader?: string;
     jsonBody?: Record<string, unknown>;
+    formBody?: Record<string, string>;
   }>;
   tokenRequested: Deferred<void>;
   refreshRequested: Deferred<void>;
@@ -148,6 +150,7 @@ type TestProvider = {
 
 async function createTestProvider(
   options: {
+    configuredClientMetadata?: boolean;
     holdToken?: boolean;
     holdTokenRequests?: number[];
     numberedTokenResponses?: boolean;
@@ -223,12 +226,17 @@ async function createTestProvider(
           ...(options.rejectDynamicRegistration || options.holdDynamicRegistration
             ? { registration_endpoint: `${baseUrl}/register` }
             : {}),
+          ...(options.configuredClientMetadata
+            ? { token_endpoint_auth_methods_supported: ['client_secret_basic'] }
+            : {}),
           response_types_supported: ['code'],
           code_challenge_methods_supported: ['S256'],
           // The DCR fixture deliberately omits RFC 9207 response-issuer
           // support. Reaching /register therefore proves that the canonical
           // catalog row selected Marketplace policy rather than strict.
-          ...(options.rejectDynamicRegistration || options.holdDynamicRegistration
+          ...(options.configuredClientMetadata ||
+          options.rejectDynamicRegistration ||
+          options.holdDynamicRegistration
             ? {}
             : { authorization_response_iss_parameter_supported: true }),
         })
@@ -270,6 +278,7 @@ async function createTestProvider(
     if (url.pathname === '/token') {
       let body = '';
       for await (const chunk of request) body += String(chunk);
+      recordedRequest.formBody = Object.fromEntries(new URLSearchParams(body));
       const isRefresh = new URLSearchParams(body).get('grant_type') === 'refresh_token';
       if (isRefresh) {
         if (options.gitlab) {
@@ -411,6 +420,7 @@ type SQLiteHarness = {
   db: TenantScopeAwareDatabase;
   rawDb: Awaited<ReturnType<typeof createDatabaseAsync>>;
   user: User;
+  ownerUser: User;
   server: MCPServer;
   emittedBrowserEvents: Array<Record<string, unknown>>;
   gatewayOAuthResults: Array<{
@@ -420,7 +430,7 @@ type SQLiteHarness = {
     success: boolean;
   }>;
   nextAuthorizationUrl: () => Promise<string>;
-  callback: (state: string) => Promise<{ status: number; body: string }>;
+  callback: (state: string, issuer?: string | null) => Promise<{ status: number; body: string }>;
   deny: (state: string) => Promise<{ status: number; body: string }>;
   liveSocket: {
     id: string;
@@ -433,6 +443,7 @@ async function createHarness(
   provider: TestProvider,
   oauthMode?: 'per_user' | 'shared',
   options: {
+    memberOwned?: boolean;
     catalogPeer?: boolean;
     catalogEntry?: MCPCatalogEntry;
     durableAuthority?: NonNullable<RegisterServicesContext['mcpOAuthPendingFlowAuthority']>;
@@ -452,6 +463,12 @@ async function createHarness(
     email: `sqlite-oauth-${Math.random()}@example.com`,
     role: 'admin',
   });
+  const ownerUser = options.memberOwned
+    ? await new UsersRepository(rawDb).create({
+        email: `member-${generateId()}@example.test`,
+        role: 'member',
+      })
+    : user;
   const catalogEntry = options.catalogEntry;
   const server = await new MCPServerRepository(rawDb).create({
     name: 'sqlite-oauth-authority',
@@ -459,7 +476,7 @@ async function createHarness(
     url: provider.savedMcpUrl,
     headers: options.catalogPeer || catalogEntry ? undefined : { 'X-Saved-Config': 'true' },
     scope: 'global',
-    owner_user_id: user.user_id as UserID,
+    owner_user_id: ownerUser.user_id as UserID,
     ...(catalogEntry ? { source: 'catalog' as const, catalog_entry_name: catalogEntry.name } : {}),
     auth: {
       type: 'oauth',
@@ -587,6 +604,7 @@ async function createHarness(
     db,
     rawDb,
     user,
+    ownerUser,
     server,
     emittedBrowserEvents,
     gatewayOAuthResults,
@@ -595,8 +613,12 @@ async function createHarness(
       nextUrl = deferred<string>();
       return value;
     },
-    callback: (state: string) =>
-      invokeCallback({ code: 'authorization-code', state, iss: provider.baseUrl }),
+    callback: (state: string, issuer: string | null = provider.baseUrl) =>
+      invokeCallback({
+        code: 'authorization-code',
+        state,
+        ...(issuer === null ? {} : { iss: issuer }),
+      }),
     deny: (state: string) => invokeCallback({ error: 'access_denied', state }),
     liveSocket,
   } satisfies SQLiteHarness;
@@ -1212,6 +1234,251 @@ afterEach(async () => {
   else process.env.AGOR_BASE_URL = previousBaseUrl;
   if (previousMasterSecret === undefined) delete process.env.AGOR_MASTER_SECRET;
   else process.env.AGOR_MASTER_SECRET = previousMasterSecret;
+});
+
+describe('configured-client catalog OAuth through registered services', () => {
+  const clientId = 'fixture-configured-client';
+  const clientSecret = 'fixture-only-not-a-real-secret';
+  const redirectUri = 'https://agor.example.test/mcp-servers/oauth-callback';
+
+  afterEach(async () => {
+    const original =
+      await vi.importActual<typeof import('@agor/core/mcp-catalog')>('@agor/core/mcp-catalog');
+    vi.mocked(loadCatalog).mockImplementation(original.loadCatalog);
+  });
+
+  async function configuredFixture() {
+    // Local analogue of the Asana V2 recipe, not a live Asana request. Keep
+    // the AS's absent RFC 9207 declaration, S256 and Basic advertisement.
+    // Advertising a registration endpoint makes any unintended DCR visible.
+    const provider = await createTestProvider({
+      configuredClientMetadata: true,
+      rejectDynamicRegistration: true,
+    });
+    providers.push(provider);
+    const catalogEntry: MCPCatalogEntry = {
+      name: 'test/configured-client-v2',
+      title: 'Configured client V2 fixture',
+      category: 'productivity',
+      capabilities: ['tasks', 'projects'],
+      benefit: 'Exercises configured client sign-in.',
+      starter_prompt: 'Exercise configured client sign-in.',
+      permission_disclosure: 'Local fixture only.',
+      popularity_rank: 999_999,
+      transport: 'streamable-http',
+      remote_url: provider.savedMcpUrl,
+      has_remote: true,
+      auth_type: 'oauth',
+      oauth: { configured_client: true, dcr_mode: 'disabled' },
+    };
+    vi.mocked(loadCatalog).mockResolvedValue([catalogEntry]);
+    const harness = await createHarness(provider, 'per_user', { catalogEntry, memberOwned: true });
+    databases.push(harness.rawDb);
+    await harness.app.service('mcp-servers').patch(
+      harness.server.mcp_server_id,
+      {
+        auth: {
+          type: 'oauth',
+          oauth_mode: 'per_user',
+          oauth_dcr_mode: 'disabled',
+          oauth_client_id: clientId,
+          oauth_client_secret: clientSecret,
+        },
+      },
+      paramsFor(harness)
+    );
+    const member = harness.ownerUser;
+    const memberParams = addLiveAuthority(harness, 'default', member.user_id, 'configured-member');
+    const start = async () => {
+      const result = await harness.app
+        .service('mcp-servers/oauth-start')
+        .create(
+          { mcp_server_id: harness.server.mcp_server_id, client_id: 'untrusted-request-client' },
+          memberParams
+        );
+      expect(result, JSON.stringify(result)).toMatchObject({ success: true });
+      return new URL(result.authorizationUrl);
+    };
+    const tokens = new UserMCPOAuthTokenRepository(harness.rawDb);
+    const readGrant = () =>
+      tokens.getToken(member.user_id as UserID, harness.server.mcp_server_id as MCPServerID);
+    return { provider, harness, member, memberParams, start, tokens, readGrant };
+  }
+
+  it('lets a member sign in without DCR, persists exact binding and refreshes the same client/resource', async () => {
+    const { provider, harness, member, memberParams, start, tokens, readGrant } =
+      await configuredFixture();
+    const authorization = await start();
+    expect(authorization.origin + authorization.pathname).toBe(`${provider.baseUrl}/authorize`);
+    expect(Object.fromEntries(authorization.searchParams)).toMatchObject({
+      client_id: clientId,
+      response_type: 'code',
+      redirect_uri: redirectUri,
+      resource: provider.savedMcpUrl,
+      code_challenge_method: 'S256',
+    });
+    const state = authorization.searchParams.get('state')!;
+    expect(state).toBeTruthy();
+    expect(authorization.searchParams.get('code_challenge')).toMatch(/^[A-Za-z0-9_-]{43}$/);
+    // Marketplace tolerates an absent issuer parameter only when it was not
+    // advertised; metadata and persisted grant still bind the exact issuer.
+    expect((await harness.callback(state, null)).status).toBe(200);
+    const exchange = provider.requests.filter((request) => request.path === '/token');
+    expect(exchange).toHaveLength(1);
+    expect(exchange[0].formBody).toMatchObject({
+      grant_type: 'authorization_code',
+      code: 'authorization-code',
+      redirect_uri: redirectUri,
+      resource: provider.savedMcpUrl,
+    });
+    expect(
+      createHash('sha256').update(exchange[0].formBody!.code_verifier).digest('base64url')
+    ).toBe(authorization.searchParams.get('code_challenge'));
+    const grant = await readGrant();
+    expect(grant).toMatchObject({
+      user_id: member.user_id,
+      oauth_access_token: 'sqlite-access-token',
+      oauth_refresh_token: 'refresh',
+      oauth_client_id: clientId,
+      oauth_resource_uri: provider.savedMcpUrl,
+      oauth_issuer: provider.baseUrl,
+      oauth_authorization_endpoint: `${provider.baseUrl}/authorize`,
+      oauth_token_endpoint: `${provider.baseUrl}/token`,
+      oauth_redirect_uri: redirectUri,
+      grant_binding_version: 4,
+    });
+    expect(grant?.grant_binding_fingerprint).toMatch(/^[a-f0-9]{64}$/);
+    await expect(
+      tokens.getToken(null, harness.server.mcp_server_id as MCPServerID)
+    ).resolves.toBeNull();
+    await expect(
+      tokens.getToken(harness.user.user_id as UserID, harness.server.mcp_server_id as MCPServerID)
+    ).resolves.toBeNull();
+
+    await expect(
+      harness.app
+        .service('mcp-servers/oauth-refresh')
+        .create({ mcp_server_id: harness.server.mcp_server_id }, memberParams)
+    ).resolves.toMatchObject({ success: true });
+    const requests = provider.requests.filter((request) => request.path === '/token');
+    expect(requests).toHaveLength(2);
+    expect(requests[1].formBody).toMatchObject({
+      grant_type: 'refresh_token',
+      refresh_token: 'refresh',
+      resource: provider.savedMcpUrl,
+    });
+    for (const request of requests) {
+      expect(request.authorization).toBe(
+        `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString('base64')}`
+      );
+      expect(request.formBody).not.toHaveProperty('client_secret');
+    }
+    await expect(readGrant()).resolves.toMatchObject({
+      oauth_access_token: 'stale-refreshed-access-token',
+      oauth_client_id: clientId,
+      oauth_resource_uri: provider.savedMcpUrl,
+    });
+    expect((await harness.callback(state, null)).status).not.toBe(200);
+    expect(provider.requests.filter((request) => request.path === '/token')).toHaveLength(2);
+    expect(
+      provider.requests.filter((request) => ['/register', '/authorize'].includes(request.path))
+    ).toEqual([]);
+  });
+
+  it('rejects foreign-user/tenant completion and another user refresh before provider I/O', async () => {
+    const { provider, harness, start, readGrant } = await configuredFixture();
+    const authorization = await start();
+    const state = authorization.searchParams.get('state')!;
+    const before = provider.requests.length;
+    const deniedMember = await new UsersRepository(harness.rawDb).create({
+      email: `denied-member-${generateId()}@example.test`,
+      role: 'member',
+    });
+    const deniedParams = addLiveAuthority(
+      harness,
+      'default',
+      deniedMember.user_id,
+      'denied-configured-member'
+    );
+    await expect(
+      harness.app
+        .service('mcp-servers/oauth-start')
+        .create({ mcp_server_id: harness.server.mcp_server_id }, deniedParams)
+    ).resolves.toMatchObject({ success: false });
+    expect(provider.requests).toHaveLength(before);
+    for (const params of [
+      paramsFor(harness),
+      addLiveAuthority(
+        harness,
+        'foreign-tenant',
+        harness.ownerUser.user_id,
+        'foreign-configured-member'
+      ),
+    ]) {
+      await expect(
+        harness.app
+          .service('mcp-servers/oauth-complete')
+          .create({ code: 'authorization-code', state }, params)
+      ).resolves.toMatchObject({ success: false });
+      expect(provider.requests).toHaveLength(before);
+    }
+    expect((await harness.callback(state, null)).status).toBe(200);
+    const after = provider.requests.length;
+    await expect(
+      harness.app
+        .service('mcp-servers/oauth-refresh')
+        .create({ mcp_server_id: harness.server.mcp_server_id }, paramsFor(harness))
+    ).resolves.toMatchObject({ success: false });
+    expect(provider.requests).toHaveLength(after);
+    await expect(readGrant()).resolves.toMatchObject({ oauth_access_token: 'sqlite-access-token' });
+  });
+
+  it('rejects incorrect callback issuer and unknown state before token exchange', async () => {
+    const { provider, harness, start, readGrant } = await configuredFixture();
+    const authorization = await start();
+    const before = provider.requests.length;
+    expect((await harness.callback('unknown-configured-state', null)).status).not.toBe(200);
+    expect(
+      (
+        await harness.callback(
+          authorization.searchParams.get('state')!,
+          'https://foreign-issuer.example'
+        )
+      ).status
+    ).not.toBe(200);
+    expect(provider.requests).toHaveLength(before);
+    await expect(readGrant()).resolves.toBeNull();
+  });
+
+  it('revokes the member grant on an explicit saved client configuration change', async () => {
+    const { provider, harness, memberParams, start, readGrant } = await configuredFixture();
+    const authorization = await start();
+    expect((await harness.callback(authorization.searchParams.get('state')!, null)).status).toBe(
+      200
+    );
+    await expect(readGrant()).resolves.not.toBeNull();
+    const before = provider.requests.length;
+    await harness.app.service('mcp-servers').patch(
+      harness.server.mcp_server_id,
+      {
+        auth: {
+          type: 'oauth',
+          oauth_mode: 'per_user',
+          oauth_dcr_mode: 'disabled',
+          oauth_client_id: 'replacement-fixture-client',
+          oauth_client_secret: 'replacement-fixture-secret',
+        },
+      },
+      paramsFor(harness)
+    );
+    await expect(readGrant()).resolves.toBeNull();
+    await expect(
+      harness.app
+        .service('mcp-servers/oauth-refresh')
+        .create({ mcp_server_id: harness.server.mcp_server_id }, memberParams)
+    ).resolves.toMatchObject({ success: false });
+    expect(provider.requests).toHaveLength(before);
+  });
 });
 
 describe('Slack MCP recovery authenticated route', () => {

--- a/apps/agor-daemon/src/register-services.ts
+++ b/apps/agor-daemon/src/register-services.ts
@@ -5920,7 +5920,7 @@ export async function registerMCPServices(
                 assertCurrent: mcpEgressAssertCurrent,
                 resolveDns: ctx.mcpOutboundDnsLookup,
               });
-              if (!grant) throw missingMCPOAuthGrantError(server.auth);
+              if (!grant) throw await missingMCPOAuthGrantError(server);
               headers[serverId] = { authorization: `Bearer ${grant.oauth_access_token}` };
             } catch (error) {
               if (error instanceof OAuthRefreshAuthorityCancelledError) throw error;
@@ -6543,8 +6543,12 @@ export async function registerMCPServices(
                 resolveDns: ctx.mcpOutboundDnsLookup,
               })
             );
-            if (!selectedGrant && !browserReservation)
-              throw missingMCPOAuthGrantError(serverConfig.auth);
+            if (!selectedGrant && !browserReservation) {
+              if (!authoritativeServer) {
+                throw new Conflict('Saved MCP server authority changed. Retry.');
+              }
+              throw await missingMCPOAuthGrantError(authoritativeServer);
+            }
             oauthToken = selectedGrant?.oauth_access_token;
             if (selectedGrant && discoveryAuthority) {
               discoveryAuthority = bindMCPDiscoveryOAuthGrant(

--- a/apps/agor-daemon/src/services/mcp-catalog-connect.postgres.test.ts
+++ b/apps/agor-daemon/src/services/mcp-catalog-connect.postgres.test.ts
@@ -467,6 +467,50 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)(
       expect(result.mcp_server.mcp_server_id).not.toBe(foreignPeer.mcp_server_id);
     });
 
+    it('preserves a configured app on reconnect and isolates its row secret across tenants', async () => {
+      const actor = await buildTenant('configured-owner');
+      const foreign = await buildTenant('configured-foreign');
+      const configuredEntry: MCPCatalogEntry = {
+        ...ENTRY,
+        oauth: { configured_client: true, dcr_mode: 'disabled' },
+      };
+      const server = await runWithTenantDatabaseScope(db, actor.tenantId, (scoped) =>
+        new MCPServerRepository(scoped).create({
+          name: `configured-${generateId()}`,
+          transport: 'http',
+          url: RESOURCE,
+          scope: 'session',
+          source: 'catalog',
+          catalog_entry_name: configuredEntry.name,
+          owner_user_id: actor.user.user_id,
+          enabled: true,
+          auth: {
+            type: 'oauth',
+            oauth_mode: 'per_user',
+            oauth_dcr_mode: 'disabled',
+            oauth_client_id: 'fixture-client',
+            oauth_client_secret: 'fixture-app-secret',
+          },
+        })
+      );
+      const own = await connect(actor.user, actor.tenantId, configuredEntry);
+      expect(own.mcp_server.mcp_server_id).toBe(server.mcp_server_id);
+      expect(JSON.stringify(own)).not.toContain('fixture-app-secret');
+      const deniedRow = await runWithTenantDatabaseScope(db, foreign.tenantId, (scoped) =>
+        new MCPServerRepository(scoped).findById(server.mcp_server_id)
+      );
+      expect(deniedRow).toBeNull();
+      const other = await connect(foreign.user, foreign.tenantId, configuredEntry);
+      expect(other.mcp_server.mcp_server_id).not.toBe(server.mcp_server_id);
+      expect(JSON.stringify(other)).not.toContain('fixture-app-secret');
+      const after = await runWithTenantDatabaseScope(db, actor.tenantId, (scoped) =>
+        new MCPServerRepository(scoped).findById(server.mcp_server_id)
+      );
+      // Read raw authority, not the API sentinel: reconnect must not replace
+      // the actual app secret, revision or existing consent configuration.
+      expect(after).toEqual(server);
+    });
+
     it('rejects a grant whose durable binding drifted through the full connect path', async () => {
       const actor = await buildTenant('binding-drift');
       const peer = await seedPeer(actor.tenantId, actor.user, { fingerprintDrift: true });

--- a/apps/agor-daemon/src/services/mcp-catalog-connect.test.ts
+++ b/apps/agor-daemon/src/services/mcp-catalog-connect.test.ts
@@ -464,6 +464,105 @@ const request = {
   acknowledged_disclosure: CURATED.permission_disclosure as string,
 };
 
+describe('Asana V2 configured app reconnect', () => {
+  const asana: MCPCatalogEntry = {
+    ...CURATED,
+    name: 'com.asana/mcp',
+    title: 'Asana',
+    remote_url: 'https://mcp.asana.com/v2/mcp',
+    auth_type: 'oauth',
+    oauth: { configured_client: true, dcr_mode: 'disabled' },
+  };
+  const configured = (): Omit<ReturnType<typeof installOf>, 'auth'> & { auth: MCPAuth } => ({
+    ...installOf({
+      catalog_entry_name: asana.name,
+      url: asana.remote_url,
+    }),
+    auth: {
+      type: 'oauth',
+      oauth_mode: 'per_user',
+      oauth_dcr_mode: 'disabled',
+      oauth_client_id: 'fixture-client',
+      oauth_client_secret: 'fixture-secret',
+    },
+  });
+  const connectRequest = { ...request, catalog_key: asana.name };
+
+  beforeEach(() => probeRemoteAuthType.mockResolvedValue('oauth'));
+  afterEach(() => vi.clearAllMocks());
+
+  it.each([undefined, 'strict', 'legacy'] as const)(
+    'connects normally and preserves the saved app and %s policy without replacing auth',
+    async (mode) => {
+      const row = configured();
+      if (mode) row.auth = { ...row.auth, oauth_compatibility_mode: mode };
+      const harness = buildApp(asana, [row]);
+      const result = await createMCPCatalogConnectService(harness.app, harness.deps).create(
+        connectRequest,
+        params
+      );
+      expect(result.mcp_server.mcp_server_id).toBe(row.mcp_server_id);
+      // Main's staged tryout flow creates a session only on the explicit
+      // Start new session action, not during authentication/Connect.
+      expect(harness.created.sessions).toHaveLength(0);
+      expect(harness.created.attachments).toHaveLength(0);
+      expect(harness.patched).toEqual([]);
+      expect(JSON.stringify(result)).not.toContain('fixture-secret');
+    }
+  );
+
+  it.each([true, false])(
+    'tries an expired configured grant once, retaining recovery on refresh success=%s',
+    async (success) => {
+      const row = configured();
+      row.auth.oauth_access_token = 'fixture-expired-access';
+      row.auth.oauth_token_expires_at = 1;
+      const savedAuth = structuredClone(row.auth);
+      const harness = buildApp(asana, [row], async () => {
+        if (success) row.auth.oauth_token_expires_at = Date.now() + 3_600_000;
+        return { success };
+      });
+      const result = await createMCPCatalogConnectService(harness.app, harness.deps).create(
+        connectRequest,
+        params
+      );
+      expect(harness.refreshed).toEqual([row.mcp_server_id]);
+      expect(harness.patched).toEqual([]);
+      expect(result.reuse_kind).toBe('catalog_install');
+      expect(result.mcp_server.auth?.oauth_access_token).toBe(
+        success ? MCP_HEADER_REDACTED_SENTINEL : undefined
+      );
+      expect(row.auth.oauth_client_secret).toBe(savedAuth.oauth_client_secret);
+    }
+  );
+
+  it.each([
+    { url: 'https://mcp.asana.com/sse', transport: 'sse' },
+    {
+      auth: {
+        type: 'oauth',
+        oauth_mode: 'per_user',
+        oauth_dcr_mode: 'disabled',
+        oauth_client_id: 'fixture-client',
+        oauth_client_secret: 'fixture-secret',
+        oauth_token_url: 'https://other.example/token',
+      },
+    },
+  ])('leaves existing V1 or edited configuration and grants untouched', async (change) => {
+    const row = { ...configured(), ...change };
+    const before = structuredClone(row);
+    const harness = buildApp(asana, [row]);
+    await expect(
+      createMCPCatalogConnectService(harness.app, harness.deps).create(connectRequest, params)
+    ).rejects.toThrow('Edit its URL, transport and OAuth app settings explicitly');
+    expect(row).toEqual(before);
+    expect(harness.patched).toEqual([]);
+    expect(harness.removed).toEqual([]);
+    expect(harness.created.sessions).toEqual([]);
+    expect(harness.refreshed).toEqual([]);
+  });
+});
+
 /** Typed access to the stub services a test needs to make fail. */
 type StubFn = ReturnType<typeof vi.fn>;
 const serversOf = (app: { service: (p: string) => unknown }) =>

--- a/apps/agor-daemon/src/services/mcp-catalog-connect.ts
+++ b/apps/agor-daemon/src/services/mcp-catalog-connect.ts
@@ -716,6 +716,23 @@ export function createMCPCatalogConnectService(
         kind: selected.liveKind!,
       };
     }
+    // Configured app secrets deliberately remain ineligible as arbitrary
+    // credential peers. The caller's own canonical install can nevertheless
+    // refresh its own bound per-user grant through the existing authority.
+    if (
+      entry.oauth?.configured_client &&
+      selected.currentCatalog?.server.owner_user_id === userId &&
+      selected.currentCatalog.grant?.has_access_token &&
+      selected.currentCatalog.grant.resource_uri === entry.remote_url
+    ) {
+      const refreshed = await findReusableCredential(
+        entry,
+        [selected.currentCatalog],
+        userId,
+        params
+      );
+      if (refreshed) return { ...refreshed, kind: 'catalog_install' };
+    }
     const revived = await findReusableCredential(entry, selected.compatibleOAuth, userId, params);
     if (revived) return revived;
     if (selected.ownedCatalog) {
@@ -1025,6 +1042,16 @@ export function createMCPCatalogConnectService(
           !isCurrentCatalogInstall(mcpServer, entry, auth, {
             reconcileMissingCompatibilityMode: true,
           }));
+      // Configured app credentials and old V1 grants are user-owned. Connect
+      // must never replace their URL/auth under an existing consent binding.
+      // Current installs still take the normal Connect / Sign in path.
+      if (needsReconciliation && entry.oauth?.configured_client) {
+        throw new CatalogConnectControlError(
+          `The saved ${catalogDisplayName(entry)} configuration differs from the current catalog. ` +
+            'Edit its URL, transport and OAuth app settings explicitly, then sign in again; ' +
+            'Catalog has not changed the saved configuration or grants.'
+        );
+      }
       const preservedCompatibilityOverride =
         selection?.kind === 'catalog_install' &&
         mcpServer.auth?.type === 'oauth' &&

--- a/apps/agor-daemon/src/services/mcp-catalog-install-policy.ts
+++ b/apps/agor-daemon/src/services/mcp-catalog-install-policy.ts
@@ -37,10 +37,28 @@ function significantAuth(value: MCPAuth | undefined): Record<string, unknown> {
 function isPrescribedCatalogAuth(
   auth: MCPAuth | undefined,
   prescribed: MCPAuth,
-  reconcileMissingCompatibilityMode: boolean
+  reconcileMissingCompatibilityMode: boolean,
+  configuredClient: boolean
 ): boolean {
   const actual = significantAuth(auth);
   const expected = significantAuth(prescribed);
+  // A reviewed configured-client recipe delegates only these two fields to
+  // the saved row. They remain covered by grant fingerprints and redaction;
+  // this is not permission to reuse another owner's row secret.
+  if (configuredClient) {
+    delete actual.oauth_client_id;
+    delete actual.oauth_client_secret;
+    // Public compatibility overrides are independently authoritative at flow
+    // start. Reconnect must preserve them, not mistake Strict for recipe drift
+    // and not replace the configured client with a catalog auth object.
+    if (
+      actual.oauth_compatibility_mode === 'strict' ||
+      actual.oauth_compatibility_mode === 'legacy'
+    ) {
+      delete actual.oauth_compatibility_mode;
+      delete expected.oauth_compatibility_mode;
+    }
+  }
   // Compatibility policy is evaluated from the current catalog. This one
   // reconciliation lets installs created before an entry acquired an explicit
   // strict policy remain the same install without mutating their row.
@@ -82,11 +100,14 @@ export function isCurrentCatalogInstall(
     server.source === 'catalog' &&
     server.catalog_entry_name === entry.name &&
     server.transport === catalogServerTransport(entry) &&
-    sameCatalogEndpoint(server.url, entry.remote_url) &&
+    (entry.oauth?.configured_client
+      ? server.url === entry.remote_url
+      : sameCatalogEndpoint(server.url, entry.remote_url)) &&
     isPrescribedCatalogAuth(
       server.auth,
       prescribed,
-      options.reconcileMissingCompatibilityMode === true
+      options.reconcileMissingCompatibilityMode === true,
+      entry.oauth?.configured_client === true
     ) &&
     Object.keys(server.headers ?? {}).length === 0
   );

--- a/apps/agor-daemon/src/services/mcp-oauth-compatibility.test.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-compatibility.test.ts
@@ -1,5 +1,7 @@
 import type { MCPCatalogEntry, MCPServer } from '@agor/core/types';
 import { describe, expect, it } from 'vitest';
+import { selectCatalogCandidate } from './mcp-catalog-credential-match.js';
+import { catalogOAuthConfig } from './mcp-catalog-install-policy.js';
 import {
   presentMCPOAuthCompatibilityPolicy,
   resolveMCPOAuthCompatibilityPolicy,
@@ -36,6 +38,81 @@ function catalogServer(overrides: Partial<MCPServer> = {}): MCPServer {
     ...overrides,
   };
 }
+
+describe('reviewed configured-client catalog policy', () => {
+  const asana: MCPCatalogEntry & { remote_url: string } = {
+    ...entry,
+    name: 'com.asana/mcp',
+    remote_url: 'https://mcp.asana.com/v2/mcp',
+    oauth: { configured_client: true, dcr_mode: 'disabled' },
+  };
+  const server = () =>
+    catalogServer({
+      catalog_entry_name: asana.name,
+      url: asana.remote_url,
+      owner_user_id: '01900000-0000-7000-8000-000000000002' as MCPServer['owner_user_id'],
+      auth: {
+        ...catalogOAuthConfig(asana),
+        oauth_client_id: 'fixture-client',
+        oauth_client_secret: 'fixture-secret',
+      },
+    });
+
+  it('keeps normal catalog sign-in after saving the app, without relaxing general strict', async () => {
+    await expect(resolveMCPOAuthCompatibilityPolicy(server(), [asana])).resolves.toMatchObject({
+      mode: 'marketplace',
+    });
+    for (const changed of [
+      { source: 'user' as const },
+      { source: 'imported' as const },
+      { url: 'https://mcp.asana.com/sse' },
+      { url: `${asana.remote_url}/` },
+      { transport: 'sse' as const },
+      { headers: { 'X-Custom': 'value' } },
+      { auth: { ...server().auth!, oauth_token_url: 'https://other.example/token' } },
+      { auth: { ...server().auth!, oauth_scope: 'other-scope' } },
+      { auth: { ...server().auth!, oauth_dcr_mode: 'advertised' as const } },
+      { auth: { ...server().auth!, oauth_mode: 'shared' as const } },
+      { auth: { ...server().auth!, oauth_compatibility_mode: 'strict' as const } },
+    ]) {
+      await expect(
+        resolveMCPOAuthCompatibilityPolicy({ ...server(), ...changed }, [asana])
+      ).resolves.toMatchObject({ mode: 'strict' });
+    }
+    await expect(
+      resolveMCPOAuthCompatibilityPolicy(server(), [{ ...asana, oauth: undefined }])
+    ).resolves.toMatchObject({ mode: 'strict' });
+    await expect(resolveMCPOAuthCompatibilityPolicy(server(), [])).resolves.toMatchObject({
+      mode: 'strict',
+    });
+  });
+
+  it('does not lend a row client secret to another catalog caller', async () => {
+    const candidate = { server: server(), has_row_secret: true };
+    const deps = { isGrantAuthorized: async () => false };
+    const own = await selectCatalogCandidate(
+      asana,
+      catalogOAuthConfig(asana),
+      [candidate],
+      candidate.server.owner_user_id!,
+      Date.now(),
+      deps
+    );
+    expect(own.currentCatalog).toBe(candidate);
+    const other = await selectCatalogCandidate(
+      asana,
+      catalogOAuthConfig(asana),
+      [candidate],
+      'other-user',
+      Date.now(),
+      deps
+    );
+    expect(other.currentCatalog).toBeUndefined();
+    expect(other.ownedCatalog).toBeUndefined();
+    expect(other.live).toBeUndefined();
+    expect(other.compatibleOAuth).toEqual([]);
+  });
+});
 
 describe('resolveMCPOAuthCompatibilityPolicy', () => {
   it('derives marketplace only from a canonical install of a current OAuth entry', async () => {

--- a/apps/agor-daemon/src/services/mcp-oauth-use.ts
+++ b/apps/agor-daemon/src/services/mcp-oauth-use.ts
@@ -1,4 +1,5 @@
 import { runWithTenantDatabaseScope, UserMCPOAuthTokenRepository } from '@agor/core/db';
+import { findCatalogEntry, loadCatalog } from '@agor/core/mcp-catalog';
 import { assertMcpGrantSubjectEntitled } from '@agor/core/tools/mcp/grant-entitlement';
 import {
   AmbiguousRefreshError,
@@ -8,7 +9,8 @@ import {
   type RefreshAndPersistDeps,
   refreshAndPersistToken,
 } from '@agor/core/tools/mcp/oauth-refresh';
-import type { MCPAuth } from '@agor/core/types';
+import type { MCPCatalogEntry, MCPServer } from '@agor/core/types';
+import { catalogOAuthConfig, isCurrentCatalogInstall } from './mcp-catalog-install-policy.js';
 
 /** A live newer rotation is contention, not lost authorization. */
 export class MCPOAuthRefreshBusyError extends Error {
@@ -26,12 +28,36 @@ export class MCPClientCredentialsConfigurationError extends Error {
   }
 }
 
-export function missingMCPOAuthGrantError(auth: MCPAuth): Error {
+export async function missingMCPOAuthGrantError(
+  server: Pick<
+    MCPServer,
+    'source' | 'catalog_entry_name' | 'transport' | 'url' | 'auth' | 'headers'
+  >
+): Promise<Error> {
+  const auth = server.auth;
+  // A canonical configured-client recipe prescribes browser authorization,
+  // not machine-token minting. Only the saved definition can establish this;
+  // a client ID/secret, endpoint, or historical catalog stamp alone cannot.
+  if (!auth?.oauth_grant_type && server.source === 'catalog' && server.catalog_entry_name) {
+    const entry = findCatalogEntry(await loadCatalog(), server.catalog_entry_name);
+    if (
+      entry?.remote_url &&
+      entry.auth_type === 'oauth' &&
+      entry.oauth?.configured_client === true &&
+      isCurrentCatalogInstall(
+        server,
+        entry as MCPCatalogEntry & { remote_url: string },
+        catalogOAuthConfig(entry)
+      )
+    ) {
+      return new MissingRefreshTokenError();
+    }
+  }
   // Legacy forms defaulted an omitted grant type to client_credentials. Do not
   // mint a machine token here: a missing row can also be a retired browser grant.
   if (
-    auth.oauth_grant_type === 'client_credentials' ||
-    (!auth.oauth_grant_type && auth.oauth_client_id && auth.oauth_client_secret)
+    auth?.oauth_grant_type === 'client_credentials' ||
+    (!auth?.oauth_grant_type && auth?.oauth_client_id && auth.oauth_client_secret)
   ) {
     return new MCPClientCredentialsConfigurationError();
   }

--- a/apps/agor-docs/content/guide/mcp-servers.mdx
+++ b/apps/agor-docs/content/guide/mcp-servers.mdx
@@ -63,6 +63,68 @@ require replacing a healthy grant. For rotating credentials, even a crash after 
 dispatch fence but before network dispatch can require one sign-in: Agor cannot safely prove
 that the provider did not consume the token and will not replay it.
 
+### Asana V2: configure an MCP app, then sign in
+
+Asana V2 uses **Streamable HTTP** at `https://mcp.asana.com/v2/mcp` (the saved-server
+transport is **HTTP**). It requires a pre-registered **MCP app**, not an Asana API
+app or PAT, and does not support Dynamic Client Registration. Catalog Connect
+and **Sign in** remain the normal flow; registration credentials are configured
+on the saved server, not published in the catalog.
+
+An administrator responsible for the Asana app must explicitly perform these
+provider-side steps in the [Asana developer console](https://app.asana.com/my-apps):
+
+1. Create an app with type **MCP app**.
+2. In **OAuth**, register the exact callback URL shown by Agor's OAuth settings:
+   the deployment's public callback origin followed by `/mcp-servers/oauth-callback`.
+   Register each intended deployment callback explicitly; do not substitute a
+   wildcard, another cell's URL, or a loopback URL for a public deployment.
+3. In **Manage distribution**, select the intended workspaces and add at least
+   one, or explicitly choose **Any workspace** if that is the intended policy.
+4. Configure the saved Asana Catalog server under **Advanced — OAuth settings**
+   with the app's **Client ID** and **Client Secret**, and **DCR disabled**. Leave
+   the scope and endpoint overrides empty and retain **Catalog compatibility
+   (managed)**. Save, then choose **Sign in**.
+
+Use Agor's existing protected credential-entry surfaces; never put the client
+secret into chat, URLs, logs, source code, or `curated.yaml`. An agent collecting
+credentials must use Agor's secure environment-variable widget, not ask for
+values in chat. Environment variables are not automatically wired to this
+browser OAuth flow: the administrator must configure the saved OAuth client
+fields through a secure surface. See the storage guarantees below.
+
+Each authorized user signs in as themselves and gets their own grant. App
+credentials are not shared Asana user consent. The existing saved-server access
+rules still apply, and Catalog never borrows another owner's row-level client
+secret. An administrator may manage an appropriately shared saved server with
+**per-user OAuth** for users to attach and sign into individually; this is not
+the **shared OAuth grant** mode. No installation-wide app secret is introduced.
+
+Asana's current authorization metadata omits an RFC 9207 `iss` support
+declaration. A current configured Catalog install therefore retains Agor's
+catalog compatibility handling. Asana V2 additionally requires the exact
+`/v2/mcp` resource, the reviewed Asana issuer/endpoints, S256 and HTTP Basic
+client authentication. Returned callback `iss` values, when present, must match
+exactly. An explicit **Strict** setting remains strict and can refuse this
+metadata; it is never automatically relaxed.
+
+**Existing V1 installs:** updating Agor does not rewrite the saved `/sse` URL,
+transport, app configuration, or grants. Catalog reconnect will not silently
+reconcile an old/edited configured-client install. Explicitly edit the existing
+row to the V2 URL and HTTP transport, configure the MCP app and disable DCR,
+then sign in again. The edit invalidates old Agor grant bindings; it does not
+revoke tokens at Asana. Other users must sign in again on a shared saved server.
+Explicit compatibility overrides remain unchanged. Deleting an obsolete row
+and connecting a fresh V2 catalog install is another explicit migration choice.
+
+See [Asana's integration guide](https://developers.asana.com/docs/integrating-with-asanas-mcp-server).
+Its example `resource=https://mcp.asana.com/v2` is not Agor's resource: current
+path-specific metadata at
+`https://mcp.asana.com/.well-known/oauth-protected-resource/v2/mcp` identifies
+the exact `/v2/mcp` endpoint. The catalog health audit checks metadata without
+creating apps or obtaining tokens, and reports **credential-required**, not
+live authentication verified.
+
 ### Recovering a provider-deleted OAuth client (administrators)
 
 If sign-in repeatedly fails at the provider with an unknown/deleted client, ordinary reconnect may keep selecting the same saved Dynamic Client Registration (DCR). Agor automatically retires that exact registration only when the provider's token endpoint returns a structured `invalid_client` or `unauthorized_client` error. A browser/authorization-page error alone does not authorize retirement.

--- a/apps/agor-docs/content/guide/mcp-servers.mdx
+++ b/apps/agor-docs/content/guide/mcp-servers.mdx
@@ -58,6 +58,10 @@ secrets can also belong to browser OAuth; an existing bound grant continues to w
 of the legacy form's grant-type default. Agor never falls back to machine-token minting after
 a browser grant fails or is retired.
 
+A current Catalog recipe for a configured browser client (such as Asana V2) still uses
+normal sign-in recovery when no grant exists. Its app credentials do not imply a
+machine-token configuration. Edited or imported configurations do not inherit that recipe.
+
 A newer refresh on another daemon may temporarily require retrying a request; it does not
 require replacing a healthy grant. For rotating credentials, even a crash after the durable
 dispatch fence but before network dispatch can require one sign-in: Agor cannot safely prove

--- a/apps/agor-ui/src/components/MCPServer/AsanaOAuth.browser.test.tsx
+++ b/apps/agor-ui/src/components/MCPServer/AsanaOAuth.browser.test.tsx
@@ -1,0 +1,281 @@
+import type { MCPMarketplaceOverview, MCPOAuthAttemptResult } from '@agor/core/types';
+import type { AgorClient, MCPServer, UpdateMCPServerInput } from '@agor-live/client';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { App, ConfigProvider, message } from 'antd';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { userEvent } from 'vitest/browser';
+import { agorStore } from '../../store/agorStore';
+import { checkBrowserSanity } from '../../test/browserSanity';
+import {
+  catalogOverview,
+  catalogUser,
+  makeCatalogClient,
+} from '../Marketplace/MCPCatalogModal.test-fixtures';
+import { MyServersTab } from '../Marketplace/MyServersTab';
+import { MCPServerEditModal } from './MCPServerEditModal';
+
+// API/window boundaries only: the editor, inventory, hooks and polling are real.
+// No request or popup ever reaches Asana. Catalog transport streamable-http maps
+// to the saved-server transport http; backend OAuth/tenant enforcement is not mocked proof.
+checkBrowserSanity();
+const server = {
+  mcp_server_id: '01900000-0000-7000-8000-000000000001',
+  name: 'asana',
+  display_name: 'Asana',
+  source: 'catalog',
+  catalog_entry_name: 'com.asana/mcp',
+  transport: 'http',
+  url: 'https://mcp.asana.com/v2/mcp',
+  scope: 'session',
+  owner_user_id: catalogUser.user_id,
+  enabled: true,
+  config_version: 7,
+  auth: {
+    type: 'oauth',
+    oauth_mode: 'per_user',
+    oauth_dcr_mode: 'disabled',
+    oauth_client_id: 'synthetic-asana-app',
+    oauth_client_secret: '••••••••',
+  },
+} as MCPServer;
+const authorizationUrl = 'https://oauth.example.test/authorize?state=synthetic';
+const overview: MCPMarketplaceOverview = {
+  ...catalogOverview,
+  attachments: [],
+  servers: [
+    {
+      ...catalogOverview.servers[0],
+      mcp_server_id: server.mcp_server_id,
+      name: 'asana',
+      display_name: 'Asana',
+      session_count: 0,
+    },
+  ],
+  credentials: [
+    {
+      ...catalogOverview.credentials[0],
+      mcp_server_id: server.mcp_server_id,
+      server_name: 'asana',
+      server_display_name: 'Asana',
+      status: 'attention',
+      detail_status: 'not_connected',
+    },
+  ],
+};
+function Shell({ children }: { children: ReactNode }) {
+  return (
+    <ConfigProvider theme={{ token: { motion: false } }}>
+      <App>{children}</App>
+    </ConfigProvider>
+  );
+}
+function api() {
+  const base = makeCatalogClient();
+  let attempt: MCPOAuthAttemptResult = { status: 'pending' };
+  const patch = vi.fn(async (_id: string, _data: UpdateMCPServerInput) => ({
+    ...server,
+    config_version: 8,
+  }));
+  const start = vi.fn(
+    async (): Promise<unknown> => ({
+      success: true,
+      authorizationUrl,
+      attempt_id: 'synthetic-attempt',
+    })
+  );
+  const poll = vi.fn(async () => attempt);
+  const status = vi.fn(async () => ({ authenticated_server_ids: [server.mcp_server_id] }));
+  const get = vi.fn(async () => server);
+  const client = {
+    ...base.client,
+    service: (path: string) => {
+      if (path === 'mcp-servers') return { ...base.client.service(path), patch, get };
+      if (path === 'mcp-servers/oauth-start') return { create: start };
+      if (path === 'mcp-servers/oauth-attempt-status') return { get: poll };
+      if (path === 'mcp-servers/oauth-status') return { find: status };
+      return base.client.service(path as 'mcp-servers');
+    },
+  } as unknown as AgorClient;
+  return {
+    client,
+    patch,
+    start,
+    poll,
+    status,
+    get,
+    complete: (value: MCPOAuthAttemptResult) => {
+      attempt = value;
+    },
+  };
+}
+function editor(h: ReturnType<typeof api>, identityKey = catalogUser.user_id) {
+  return (
+    <MCPServerEditModal
+      server={server}
+      open
+      client={h.client}
+      identityKey={identityKey}
+      authorityKey={`${identityKey}:member:1`}
+      authGeneration={1}
+      mutationAllowed
+      onClose={vi.fn()}
+    />
+  );
+}
+async function advanced() {
+  await userEvent.click(await screen.findByText('Advanced — OAuth settings'));
+  return screen.findByLabelText('Client Secret');
+}
+beforeEach(() => {
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+  agorStore.getState().reset();
+  vi.spyOn(window, 'open').mockReturnValue(null);
+});
+afterEach(async () => {
+  cleanup();
+  message.destroy();
+  // AntD's portal destruction is scheduled, not synchronous. Wait for the
+  // previous test's notices to leave the real document before asserting that
+  // a different OAuth attempt has not emitted success. Do not mock the toast
+  // API or weaken the within-attempt pending/identity assertions below.
+  await waitFor(() => expect(document.querySelector('.ant-message-notice')).toBeNull(), {
+    timeout: 5000,
+  });
+  agorStore.getState().reset();
+  vi.restoreAllMocks();
+});
+
+describe('Asana V2 saved OAuth in real Chromium', () => {
+  it('lets an ordinary authorized member sign in from server settings without configuring again', async () => {
+    const h = api();
+    const refresh = vi.fn(async () => undefined);
+    render(
+      <MyServersTab
+        client={h.client}
+        currentUser={catalogUser}
+        connected
+        connecting={false}
+        authGeneration={1}
+        overview={overview}
+        loading={false}
+        error={null}
+        refresh={refresh}
+      />,
+      { wrapper: Shell }
+    );
+    await userEvent.click(await screen.findByRole('button', { name: 'Settings for Asana' }));
+    // The inventory names normal Sign in "Connect" for a not-connected grant.
+    const signIn = await screen.findByRole('button', { name: 'Connect Asana account' });
+    await waitFor(() => expect(signIn).toBeEnabled());
+    await userEvent.click(signIn);
+    await waitFor(() => expect(h.poll).toHaveBeenCalled());
+    expect(h.start).toHaveBeenCalledWith({ mcp_server_id: server.mcp_server_id });
+    expect(h.patch).not.toHaveBeenCalled();
+    expect(window.open).toHaveBeenCalledWith(authorizationUrl, '_blank', 'noopener,noreferrer');
+    expect(refresh).not.toHaveBeenCalled();
+    expect(h.status).not.toHaveBeenCalled();
+    h.complete({ status: 'succeeded' });
+    await waitFor(() => expect(refresh).toHaveBeenCalledOnce());
+    expect(h.status).toHaveBeenCalledOnce();
+    expect(agorStore.getState().userAuthenticatedMcpServerIds.has(server.mcp_server_id)).toBe(true);
+    // The inventory uses AntD's static portal; its queued render must settle
+    // before teardown can destroy it and before the next attempt's assertions.
+    await screen.findByText('OAuth authentication successful!');
+  });
+
+  it('saves Advanced configured-app settings with the redacted secret preserved before opening OAuth', async () => {
+    const h = api();
+    render(editor(h), { wrapper: Shell });
+    const secret = await advanced();
+    expect(secret).toHaveAttribute('type', 'password');
+    expect(secret).toHaveValue('••••••••');
+    await userEvent.fill(screen.getByLabelText('Client ID'), 'synthetic-replacement-app');
+    await userEvent.click(screen.getByRole('button', { name: 'Start OAuth Flow' }));
+    await screen.findByText('Waiting for authentication to complete in the browser tab...');
+    expect(h.patch).toHaveBeenCalledWith(
+      server.mcp_server_id,
+      expect.objectContaining({
+        url: server.url,
+        transport: 'http',
+        expected_config_version: 7,
+        auth: expect.objectContaining({
+          type: 'oauth',
+          oauth_mode: 'per_user',
+          oauth_dcr_mode: 'disabled',
+          oauth_client_id: 'synthetic-replacement-app',
+          oauth_client_secret: '••••••••',
+        }),
+      })
+    );
+    expect(h.patch.mock.invocationCallOrder[0]).toBeLessThan(h.start.mock.invocationCallOrder[0]);
+    expect(h.status).not.toHaveBeenCalled();
+    // window.open can return null with noopener or a blocked popup: neither is success.
+    expect(screen.queryByText('OAuth authentication successful!')).not.toBeInTheDocument();
+    h.complete({ status: 'succeeded' });
+    await screen.findByText('OAuth authentication successful!');
+    await waitFor(() =>
+      expect(
+        screen.queryByText('Waiting for authentication to complete in the browser tab...')
+      ).not.toBeVisible()
+    );
+    expect(h.get).toHaveBeenCalledWith(server.mcp_server_id);
+  });
+
+  it('omits a blank saved secret from the Save patch instead of deleting it', async () => {
+    const h = api();
+    render(editor(h), { wrapper: Shell });
+    await userEvent.clear(await advanced());
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(h.patch).toHaveBeenCalledOnce());
+    expect(h.patch.mock.calls[0]?.[1].auth).toMatchObject({
+      type: 'oauth',
+      oauth_client_id: 'synthetic-asana-app',
+      oauth_dcr_mode: 'disabled',
+    });
+    expect(h.patch.mock.calls[0]?.[1].auth).not.toHaveProperty('oauth_client_secret');
+    expect(h.start).not.toHaveBeenCalled();
+  });
+
+  it('recovers from a failed start using the existing Advanced client secret and retry controls', async () => {
+    const h = api();
+    h.start.mockResolvedValueOnce({
+      success: false,
+      error: 'Synthetic client rejected. Check the configured app.',
+    });
+    render(editor(h), { wrapper: Shell });
+    await userEvent.click(await screen.findByRole('button', { name: 'Start OAuth Flow' }));
+    await screen.findByText('Synthetic client rejected. Check the configured app.');
+    expect(window.open).not.toHaveBeenCalled();
+    await userEvent.fill(await advanced(), 'synthetic-replacement-secret');
+    await userEvent.click(screen.getByRole('button', { name: 'Retry OAuth Flow' }));
+    await screen.findByText('Waiting for authentication to complete in the browser tab...');
+    expect(h.patch.mock.calls[1]?.[1]).toMatchObject({
+      expected_config_version: 8,
+      auth: { oauth_client_secret: 'synthetic-replacement-secret', oauth_dcr_mode: 'disabled' },
+    });
+    expect(
+      screen.queryByText('Synthetic client rejected. Check the configured app.')
+    ).not.toBeInTheDocument();
+    h.complete({ status: 'expired' });
+    await screen.findByText('OAuth sign-in expired. Start a new sign-in.');
+    expect(h.status).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: 'Retry OAuth Flow' })).toBeEnabled();
+  });
+
+  it('discards private draft credentials and a pending completion when the authenticated identity changes', async () => {
+    const h = api();
+    const view = render(editor(h), { wrapper: Shell });
+    await userEvent.fill(await advanced(), 'synthetic-alice-private-draft');
+    await userEvent.click(screen.getByRole('button', { name: 'Start OAuth Flow' }));
+    await waitFor(() => expect(h.poll).toHaveBeenCalled());
+    view.rerender(editor(h, 'bob' as typeof catalogUser.user_id));
+    h.complete({ status: 'succeeded' });
+    expect(await advanced()).toHaveValue('••••••••');
+    // Let the real polling interval pass: the old identity must not refetch/apply its grant.
+    await new Promise((resolve) => window.setTimeout(resolve, 900));
+    expect(h.status).not.toHaveBeenCalled();
+    expect(agorStore.getState().userAuthenticatedMcpServerIds.size).toBe(0);
+    expect(screen.queryByText('OAuth authentication successful!')).not.toBeInTheDocument();
+  });
+});

--- a/apps/agor-ui/src/components/MCPServer/AsanaOAuth.browser.test.tsx
+++ b/apps/agor-ui/src/components/MCPServer/AsanaOAuth.browser.test.tsx
@@ -129,21 +129,31 @@ async function advanced() {
 }
 beforeEach(() => {
   (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = false;
+  // Static message creates a separate React root, outside Shell. Disable its
+  // presentation motion too: hosted Chromium can otherwise leave destroy()
+  // waiting indefinitely for a CSS animationend from an unmounted test tree.
+  ConfigProvider.config({
+    holderRender: (children) => (
+      <ConfigProvider theme={{ token: { motion: false } }}>{children}</ConfigProvider>
+    ),
+  });
   agorStore.getState().reset();
   vi.spyOn(window, 'open').mockReturnValue(null);
 });
 afterEach(async () => {
-  cleanup();
-  message.destroy();
-  // AntD's portal destruction is scheduled, not synchronous. Wait for the
-  // previous test's notices to leave the real document before asserting that
-  // a different OAuth attempt has not emitted success. Do not mock the toast
-  // API or weaken the within-attempt pending/identity assertions below.
-  await waitFor(() => expect(document.querySelector('.ant-message-notice')).toBeNull(), {
-    timeout: 5000,
-  });
-  agorStore.getState().reset();
-  vi.restoreAllMocks();
+  try {
+    cleanup();
+    message.destroy();
+    // Assert real portal removal, not merely an API call or hidden animation.
+    // Pending/identity negatives below still observe the actual notifications.
+    await waitFor(() => expect(document.querySelector('.ant-message-notice')).toBeNull());
+  } finally {
+    // A teardown failure must not leak popup history or global presentation
+    // settings into another test and produce misleading OAuth failures.
+    agorStore.getState().reset();
+    vi.restoreAllMocks();
+    ConfigProvider.config({ holderRender: undefined });
+  }
 });
 
 describe('Asana V2 saved OAuth in real Chromium', () => {

--- a/packages/core/src/mcp-catalog/curated-loader.test.ts
+++ b/packages/core/src/mcp-catalog/curated-loader.test.ts
@@ -398,6 +398,22 @@ ${block}
     const [entry] = parseCuratedCatalog(VALID_ENTRY);
     expect(entry.oauth).toBeUndefined();
   });
+
+  it('accepts an external configured app recipe but never catalog app secrets or ambiguous registration', () => {
+    const recipe = '      configured_client: true\n      dcr_mode: disabled';
+    expect(parseCuratedCatalog(withOAuth(recipe))[0].oauth).toEqual({
+      configured_client: true,
+      dcr_mode: 'disabled',
+    });
+    for (const extra of ['      client_id: public-client', '      client_secret: fixture-secret']) {
+      expect(() => parseCuratedCatalog(withOAuth(`${recipe}\n${extra}`))).toThrow(
+        CuratedCatalogError
+      );
+    }
+    expect(() => parseCuratedCatalog(withOAuth('      configured_client: true'))).toThrow(
+      CuratedCatalogError
+    );
+  });
 });
 
 describe('the shipped catalog', () => {
@@ -570,7 +586,9 @@ describe('the shipped catalog', () => {
     // defensively pending production validation, not claimed to have passed it.
     const entries = await loadCuratedCatalog();
     expect(
-      entries.filter((entry) => entry.oauth !== undefined).map((entry) => [entry.name, entry.oauth])
+      entries
+        .filter((entry) => entry.oauth?.compatibility_mode !== undefined)
+        .map((entry) => [entry.name, entry.oauth])
     ).toEqual([
       ['com.monday/monday.com', { compatibility_mode: 'strict' }],
       ['com.cloudflare/mcp', { compatibility_mode: 'strict' }],

--- a/packages/core/src/mcp-catalog/curated-loader.ts
+++ b/packages/core/src/mcp-catalog/curated-loader.ts
@@ -60,6 +60,7 @@ const catalogEntryOAuthSchema = z
   .object({
     scope: nonEmpty.optional(),
     client_id: nonEmpty.optional(),
+    configured_client: z.literal(true).optional(),
     dcr_mode: z.enum(MCP_OAUTH_DCR_MODES).optional(),
     compatibility_mode: z.enum(MCP_OAUTH_COMPATIBILITY_MODES).optional(),
   })
@@ -70,15 +71,19 @@ const catalogEntryOAuthSchema = z
   .refine((value) => Object.values(value).some((field) => field !== undefined), {
     message: 'must state at least one setting, or be omitted entirely',
   })
-  // `disabled` is the one mode that has to bring its own client. The other two
-  // allow registration to supply one, so an absent `client_id` there is the
-  // ordinary case; with registration off, nothing else can supply it and
-  // `startOAuthFlow` refuses the pair. That refusal lands per-user at sign-in,
-  // long after the entry was reviewed, which is the wrong place to learn that a
-  // combination could never have worked.
-  .refine((value) => value.dcr_mode !== 'disabled' || value.client_id !== undefined, {
-    message: 'must state a client_id when dcr_mode is disabled, since nothing else can supply one',
-  });
+  // Disabled DCR needs a reviewed client source: either a public catalog ID
+  // or an app configured on the saved row. The latter never supplies secret
+  // material through this public file and cannot also request registration.
+  .refine(
+    (value) =>
+      value.dcr_mode !== 'disabled' || value.client_id !== undefined || value.configured_client,
+    { message: 'must state a client_id or configured_client when dcr_mode is disabled' }
+  )
+  .refine(
+    (value) =>
+      !value.configured_client || (value.dcr_mode === 'disabled' && value.client_id === undefined),
+    { message: 'configured_client requires disabled DCR and no catalog client_id' }
+  );
 
 const catalogEntryCredentialsSchema = z
   .object({

--- a/packages/core/src/mcp-catalog/curated.yaml
+++ b/packages/core/src/mcp-catalog/curated.yaml
@@ -600,9 +600,14 @@ unpublished:
     permission_disclosure: Reads and writes tasks, projects, and comments in the Asana workspaces you authorise.
     icon_url: https://api.smithery.ai/servers/asana/icon
     popularity_rank: 22
-    remote_url: https://mcp.asana.com/sse
-    transport: sse
+    remote_url: https://mcp.asana.com/v2/mcp
+    transport: streamable-http
     auth_type: oauth
+    # V2 requires a developer-console MCP app; credentials belong to the
+    # access-controlled saved server, never the public catalog. No DCR.
+    oauth:
+      configured_client: true
+      dcr_mode: disabled
 
   - name: com.clickup/mcp
     category: productivity

--- a/packages/core/src/mcp-catalog/health-audit.test.ts
+++ b/packages/core/src/mcp-catalog/health-audit.test.ts
@@ -30,6 +30,32 @@ function entry(auth_type: MCPCatalogEntry['auth_type']): MCPCatalogEntry {
 }
 
 describe('auditCatalogHealth', () => {
+  it('validates configured-app metadata but does not claim live client authentication', async () => {
+    const asana = {
+      ...entry('oauth'),
+      oauth: { configured_client: true, dcr_mode: 'disabled' },
+    } satisfies MCPCatalogEntry;
+    oauthMocks.resolveMCPOAuthDiscovery.mockResolvedValue({
+      kind: 'resource-metadata',
+      metadataUrl: 'https://mcp.example.com/metadata',
+      source: 'well-known',
+    });
+    oauthMocks.validateMCPOAuthMetadata.mockResolvedValue({ registrationEndpoint: undefined });
+    const [result] = await auditCatalogHealth([asana], {
+      probe: async () => ({ authType: 'oauth' }),
+    });
+    expect(result).toMatchObject({
+      status: 'credential-required',
+      reason: 'credential_not_verified',
+    });
+    oauthMocks.validateMCPOAuthMetadata.mockRejectedValueOnce(
+      new OAuthConfigurationError('issuer_mismatch')
+    );
+    const [drift] = await auditCatalogHealth([asana], {
+      probe: async () => ({ authType: 'oauth' }),
+    });
+    expect(drift).toMatchObject({ status: 'oauth-metadata-not-ready', reason: 'issuer_mismatch' });
+  });
   it('retains the closed storage-policy reason without provider prose', async () => {
     const [result] = await auditCatalogHealth([entry('oauth')], {
       probe: async () => ({ authType: 'oauth' }),

--- a/packages/core/src/mcp-catalog/health-audit.ts
+++ b/packages/core/src/mcp-catalog/health-audit.ts
@@ -72,7 +72,7 @@ async function assertOAuthMetadataReady(
   const validated = await validateMCPOAuthMetadata(discovery, entry.remote_url, {
     compatibilityMode,
   });
-  if (entry.oauth?.client_id) return;
+  if (entry.oauth?.client_id || entry.oauth?.configured_client) return;
   if (entry.oauth?.dcr_mode === 'disabled' || !validated.registrationEndpoint) {
     throw new OAuthConfigurationError(
       'client_registration_required',
@@ -182,7 +182,7 @@ export async function auditCatalogHealth(
     // The public challenge was checked, but only an authenticated initialize
     // can establish that a PAT/credential really works. Scheduled audits have
     // no user secret and must not call that state fully verified.
-    if (entry.auth_type === 'credentials') {
+    if (entry.auth_type === 'credentials' || entry.oauth?.configured_client) {
       return {
         ...base,
         status: 'credential-required',

--- a/packages/core/src/tools/mcp/oauth-asana.test.ts
+++ b/packages/core/src/tools/mcp/oauth-asana.test.ts
@@ -1,0 +1,226 @@
+import { createHash } from 'node:crypto';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { loadCatalog } from '../../mcp-catalog/catalog';
+import { safeOutboundFetch } from '../../utils/safe-outbound-fetch';
+import {
+  type AuthorizationServerMetadata,
+  completeMCPOAuthFlow,
+  resolveMCPOAuthDiscovery,
+  startMCPOAuthFlow,
+  validateMCPOAuthMetadata,
+} from './oauth-mcp-transport';
+import { refreshMCPToken } from './oauth-refresh';
+
+vi.mock('../../utils/safe-outbound-fetch', async (original) => ({
+  ...(await original<typeof import('../../utils/safe-outbound-fetch')>()),
+  safeOutboundFetch: vi.fn(),
+}));
+
+// Public metadata subsets verified by unauthenticated GET, 2026-09-10.
+// Codes, client credentials and token responses below are synthetic, not live receipts.
+const resource = 'https://mcp.asana.com/v2/mcp';
+const metadataUrl = 'https://mcp.asana.com/.well-known/oauth-protected-resource/v2/mcp';
+const issuer = 'https://app.asana.com';
+const callback = 'https://cell.example.test/mcp-servers/oauth-callback';
+const metadata: AuthorizationServerMetadata = {
+  issuer,
+  authorization_endpoint: `${issuer}/-/oauth_authorize`,
+  token_endpoint: `${issuer}/-/oauth_token`,
+  response_types_supported: ['code'],
+  grant_types_supported: ['authorization_code', 'refresh_token'],
+  code_challenge_methods_supported: ['S256'],
+  token_endpoint_auth_methods_supported: ['client_secret_post', 'client_secret_basic'],
+};
+
+function provider(overrides: Partial<AuthorizationServerMetadata> = {}, statedResource = resource) {
+  vi.mocked(safeOutboundFetch).mockImplementation(async (input, options) => {
+    const url = String(input);
+    if (options?.method === 'POST') {
+      expect(url).toBe(metadata.token_endpoint);
+      expect(options.redirect).toBe('error');
+      return Response.json({
+        access_token: 'fixture-access',
+        refresh_token: 'fixture-refresh',
+        token_type: 'Bearer',
+        expires_in: 3600,
+      });
+    }
+    if (url === metadataUrl) {
+      return Response.json({
+        resource: statedResource,
+        authorization_servers: [issuer],
+        scopes_supported: ['default'],
+      });
+    }
+    if (url === `${issuer}/.well-known/oauth-authorization-server`) {
+      return Response.json({ ...metadata, ...overrides });
+    }
+    throw new Error('Unexpected fixture request');
+  });
+}
+
+function start(
+  clientId: string | undefined = 'fixture-client',
+  clientSecret: string | undefined = 'fixture-secret'
+) {
+  return startMCPOAuthFlow('', clientId, callback, {
+    resourceUri: resource,
+    resourceMetadataUrl: metadataUrl,
+    compatibilityMode: 'marketplace',
+    dcrMode: 'disabled',
+    clientSecret,
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+describe('Asana V2 configured MCP app (mocked provider)', () => {
+  it('ships the V2 Streamable HTTP recipe, with no app credentials or DCR', async () => {
+    const entry = (await loadCatalog()).find((entry) => entry.name === 'com.asana/mcp');
+    expect(entry).toMatchObject({
+      remote_url: resource,
+      transport: 'streamable-http',
+      auth_type: 'oauth',
+      oauth: { configured_client: true, dcr_mode: 'disabled' },
+    });
+    expect(entry?.oauth).not.toHaveProperty('client_id');
+  });
+
+  it('discovers the exact V2 resource, exchanges and refreshes with the same configured client', async () => {
+    const logs = vi.spyOn(console, 'log').mockImplementation(() => {});
+    provider();
+    const discovery = await resolveMCPOAuthDiscovery(null, resource, {
+      compatibilityMode: 'marketplace',
+    });
+    expect(discovery).toEqual({ kind: 'resource-metadata', metadataUrl, source: 'well-known' });
+    await expect(
+      validateMCPOAuthMetadata(discovery!, resource, { compatibilityMode: 'marketplace' })
+    ).resolves.toMatchObject({ issuer });
+    const context = await start();
+    const authUrl = context.authorizationUrl;
+    const url = new URL(authUrl);
+    expect(url.origin + url.pathname).toBe(metadata.authorization_endpoint);
+    expect(Object.fromEntries(url.searchParams)).toMatchObject({
+      client_id: 'fixture-client',
+      redirect_uri: callback,
+      resource,
+      response_type: 'code',
+      code_challenge_method: 'S256',
+      state: context.state,
+      code_challenge: createHash('sha256').update(context.pkceVerifier).digest('base64url'),
+    });
+    expect(url.searchParams.has('scope')).toBe(false);
+    expect(authUrl).not.toContain('fixture-secret');
+    expect(context.authorizationResponseIssuerParameterSupported).toBe(false);
+    expect(
+      vi.mocked(safeOutboundFetch).mock.calls.every(([, options]) => options?.method !== 'POST')
+    ).toBe(true);
+    await completeMCPOAuthFlow(context, 'fixture-code', context.state, { cacheToken: false });
+    const exchange = vi.mocked(safeOutboundFetch).mock.calls.at(-1)![1]!;
+    const basic = `Basic ${Buffer.from('fixture-client:fixture-secret').toString('base64')}`;
+    expect(exchange.headers).toMatchObject({ Authorization: basic });
+    expect(Object.fromEntries(new URLSearchParams(String(exchange.body)))).toEqual({
+      grant_type: 'authorization_code',
+      code: 'fixture-code',
+      redirect_uri: callback,
+      code_verifier: context.pkceVerifier,
+      resource,
+    });
+    await refreshMCPToken({
+      tokenEndpoint: context.tokenEndpoint,
+      clientId: context.clientId,
+      clientSecret: context.clientSecret,
+      refreshToken: 'fixture-refresh',
+      resourceUri: context.resourceUri,
+    });
+    const refresh = vi.mocked(safeOutboundFetch).mock.calls.at(-1)![1]!;
+    expect(refresh.headers).toMatchObject({ Authorization: basic });
+    expect(Object.fromEntries(new URLSearchParams(String(refresh.body)))).toEqual({
+      grant_type: 'refresh_token',
+      refresh_token: 'fixture-refresh',
+      resource,
+    });
+    const logged = JSON.stringify(logs.mock.calls);
+    for (const privateValue of [
+      'fixture-secret',
+      'fixture-code',
+      'fixture-access',
+      'fixture-refresh',
+    ]) {
+      expect(logged).not.toContain(privateValue);
+    }
+  });
+
+  it.each([
+    ['issuer', { issuer: `${issuer}/` }],
+    ['authorization endpoint', { authorization_endpoint: `${issuer}/other` }],
+    ['token endpoint', { token_endpoint: 'https://other.example/token' }],
+    ['missing S256', { code_challenge_methods_supported: undefined }],
+    ['POST-only client auth', { token_endpoint_auth_methods_supported: ['client_secret_post'] }],
+  ] satisfies Array<[string, Partial<AuthorizationServerMetadata>]>)(
+    'rejects drift in %s before sending credentials',
+    async (_name, changed) => {
+      provider(changed);
+      await expect(start()).rejects.toThrow();
+      expect(
+        vi.mocked(safeOutboundFetch).mock.calls.every(([, options]) => options?.method !== 'POST')
+      ).toBe(true);
+    }
+  );
+
+  it.each(['https://mcp.asana.com', 'https://mcp.asana.com/v2', 'https://mcp.asana.com/sse'])(
+    'refuses resource alias %s even in marketplace mode',
+    async (alias) => {
+      provider({}, alias);
+      await expect(start()).rejects.toMatchObject({ failureCode: 'metadata_incompatible' });
+    }
+  );
+
+  it('keeps explicit strict validation and exact callback state/issuer checks', async () => {
+    provider();
+    await expect(
+      startMCPOAuthFlow('', 'fixture-client', callback, {
+        resourceUri: resource,
+        resourceMetadataUrl: metadataUrl,
+        clientSecret: 'fixture-secret',
+        compatibilityMode: 'strict',
+      })
+    ).rejects.toMatchObject({ failureCode: 'metadata_incompatible' });
+    const context = await start();
+    await expect(
+      completeMCPOAuthFlow(context, 'fixture-code', 'wrong-state')
+    ).rejects.toMatchObject({ failureCode: 'callback_state_mismatch' });
+    await expect(
+      completeMCPOAuthFlow(context, 'fixture-code', context.state, { issuer: `${issuer}/` })
+    ).rejects.toMatchObject({ failureCode: 'callback_issuer_mismatch' });
+    expect(
+      vi.mocked(safeOutboundFetch).mock.calls.every(([, options]) => options?.method !== 'POST')
+    ).toBe(true);
+  });
+
+  it('reports missing configured credentials without attempting registration', async () => {
+    provider({ registration_endpoint: `${issuer}/register` });
+    await expect(
+      startMCPOAuthFlow('', undefined, callback, {
+        resourceUri: resource,
+        resourceMetadataUrl: metadataUrl,
+        compatibilityMode: 'marketplace',
+      })
+    ).rejects.toMatchObject({ failureCode: 'client_registration_required' });
+    await expect(start('fixture-client', '')).rejects.toMatchObject({
+      failureCode: 'client_registration_required',
+    });
+    await expect(start('{{ user.env.CLIENT_ID }}', 'fixture-secret')).rejects.toMatchObject({
+      failureCode: 'client_registration_required',
+    });
+    await expect(start('fixture-client', '{{ user.env.CLIENT_SECRET }}')).rejects.toMatchObject({
+      failureCode: 'client_registration_required',
+    });
+    expect(
+      vi.mocked(safeOutboundFetch).mock.calls.every(([, options]) => options?.method !== 'POST')
+    ).toBe(true);
+  });
+});

--- a/packages/core/src/tools/mcp/oauth-mcp-transport.ts
+++ b/packages/core/src/tools/mcp/oauth-mcp-transport.ts
@@ -9,6 +9,7 @@
 import crypto from 'node:crypto';
 import http from 'node:http';
 import { z } from 'zod';
+import { hasTemplateMarker } from '../../mcp/template-patterns.js';
 import type {
   MCPOAuthClientRegistrationID,
   MCPOAuthDCRDiagnostic,
@@ -56,6 +57,14 @@ export function __seedAuthCodeTokenCacheForTests(
 // value. The persisted lifecycle is handled in `oauth-cache.ts` (initial
 // auth) and `oauth-refresh.ts` (refresh) which both use the resolver.
 const UNKNOWN_EXPIRY_CACHE_TTL_SECONDS = 3600;
+
+// Reviewed V2 contract. These bounds only tighten existing compatibility
+// policy: Asana does not advertise RFC 9207, so catalog installs use the
+// existing marketplace callback handling, but none of its discovery/resource
+// fallbacks are needed here. Never treat V1 or the documentation's /v2 example
+// as the resource for a V2 grant.
+const ASANA_V2_RESOURCE = 'https://mcp.asana.com/v2/mcp';
+const ASANA_V2_ISSUER = 'https://app.asana.com';
 
 /**
  * Raw OAuth 2.0 token response shape.
@@ -174,6 +183,7 @@ export interface AuthorizationServerMetadata {
   grant_types_supported?: string[];
   code_challenge_methods_supported?: string[];
   authorization_response_iss_parameter_supported?: boolean;
+  token_endpoint_auth_methods_supported?: string[];
 }
 
 // Re-export the canonical OAuthTokenResponse from oauth-auth to avoid duplication
@@ -1562,6 +1572,20 @@ async function resolveOAuthClient(options: {
   resolveDynamicClientRegistration?: MCPOAuthDynamicClientRegistrationResolver;
   assertCurrent?: () => void;
 }): Promise<MCPOAuthResolvedClient> {
+  if (
+    options.resourceUri === ASANA_V2_RESOURCE &&
+    (!options.clientId?.trim() ||
+      !options.clientSecret?.trim() ||
+      hasTemplateMarker(options.clientId) ||
+      hasTemplateMarker(options.clientSecret))
+  ) {
+    throw new OAuthConfigurationError(
+      'client_registration_required',
+      'Asana V2 requires the Client ID and Client Secret of a pre-registered MCP app. ' +
+        'Save literal values in Advanced — OAuth settings, then sign in again; ' +
+        'environment templates are not supported by this browser OAuth flow.'
+    );
+  }
   if (options.clientId) {
     return {
       clientId: options.clientId,
@@ -1705,7 +1729,7 @@ function assertOAuthProtectedResourceMetadata(
   compatibilityMode: MCPOAuthRuntimeCompatibilityMode
 ): void {
   if (
-    compatibilityMode === 'strict'
+    compatibilityMode === 'strict' || resourceUri === ASANA_V2_RESOURCE
       ? statedResource !== resourceUri
       : compatibilityMode === 'marketplace' &&
         !marketplaceResourceMetadataMatches(metadataUrl, statedResource, resourceUri)
@@ -1722,7 +1746,7 @@ function assertOAuthDirectDiscoveryIssuer(
   resourceUri: string,
   compatibilityMode: MCPOAuthRuntimeCompatibilityMode
 ): void {
-  if (compatibilityMode === 'strict') {
+  if (compatibilityMode === 'strict' || resourceUri === ASANA_V2_RESOURCE) {
     throw new OAuthConfigurationError(
       'metadata_incompatible',
       'Authorization-server-direct discovery requires explicit marketplace or legacy mode'
@@ -1767,6 +1791,23 @@ function resolveOAuthAuthorizationContract(options: OAuthAuthorizationContractOp
     authorizationUrlOverride,
     tokenUrlOverride,
   } = options;
+  if (
+    resourceUri === ASANA_V2_RESOURCE &&
+    (issuer !== ASANA_V2_ISSUER ||
+      authServerMetadata?.issuer !== ASANA_V2_ISSUER ||
+      authServerMetadata.authorization_endpoint !== `${ASANA_V2_ISSUER}/-/oauth_authorize` ||
+      authServerMetadata.token_endpoint !== `${ASANA_V2_ISSUER}/-/oauth_token` ||
+      !authServerMetadata.code_challenge_methods_supported?.includes('S256') ||
+      !authServerMetadata.token_endpoint_auth_methods_supported?.includes('client_secret_basic') ||
+      (authorizationUrlOverride !== undefined &&
+        authorizationUrlOverride !== authServerMetadata.authorization_endpoint) ||
+      (tokenUrlOverride !== undefined && tokenUrlOverride !== authServerMetadata.token_endpoint))
+  ) {
+    throw new OAuthConfigurationError(
+      'metadata_incompatible',
+      'Asana V2 metadata no longer matches its reviewed issuer, endpoints, PKCE and client authentication contract.'
+    );
+  }
   const tokenEndpoint = tokenUrlOverride || authServerMetadata?.token_endpoint;
   if (!tokenEndpoint) {
     throw new OAuthConfigurationError(
@@ -2329,7 +2370,7 @@ export async function completeMCPOAuthFlow(
     throw new OAuthCallbackValidationError('callback_issuer_missing');
   }
   if (
-    context.compatibilityMode !== 'legacy' &&
+    (context.compatibilityMode !== 'legacy' || context.resourceUri === ASANA_V2_RESOURCE) &&
     options.issuer != null &&
     options.issuer !== context.issuer
   ) {

--- a/packages/core/src/types/mcp-catalog.ts
+++ b/packages/core/src/types/mcp-catalog.ts
@@ -233,8 +233,8 @@ export interface MCPCatalogEntryCredentials {
  *
  * - **No client secret.** `curated.yaml` is checked into a public repository
  *   and is byte-identical for every tenant, so a secret in it is a published
- *   secret shared by everyone. A server that cannot work without a confidential
- *   client cannot be a catalog entry.
+ *   secret shared by everyone. `configured_client` instead uses the existing
+ *   saved server's access-controlled OAuth client fields, never this file.
  * - **No `authorization_url` / `token_url`.** These are where an authorization
  *   code and a client credential are sent, so a stale one does not fail closed
  *   — it delivers a live grant to whatever now answers at that hostname. They
@@ -252,6 +252,8 @@ export interface MCPCatalogEntryOAuth {
   scope?: string;
   /** A pre-registered *public* client id. Never a confidential one. */
   client_id?: string;
+  /** Reviewed pre-registered app route; client credentials live only on the saved server. */
+  configured_client?: true;
   /** Dynamic Client Registration policy; defaults to `advertised`. */
   dcr_mode?: MCPOAuthDCRMode;
   /** Explicit authorization-metadata policy; omission uses marketplace interoperability. */


### PR DESCRIPTION
## Summary

Implement Asana MCP V2 on main `c2a0bb719036a8b080841c004399e569d6f288ca`, preserving #2715's Connect/Start-session separation and #2718's bound use-time refresh/discovery changes.

- Switch the existing `com.asana/mcp` catalog identity from retired V1 `/sse` to `https://mcp.asana.com/v2/mcp`, Streamable HTTP (saved transport `http`).
- Add a reviewed `oauth.configured_client: true` recipe with DCR disabled. Reuse **existing saved-server OAuth Client ID/Client Secret fields**, redaction, permissions, grant fingerprints, callback lifecycle and per-user token store. No new global credential infrastructure, secret catalog fields, database migration, provider registration, or eligibility gate.
- A current configured install retains normal **Connect / Sign in** after saving its app credentials. Only the client fields and already-authoritative explicit compatibility choice vary from the recipe; endpoint/transport/provenance/scope/other auth/header drift still fails closed. Explicit Strict stays Strict. Manual/imported installs do not acquire Catalog compatibility.
- Asana-specific validation tightens the existing catalog profile: exact V2 resource, exact reviewed issuer/authorization/token endpoints, affirmative S256 and Basic support, no AS-direct resource fallback, no DCR, and a literal confidential client. Reject unresolved client templates before building authorization or sending credentials. Supplied callback `iss` must match exactly, including explicit Legacy for this resource.
- Refresh the caller-owned canonical configured install via the existing authenticated refresh service on reconnect. No arbitrary credential-peer widening or borrowing another owner's row secret. Failed refresh keeps normal recovery.
- Never silently reconcile a V1/edited configured install: explicit saved-row edit and reauthorization are required. Existing revision checks and grant invalidation own that edit; other users' consent is not reused or copied.
- Health audit validates metadata, then reports `credential-required`, not fictional live-auth readiness. Document app setup and migration in the existing user guide.

## Verified provider contract and related work

Rechecked [Asana's official integration guide](https://developers.asana.com/docs/integrating-with-asanas-mcp-server), plus safe unauthenticated metadata GETs on 2026-09-10. V2 requires a developer-console **MCP app** and does not support DCR.

The guide's printed `/v2/.well-known/oauth-protected-resource` returned 404. The standard [path-specific resource metadata](https://mcp.asana.com/.well-known/oauth-protected-resource/v2/mcp) returned the exact `/v2/mcp` resource and `https://app.asana.com` issuer. [Authorization metadata](https://app.asana.com/.well-known/oauth-authorization-server) advertised S256, both Basic and POST client authentication, no DCR, and no RFC 9207 `iss` support declaration. The **production metadata discovery/validation functions also passed against these live GETs**. The guide's abbreviated `/v2` authorization example is not used as Agor's resource.

Inspected open #2714 and #2550 bodies/diffs and current main before choosing the implementation. Neither is transplanted: Asana advertises Basic, so this does not need #2550's POST-auth persistence/schema changes. General Strict is not relaxed to compensate for missing callback-issuer metadata. Current catalog compatibility handles optional `iss`, with the additional Asana bounds above.

Pins protect newly established V2 flows; they are not a retroactive universal validator for all historical/static grants or a live metadata check before every refresh. Existing bound-grant authority still owns refresh. A provider exchange admitted before a concurrent edit may finish externally, while stale persistence is rejected; this PR does not promise synchronous provider revocation.

## CI/conflict repair and final validation

Final head: **`0b74b267bcc300c47e1f832280ff0e3da1194532`**. Rebased onto `c2a0bb719036a8b080841c004399e569d6f288ca`; retained both upstream expiry/client-credentials documentation and the Asana section. Published only this PR branch with explicit `--force-with-lease=refs/heads/asana-v2-mcp-integration:57fc5fa6e03a6a694669d1c165c4cf57858cf9cf`. Normal hooks passed; no bypass, merge, or deployment.

- **Hosted browser failure fixed:** old head's [failed browser job](https://github.com/preset-io/agor/actions/runs/34483869971/job/102893118367) had 10 Asana failures. Its static AntD message root did not inherit the test's motion-disabled provider, leaving the toast in CSS `fade-leave-active`. A failed cleanup then skipped mock restoration and leaked popup history. Configure the actual static holder with motion disabled and restore globals/mocks/store in `finally`. Real notifications, portal-removal assertions, pending/identity negatives, all timeouts and production UI remain unchanged.
- **Semantic upstream integration fixed:** #2718's missing-grant heuristic classified an omitted grant type plus client ID/secret as a machine client. Recognize only the exact current configured-client Catalog recipe from the saved authoritative row as browser reauthentication. Do not mint machine tokens, infer compatibility from a URL, broaden peers, or relax explicit policies. Eight regressions cover default/Strict/Legacy recovery and header/endpoint/manual-provenance/machine-grant/removed-entry negatives at discovery and execution-header boundaries, with zero provider requests.
- Core OAuth/refresh/catalog: **313 passed** (8 files).
- Impacted daemon suites: **306 passed** (9 files), including **91 registered SQLite OAuth integration tests** and unchanged machine-client recovery negatives.
- Full real Chromium: **364 passed** (88 project-files, all four viewports), using `--maxWorkers=2` for local worker scheduling; all tests, viewport projects, assertions, and timeouts unchanged. API and `window.open` remain mocked; not deployed/full-stack or live-provider proof.
- [Exact-head hosted PostgreSQL](https://github.com/preset-io/agor/actions/runs/34500174582): **324 passed, 0 failed, 0 skipped across 68 files**, non-superuser/NOBYPASSRLS, including configured-secret/tenant isolation and upstream refresh concurrency cases. Local final replay also passed **324/324**; interruption/process/database/report cleanup passed and its disposable container was removed.
- Source-only core/daemon noEmit and browser-test typecheck passed. Expanded daemon-test-only lane remains **48 baseline diagnostics / 48 current / zero added**, not a clean expanded lane.
- Full repository Biome (**2907 files**), **330 frontend design-system fixtures**, Prettier, whitespace, tenant/filesystem/realtime boundaries, CI coverage, and image-publication policy checks passed.
- Hosted exact-head [CI](https://github.com/preset-io/agor/actions/runs/34500174507): **SUCCESS** (all CI jobs green, including browser 364/364). Docs, Catalog health, PostgreSQL, PR image smoke and packaged-install smoke workflows also passed for this SHA. Only normally inapplicable promotion/integration jobs are skipped.

**GPT-6 Astra approved exact `0b74b267` with no outstanding code-review blockers.** Reviewed semantic rebase, configured-client recovery, saved authority/tenant boundaries, test isolation and full-lane receipts. Test execution receipts were supplied to the reviewer, not independently rerun by it.

<details>
<summary>Earlier local run failures, retained for transparency</summary>

An unconstrained run before the test-isolation change passed 364 tests locally despite the old hosted failure. After the fix, concurrent heavy local lanes produced one unrelated CatalogTryout timeout (363/364) and a knowledge-index 10-second PostgreSQL timeout (323/324). Another unconstrained browser rerun reported MCPServerSelect/MCPCatalogModal timeouts and stalled; it was stopped with SIGINT and contributes no success evidence. The complete unchanged browser lane subsequently passed with bounded workers, and exact-head hosted browser/PostgreSQL passed. No tests were skipped, timeouts raised, or CI settings weakened.

</details>

## Image publication

Supported manual [Build image run](https://github.com/preset-io/agor/actions/runs/34501133911) **SUCCESS**, dispatched only after exact-head CI passed. Verified `workflow_dispatch`, exact head SHA, successful smoke test and actual **Push image** step. Main/latest promotion was skipped.

Published SHA tag:
```text
docker.io/preset/agor:0b74b267bcc300c47e1f832280ff0e3da1194532
```
Immutable deployment reference:
```text
docker.io/preset/agor@sha256:bd7d77d78871717fd0a96d1936740d5e94474c49ef362dec97f20511f0d7f3f4
```

Independent registry verification via the existing authenticated Docker client resolved that tag to this exact digest. Image config's `org.opencontainers.image.revision` equals the final SHA; inspection did not print configuration/env/credential values. Digest matches the successful workflow push receipt. Anonymous registry inspection returned 401 and is **not** the publication proof; authenticated inspection succeeded. No container deployment/start, main/latest promotion, or merge performed.

Final remote check: `origin/main` remains `c2a0bb719036a8b080841c004399e569d6f288ca` and is an ancestor of the final SHA; remote PR branch equals that SHA; worktree clean. GitHub reports **MERGEABLE**, 17 successful applicable checks and two expected skips, no failed/pending checks. PR remains **OPEN**, auto-merge unset. Repository merge protection still reports **REVIEW_REQUIRED** (not a merge conflict); human approval remains necessary to merge.

## Remaining live-auth prerequisites — not performed

**Code-ready, not live-OAuth-tested.** No real client credentials, registration POST, consent, token exchange, refresh, or Asana tool call was performed. No provider configuration/distribution mutation is authorized by this PR.

With explicit approval, an administrator must:
1. Create an **MCP app** (not an API app/PAT) in the Asana developer console.
2. Register the **exact deployment callback** shown by Agor: its public callback origin plus `/mcp-servers/oauth-callback`. Explicitly register each intended deployment; no wildcard or substituted callback.
3. Configure distribution for the intended workspaces (at least one selected) or explicitly approve Any workspace.
4. Securely configure the saved Catalog server's **Client ID and Client Secret**, per-user OAuth, DCR disabled, empty scope/endpoint overrides, and managed Catalog compatibility; then authorized users use normal Sign in.
5. Exercise consent, a read-only MCP operation, expiry/refresh and reconnect against the deployed code. Migrate old V1 rows only through explicit edit (or explicit deletion/new installation) and reauthorization.

Credentials must never enter chat, URLs, logs, prompts or git. Agent-assisted collection must use Agor's secure env widget; browser OAuth does not automatically resolve those variables or template references, so the saved client fields must be configured through a secure surface. No credential was needed for the fixture/metadata-only work here.

## Retry evidence

Original failed turn was verified clean at `b6567f9a`; no leftover test/browser process was visible in the executor namespace before resuming. A later browser-helper retry failed with only Agor runtime notice reference `1a232b94-a8c3-4652-8711-ce90284e172b:1`; it produced no new edits/log. Parent verified outcomes and completed the browser investigation/rerun directly. No success is attributed to the failed helper turn.

The first pre-commit attempt failed before checks because lint-staged could not create its Git backup. Reproduced with the inherited mismatched PWD (`/var/lib/...`) versus Node working directory (`/home/...`); using the actual working directory for the Git process PWD made backup succeed while preserving Git security settings. All edits remained intact. An initial push contained only the prior base; the verified implementation commit above was subsequently pushed normally. No hooks were skipped.

