### PR TITLE
fix(daemon): keep Stop pending until a remote executor connects

### DIFF
--- a/apps/agor-daemon/src/mcp/tools/sessions.ts
+++ b/apps/agor-daemon/src/mcp/tools/sessions.ts
@@ -1705,7 +1705,7 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
     'agor_sessions_stop',
     {
       description:
-        'Request that a running session stop. The session becomes idle only after Agor verifies executor quiescence or process absence; otherwise it remains guarded in stopping. Use this for emergency stops, timeout-based cancellation, or human-in-the-loop gates. Only works on sessions in active states (running, stopping, awaiting_permission, awaiting_input).',
+        'Request that a running session stop. The session becomes idle only after Agor verifies executor quiescence or process absence. A stop can also be accepted as pending (outcome "pending" with a pendingCode such as "awaiting_remote_executor" while a remote executor has not connected yet, or an HA coordination code); the request is durable and settles later without another call. Only an "unverified" outcome leaves the task guarded in stopping and requires an owner/admin force-fail. Use this for emergency stops, timeout-based cancellation, or human-in-the-loop gates. Only works on sessions in active states (running, stopping, awaiting_permission, awaiting_input).',
       annotations: { destructiveHint: true },
       inputSchema: z.object({
         sessionId: mcpRequiredId('sessionId', 'Session', 'Session ID to stop (UUIDv7 or short ID)'),
@@ -1725,12 +1725,33 @@ export function registerSessionTools(server: McpServer, ctx: McpContext): void {
           { ...ctx.baseServiceParams, route: { id: sessionId } }
         );
 
-      const stopResult = result as { success: boolean; status?: string; reason?: string };
+      const stopResult = result as {
+        success: boolean;
+        outcome?: string;
+        status?: string;
+        reason?: string;
+        pendingCode?: string;
+        stoppedTaskId?: string;
+      };
 
       if (!stopResult.success) {
+        if (stopResult.outcome === 'pending') {
+          // Accepted, not failed: the durable request settles without another call.
+          return textResult({
+            success: false,
+            accepted: true,
+            sessionId,
+            outcome: 'pending',
+            status: stopResult.status,
+            pendingCode: stopResult.pendingCode,
+            stoppedTaskId: stopResult.stoppedTaskId,
+            note: stopResult.reason || 'Stop accepted; waiting for executor termination.',
+          });
+        }
         return textResult({
           success: false,
           sessionId,
+          ...(stopResult.outcome ? { outcome: stopResult.outcome } : {}),
           error: stopResult.reason || 'Failed to stop session',
         });
       }

--- a/apps/agor-daemon/src/services/executor-heartbeat-supervisor.test.ts
+++ b/apps/agor-daemon/src/services/executor-heartbeat-supervisor.test.ts
@@ -196,8 +196,10 @@ describe('TaskRuntimeReconciler', () => {
 
     await create({ localOwnerGraceMs: 1000 }).checkOnce();
 
+    // A discovered remote request whose executor never connected has passed
+    // the database-time startup deadline, so it resumes as deadline-expired.
     expect(requestExecutorTermination).toHaveBeenCalledWith(
-      expect.objectContaining({ taskId: remote.task_id })
+      expect.objectContaining({ taskId: remote.task_id, remoteConnectDeadlineExpired: true })
     );
     expect(requestExecutorTermination).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -205,6 +207,9 @@ describe('TaskRuntimeReconciler', () => {
         allowUnownedLocalContainment: true,
         unownedLocalOwnerGraceMs: 1000,
       })
+    );
+    expect(requestExecutorTermination).not.toHaveBeenCalledWith(
+      expect.objectContaining({ taskId: local.task_id, remoteConnectDeadlineExpired: true })
     );
     expect(getTrackedExecutor).toHaveBeenCalledWith(local.session_id, expect.anything());
   });

--- a/apps/agor-daemon/src/services/task-runtime-reconciler.ts
+++ b/apps/agor-daemon/src/services/task-runtime-reconciler.ts
@@ -181,8 +181,10 @@ export class TaskRuntimeReconciler {
         : [];
       advanceCursor('heartbeat_stale', heartbeat);
       // A stop claimed before a remote executor connected has no lease and no
-      // guard. Keep it out of the scan until the remote startup deadline so
-      // the pending request neither churns nor masks a stranded stop.
+      // guard. The repository keeps it out of the scan until the remote startup
+      // deadline (database time, anchored on dispatch), so the pending request
+      // neither churns nor masks a stranded stop. Discovery is therefore the
+      // authoritative deadline: a discovered awaiting row has expired.
       const termination = await repo.findStrandedTerminationRefs({
         ...discoveryOptions('termination_stranded'),
         unconnectedGraceMs: this.dispatchConnectTimeoutMs(),
@@ -244,18 +246,6 @@ export class TaskRuntimeReconciler {
 
   private dispatchConnectTimeoutMs(): number {
     return this.options.dispatchConnectTimeoutMs ?? DEFAULT_DISPATCH_CONNECT_TIMEOUT_MS;
-  }
-
-  /**
-   * Whether a templated executor that never connected has exhausted the same
-   * startup window the dispatch scan allows. Anchored on dispatch time, not on
-   * the stop request, so a Stop cannot grant an overdue launch another window.
-   */
-  private remoteConnectDeadlineExpired(task: Task): boolean {
-    const anchor = Date.parse(task.started_at ?? task.termination_request?.requested_at ?? '');
-    if (!Number.isFinite(anchor)) return true;
-    const now = this.options.now?.() ?? new Date();
-    return now.getTime() - anchor >= this.dispatchConnectTimeoutMs();
   }
 
   private async reconcileDispatchTimeout(
@@ -350,8 +340,9 @@ export class TaskRuntimeReconciler {
     if (localMode && !ownsLocalHandle && task.sdk_failure?.termination === 'unverified') {
       return false;
     }
+    // Discovery already applied the dispatch-anchored startup deadline in
+    // database time; do not re-evaluate it against this daemon's clock.
     const awaitingRemoteExecutor = isAwaitingRemoteExecutor(task);
-    if (awaitingRemoteExecutor && !this.remoteConnectDeadlineExpired(task)) return false;
     const result = await requestExecutorTermination({
       app: this.options.app,
       taskId: task.task_id,

--- a/apps/agor-daemon/src/services/task-runtime-reconciler.ts
+++ b/apps/agor-daemon/src/services/task-runtime-reconciler.ts
@@ -18,7 +18,10 @@ import type { AuthenticatedParams, Task, TenantID } from '@agor/core/types';
 import { TaskStatus } from '@agor/core/types';
 import type { Application, TasksServiceImpl } from '../declarations.js';
 import { getTrackedExecutor } from '../executor-tracking.js';
-import { requestExecutorTermination } from '../termination-coordinator.js';
+import {
+  isAwaitingRemoteExecutor,
+  requestExecutorTermination,
+} from '../termination-coordinator.js';
 import { withFreshTenantWrite } from '../utils/tenant-db-scope.js';
 
 export const EXECUTOR_HEARTBEAT_LOST_MESSAGE =
@@ -62,6 +65,7 @@ const DEFAULT_SCAN_BATCH_SIZE = 25;
 const DEFAULT_MAX_IDLE_INTERVAL_MS = 60_000;
 const DEFAULT_STARTUP_OFFSET_MAX_MS = 30_000;
 const DEFAULT_LOCAL_OWNER_GRACE_MS = 15_000;
+const DEFAULT_DISPATCH_CONNECT_TIMEOUT_MS = 5 * 60_000;
 const SATURATED_DRAIN_BASE_MS = 150;
 const SATURATED_DRAIN_JITTER_RATIO = 2 / 3; // 50..250ms
 
@@ -165,7 +169,7 @@ export class TaskRuntimeReconciler {
       // postgres.js does not permit concurrent queries on one transaction
       // connection, and these scans deliberately do not lock candidate rows.
       const dispatch = await repo.findExpiredDispatchRefs(
-        this.options.dispatchConnectTimeoutMs ?? 5 * 60_000,
+        this.dispatchConnectTimeoutMs(),
         discoveryOptions('dispatch_timeout')
       );
       advanceCursor('dispatch_timeout', dispatch);
@@ -176,9 +180,13 @@ export class TaskRuntimeReconciler {
           )
         : [];
       advanceCursor('heartbeat_stale', heartbeat);
-      const termination = await repo.findStrandedTerminationRefs(
-        discoveryOptions('termination_stranded')
-      );
+      // A stop claimed before a remote executor connected has no lease and no
+      // guard. Keep it out of the scan until the remote startup deadline so
+      // the pending request neither churns nor masks a stranded stop.
+      const termination = await repo.findStrandedTerminationRefs({
+        ...discoveryOptions('termination_stranded'),
+        unconnectedGraceMs: this.dispatchConnectTimeoutMs(),
+      });
       advanceCursor('termination_stranded', termination);
       const withTenant = (ref: TaskRuntimeDiscoveryRef): TaskRuntimeDiscoveryRef => ({
         ...ref,
@@ -232,6 +240,22 @@ export class TaskRuntimeReconciler {
     work: () => Promise<T>
   ): Promise<T> {
     return withFreshTenantWrite(this.options.db, tenantId, work);
+  }
+
+  private dispatchConnectTimeoutMs(): number {
+    return this.options.dispatchConnectTimeoutMs ?? DEFAULT_DISPATCH_CONNECT_TIMEOUT_MS;
+  }
+
+  /**
+   * Whether a templated executor that never connected has exhausted the same
+   * startup window the dispatch scan allows. Anchored on dispatch time, not on
+   * the stop request, so a Stop cannot grant an overdue launch another window.
+   */
+  private remoteConnectDeadlineExpired(task: Task): boolean {
+    const anchor = Date.parse(task.started_at ?? task.termination_request?.requested_at ?? '');
+    if (!Number.isFinite(anchor)) return true;
+    const now = this.options.now?.() ?? new Date();
+    return now.getTime() - anchor >= this.dispatchConnectTimeoutMs();
   }
 
   private async reconcileDispatchTimeout(
@@ -326,12 +350,15 @@ export class TaskRuntimeReconciler {
     if (localMode && !ownsLocalHandle && task.sdk_failure?.termination === 'unverified') {
       return false;
     }
+    const awaitingRemoteExecutor = isAwaitingRemoteExecutor(task);
+    if (awaitingRemoteExecutor && !this.remoteConnectDeadlineExpired(task)) return false;
     const result = await requestExecutorTermination({
       app: this.options.app,
       taskId: task.task_id,
       cause: request.cause,
       errorMessage: request.error_message ?? 'Resuming durable executor termination.',
       params,
+      ...(awaitingRemoteExecutor ? { remoteConnectDeadlineExpired: true } : {}),
       allowUnownedLocalContainment: localMode && !ownsLocalHandle,
       ...(localMode && !ownsLocalHandle
         ? {

--- a/apps/agor-daemon/src/services/task-runtime-reconciler.ts
+++ b/apps/agor-daemon/src/services/task-runtime-reconciler.ts
@@ -15,13 +15,10 @@ import {
   type TenantScopeAwareDatabase,
 } from '@agor/core/db';
 import type { AuthenticatedParams, Task, TenantID } from '@agor/core/types';
-import { TaskStatus } from '@agor/core/types';
+import { isAwaitingRemoteExecutor, TaskStatus } from '@agor/core/types';
 import type { Application, TasksServiceImpl } from '../declarations.js';
 import { getTrackedExecutor } from '../executor-tracking.js';
-import {
-  isAwaitingRemoteExecutor,
-  requestExecutorTermination,
-} from '../termination-coordinator.js';
+import { requestExecutorTermination } from '../termination-coordinator.js';
 import { withFreshTenantWrite } from '../utils/tenant-db-scope.js';
 
 export const EXECUTOR_HEARTBEAT_LOST_MESSAGE =

--- a/apps/agor-daemon/src/termination-coordinator.test.ts
+++ b/apps/agor-daemon/src/termination-coordinator.test.ts
@@ -26,8 +26,12 @@ function task(status = TaskStatus.RUNNING, extra: Record<string, unknown> = {}) 
   return { task_id: taskId, session_id: sessionId, status, created_at: '2026-01-01', ...extra };
 }
 
-function appDouble(tool = 'codex') {
+function appDouble(tool = 'codex', options: { getDelayMs?: number } = {}) {
   let current = task();
+  const getCurrent = async () => {
+    if (options.getDelayMs) await new Promise((resolve) => setTimeout(resolve, options.getDelayMs));
+    return current;
+  };
   const claimTermination = vi.fn();
   const claimTerminationCoordination = vi.fn(async (input: { claimToken: string }) => {
     current = {
@@ -51,7 +55,7 @@ function appDouble(tool = 'codex') {
     service: (name: string) =>
       name === 'tasks'
         ? {
-            get: async () => current,
+            get: getCurrent,
             claimTermination,
             claimTerminationCoordination,
             settleTermination,
@@ -739,7 +743,9 @@ describe('termination coordinator: remote executor not yet connected', () => {
   });
 
   it('reports the measured wait, not the configured grace, for a connected executor', async () => {
-    const state = appDouble();
+    // Each durable read takes longer than the whole grace, so the real wait is
+    // several times the configured 120ms; reporting the grace would fail.
+    const state = appDouble('codex', { getDelayMs: 250 });
     const remoteStopping = {
       ...stopping('user_stop'),
       executor_mode: 'templated',
@@ -763,7 +769,42 @@ describe('termination coordinator: remote executor not yet connected', () => {
     const reason = (result as { reason: string }).reason;
     const waited = Number(/within (\d+)ms/.exec(reason)?.[1]);
     expect(result.status).toBe('unverified');
-    expect(waited).toBeGreaterThanOrEqual(100);
+    expect(waited).toBeGreaterThanOrEqual(240);
     expect(waited).toBeLessThan(5_000);
+  });
+
+  it('does not report pending when absence is already verified', async () => {
+    const state = appDouble();
+    state.claim(remoteDispatching());
+    state.settle(task(TaskStatus.STOPPED));
+
+    await expect(
+      requestExecutorTermination({
+        app: state.app,
+        taskId,
+        cause: 'user_stop',
+        errorMessage: 'Stopped by user',
+        absenceVerified: true,
+        runInFreshTenantWriteDatabase,
+      })
+    ).resolves.toMatchObject({ status: 'terminal', task: { status: TaskStatus.STOPPED } });
+    expect(state.claimTerminationCoordination).toHaveBeenCalledOnce();
+  });
+
+  it('keeps a repeated beginExecutorTermination pending without claiming coordination', async () => {
+    const state = appDouble();
+    state.claim(remoteDispatching(), 'unchanged');
+
+    await expect(
+      beginExecutorTermination({
+        app: state.app,
+        taskId,
+        cause: 'user_stop',
+        errorMessage: 'Stopped by user',
+        runInFreshTenantWriteDatabase,
+      })
+    ).resolves.toMatchObject({ status: TaskStatus.STOPPING });
+    expect(state.claimTerminationCoordination).not.toHaveBeenCalled();
+    expect(state.settleTermination).not.toHaveBeenCalled();
   });
 });

--- a/apps/agor-daemon/src/termination-coordinator.test.ts
+++ b/apps/agor-daemon/src/termination-coordinator.test.ts
@@ -604,3 +604,166 @@ describe('termination coordinator', () => {
     securityLog.mockRestore();
   });
 });
+
+describe('termination coordinator: remote executor not yet connected', () => {
+  beforeEach(() => {
+    containExecutorProcess.mockReset();
+    getTrackedExecutor.mockReset();
+    getTrackedExecutor.mockReturnValue(undefined);
+    untrackExecutorProcess.mockReset();
+  });
+
+  const remoteDispatching = () => ({
+    ...stopping('user_stop'),
+    executor_mode: 'templated',
+    started_at: '2026-01-01T00:00:00.500Z',
+  });
+
+  it('returns pending without a lease or an unverified guard on the first Stop', async () => {
+    const state = appDouble();
+    state.claim(remoteDispatching());
+    const startedAt = Date.now();
+
+    await expect(request(state.app, 'user_stop')).resolves.toMatchObject({
+      status: 'pending',
+      pendingCode: 'awaiting_remote_executor',
+      task: { status: TaskStatus.STOPPING },
+    });
+    expect(Date.now() - startedAt).toBeLessThan(1_000);
+    expect(state.claimTerminationCoordination).not.toHaveBeenCalled();
+    expect(state.settleTermination).not.toHaveBeenCalled();
+    expect(containExecutorProcess).not.toHaveBeenCalled();
+  });
+
+  it('stays pending on a repeated Stop whose claim is unchanged', async () => {
+    const state = appDouble();
+    state.claim(remoteDispatching(), 'unchanged');
+
+    await expect(request(state.app, 'user_stop')).resolves.toMatchObject({
+      status: 'pending',
+      pendingCode: 'awaiting_remote_executor',
+    });
+    expect(state.claimTerminationCoordination).not.toHaveBeenCalled();
+    expect(state.settleTermination).not.toHaveBeenCalled();
+  });
+
+  it('does not report pending for a task already guarded as unverified', async () => {
+    const state = appDouble();
+    state.claim(
+      {
+        ...remoteDispatching(),
+        sdk_failure: { reason: 'termination_unverified', termination: 'unverified' },
+      },
+      'unchanged'
+    );
+    state.settle(
+      task(TaskStatus.STOPPING, { sdk_failure: { termination: 'unverified' } }),
+      'condition_changed'
+    );
+
+    const result = await request(state.app, 'user_stop');
+    expect(result.status).not.toBe('pending');
+  });
+
+  it('keeps the pending request out of beginExecutorTermination containment', async () => {
+    const state = appDouble();
+    state.claim(remoteDispatching());
+
+    await expect(
+      beginExecutorTermination({
+        app: state.app,
+        taskId,
+        cause: 'user_stop',
+        errorMessage: 'Stopped by user',
+        runInFreshTenantWriteDatabase,
+      })
+    ).resolves.toMatchObject({ status: TaskStatus.STOPPING });
+    expect(state.claimTerminationCoordination).not.toHaveBeenCalled();
+    expect(state.settleTermination).not.toHaveBeenCalled();
+  });
+
+  it('settles stopped when the late executor reports quiescence without ever connecting', async () => {
+    const state = appDouble();
+    state.claim(
+      {
+        ...remoteDispatching(),
+        termination_request: {
+          ...stopping('user_stop').termination_request,
+          executor_quiesced_at: '2026-01-01T00:00:40.000Z',
+        },
+      },
+      'unchanged'
+    );
+    state.settle(task(TaskStatus.STOPPED));
+
+    await expect(request(state.app, 'user_stop')).resolves.toMatchObject({
+      status: 'terminal',
+      task: { status: TaskStatus.STOPPED },
+    });
+    expect(containExecutorProcess).not.toHaveBeenCalled();
+  });
+
+  it('settles a guarded "never connected" result only when the reconciler reports the deadline expired', async () => {
+    const state = appDouble();
+    state.claim(remoteDispatching(), 'unchanged');
+    state.settle(
+      task(TaskStatus.STOPPING, {
+        ...remoteDispatching(),
+        sdk_failure: { termination: 'unverified' },
+      }),
+      'unverified'
+    );
+
+    const result = await requestExecutorTermination({
+      app: state.app,
+      taskId,
+      cause: 'user_stop',
+      errorMessage: 'Stopped by user',
+      remoteConnectDeadlineExpired: true,
+      runInFreshTenantWriteDatabase,
+    });
+
+    expect(result).toMatchObject({
+      status: 'unverified',
+      reason: expect.stringContaining('never connected before the startup deadline'),
+    });
+    expect((result as { reason: string }).reason).not.toContain('within');
+    expect(state.settleTermination).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outcome: 'unverified',
+        errorMessage: expect.stringContaining('never connected before the startup deadline'),
+      }),
+      expect.anything()
+    );
+    expect(containExecutorProcess).not.toHaveBeenCalled();
+  });
+
+  it('reports the measured wait, not the configured grace, for a connected executor', async () => {
+    const state = appDouble();
+    const remoteStopping = {
+      ...stopping('user_stop'),
+      executor_mode: 'templated',
+      executor_connected_at: '2026-01-01T00:00:00.000Z',
+    };
+    state.claim(remoteStopping);
+    state.settle(
+      task(TaskStatus.STOPPING, { ...remoteStopping, sdk_failure: { termination: 'unverified' } }),
+      'unverified'
+    );
+
+    const result = await requestExecutorTermination({
+      app: state.app,
+      taskId,
+      cause: 'user_stop',
+      errorMessage: 'Stopped by user',
+      cooperativeGraceMs: 120,
+      runInFreshTenantWriteDatabase,
+    });
+
+    const reason = (result as { reason: string }).reason;
+    const waited = Number(/within (\d+)ms/.exec(reason)?.[1]);
+    expect(result.status).toBe('unverified');
+    expect(waited).toBeGreaterThanOrEqual(100);
+    expect(waited).toBeLessThan(5_000);
+  });
+});

--- a/apps/agor-daemon/src/termination-coordinator.ts
+++ b/apps/agor-daemon/src/termination-coordinator.ts
@@ -47,6 +47,12 @@ export interface TerminationInput {
   requireExecutorDisconnected?: boolean;
   /** Permit guarded recovery when this daemon does not own a local process handle. */
   allowUnownedLocalContainment?: boolean;
+  /**
+   * The remote startup deadline has passed for a templated executor that never
+   * connected. Only the runtime reconciler sets this; it turns the normally
+   * pending `awaiting_remote_executor` state into a guarded unverified result.
+   */
+  remoteConnectDeadlineExpired?: boolean;
   /** Database-time age required before a non-owner may reclaim local containment. */
   unownedLocalOwnerGraceMs?: number;
   /** Task-specific containment lease; long enough for cooperative + signal grace. */
@@ -119,6 +125,48 @@ function runInFreshTenantWriteDatabase<T>(
   return input.runInFreshTenantWriteDatabase(work);
 }
 
+/**
+ * A templated/remote executor that has not claimed its dispatch cannot have
+ * received the stop request yet. Its startup path reads the durable request
+ * and reports quiescence, so the request is pending rather than unverified.
+ */
+export function isAwaitingRemoteExecutor(task: Task): boolean {
+  return (
+    task.status === TaskStatus.STOPPING &&
+    task.executor_mode === 'templated' &&
+    !task.executor_connected_at &&
+    !!task.termination_request &&
+    !task.termination_request.executor_quiesced_at &&
+    task.sdk_failure?.termination !== 'unverified'
+  );
+}
+
+const AWAITING_REMOTE_EXECUTOR_REASON =
+  'Stop is recorded. The remote executor has not connected yet; it will stop as soon as it starts.';
+
+function awaitingRemoteExecutorResult(task: Task): TerminationResult {
+  return {
+    status: 'pending',
+    task,
+    reason: AWAITING_REMOTE_EXECUTOR_REASON,
+    pendingCode: 'awaiting_remote_executor',
+  };
+}
+
+function remoteUnverifiedReason(task: Task, waitedMs: number): string {
+  if (!task.executor_connected_at) {
+    const requestedAt = Date.parse(task.termination_request?.requested_at ?? '');
+    const sinceRequest = Number.isFinite(requestedAt)
+      ? ` The stop was requested ${Math.round((Date.now() - requestedAt) / 1000)}s ago.`
+      : '';
+    return `Remote executor never connected before the startup deadline.${sinceRequest}`;
+  }
+  return (
+    `Remote executor did not acknowledge quiescence for this termination request ` +
+    `within ${waitedMs}ms.`
+  );
+}
+
 function unverifiedMessage(taskId: string, detail: string): string {
   return (
     `${detail} Agor could not verify that this executor stopped. It may still be running ` +
@@ -156,17 +204,27 @@ async function loadAgenticTool(input: TerminationInput): Promise<PersistedAgenti
   });
 }
 
-async function waitForExecutorQuiescence(input: TerminationInput, requested: Task): Promise<Task> {
+interface QuiescenceWait {
+  task: Task;
+  /** Wall-clock time actually spent waiting for the executor, for diagnostics. */
+  waitedMs: number;
+}
+
+async function waitForExecutorQuiescence(
+  input: TerminationInput,
+  requested: Task
+): Promise<QuiescenceWait> {
   if (
     !requested.executor_connected_at ||
     requested.termination_request?.executor_quiesced_at ||
     isTerminalTaskStatus(requested.status)
   ) {
-    return requested;
+    return { task: requested, waitedMs: 0 };
   }
 
   const graceMs = cooperativeGraceMs(input, requested);
-  if (graceMs <= 0) return requested;
+  if (graceMs <= 0) return { task: requested, waitedMs: 0 };
+  const startedAt = Date.now();
 
   const tasks = input.app.service('tasks');
   const requestedAt = requested.termination_request?.requested_at;
@@ -187,10 +245,10 @@ async function waitForExecutorQuiescence(input: TerminationInput, requested: Tas
       current.termination_request?.coordination?.claim_token !== coordinationToken ||
       current.termination_request?.executor_quiesced_at
     ) {
-      return current;
+      return { task: current, waitedMs: Date.now() - startedAt };
     }
   }
-  return current;
+  return { task: current, waitedMs: Date.now() - startedAt };
 }
 
 async function runContainment(
@@ -203,7 +261,7 @@ async function runContainment(
   if (!coordinationToken && !isTerminalTaskStatus(requested.status)) {
     return { status: 'condition_changed', task: requested };
   }
-  const current = await waitForExecutorQuiescence(input, requested);
+  const { task: current, waitedMs } = await waitForExecutorQuiescence(input, requested);
   if (
     current.status === TaskStatus.STOPPING &&
     current.termination_request?.coordination?.claim_token !== coordinationToken
@@ -228,9 +286,7 @@ async function runContainment(
         ? ({ status: 'verified_absent' } as const)
         : ({
             status: 'unverified',
-            reason:
-              `Remote executor did not acknowledge quiescence for this termination request ` +
-              `within ${cooperativeGraceMs(input, current)}ms.`,
+            reason: remoteUnverifiedReason(current, waitedMs),
           } as const)
       : executorQuiesced
         ? await containExecutorProcess(
@@ -380,6 +436,15 @@ export async function requestExecutorTermination(
   const existing = operationsFor(input.app).get(claim.task.task_id);
   if (existing) return existing.promise;
   if (claim.outcome === 'terminal') return startContainment(input, claim.task, tool);
+  if (
+    !input.absenceVerified &&
+    !input.remoteConnectDeadlineExpired &&
+    isAwaitingRemoteExecutor(claim.task)
+  ) {
+    // No lease and no unverified guard: the durable request alone is enough
+    // for the executor's startup recovery, and the reconciler bounds the wait.
+    return awaitingRemoteExecutorResult(claim.task);
+  }
 
   const coordination = await claimContainmentCoordination(input, claim.task);
   if (coordination.outcome !== 'claimed') {
@@ -428,6 +493,13 @@ export async function beginExecutorTermination(input: TerminationInput): Promise
   if (operations.has(claim.task.task_id)) return claim.task;
   if (claim.outcome === 'terminal') {
     startContainment(input, claim.task, tool);
+    return claim.task;
+  }
+  if (
+    !input.absenceVerified &&
+    !input.remoteConnectDeadlineExpired &&
+    isAwaitingRemoteExecutor(claim.task)
+  ) {
     return claim.task;
   }
   const coordination = await claimContainmentCoordination(input, claim.task);

--- a/apps/agor-daemon/src/termination-coordinator.ts
+++ b/apps/agor-daemon/src/termination-coordinator.ts
@@ -10,7 +10,12 @@ import type {
   TerminationCause,
   TerminationCoordinationPendingCode,
 } from '@agor/core/types';
-import { isAgenticToolName, isTerminalTaskStatus, TaskStatus } from '@agor/core/types';
+import {
+  isAgenticToolName,
+  isAwaitingRemoteExecutor,
+  isTerminalTaskStatus,
+  TaskStatus,
+} from '@agor/core/types';
 import type { TasksServiceImpl } from './declarations.js';
 import {
   containExecutorProcess,
@@ -123,22 +128,6 @@ function runInFreshTenantWriteDatabase<T>(
   work: () => Promise<T>
 ): Promise<T> {
   return input.runInFreshTenantWriteDatabase(work);
-}
-
-/**
- * A templated/remote executor that has not claimed its dispatch cannot have
- * received the stop request yet. Its startup path reads the durable request
- * and reports quiescence, so the request is pending rather than unverified.
- */
-export function isAwaitingRemoteExecutor(task: Task): boolean {
-  return (
-    task.status === TaskStatus.STOPPING &&
-    task.executor_mode === 'templated' &&
-    !task.executor_connected_at &&
-    !!task.termination_request &&
-    !task.termination_request.executor_quiesced_at &&
-    task.sdk_failure?.termination !== 'unverified'
-  );
 }
 
 const AWAITING_REMOTE_EXECUTOR_REASON =

--- a/apps/agor-daemon/src/utils/session-stop.test.ts
+++ b/apps/agor-daemon/src/utils/session-stop.test.ts
@@ -378,6 +378,59 @@ describe('stopSessionPreserveQueue', () => {
     expect(requestTermination).toHaveBeenCalledOnce();
   });
 
+  it('surfaces a stop claimed before the remote executor connected as structured pending', async () => {
+    const sessionId = 'session-remote-dispatching';
+    const dispatchingTask = {
+      task_id: 'task-remote-dispatching',
+      session_id: sessionId,
+      status: 'dispatching',
+      executor_mode: 'templated',
+      created_at: '2026-01-01T00:00:00.000Z',
+    };
+    const requestTermination = vi.fn().mockResolvedValue({
+      status: 'pending',
+      task: {
+        ...dispatchingTask,
+        status: 'stopping',
+        termination_request: { cause: 'user_stop', requested_at: '2026-01-01T00:00:01.000Z' },
+      },
+      pendingCode: 'awaiting_remote_executor',
+      reason: 'Stop is recorded. The remote executor has not connected yet.',
+    });
+
+    await expect(
+      stopSessionPreserveQueue(
+        {
+          app: {} as never,
+          taskRepo: { findQueued: vi.fn().mockResolvedValue([{ task_id: 'queued-1' }]) } as never,
+          sessionsService: {
+            get: vi.fn().mockResolvedValue({
+              session_id: sessionId,
+              agentic_tool: 'codex',
+              status: 'running',
+              ready_for_prompt: false,
+              tasks: [dispatchingTask.task_id],
+            }),
+            patch: vi.fn(),
+          } as never,
+          findActiveTasks: vi.fn().mockResolvedValue([dispatchingTask]) as never,
+          requestTermination: requestTermination as never,
+          runInTenantDatabaseScope,
+          runInFreshTenantWriteDatabase,
+        },
+        sessionId as never
+      )
+    ).resolves.toEqual({
+      success: false,
+      outcome: 'pending',
+      status: 'stopping',
+      reason: 'Stop is recorded. The remote executor has not connected yet.',
+      stoppedTaskId: dispatchingTask.task_id,
+      queuedTasksPreserved: 1,
+      pendingCode: 'awaiting_remote_executor',
+    });
+  });
+
   it('does not claim a successor task when the expected execution generation changed', async () => {
     const sessionId = 'session-generation-changed';
     const runningTask = {

--- a/context/concepts/task-runtime-state.md
+++ b/context/concepts/task-runtime-state.md
@@ -188,6 +188,12 @@ an explicit mapping-review point.
   coordination token and expiring lease unconditionally fence normal
   containment settlement. Guarded-unverified state clears the token and
   rejects any later stale-coordinator settlement.
+- A `stopping` request claimed before a templated executor connected is
+  pending (`awaiting_remote_executor`), not stranded: it holds no coordination
+  lease and no unverified guard, and the stranded-termination scan skips it
+  until the same remote startup deadline the dispatch scan uses, anchored on
+  dispatch time rather than on the Stop. Past that deadline the reconciler
+  settles it as guarded unverified with a "never connected" diagnosis.
 - A replacement daemon resumes an existing durable `stopping` request after
   the prior claim expires. Durable unverified containment is excluded from
   rediscovery and remains owner/admin-guarded unless a first, correctly
@@ -242,17 +248,23 @@ transaction, eliminating a daemon-death gap between durable commits.
 
 Containment then depends on execution mode:
 
-| Runtime                   | Evidence required before terminal settlement                                                                                                                                                |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Local executor            | Cooperative quiescence when available, followed by process-group absence verification by the daemon application that owns the PID/PGID handle; escalation can use `SIGTERM` then `SIGKILL`. |
-| Templated/remote executor | The scoped executor's fenced quiescence report, because the daemon cannot inspect a process group on another host.                                                                          |
-| OpenCode provider work    | Local process absence is insufficient to prove server-side work stopped, so termination can remain unverified.                                                                              |
+| Runtime                   | Evidence required before terminal settlement                                                                                                                                                   |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Local executor            | Cooperative quiescence when available, followed by process-group absence verification by the daemon application that owns the PID/PGID handle; escalation can use `SIGTERM` then `SIGKILL`.    |
+| Templated/remote executor | The scoped executor's fenced quiescence report, because the daemon cannot inspect a process group on another host. Before that executor has connected, Stop is pending rather than unverified. |
+| OpenCode provider work    | Local process absence is insufficient to prove server-side work stopped, so termination can remain unverified.                                                                                 |
 
 Local cooperative shutdown gives the process wrapper 250 ms to disappear before
 signaling. A PGID probe may still be `unverified` because of an OS inspection
 error; only an explicit later `absent` result verifies termination. Persistent
 uncertainty fails closed. Templated/remote executors get a 15 second cooperative
-window because the daemon has no local signal fallback.
+window because the daemon has no local signal fallback; the unverified
+diagnosis reports the wait actually spent. A templated executor that has not
+claimed its dispatch cannot have received the request, so Stop returns
+`pending` with `awaiting_remote_executor` and the request stays durable. The
+late executor's startup recovery reads it, reports quiescence, and settles the
+task without ever connecting. Only the remote startup deadline turns that
+pending request into a guarded unverified one.
 
 After provider cleanup returns, the executor makes bounded, idempotent retries
 to report its exact Task/request-fenced quiescence fact. A failed write is

--- a/context/concepts/task-runtime-state.md
+++ b/context/concepts/task-runtime-state.md
@@ -191,9 +191,13 @@ an explicit mapping-review point.
 - A `stopping` request claimed before a templated executor connected is
   pending (`awaiting_remote_executor`), not stranded: it holds no coordination
   lease and no unverified guard, and the stranded-termination scan skips it
-  until the same remote startup deadline the dispatch scan uses, anchored on
-  dispatch time rather than on the Stop. Past that deadline the reconciler
-  settles it as guarded unverified with a "never connected" diagnosis.
+  until the same remote startup deadline the dispatch scan uses, evaluated in
+  database time and anchored on dispatch time rather than on the Stop. The
+  skip applies only to templated rows with neither a connection nor a fenced
+  quiescence report; local rows and quiesced rows stay discoverable so a
+  daemon crash never delays their recovery. Once discovered past that deadline
+  the reconciler settles the request as guarded unverified with a "never
+  connected" diagnosis.
 - A replacement daemon resumes an existing durable `stopping` request after
   the prior claim expires. Durable unverified containment is excluded from
   rediscovery and remains owner/admin-guarded unless a first, correctly

--- a/packages/core/src/db/repositories/tasks.test.ts
+++ b/packages/core/src/db/repositories/tasks.test.ts
@@ -428,6 +428,67 @@ describe('TaskRepository runtime reconciliation', () => {
   });
 
   dbTest(
+    'keeps a stop claimed before the remote executor connected out of stranded discovery until the startup deadline',
+    async ({ db }) => {
+      const tasks = new TaskRepository(db);
+      const sessionId = await createSessionWithDeps(db);
+      const dispatchedAt = new Date('2026-08-06T12:00:00.000Z');
+      const pending = await tasks.create(
+        createTaskData({
+          session_id: sessionId,
+          status: TaskStatus.DISPATCHING,
+          started_at: dispatchedAt.toISOString(),
+          executor_mode: 'templated',
+        })
+      );
+      await tasks.claimTermination({
+        taskId: pending.task_id,
+        cause: 'user_stop',
+        errorMessage: 'Stopped by user.',
+        now: new Date('2026-08-06T12:00:30.000Z'),
+      });
+      const stopped = await tasks.findById(pending.task_id);
+      expect(stopped?.status).toBe(TaskStatus.STOPPING);
+      expect(stopped?.executor_connected_at).toBeUndefined();
+
+      const graceMs = 5 * 60_000;
+      const inside = await tasks.findStrandedTerminationRefs({
+        now: new Date('2026-08-06T12:04:59.000Z'),
+        unconnectedGraceMs: graceMs,
+      });
+      expect(inside.map((ref) => ref.task_id)).not.toContain(pending.task_id);
+
+      // Without the grace option the row is still routable, as before.
+      const legacy = await tasks.findStrandedTerminationRefs({
+        now: new Date('2026-08-06T12:04:59.000Z'),
+      });
+      expect(legacy.map((ref) => ref.task_id)).toContain(pending.task_id);
+
+      const past = await tasks.findStrandedTerminationRefs({
+        now: new Date('2026-08-06T12:05:00.000Z'),
+        unconnectedGraceMs: graceMs,
+      });
+      expect(past.map((ref) => ref.task_id)).toContain(pending.task_id);
+
+      // A coordinator that already claimed a lease is stranded when it expires,
+      // regardless of whether the executor ever connected.
+      await tasks.claimTerminationCoordination({
+        taskId: pending.task_id,
+        claimToken: 'dead-coordinator',
+        leaseDurationMs: 1_000,
+        instanceId: 'daemon-a',
+        bootId: 'boot-a',
+        now: new Date('2026-08-06T12:00:31.000Z'),
+      });
+      const leased = await tasks.findStrandedTerminationRefs({
+        now: new Date('2026-08-06T12:00:33.000Z'),
+        unconnectedGraceMs: graceMs,
+      });
+      expect(leased.map((ref) => ref.task_id)).toContain(pending.task_id);
+    }
+  );
+
+  dbTest(
     'reclaims an expired coordinator and does not rediscover guarded unverified work',
     async ({ db }) => {
       const tasks = new TaskRepository(db);

--- a/packages/core/src/db/repositories/tasks.test.ts
+++ b/packages/core/src/db/repositories/tasks.test.ts
@@ -432,59 +432,71 @@ describe('TaskRepository runtime reconciliation', () => {
     async ({ db }) => {
       const tasks = new TaskRepository(db);
       const sessionId = await createSessionWithDeps(db);
-      const dispatchedAt = new Date('2026-08-06T12:00:00.000Z');
-      const pending = await tasks.create(
+      const dispatchedAt = '2026-08-06T12:00:00.000Z';
+      const graceMs = 5 * 60_000;
+      const claimedAt = new Date('2026-08-06T12:00:30.000Z');
+      const insideWindow = new Date('2026-08-06T12:04:59.000Z');
+      const stop = async (taskId: string) =>
+        tasks.claimTermination({
+          taskId,
+          cause: 'user_stop',
+          errorMessage: 'Stopped by user.',
+          now: claimedAt,
+        });
+      const stranded = async (now: Date) =>
+        (await tasks.findStrandedTerminationRefs({ now, unconnectedGraceMs: graceMs })).map(
+          (ref) => ref.task_id
+        );
+
+      const remote = await tasks.create(
         createTaskData({
           session_id: sessionId,
+          full_prompt: 'remote, never connected',
           status: TaskStatus.DISPATCHING,
-          started_at: dispatchedAt.toISOString(),
+          started_at: dispatchedAt,
           executor_mode: 'templated',
         })
       );
-      await tasks.claimTermination({
-        taskId: pending.task_id,
-        cause: 'user_stop',
-        errorMessage: 'Stopped by user.',
-        now: new Date('2026-08-06T12:00:30.000Z'),
-      });
-      const stopped = await tasks.findById(pending.task_id);
+      const local = await tasks.create(
+        createTaskData({
+          session_id: sessionId,
+          full_prompt: 'local, never connected',
+          status: TaskStatus.DISPATCHING,
+          started_at: dispatchedAt,
+        })
+      );
+      const quiesced = await tasks.create(
+        createTaskData({
+          session_id: sessionId,
+          full_prompt: 'remote, quiesced before connecting',
+          status: TaskStatus.DISPATCHING,
+          started_at: dispatchedAt,
+          executor_mode: 'templated',
+        })
+      );
+      for (const task of [remote, local, quiesced]) await stop(task.task_id);
+      const stopped = await tasks.findById(remote.task_id);
       expect(stopped?.status).toBe(TaskStatus.STOPPING);
       expect(stopped?.executor_connected_at).toBeUndefined();
+      const quiescedTask = await tasks.findById(quiesced.task_id);
+      await tasks.recordExecutorQuiescence({
+        task_id: quiesced.task_id,
+        requested_at: quiescedTask!.termination_request!.requested_at,
+      });
 
-      const graceMs = 5 * 60_000;
-      const inside = await tasks.findStrandedTerminationRefs({
-        now: new Date('2026-08-06T12:04:59.000Z'),
-        unconnectedGraceMs: graceMs,
-      });
-      expect(inside.map((ref) => ref.task_id)).not.toContain(pending.task_id);
+      // The pending remote stop waits for the startup deadline; a local stop
+      // and a remote stop with durable quiescence evidence stay recoverable.
+      const inside = await stranded(insideWindow);
+      expect(inside).not.toContain(remote.task_id);
+      expect(inside).toContain(local.task_id);
+      expect(inside).toContain(quiesced.task_id);
 
-      // Without the grace option the row is still routable, as before.
-      const legacy = await tasks.findStrandedTerminationRefs({
-        now: new Date('2026-08-06T12:04:59.000Z'),
-      });
-      expect(legacy.map((ref) => ref.task_id)).toContain(pending.task_id);
+      // Without the grace option the remote row is still routable, as before.
+      expect(await tasks.findStrandedTerminationRefs({ now: insideWindow })).toEqual(
+        expect.arrayContaining([expect.objectContaining({ task_id: remote.task_id })])
+      );
 
-      const past = await tasks.findStrandedTerminationRefs({
-        now: new Date('2026-08-06T12:05:00.000Z'),
-        unconnectedGraceMs: graceMs,
-      });
-      expect(past.map((ref) => ref.task_id)).toContain(pending.task_id);
-
-      // A coordinator that already claimed a lease is stranded when it expires,
-      // regardless of whether the executor ever connected.
-      await tasks.claimTerminationCoordination({
-        taskId: pending.task_id,
-        claimToken: 'dead-coordinator',
-        leaseDurationMs: 1_000,
-        instanceId: 'daemon-a',
-        bootId: 'boot-a',
-        now: new Date('2026-08-06T12:00:31.000Z'),
-      });
-      const leased = await tasks.findStrandedTerminationRefs({
-        now: new Date('2026-08-06T12:00:33.000Z'),
-        unconnectedGraceMs: graceMs,
-      });
-      expect(leased.map((ref) => ref.task_id)).toContain(pending.task_id);
+      expect(await stranded(new Date('2026-08-06T12:05:00.000Z'))).toContain(remote.task_id);
     }
   );
 

--- a/packages/core/src/db/repositories/tasks.ts
+++ b/packages/core/src/db/repositories/tasks.ts
@@ -313,10 +313,12 @@ export interface TaskRuntimeDiscoveryOptions {
   /** Deterministic test clock. PostgreSQL uses database time when omitted. */
   now?: Date;
   /**
-   * Stranded-termination discovery only: leave a STOPPING row whose executor
-   * never connected and that no coordinator has ever claimed out of the scan
-   * until this long after dispatch. A templated stop claimed before the pod
-   * connected is pending, not stranded, during the remote startup window.
+   * Stranded-termination discovery only: leave a STOPPING templated row whose
+   * executor has neither connected nor reported quiescence out of the scan
+   * until this long after dispatch (database time). Such a stop is pending,
+   * not stranded, during the remote startup window; local rows and rows with
+   * durable quiescence evidence stay discoverable so crash recovery is not
+   * delayed.
    */
   unconnectedGraceMs?: number;
 }
@@ -988,6 +990,20 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
     }
   }
 
+  /** `data.executor_mode` is absent for local executors; only 'templated' waits for a remote pod. */
+  private executorModeIsNotTemplated() {
+    return isSQLiteDatabase(this.db)
+      ? sql`coalesce(json_extract(${tasks.data}, '$.executor_mode'), 'local') <> 'templated'`
+      : sql`coalesce(${tasks.data}->>'executor_mode', 'local') <> 'templated'`;
+  }
+
+  /** A fenced executor quiescence report is durable proof that must not wait for the startup deadline. */
+  private executorQuiescenceRecorded() {
+    return isSQLiteDatabase(this.db)
+      ? sql`json_extract(${tasks.data}, '$.termination_request.executor_quiesced_at') IS NOT NULL`
+      : sql`${tasks.data}->'termination_request'->>'executor_quiesced_at' IS NOT NULL`;
+  }
+
   private runtimeDiscoveryColumns() {
     const tenantColumn = (tasks as unknown as { tenant_id?: unknown }).tenant_id;
     return {
@@ -1166,7 +1182,8 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
           options.unconnectedGraceMs !== undefined
             ? or(
                 isNotNull(tasks.executor_connected_at),
-                isNotNull(tasks.termination_coordination_claimed_at),
+                this.executorModeIsNotTemplated(),
+                this.executorQuiescenceRecorded(),
                 isNull(tasks.started_at),
                 lte(tasks.started_at, this.databaseCutoff(options.unconnectedGraceMs, options.now))
               )

--- a/packages/core/src/db/repositories/tasks.ts
+++ b/packages/core/src/db/repositories/tasks.ts
@@ -312,6 +312,13 @@ export interface TaskRuntimeDiscoveryOptions {
   after?: TaskRuntimeDiscoveryCursor;
   /** Deterministic test clock. PostgreSQL uses database time when omitted. */
   now?: Date;
+  /**
+   * Stranded-termination discovery only: leave a STOPPING row whose executor
+   * never connected and that no coordinator has ever claimed out of the scan
+   * until this long after dispatch. A templated stop claimed before the pod
+   * connected is pending, not stranded, during the remote startup window.
+   */
+  unconnectedGraceMs?: number;
 }
 
 export interface TaskFindPageOptions {
@@ -1156,6 +1163,14 @@ export class TaskRepository implements BaseRepository<Task, Partial<Task>> {
             isNull(tasks.termination_coordination_expires_at),
             lte(tasks.termination_coordination_expires_at, this.databaseNow(options.now))
           ),
+          options.unconnectedGraceMs !== undefined
+            ? or(
+                isNotNull(tasks.executor_connected_at),
+                isNotNull(tasks.termination_coordination_claimed_at),
+                isNull(tasks.started_at),
+                lte(tasks.started_at, this.databaseCutoff(options.unconnectedGraceMs, options.now))
+              )
+            : undefined,
           after
         )
       )

--- a/packages/core/src/db/task-runtime-ha.postgres.test.ts
+++ b/packages/core/src/db/task-runtime-ha.postgres.test.ts
@@ -532,6 +532,68 @@ describe.skipIf(!postgresUrl || !usesPostgresSchema)('Task runtime HA (PostgreSQ
     });
   });
 
+  it('keeps a pre-connection remote stop out of stranded discovery until the startup deadline', async () => {
+    const owner = await seedTenant(db, 'awaiting-remote');
+    const dispatchedAt = '2026-08-06T12:00:00.000Z';
+    const graceMs = 5 * 60_000;
+    const ids = await runWithTenantDatabaseScope(db, owner.tenantId, async (scoped) => {
+      const tasks = new TaskRepository(scoped);
+      const remote = await tasks.create(
+        taskInput(owner, TaskStatus.DISPATCHING, {
+          executor_mode: 'templated',
+          started_at: dispatchedAt,
+        })
+      );
+      const local = await tasks.create(
+        taskInput(owner, TaskStatus.DISPATCHING, {
+          executor_mode: 'local',
+          started_at: dispatchedAt,
+        })
+      );
+      const quiesced = await tasks.create(
+        taskInput(owner, TaskStatus.DISPATCHING, {
+          executor_mode: 'templated',
+          started_at: dispatchedAt,
+        })
+      );
+      for (const task of [remote, local, quiesced]) {
+        await tasks.claimTermination({
+          taskId: task.task_id,
+          cause: 'user_stop',
+          errorMessage: 'Stopped by user',
+          now: new Date('2026-08-06T12:00:30.000Z'),
+        });
+      }
+      const quiescedRequest = (await tasks.findById(quiesced.task_id))!.termination_request!;
+      await tasks.recordExecutorQuiescence(
+        { task_id: quiesced.task_id, requested_at: quiescedRequest.requested_at },
+        new Date('2026-08-06T12:00:31.000Z')
+      );
+      return { remote: remote.task_id, local: local.task_id, quiesced: quiesced.task_id };
+    });
+
+    const stranded = (now: Date) =>
+      runWithSystemDatabaseScope(
+        db,
+        'awaiting remote discovery',
+        async (systemDb) =>
+          (
+            await new TaskRepository(systemDb).findStrandedTerminationRefs({
+              now,
+              limit: 1_000,
+              unconnectedGraceMs: graceMs,
+            })
+          ).map((ref) => ref.task_id),
+        { capability: 'task_runtime_discovery' }
+      );
+
+    const inside = await stranded(new Date('2026-08-06T12:04:59.000Z'));
+    expect(inside).not.toContain(ids.remote);
+    expect(inside).toContain(ids.local);
+    expect(inside).toContain(ids.quiesced);
+    expect(await stranded(new Date('2026-08-06T12:05:00.000Z'))).toContain(ids.remote);
+  });
+
   it('discovers routing refs globally but rejects cross-tenant reload and mutation', async () => {
     const a = await seedTenant(db, 'tenant-a');
     const b = await seedTenant(db, 'tenant-b');

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -90,10 +90,19 @@ export type TerminationCause =
 export const AUTHORIZATION_REVOKED_TERMINATION_MESSAGE =
   'Authorization to continue this task was revoked.';
 
-/** Why a durable termination request is waiting for another HA coordinator. */
+/**
+ * Why a durable termination request is not settled yet.
+ *
+ * `non_owner_replica` and `coordination_in_progress` wait for another HA
+ * coordinator. `awaiting_remote_executor` waits for a templated/remote
+ * executor that has not connected yet; it can still observe the durable stop
+ * request when it starts, so the daemon must not declare containment
+ * unverified before the remote startup deadline.
+ */
 export const TERMINATION_COORDINATION_PENDING_CODES = [
   'non_owner_replica',
   'coordination_in_progress',
+  'awaiting_remote_executor',
 ] as const;
 
 export type TerminationCoordinationPendingCode =

--- a/packages/core/src/types/task.ts
+++ b/packages/core/src/types/task.ts
@@ -308,6 +308,24 @@ export function isTaskPendingDispatch(task: Pick<Task, 'status'>): task is Pick<
  * continue. CREATED and QUEUED are intentionally excluded: CREATED is a
  * pre-executor row and QUEUED is waiting for a future turn.
  */
+/**
+ * A templated/remote executor that has not claimed its dispatch cannot have
+ * received the stop request yet. Its startup path reads the durable request
+ * and reports quiescence, so the request is pending rather than unverified.
+ * A pure predicate over the Task DTO; shared by the termination coordinator
+ * and the runtime reconciler.
+ */
+export function isAwaitingRemoteExecutor(task: Task): boolean {
+  return (
+    task.status === TaskStatus.STOPPING &&
+    task.executor_mode === 'templated' &&
+    !task.executor_connected_at &&
+    !!task.termination_request &&
+    !task.termination_request.executor_quiesced_at &&
+    task.sdk_failure?.termination !== 'unverified'
+  );
+}
+
 export const EXECUTING_TASK_STATUSES: ReadonlySet<TaskStatus> = new Set<TaskStatus>([
   TaskStatus.DISPATCHING,
   TaskStatus.RUNNING,

--- a/packages/executor/src/index.test.ts
+++ b/packages/executor/src/index.test.ts
@@ -194,6 +194,47 @@ describe('AgorExecutor watchdog handoff', () => {
     });
   });
 
+  it('reports quiescence for a stop claimed before this executor could connect', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const reportTerminationComplete = vi.fn().mockResolvedValue({});
+    const get = vi.fn().mockResolvedValue({
+      task_id: 'task-1',
+      status: 'stopping',
+      executor_mode: 'templated',
+      termination_request: {
+        cause: 'user_stop',
+        requested_at: '2026-07-23T12:00:00.000Z',
+      },
+    });
+    const executor = new AgorExecutor({
+      sessionToken: 'token',
+      sessionId: 'session-1',
+      taskId: 'task-1',
+      prompt: 'prompt',
+      tool: 'codex',
+      daemonUrl: 'http://daemon',
+    }) as unknown as {
+      client: {
+        service: () => {
+          reportTerminationComplete: typeof reportTerminationComplete;
+          get: typeof get;
+        };
+      };
+      recoverTerminationAfterExecutionError(): Promise<boolean>;
+    };
+    executor.client = { service: () => ({ reportTerminationComplete, get }) };
+
+    // connectExecutor rejected with Conflict because the task was already
+    // stopping; no termination request had been observed over the socket.
+    await expect(executor.recoverTerminationAfterExecutionError()).resolves.toBe(true);
+    expect(get).toHaveBeenCalledOnce();
+    expect(reportTerminationComplete).toHaveBeenCalledWith({
+      task_id: 'task-1',
+      requested_at: '2026-07-23T12:00:00.000Z',
+    });
+    expect(runtime.execute).not.toHaveBeenCalled();
+  });
+
   it('warns once when provider cleanup remains active after Stop', async () => {
     vi.useFakeTimers();
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);


### PR DESCRIPTION
## Linked issue

Fixes #2738

## Summary

- Stop on a templated (remote) task whose executor has not connected yet now returns a structured `pending` result with `pendingCode: "awaiting_remote_executor"` instead of an immediate unverified failure. The task stays `stopping`, no coordination lease is claimed, and no unverified guard is written, so the executor's existing startup recovery can still observe the durable request and report quiescence.
- Stranded-termination discovery skips only those rows (templated, not connected, no fenced quiescence report) until the dispatch-anchored remote startup deadline, evaluated in database time. Past that deadline the reconciler settles the request as guarded unverified with a "never connected" diagnosis, which exposes force-fail as before.
- The connected-executor unverified diagnosis now reports the wait actually spent rather than the configured grace.
- The MCP `agor_sessions_stop` tool preserves the pending outcome fields instead of reporting an error, and its description distinguishes pending from guarded unverified.
- Runtime-state concept doc updated; tests added for the coordinator, session Stop mapping, repository discovery on SQLite and PostgreSQL, and executor startup recovery.

## Why / context

`waitForExecutorQuiescence` returns immediately when the task has no `executor_connected_at`, and the remote branch of `runContainment` then reported "within 15000ms" using the configured grace, not the measured wait. So a Stop aimed at a `dispatching` templated task settled unverified in milliseconds with misleading wording. Queued messages make this easy to hit: Stop preserves the queue and triggers a drain right after a successful stop, which dispatches the next task as a new pod; a second Stop during that pod's startup lands on the instant-unverified path. The same happens on the first Stop when messages were queued while the first pod was still starting. Local mode never shows this because local containment inspects the process group it spawned.

Because cloud executor Jobs do not retry, a pod that fails to start would otherwise leave the task guarded until force-fail; the new deadline path keeps that exit while removing the false alarm for pods that are merely slow.

## Implementation notes

- `apps/agor-daemon/src/termination-coordinator.ts`: `isAwaitingRemoteExecutor` gate after the stop claim in both `requestExecutorTermination` and `beginExecutorTermination`; applies to claim outcomes `claimed` and `unchanged`, never when a guard or quiescence exists, when absence is verified, or when the reconciler passes `remoteConnectDeadlineExpired`. The wait helper now returns the measured duration.
- `packages/core/src/db/repositories/tasks.ts`: new `unconnectedGraceMs` discovery option with dialect-aware JSON predicates (`json_extract` on SQLite, `->>` on PostgreSQL). Local rows and rows with a fenced quiescence report stay discoverable so a daemon crash never delays their recovery. The existing partial index predicate on stopping rows is unchanged; the JSON conditions are residual filters.
- `apps/agor-daemon/src/services/task-runtime-reconciler.ts`: passes the dispatch connect timeout as the grace and treats a discovered awaiting row as past its deadline; no daemon-clock recheck.
- Review focus: the discovery predicate and its interaction with lease expiry and guard-cleared quiescence recovery; the coordinator gate ordering relative to terminal and condition-changed handling.

## Validation / test plan

- [x] `pnpm typecheck`, `pnpm lint`, `check:shortid`, `check:multitenancy-boundaries`, `check:daemon-filesystem-boundaries`, `check:realtime-boundaries`
- [x] Unit: `termination-coordinator.test.ts` (7 new cases), `utils/session-stop.test.ts`, core `repositories/tasks.test.ts` (SQLite discovery cases), executor `index.test.ts` (startup recovery of a pre-claimed stop), MCP tool suites
- [x] PostgreSQL: `task-runtime-ha.postgres.test.ts` (new discovery case) and `task-runtime-reconciler.postgres.test.ts` via `test:postgres:docker`; the full suite also ran, with three unrelated files timing out under load and passing on isolated rerun
- [x] Behavioral, on an isolated SQLite daemon with `execution.executor_command_template` pointing at a launcher that simulates a remote executor: (a) launcher connects after 40 s: Stop returned pending in about 30 ms with no lease or guard, a second Stop stayed pending, the executor reported quiescence on startup recovery, task settled `stopped` and session `idle` after 41 s; (b) launcher never connects with `dispatch_connect_timeout_ms: 60000`: pending, then guarded unverified with the "never connected" diagnosis after the deadline, force-fail succeeded
- [x] Validated on an Agor Cloud deploy (2026-09-14): a sandbox Cell was rolled to a Release whose daemon and executor images are built from this commit, then a workspace session was exercised through the UI. Stopping a session with several queued messages while a task was running ended idle with no "remote executor did not acknowledge quiescence" error and the queued messages preserved; stopping within the first seconds of a prompt, before the executor had connected, showed a pending stop and settled to idle once the executor reported in; a subsequent prompt ran normally.
- [ ] Not exercised on Cloud: deliberately breaking pod startup to confirm force-fail appears only after the startup deadline (covered by the local behavioral case (b) above)

## Screenshots / demos

Not applicable; the user-visible change is the Stop notice text and the absence of the premature force-fail prompt.

## Risks / rollout / rollback

- Daemon and executor are one runtime contract; roll out together as usual. No schema migration; the discovery filter is a query change on existing columns and the JSON `data` blob.
- Rollback is a revert; no persisted state depends on the new pending code.
- Behavior change for operators: a stop against a not-yet-connected remote executor is reported as pending and resolves on its own; force-fail becomes available only after the remote startup deadline (default five minutes from dispatch).

## Out of scope / follow-ups

- A stop-and-clear-queue option, since preserving the queue is what re-dispatches the next pod right after a stop.
- Surfacing failed cloud executor Jobs to the daemon as authoritative launcher failure, so a pod that can never start does not have to wait for the startup deadline. That is a control-plane contract change.


